### PR TITLE
fix: unmount SplashScreenHider after fade to restore touch and content

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -123,11 +123,12 @@ function Kiroku() {
   // For logged-out users, theme is ready immediately (system default will be used)
   const isThemeReady = !isAuthenticated || preferredTheme !== undefined;
 
-  const shouldHideSplash =
+  const shouldHideSplash = !!(
     shouldInit &&
     authenticationChecked &&
     isThemeReady &&
-    splashScreenState === CONST.BOOT_SPLASH_STATE.VISIBLE;
+    splashScreenState === CONST.BOOT_SPLASH_STATE.VISIBLE
+  );
 
   const initializeClient = () => {
     if (!Visibility.isVisible()) {
@@ -309,9 +310,12 @@ function Kiroku() {
         lastVisitedPath={lastVisitedPath as Route}
         initialUrl={initialUrl}
       />
-      {/* SplashScreenHider is always rendered to cover content until app is ready.
-          When shouldHideSplash becomes true, isVisible becomes false and the hide animation triggers. */}
-      <SplashScreenHider onHide={onSplashHide} isVisible={!shouldHideSplash} />
+      {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN && (
+        <SplashScreenHider
+          shouldHideSplash={shouldHideSplash}
+          onHide={onSplashHide}
+        />
+      )}
     </>
   );
 }

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -20,7 +20,7 @@ import type {
 
 function SplashScreenHider({
   onHide = () => {},
-  isVisible = true,
+  shouldHideSplash,
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const styles = useThemeStyles();
   const logoSizeRatio = BootSplash.logoSizeRatio || 1;
@@ -69,13 +69,12 @@ function SplashScreenHider({
     });
   }, [opacity, scale, onHide]);
 
-  // Trigger hide when isVisible becomes false (i.e., when app is ready)
   useEffect(() => {
-    if (isVisible) {
+    if (!shouldHideSplash) {
       return;
     }
     hide();
-  }, [isVisible, hide]);
+  }, [shouldHideSplash, hide]);
 
   return (
     <Reanimated.View

--- a/src/components/SplashScreenHider/index.tsx
+++ b/src/components/SplashScreenHider/index.tsx
@@ -7,18 +7,17 @@ import type {
 
 function SplashScreenHider({
   onHide = () => {},
-  isVisible = true,
+  shouldHideSplash,
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const hideHasBeenCalled = useRef(false);
 
   useEffect(() => {
-    // Only hide when isVisible becomes false and hide hasn't been called yet
-    if (isVisible || hideHasBeenCalled.current) {
+    if (!shouldHideSplash || hideHasBeenCalled.current) {
       return;
     }
     hideHasBeenCalled.current = true;
     BootSplash.hide().then(() => onHide());
-  }, [isVisible, onHide]);
+  }, [shouldHideSplash, onHide]);
 
   return null;
 }

--- a/src/components/SplashScreenHider/types.ts
+++ b/src/components/SplashScreenHider/types.ts
@@ -1,11 +1,11 @@
 import type {ReactNode} from 'react';
 
 type SplashScreenHiderProps = {
-  /** Splash screen has been hidden */
+  /** Callback fired after the hide animation completes */
   onHide: () => void;
 
-  /** Whether the splash screen should remain visible (default: true) */
-  isVisible?: boolean;
+  /** When true, triggers the hide animation */
+  shouldHideSplash: boolean;
 };
 
 type SplashScreenHiderReturnType = ReactNode;


### PR DESCRIPTION
## Summary

- The always-mounted `SplashScreenHider` (introduced in e0e97772) combined with `zIndex: 20` (f8f60f3d) left a permanent full-screen overlay in the React tree after the hide animation — transparent but with default `pointerEvents: "auto"`, blocking all touches and leaving the user staring at the white `appBG` with nothing responding.
- Aligns with the Expensify upstream pattern: `SplashScreenHider` is now conditionally rendered, only mounted while `splashScreenState !== HIDDEN`. Once `onHide` fires and sets the state to `HIDDEN`, the component unmounts cleanly — no ghost overlay, no blocked touches.
- Renames the prop from the inverse `isVisible` to the direct `shouldHideSplash` to match upstream naming.

## Test plan

- [ ] Launch app on iOS simulator — confirm splash logo is visible on startup
- [ ] Confirm smooth fade-out once all readiness conditions are met (nav ready, auth checked, theme loaded)
- [ ] Confirm underlying screen (login or home) is fully visible and tappable after the fade completes
- [ ] Confirm no ghost overlay blocks interaction on subsequent taps/navigations
- [ ] Launch on Android emulator and repeat above

🤖 Generated with [Claude Code](https://claude.com/claude-code)