### PR TITLE
fix(ci): seed macOS node_modules cache on master pushes

### DIFF
--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -25,8 +25,6 @@ runs:
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('normalized-package-lock.json', 'patches/**') }}
-        restore-keys: |
-          ${{ runner.os }}-node-modules-
 
     - name: Install root project node packages
       if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -16,6 +16,13 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
+  warmMacosCache:
+    name: Seed macOS node_modules cache
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/composite/setupNode
+
   confirmPassingBuild:
     runs-on: ubuntu-latest
     needs: [typecheck, lint, test]


### PR DESCRIPTION
## What

- Adds a `warmMacosCache` job to `preDeploy.yml` that runs `setupNode` on `macos-26` on every push to `master`
- Removes the wasted `restore-keys` fallback from the `setupNode` composite action

## Why

macOS iOS build jobs (`platformDeploy` on `macos-26`, `testBuild` on `macos-13`) were **always missing** the `node_modules` cache and falling through to a full `npm ci` on every run.

Root cause: the cache key is prefixed with `${{ runner.os }}`, creating separate `Linux-node-modules-*` and `macOS-node-modules-*` caches. Only `ubuntu-latest` jobs run on push to master (lint/test/typecheck via preDeploy), so the Linux cache is seeded there — but **no macOS runner ever runs on master**, leaving `macOS-node-modules-*` empty under the default-branch cache scope. GitHub Actions falls back to the default branch's cache for all branches, so seeding on master fixes all consumers.

The `restore-keys` fallback is also removed: when the exact key misses and a partial key matches, `cache-hit` is `false`, so `npm ci` runs anyway and wipes `node_modules` before reinstalling. The stale partial restore is downloaded and immediately discarded — wasted bandwidth. Expensify's equivalent action omits this fallback for the same reason.

## Impact

After the first master push post-merge, the `macOS-node-modules-{hash}` key is populated. Subsequent iOS builds where `package-lock.json` and `patches/**` haven't changed will hit the cache and skip `npm ci`, saving multiple minutes per build.

`warmMacosCache` is intentionally excluded from `confirmPassingBuild`'s `needs:` — a transient macOS runner blip should not block a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)