### PR TITLE
fix: bump google-services to 4.4.2 for Crashlytics Gradle plugin v3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("com.google.gms:google-services:4.3.4")
+        classpath("com.google.gms:google-services:4.4.2")
         classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.3")
         // REMOVED: classpath("com.google.firebase:perf-plugin:1.4.1")
 


### PR DESCRIPTION
## Summary

- Bumps `com.google.gms:google-services` from `4.3.4` → `4.4.2` in `android/build.gradle`
- Fixes Android CI build failure: `@react-native-firebase/crashlytics` v24 bundles Crashlytics Gradle plugin v3, which hard-requires `google-services >= 4.4.1` and was failing at Gradle configuration time with: _"The Crashlytics Gradle plugin 3 requires Google-Services 4.4.1 and above"_

## Test plan

- [ ] Trigger a staging deploy and verify the Android `bundleProductionRelease` Gradle task completes successfully
- [ ] Confirm the `.aab` is uploaded to the GitHub Release as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)