### PR TITLE
fix(android): increase JVM metaspace to 1g to prevent R8 OOM

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Summary

- Increases `MaxMetaspaceSize` from `512m` to `1g` in `android/gradle.properties`
- Adds `-XX:+UseG1GC` for better garbage collection behavior under heavy load

## Root cause

The Android CI build ([run 25741743943](https://github.com/PetrCala/Kiroku/actions/runs/25741743943)) failed with repeated `OutOfMemoryError: Metaspace` after ~1h10m of R8 dex compilation across all 4 architectures (`armeabi-v7a`, `arm64-v8a`, `x86`, `x86_64`). JVM metaspace stores class metadata, and R8 loads enormous numbers of class descriptors during minification — 512m is not enough for a release build of this size.

## Test plan

- [ ] Trigger Android deploy and confirm Fastlane completes without `OutOfMemoryError: Metaspace`
- [ ] Verify the generated AAB is uploaded to Google Play internal track successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)