### PR TITLE
fix: add missing jsbundle step to iOS deploy in platformDeploy.yml

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -135,9 +135,17 @@ jobs:
           fi
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.289.0
         with:
           bundler-cache: true
+
+      - name: Setup Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.1.1.app
+
+      - name: Set up NODE_BINARY for Xcode
+        run: |
+          echo "export NODE_BINARY=$(which node)" >> "$HOME/.bash_profile"
+          source "$HOME/.bash_profile"
 
       - name: Cache Pod dependencies
         uses: actions/cache@v4
@@ -211,6 +219,13 @@ jobs:
         run: gh release upload ${{ inputs.RELEASE_TAG }} "$GITHUB_WORKSPACE/kiroku.ipa" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.KIROKU_ADMIN_TOKEN }}
+
+      - name: Upload gym log on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gym-log
+          path: ~/Library/Logs/gym/
 
       - name: Warn deployers if iOS production deploy failed
         if: ${{ failure() }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -181,6 +181,9 @@ jobs:
       - name: Set iOS version in ENV
         run: echo "IOS_VERSION=$(echo '${{ inputs.APP_VERSION }}' | tr '-' '.')" >> "$GITHUB_ENV"
 
+      - name: Bundle React Native code and images
+        run: npm run jsbundle
+
       - name: Run Fastlane
         run: bundle exec fastlane ios ${{ inputs.SHOULD_DEPLOY_PRODUCTION && 'production' || 'beta' }}
         env:


### PR DESCRIPTION
## Summary

Syncs the iOS job in \`platformDeploy.yml\` with \`iosBeta.yml\`, which was the reference that worked correctly.

- **Add \`npm run jsbundle\` step** — \`ios/main.jsbundle\` is gitignored so it never exists on CI; Xcode references it as a static resource and fails with \`lstat: No such file or directory\` without this step
- **Add explicit \`xcode-select\` step** — ensures the correct Xcode version is active, not just set via \`DEVELOPER_DIR\`
- **Add \`NODE_BINARY\` setup** — required so Xcode's own RN build phase can find Node if it runs
- **Upgrade \`ruby/setup-ruby\`** from \`v1.190.0\` → \`v1.289.0\`
- **Add gym log upload on failure** — makes future iOS build failures much easier to debug

## Test plan

- [ ] Deploy workflow runs after merge
- [ ] \`Build and deploy iOS\` job passes the archive step

🤖 Generated with [Claude Code](https://claude.com/claude-code)