### PR TITLE
fix(ci): pin @types/node, memfs, and eslint-plugin-react-hooks to prevent breaking upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "react-native-performance": "^5.1.4",
         "react-native-permissions": "^5.4.0",
         "react-native-picker-select": "^9.1.3",
-        "react-native-quick-sqlite": "git+https://github.com/margelo/react-native-quick-sqlite#99f34ebefa91698945f3ed26622e002bd79489e0",
         "react-native-reanimated": "4.1.5",
         "react-native-render-html": "6.3.1",
         "react-native-safe-area-context": "5.4.0",
@@ -126,7 +125,7 @@
         "@types/jest": "^29.5.14",
         "@types/jest-when": "^3.5.5",
         "@types/lodash": "^4.14.199",
-        "@types/node": "^20.17.12",
+        "@types/node": "20.17.12",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
         "@types/react-test-renderer": "^19.1.0",
@@ -154,7 +153,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-hooks": "4.6.2",
         "eslint-plugin-react-native": "^4.1.0",
         "eslint-plugin-react-native-a11y": "^3.3.0",
         "eslint-plugin-storybook": "^0.6.15",
@@ -168,7 +167,7 @@
         "jest-expo": "54.0.12",
         "jest-transformer-svg": "^2.0.1",
         "jest-when": "^3.5.2",
-        "memfs": "^4.8.1",
+        "memfs": "4.9.3",
         "metro-minify-terser": "^0.82.5",
         "patch-package": "^8.1.0-canary.1",
         "prettier": "^3.0.0",
@@ -18440,15 +18439,6 @@
       },
       "peerDependencies": {
         "@react-native-picker/picker": "^2.4.0"
-      }
-    },
-    "node_modules/react-native-quick-sqlite": {
-      "version": "8.1.0",
-      "resolved": "git+ssh://git@github.com/margelo/react-native-quick-sqlite.git#99f34ebefa91698945f3ed26622e002bd79489e0",
-      "integrity": "sha512-7uuHmOEnc6SOAVoAdvkQhvaYhUZMORM75qo+v6PZoH6Qk21j5CmrcxJE3gNh0FhMfxK73hQ3ZtugC/NI2jVhrw==",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@types/jest": "^29.5.14",
     "@types/jest-when": "^3.5.5",
     "@types/lodash": "^4.14.199",
-    "@types/node": "^20.17.12",
+    "@types/node": "20.17.12",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
@@ -194,7 +194,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "4.6.2",
     "eslint-plugin-react-native": "^4.1.0",
     "eslint-plugin-react-native-a11y": "^3.3.0",
     "eslint-plugin-storybook": "^0.6.15",
@@ -208,7 +208,7 @@
     "jest-expo": "54.0.12",
     "jest-transformer-svg": "^2.0.1",
     "jest-when": "^3.5.2",
-    "memfs": "^4.8.1",
+    "memfs": "4.9.3",
     "metro-minify-terser": "^0.82.5",
     "patch-package": "^8.1.0-canary.1",
     "prettier": "^3.0.0",
@@ -224,7 +224,8 @@
   },
   "overrides": {
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "eslint-plugin-react-hooks": "4.6.2"
   },
   "expo": {
     "autolinking": {


### PR DESCRIPTION
## Summary

- **Pin `@types/node` to `20.17.12`** — v20.19.41 (pulled in by lockfile regeneration) broke the `NodeRequire` interface augmentation in `src/types/global.d.ts`, causing every `require<T>(...)` call in navigation files to emit TS2558.
- **Pin `memfs` to `4.9.3`** — v4.57.2 (refactored around `@jsonjoy.com/*`) removed `lib/node/types`, breaking `__mocks__/fs/promises.ts`.
- **Override + pin `eslint-plugin-react-hooks` to `4.6.2`** — `eslint-config-expensify@2.0.110` (new) bundles react-hooks v7.x which imports `zod-validation-error/v4`, a subpath not exported by the installed v3.x package, crashing ESLint before any rules run.

Root cause: commit `7f59943b` regenerated `package-lock.json` without pinning these indirect dependencies, allowing them to jump to breaking versions.

## Test plan
- [ ] `lint / ESLint check` CI job passes
- [ ] `typecheck / typecheck` CI job passes
- [ ] All other jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)