### PR TITLE
fix: guard currentChecklistData optional accesses in createOrUpdateStagingDeploy

### DIFF
--- a/.github/actions/javascript/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.ts
+++ b/.github/actions/javascript/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.ts
@@ -158,10 +158,10 @@ async function run(): Promise<IssuesCreateResponse | void> {
           deployBlockers
             .filter(blocker => blocker.isResolved)
             .map(blocker => blocker.url),
-          currentChecklistData.isIOSSmokeChecked,
-          currentChecklistData.isAndroidSmokeChecked,
-          currentChecklistData.isFirebaseChecked,
-          currentChecklistData.isGHStatusChecked,
+          currentChecklistData?.isIOSSmokeChecked ?? false,
+          currentChecklistData?.isAndroidSmokeChecked ?? false,
+          currentChecklistData?.isFirebaseChecked ?? false,
+          currentChecklistData?.isGHStatusChecked ?? false,
         );
       if (stagingDeployCashBodyAndAssignees) {
         checklistBody = stagingDeployCashBodyAndAssignees.issueBody;


### PR DESCRIPTION
## Summary

- TypeScript CI (TS18048) reported `'currentChecklistData' is possibly 'undefined'` on the four smoke-check boolean arguments passed to `generateStagingDeployCashBodyAndAssignees` in [createOrUpdateStagingDeploy.ts](.github/actions/javascript/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.ts).
- `currentChecklistData` is intentionally `undefined` when a new checklist is being created, but the existing ternary `didVersionChange ? false : currentChecklistData.isIOSSmokeChecked` doesn't narrow the type to non-undefined in the false-branch from TypeScript's perspective.
- Fixed by replacing bare property access with optional chaining + nullish coalescing (`currentChecklistData?.isXxxChecked ?? false`), consistent with the pattern already used elsewhere in the same file.

## What changed

`createOrUpdateStagingDeploy.ts` lines 157–160 (pre-Prettier): four arguments changed from `currentChecklistData.isXxxChecked` to `currentChecklistData?.isXxxChecked ?? false`.

## Test plan

- [x] `npm run typecheck-tsgo` passes locally with no errors
- [ ] TypeScript CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)