### PR TITLE
ci: auto-trigger testBuild on app code changes

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -7,8 +7,13 @@ on:
         description: Pull Request number for correct placement of apps
         required: true
   pull_request:
-    types: [opened, synchronize, labeled]
-    branches: ["*ci-test/**"]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   id-token: write
@@ -16,26 +21,8 @@ permissions:
   contents: write
 
 jobs:
-  validateActor:
-    runs-on: ubuntu-latest
-    outputs:
-      READY_TO_BUILD: ${{  fromJSON(steps.hasReadyToBuildLabel.outputs.HAS_READY_TO_BUILD_LABEL) }}
-    steps:
-      - id: hasReadyToBuildLabel
-        name: Set HAS_READY_TO_BUILD_LABEL flag
-        run: |
-          echo "HAS_READY_TO_BUILD_LABEL=$(gh pr view "${{ env.PULL_REQUEST_NUMBER }}" --repo PetrCala/Kiroku --json labels --jq '.labels[].name' | grep -q 'Ready To Build' && echo 'true')" >> "$GITHUB_OUTPUT"
-          if [[ "$HAS_READY_TO_BUILD_LABEL" != 'true' ]]; then
-            echo "The 'Ready to Build' label is not attached to the PR #${{ env.PULL_REQUEST_NUMBER }}"
-          fi
-        env:
-          PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
-          GITHUB_TOKEN: ${{ github.token }}
-
   getBranchRef:
     runs-on: ubuntu-latest
-    needs: validateActor
-    if: ${{ fromJSON(needs.validateActor.outputs.READY_TO_BUILD) }}
     outputs:
       REF: ${{steps.getHeadRef.outputs.REF}}
     steps:
@@ -58,8 +45,7 @@ jobs:
     runs-on:
       - self-hosted
       - android-large
-    needs: [validateActor, getBranchRef]
-    if: ${{ fromJSON(needs.validateActor.outputs.READY_TO_BUILD) }}
+    needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:
@@ -121,8 +107,7 @@ jobs:
 
   iOS:
     name: Build and deploy iOS for testing
-    needs: [validateActor, getBranchRef]
-    if: ${{ fromJSON(needs.validateActor.outputs.READY_TO_BUILD) }}
+    needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
       DEVELOPER_DIR: /Applications/Xcode_15.2.0.app/Contents/Developer
@@ -215,7 +200,7 @@ jobs:
   postGithubComment:
     runs-on: ubuntu-latest
     name: Post a GitHub comment with app download links for testing
-    needs: [validateActor, getBranchRef, android, iOS]
+    needs: [getBranchRef, android, iOS]
     if: ${{ always() }}
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
## Summary

- Replaces the manual \"Ready To Build\" label gate with an automatic `pull_request` trigger filtered by path
- Removes the `validateActor` job and all `READY_TO_BUILD` conditions (label-gating is unnecessary for a private single-developer repo)
- Builds now fire on any PR that touches `src/`, `android/`, `ios/`, `package.json`, or `package-lock.json`
- `workflow_dispatch` is preserved for manual runs without a PR

## Motivation

Agent-created PRs previously required manually adding the "Ready To Build" label before a test build would run. With this change, every PR that touches app code automatically gets a build — and the existing QR code comment appears in the PR ~20–30 min later, ready to scan and install on device.

PRs that only touch docs, workflow files, or tests will not trigger a build.

## Test plan

- [ ] Open a PR with a change under `src/` — confirm the workflow triggers automatically and posts QR codes
- [ ] Open a PR with only a `.md` change — confirm the workflow does NOT trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)