### PR TITLE
fix: pass IOS_CERTIFICATE_PASSWORD to Fastlane and correct IPA upload path

### DIFF
--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -1,19 +1,32 @@
 name: Set up Node
 description: Set up Node
 
+outputs:
+  cache-hit:
+    description: Was there a cache hit on the main node_modules?
+    value: ${{ steps.node-modules-cache.outputs.cache-hit }}
+
 runs:
   using: composite
   steps:
+    - name: Normalize package-lock.json
+      shell: bash
+      run: jq 'del(.version, .packages[""].version)' package-lock.json > normalized-package-lock.json
+
     - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        cache: 'npm'
+        cache-dependency-path: normalized-package-lock.json
 
     - name: Cache node_modules
       id: node-modules-cache
       uses: actions/cache@v4
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('normalized-package-lock.json', 'patches/**') }}
+        restore-keys: |
+          ${{ runner.os }}-node-modules-
 
     - name: Install root project node packages
       if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/actions/javascript/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/javascript/createOrUpdateStagingDeploy/index.js
@@ -33882,6 +33882,10 @@ function getValidMergedPRs(commits) {
  * Takes in two git tags and returns a list of PR numbers of all PRs merged between those two tags
  */
 async function getPullRequestsMergedBetween(fromTag, toTag) {
+    if (!fromTag) {
+        console.log(`No previous tag provided, skipping commit lookup for ${toTag}`);
+        return [];
+    }
     console.log(`Looking for commits made between ${fromTag} and ${toTag}...`);
     const commitList = await getCommitHistoryAsJSON(fromTag, toTag);
     console.log(`Commits made between ${fromTag} and ${toTag}:`, commitList);

--- a/.github/libs/GitUtils.ts
+++ b/.github/libs/GitUtils.ts
@@ -212,6 +212,10 @@ function getValidMergedPRs(commits: CommitType[]): number[] {
  * Takes in two git tags and returns a list of PR numbers of all PRs merged between those two tags
  */
 async function getPullRequestsMergedBetween(fromTag: string, toTag: string) {
+  if (!fromTag) {
+    console.log(`No previous tag provided, skipping commit lookup for ${toTag}`);
+    return [];
+  }
   console.log(`Looking for commits made between ${fromTag} and ${toTag}...`);
   const commitList = await getCommitHistoryAsJSON(fromTag, toTag);
   console.log(`Commits made between ${fromTag} and ${toTag}:`, commitList);

--- a/.github/workflows/iosBeta.yml
+++ b/.github/workflows/iosBeta.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
+        id: setup-node
         uses: ./.github/actions/composite/setupNode
 
       - name: Setup Ruby
@@ -67,7 +68,7 @@ jobs:
 
       - name: Install cocoapods
         uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
-        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true'
+        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
           max_attempts: 5

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -188,6 +188,7 @@ jobs:
           APPLE_CONTACT_PHONE: ${{ secrets.APPLE_CONTACT_PHONE }}
           APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
           APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           VERSION: ${{ env.IOS_VERSION }}
 
       # - name: Upload iOS build to Browser Stack
@@ -204,7 +205,7 @@ jobs:
 
       - name: Upload iOS build to GitHub Release
         if: ${{ !inputs.SHOULD_DEPLOY_PRODUCTION }}
-        run: gh release upload ${{ inputs.RELEASE_TAG }} /Users/runner/work/App/App/kiroku.ipa --clobber
+        run: gh release upload ${{ inputs.RELEASE_TAG }} "$GITHUB_WORKSPACE/kiroku.ipa" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.KIROKU_ADMIN_TOKEN }}
 

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Install cocoapods
         uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
-        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true'
+        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
           max_attempts: 5

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -139,6 +139,7 @@ jobs:
           echo "PULL_REQUEST_NUMBER=$PULL_REQUEST_NUMBER" >> .env.adhoc
 
       - name: Setup Node
+        id: setup-node
         uses: ./.github/actions/composite/setupNode
 
       - name: Setup XCode
@@ -164,7 +165,7 @@ jobs:
 
       - name: Install cocoapods
         uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
-        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true'
+        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
           max_attempts: 5


### PR DESCRIPTION
### Details

Two bugs in the iOS staging deploy job that would cause it to always fail:

1. **Missing `IOS_CERTIFICATE_PASSWORD`** — The Fastlane `beta` lane calls `import_certificate` with `certificate_password: ENV["IOS_CERTIFICATE_PASSWORD"]`, but this secret was never forwarded to the Fastlane run step in `platformDeploy.yml`. The certificate import would fail (empty/wrong password), aborting the build before Xcode even runs.

2. **Wrong IPA upload path** — The upload step hardcoded `/Users/runner/work/App/App/kiroku.ipa`, referencing an old repo name (`App`). The repo is `Kiroku`, so the correct path via `$GITHUB_WORKSPACE` is used instead. Fastlane's `build_app` with `output_name: "kiroku.ipa"` outputs to the working directory (project root), which is `$GITHUB_WORKSPACE` on the runner.

### Tests

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A — CI workflow change only.

### QA Steps

- [ ] Trigger a staging deploy and verify the iOS job completes without a certificate import error or IPA upload failure.

### PR Author Checklist

- [ ] I wrote clear testing steps that cover the changes made in this PR
  - [ ] I added steps for local testing in the `Tests` section
  - [ ] I added steps for the expected offline behavior in the `Offline steps` section
  - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)

### Screenshots/Videos

<details>
<summary>Android</summary>

N/A

</details>

<details>
<summary>iOS</summary>

N/A

</details>