### PR TITLE
fix(ios): restore RCTRootView cast, switch to ExpoReactNativeFactory, add splash safety timeout

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -14,14 +14,14 @@ import UIKit
 class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
   var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
-  var reactNativeFactory: RCTReactNativeFactory?
+  var reactNativeFactory: ExpoReactNativeFactory?
 
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     let delegate = ReactNativeDelegate()
-    let factory = RCTReactNativeFactory(delegate: delegate)
+    let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeDelegate = delegate
@@ -41,9 +41,7 @@ class AppDelegate: ExpoAppDelegate {
 
     _ = super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    // RCTSurfaceHostingProxyRootView (New Architecture) inherits from UIView, not RCTRootView.
-    // The method accepts UIView so cast directly without a subclass check.
-    if let rootView = self.window?.rootViewController?.view {
+    if let rootView = self.window?.rootViewController?.view as? RCTRootView {
       RCTBootSplash.initWithStoryboard("BootSplash", rootView: rootView)
     }
 

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -12,11 +12,17 @@ import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import ImageSVG from '@components/ImageSVG';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
+import Log from '@libs/Log';
 import colors from '@src/styles/theme/colors';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
 } from './types';
+
+// Force-hide the splash if shouldHideSplash hasn't fired by this point.
+// Protects against deadlocks where a gating condition (e.g. hasCheckedAutoLogin)
+// never flips and the user is left staring at the yellow overlay indefinitely.
+const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 
 function SplashScreenHider({
   onHide = () => {},
@@ -75,6 +81,22 @@ function SplashScreenHider({
     }
     hide();
   }, [shouldHideSplash, hide]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (hideHasBeenCalled.current) {
+        return;
+      }
+      Log.alert(
+        '[BootSplash] shouldHideSplash never became true, force-hiding splash',
+        {timeoutMs: FORCE_HIDE_TIMEOUT_MS},
+        false,
+      );
+      hide();
+    }, FORCE_HIDE_TIMEOUT_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [hide]);
 
   return (
     <Reanimated.View


### PR DESCRIPTION
## Summary

Three coordinated changes to fix the BootSplash stuck-forever bug that shipped to live in [0.3.11-15](https://github.com/PetrCala/Kiroku/releases/tag/0.3.11-15). After [#287](https://github.com/PetrCala/Kiroku/pull/287) removed the `as? RCTRootView` cast in [`ios/AppDelegate.swift`](ios/AppDelegate.swift), the previously-invisible white flash was replaced with a yellow splash that never hides.

- **Revert the cast change**: Expensify uses the *same* `as? RCTRootView` cast against a byte-identical custom `RCTBootSplash.mm` on RN 0.83 and their app works. The hypothesis from [#287](https://github.com/PetrCala/Kiroku/pull/287) that the cast "always returned nil" is contradicted by that. Mounting the native overlay outside RN's expected loadingView lifecycle (which the unconditional cast bypassed) appears to have created the new deadlock.
- **Switch factory class to `ExpoReactNativeFactory`**: matches Expensify's [AppDelegate.swift:27](https://github.com/Expensify/App/blob/main/ios/AppDelegate.swift). `ExpoReactNativeFactory` subclasses `RCTReactNativeFactory` and adds Expo module registration; auto-generated Expo SDK 53+ AppDelegates use it. Using the bare RN factory left Expo modules in a subtly inconsistent state and may have affected the installed root view class.
- **Add a 15s safety timeout in [`SplashScreenHider`](src/components/SplashScreenHider/index.native.tsx)**: defense-in-depth. If `shouldHideSplash` never becomes true (e.g., `hasCheckedAutoLogin` deadlocked because `InitialScreen`'s `useFocusEffect` never fired), force-call `BootSplash.hide()` so the user is never permanently stuck on the yellow overlay. Logs an alert when it fires so the underlying condition failure is observable in production.

## Test plan

- [ ] Build and launch the iOS app on a physical device (cold start)
- [ ] Confirm the splash hides within ~1–2s as before, no yellow stuck-forever
- [ ] Confirm no regression of the original white flash at ~200ms
- [ ] Sign out and re-launch — verify InitialScreen reachable and splash hides
- [ ] Sign in fresh — verify HomeScreen reachable and splash hides
- [ ] (Optional) Manually break `hasCheckedAutoLogin` (e.g., comment out the Onyx merge) and verify the 15s safety timeout fires and the alert is logged

## Follow-ups (out of scope)

- Detox smoke test in CI that asserts splash hides within 30s on every PR
- Audit `shouldHideSplash` conditions in [`src/Kiroku.tsx`](src/Kiroku.tsx) — consider dropping the Firebase auth dependency (`authenticationChecked`, `isThemeReady`) to match Expensify's simpler 3-condition gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)