### PR TITLE
fix: use KIROKU_ADMIN_COMMIT_TOKEN in updateProtectedBranch workflow

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -12,7 +12,7 @@ on:
       DISCORD_WEBHOOK_URL:
         description: Webhook used to comment in Discord
         required: true
-      KIROKU_ADMIN_TOKEN:
+      KIROKU_ADMIN_COMMIT_TOKEN:
         description: KirokuAdmin personal access token, used to update protected branches
         required: true
       LARGE_SECRET_PASSPHRASE:
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.getSourceBranch.outputs.SOURCE_BRANCH }}
-          token: ${{ secrets.KIROKU_ADMIN_TOKEN }}
+          token: ${{ secrets.KIROKU_ADMIN_COMMIT_TOKEN }}
 
       - name: Setup git for KirokuAdmin
         uses: ./.github/actions/composite/setupGitForKirokuAdmin


### PR DESCRIPTION
## Summary

- Replaces `KIROKU_ADMIN_TOKEN` with `KIROKU_ADMIN_COMMIT_TOKEN` in the `updateProtectedBranch` reusable workflow (both the `secrets:` declaration and the `actions/checkout` `token:` input).

## Why

The `updateStaging / updateProtectedBranch` job was failing at the checkout step with:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```
This happens when `actions/checkout@v4` receives an empty or invalid token — it sets a blank authorization header and git falls back to prompting for credentials, which is not possible in a non-interactive runner.

`KIROKU_ADMIN_TOKEN` is either not set or expired in the repository secrets. `KIROKU_ADMIN_COMMIT_TOKEN` is the token already used (and working) in `createNewVersion.yml` for the same type of protected-branch git operations.

## Reviewer notes

- `KIROKU_ADMIN_TOKEN` remains referenced in `platformDeploy`, `lockDeploys`, `finishReleaseCycle`, `deploy`, and `preDeploy` workflows for GitHub API calls — those are unaffected by this change.
- No logic changes; only the secret name used for git authentication in this one workflow is updated.

## Testing

Re-running the `preDeploy` workflow after this change should allow `updateStaging / updateProtectedBranch` to complete the checkout and push `staging` forward.