### PR TITLE
chore: add comment to typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,3 +1,4 @@
+# TypeScript type-checking workflow
 name: TypeScript Checks
 
 on:


### PR DESCRIPTION
## Summary
- Adds a trivial comment to `typecheck.yml` to verify typecheck CI runs when a non-KirokuAdmin user opens a PR

## Test plan
- [ ] Confirm `typecheck / typecheck` job runs (not skipped) in the PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)