### PR TITLE
Fix release workflow YAML parsing

### DIFF
--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -117,14 +117,7 @@ jobs:
           set -eo pipefail
 
           PR_TITLE="chore: release ${VERSION}"
-          PR_BODY=$(cat <<'EOF'
-## Summary
-- Automated version bump prepared by the deployment workflow.
-
-## Testing
-- Not applicable
-EOF
-)
+          PR_BODY=$'## Summary\n- Automated version bump prepared by the deployment workflow.\n\n## Testing\n- Not applicable'
 
           gh pr create \
             --base master \


### PR DESCRIPTION
## Summary
- Replace the version bump PR body heredoc with a shell string so the reusable workflow parses correctly.
- Restore preDeploy's ability to call the release workflow without YAML syntax errors.

## Testing
- Not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbd5fbaac8832a8a64227bef3d087e