### PR TITLE
Ensure Android workflow targets arm64 mac self-hosted runner

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -57,6 +57,8 @@ jobs:
     name: Build and deploy Android for testing
     runs-on:
       - self-hosted
+      - macOS
+      - ARM64
       - android-large
     needs: [validateActor, getBranchRef]
     if: ${{ fromJSON(needs.validateActor.outputs.READY_TO_BUILD) }}


### PR DESCRIPTION
## Summary
- require the macOS and ARM64 labels in the self-hosted Android job to match the available runner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdb3c5818832abe6c13668b4d7382