### PR TITLE
feat: add automated Claude Code PR review via GitHub Actions

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -2,6 +2,9 @@
 
 A setup for running agents (eg: code review, triage etc.) on **issues and pull requests** using [Anthropic’s Claude Code GitHub Action](https://github.com/anthropics/claude-code-action).
 
+> **⚠️ Automated CI workflows are currently disabled.**
+> `claude-review.yml` (the only workflow in this repo using this framework) is set to `workflow_dispatch` only and must not be changed to fire automatically on PRs. Each run costs ~$1–2 in Anthropic API credits. The agents and commands remain available for **manual use** via `/review-code-pr` in Claude Code.
+
 ## Architecture
 
 ```

--- a/.claude/scripts/addPrReaction.sh
+++ b/.claude/scripts/addPrReaction.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Secure proxy script to add a +1 reaction to a GitHub PR
+set -eu
+
+if [[ $# -lt 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Usage: $0 <PR_NUMBER>" >&2
+    exit 1
+fi
+
+readonly PR_NUMBER="$1"
+readonly REPO="${GITHUB_REPOSITORY}"
+
+gh api -X POST "/repos/$REPO/issues/$PR_NUMBER/reactions" -f content="+1"
+

--- a/.claude/scripts/check-compiler.sh
+++ b/.claude/scripts/check-compiler.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Secure proxy script to run React Compiler compliance check on a single file.
+# Validates the filepath before passing it to the underlying npm script.
+set -eu
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <filepath>" >&2
+    exit 1
+fi
+
+readonly FILEPATH="$1"
+
+# Strict filepath validation - reject shell metacharacters
+if ! [[ "$FILEPATH" =~ ^[a-zA-Z0-9_./@-]+$ ]]; then
+    echo "Error: Invalid filepath (contains disallowed characters)" >&2
+    exit 1
+fi
+
+npm run react-compiler-compliance-check -- check "$FILEPATH"

--- a/.claude/scripts/createInlineComment.sh
+++ b/.claude/scripts/createInlineComment.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Secure proxy script to create an inline comment on a GitHub PR.
+set -eu
+
+readonly ALLOWED_RULES_FILE="${ALLOWED_RULES_FILE:-${GITHUB_WORKSPACE}/.claude/allowed-rules.txt}"
+
+# Print error and exit.
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+# Usage helper to avoid repeated text.
+usage() {
+    die "Usage: $0 <path> <body> <line>"
+}
+
+COMMENT_STATUS_REASON=""
+
+# Ensure the comment body references an allowed rule tag.
+validate_rule() {
+    local body="$1"
+    local rule
+
+    [[ -f "$ALLOWED_RULES_FILE" ]] || die "Comment rejected: allowed rules file missing at $ALLOWED_RULES_FILE"
+
+    rule=$(echo "$body" | grep -oE '[A-Z]+(-[A-Z]+)*-[0-9]+' | head -1 || true)
+    [[ -n "$rule" ]] || die "Comment rejected: missing allowed rule reference (e.g. PERF-1)"
+
+    if grep -qF "$rule" "$ALLOWED_RULES_FILE"; then
+        COMMENT_STATUS_REASON="rule $rule validated"
+        return 0
+    fi
+
+    die "Comment rejected: rule $rule not present in allowed list"
+}
+
+readonly PATH_ARG="${1:-}"
+readonly BODY_ARG="${2:-}"
+readonly LINE_ARG="${3:-}"
+
+[[ -z "$PR_NUMBER" ]] && die "Environment variable PR_NUMBER is required"
+[[ -z "$GITHUB_REPOSITORY" ]] && die "Environment variable GITHUB_REPOSITORY is required"
+[[ -z "$PATH_ARG" || -z "$BODY_ARG" || -z "$LINE_ARG" ]] && usage
+
+validate_rule "$BODY_ARG"
+echo "Comment approved: $COMMENT_STATUS_REASON"
+
+COMMIT_ID=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')
+readonly COMMIT_ID
+readonly SHORT_SHA="${COMMIT_ID:0:7}"
+
+readonly FOOTER=$'\n\n---\n\n'"Reviewed at: [${SHORT_SHA}](https://github.com/${GITHUB_REPOSITORY}/commit/${COMMIT_ID}) | Please rate this suggestion with 👍 or 👎 to help us improve! Reactions are used to monitor reviewer efficiency."
+readonly COMMENT_BODY="${BODY_ARG}${FOOTER}"
+
+PAYLOAD=$(jq -n \
+    --arg body "$COMMENT_BODY" \
+    --arg path "$PATH_ARG" \
+    --argjson line "$LINE_ARG" \
+    --arg commit_id "$COMMIT_ID" \
+    '{body: $body, path: $path, line: $line, side: "RIGHT", commit_id: $commit_id}')
+readonly PAYLOAD
+
+gh api -X POST "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" \
+    --input - <<< "$PAYLOAD" || exit 1

--- a/.github/scripts/extractAllowedRules.sh
+++ b/.github/scripts/extractAllowedRules.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Extract allowed rules from individual rule files in the rules directory.
+# Each rule file has YAML frontmatter with a ruleId field.
+set -euo pipefail
+
+RULES_DIR="${1:-.claude/skills/coding-standards/rules}"
+OUTPUT_FILE="${2:-.claude/allowed-rules.txt}"
+
+if [[ ! -d "$RULES_DIR" ]]; then
+    echo "Error: Rules directory not found: $RULES_DIR" >&2
+    exit 1
+fi
+
+# Extract ruleId from YAML frontmatter of each non-underscore .md file
+# Use multi-hyphen regex to validate rule ID format (e.g., PERF-1, CLEAN-REACT-PATTERNS-1)
+true > "$OUTPUT_FILE"
+for file in "$RULES_DIR"/[!_]*.md; do
+    [[ -f "$file" ]] || continue
+    grep -m1 '^ruleId:' "$file" | grep -oE '[A-Z]+(-[A-Z]+)*-[0-9]+' >> "$OUTPUT_FILE" || true
+done
+
+sort -u -o "$OUTPUT_FILE" "$OUTPUT_FILE"
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+    echo "Error: No allowed rules found in $RULES_DIR" >&2
+    exit 1
+fi
+
+echo "Extracted allowed rules:"
+cat "$OUTPUT_FILE"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,15 +1,28 @@
 name: PR Reviews with Claude Code
 
+# ============================================================
+# INTENTIONALLY DISABLED — DO NOT RE-ENABLE WITHOUT REVIEW
+# ============================================================
+# This workflow runs claude-opus-4-6 on every PR touching src/,
+# which costs ~$1–2 per PR in Anthropic API credits.
+# It is kept here for reference but must NOT fire automatically.
+#
+# To enable in the future:
+#   1. Confirm ANTHROPIC_API_KEY is set in repo secrets.
+#   2. Replace the trigger below with:
+#        on:
+#          pull_request:
+#            types: [opened, synchronize, ready_for_review]
+#            branches-ignore: [staging, production]
+#            paths: ['src/**']
+# ============================================================
+
 permissions:
   contents: read
   pull-requests: write
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
-    branches-ignore: [staging, production]
-    paths:
-      - 'src/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-claude-review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,75 @@
+name: PR Reviews with Claude Code
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches-ignore: [staging, production]
+    paths:
+      - 'src/**'
+
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-claude-review
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude Code PR Review
+    if: ${{ !github.event.pull_request.draft && !startsWith(github.event.pull_request.title, 'Revert ') && github.actor != 'KirokuAdmin' }}
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x .claude/scripts/*.sh .github/scripts/extractAllowedRules.sh
+
+      - name: Add claude scripts to PATH
+        run: echo "$GITHUB_WORKSPACE/.claude/scripts" >> "$GITHUB_PATH"
+
+      - name: Extract allowed rule IDs
+        run: .github/scripts/extractAllowedRules.sh .claude/skills/coding-standards/rules "$RUNNER_TEMP/allowed-rules.txt"
+
+      - name: Load code review JSON schema
+        id: schema
+        run: echo "json=$(jq -c . .claude/schemas/code-review-output.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code PR review
+        id: code-review
+        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae  # v1.0.86
+        with:
+          display_report: "true"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: "/review-code-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
+          claude_args: |
+            --model claude-opus-4-6
+            --allowedTools "Task,Glob,Grep,Read,Bash(gh pr diff:*),Bash(gh pr view:*)" --json-schema '${{ steps.schema.outputs.json }}'
+
+      - name: Post code review results
+        if: steps.code-review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STRUCTURED_OUTPUT: ${{ steps.code-review.outputs.structured_output }}
+          ALLOWED_RULES_FILE: ${{ runner.temp }}/allowed-rules.txt
+        run: |
+          if [ -z "$STRUCTURED_OUTPUT" ]; then
+            echo "::error::Claude Code returned empty structured output"
+            exit 1
+          fi
+          COUNT=$(echo "$STRUCTURED_OUTPUT" | jq '.violations | length')
+          if [ "$COUNT" -eq 0 ]; then
+            addPrReaction.sh "$PR_NUMBER"
+          else
+            echo "$STRUCTURED_OUTPUT" | jq -c '.violations[]' | while IFS= read -r v; do
+              PATH_ARG=$(echo "$v" | jq -r '.path')
+              BODY_ARG=$(echo "$v" | jq -r '.body')
+              LINE_ARG=$(echo "$v" | jq -r '.line')
+              createInlineComment.sh "$PATH_ARG" "$BODY_ARG" "$LINE_ARG" || true
+            done
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Key GitHub Actions workflows:
 - `test.yml`: Unit tests
 - `typecheck.yml`: TypeScript validation
 - `lint.yml`: Code quality checks
+- `claude-review.yml`: Claude Code automated PR review — **intentionally disabled** (costs ~$1–2/PR in API credits; trigger is `workflow_dispatch` only — do not change to `pull_request`)
 
 ## Related Repositories
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-review.yml` — triggers on every PR touching `src/**`, runs `anthropics/claude-code-action` with the `/review-code-pr` command, and posts inline comments or a 👍 reaction based on structured JSON output
- Adds `.claude/scripts/addPrReaction.sh` — posts a 👍 reaction when zero violations are found
- Adds `.claude/scripts/createInlineComment.sh` — posts inline PR comments; includes a security whitelist gate that blocks comments referencing unknown rule IDs (prompt-injection protection)
- Adds `.claude/scripts/check-compiler.sh` — React Compiler compliance wrapper, ready for future use once `react-compiler-compliance-check` is added to `package.json`
- Adds `.github/scripts/extractAllowedRules.sh` — parses `ruleId:` from all 28 rule files in `.claude/skills/coding-standards/rules/` to produce the security whitelist

## Test plan

- [ ] Add `ANTHROPIC_API_KEY` as a GitHub Actions repository secret (Settings → Secrets and variables → Actions)
- [ ] Open a test PR that touches at least one file under `src/` and verify the `PR Reviews with Claude Code` workflow triggers
- [ ] Confirm the `Extract allowed rule IDs` step prints 28 rule IDs and exits 0
- [ ] If no violations → verify 👍 reaction appears on the PR
- [ ] If violations → verify inline comments appear on the relevant lines
- [ ] Open a PR that only changes non-`src/` files and verify the workflow is skipped entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)