### PR TITLE
feat: add Apple and Google Sign-In via Firebase OAuth

### DIFF
--- a/ios/kiroku/Info.plist
+++ b/ios/kiroku/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.200327501992-07u3boj39j65sltumv2lbd2jk5nr416q</string>
+			</array>
+		</dict>
+	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ios/kiroku/kiroku.entitlements
+++ b/ios/kiroku/kiroku.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@formatjs/intl-numberformat": "^8.10.3",
         "@formatjs/intl-pluralrules": "^5.2.14",
         "@gorhom/portal": "^1.0.14",
+        "@invertase/react-native-apple-authentication": "^2.5.1",
         "@kie/mock-github": "^2.0.1",
         "@react-native-async-storage/async-storage": "^2.1.2",
         "@react-native-clipboard/clipboard": "^1.15.0",
@@ -5298,6 +5299,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@invertase/react-native-apple-authentication": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@invertase/react-native-apple-authentication/-/react-native-apple-authentication-2.5.1.tgz",
+      "integrity": "sha512-KPKKc0wtRYpH4J0RkDfHzoKSZ+dYPEHmCXhpPdgHsT2MbK5AIkW1cYurjhAgev/kL7nOHFmWITjY1At5WhFEMQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@formatjs/intl-numberformat": "^8.10.3",
     "@formatjs/intl-pluralrules": "^5.2.14",
     "@gorhom/portal": "^1.0.14",
+    "@invertase/react-native-apple-authentication": "^2.5.1",
     "@kie/mock-github": "^2.0.1",
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-native-clipboard/clipboard": "^1.15.0",
@@ -235,7 +236,6 @@
     "autolinking": {
       "exclude": [
         "expo-file-system",
-        "@react-native-google-signin/google-signin",
         "expo-keep-awake"
       ]
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import ThemeStylesProvider from './components/ThemeStylesProvider';
 import SafeArea from './components/SafeArea';
 import CustomStatusBarAndBackground from './components/CustomStatusBarAndBackground';
 import CustomStatusBarAndBackgroundContextProvider from './components/CustomStatusBarAndBackground/CustomStatusBarAndBackgroundContextProvider';
+import AppleAuthWrapper from './components/SignInButtons/AppleAuthWrapper';
 import type {Route} from './ROUTES';
 import Kiroku from './Kiroku';
 // import OnyxUpdateManager from './libs/actions/OnyxUpdateManager';
@@ -65,6 +66,7 @@ function App({url}: KirokuProps): React.JSX.Element {
               CustomStatusBarAndBackgroundContextProvider,
               ActiveElementRoleProvider,
             ]}>
+            <AppleAuthWrapper />
             <CustomStatusBarAndBackground />
             <ErrorBoundary errorMessage="Kiroku crash caught by error boundary">
               <ColorSchemeWrapper>

--- a/src/CONFIG.ts
+++ b/src/CONFIG.ts
@@ -111,6 +111,19 @@ export default {
     SUFFIX: get(Config, 'PUSHER_DEV_SUFFIX', ''),
     CLUSTER: 'mt1',
   },
+  APPLE_SIGN_IN: {
+    SERVICE_ID: 'org.reactjs.native.example.alcohol-tracker.signin',
+    REDIRECT_URI:
+      'https://dev-alcohol-tracker-db.firebaseapp.com/__/auth/handler',
+  },
+  GOOGLE_SIGN_IN: {
+    WEB_CLIENT_ID:
+      '665512857657-59e75jfp7p7tjt3dn6rqm8pcin0oq4p8.apps.googleusercontent.com',
+    IOS_CLIENT_ID:
+      '200327501992-07u3boj39j65sltumv2lbd2jk5nr416q.apps.googleusercontent.com',
+    ANDROID_CLIENT_ID:
+      '200327501992-dd7hj1pl6rdok1fnka4rb2utfavuj6ds.apps.googleusercontent.com',
+  },
   SEND_CRASH_REPORTS: get(Config, 'SEND_CRASH_REPORTS', 'false') === 'true',
   IS_USING_EMULATORS: get(Config, 'USE_EMULATORS', 'false') === 'true',
   TEST_PROJECT_ID: 'alcohol-tracker-db',

--- a/src/components/SignInButtons/AppleAuthWrapper/index.ios.tsx
+++ b/src/components/SignInButtons/AppleAuthWrapper/index.ios.tsx
@@ -1,0 +1,32 @@
+import appleAuth from '@invertase/react-native-apple-authentication';
+import {useEffect} from 'react';
+import {useFirebase} from '@context/global/FirebaseContext';
+import * as Session from '@userActions/Session';
+
+/**
+ * Mounts at the app root on iOS. Listens for Apple credential revocation events
+ * (e.g. user removes the app from their Apple ID settings) and signs the user out.
+ *
+ * This listener is required for App Store compliance when using Sign in with Apple.
+ */
+function AppleAuthWrapper() {
+  const {auth} = useFirebase();
+
+  useEffect(() => {
+    if (!appleAuth.isSupported) {
+      return;
+    }
+
+    const removeListener = appleAuth.onCredentialRevoked(async () => {
+      await Session.signOut(auth);
+    });
+
+    return () => {
+      removeListener();
+    };
+  }, [auth]);
+
+  return null;
+}
+
+export default AppleAuthWrapper;

--- a/src/components/SignInButtons/AppleAuthWrapper/index.tsx
+++ b/src/components/SignInButtons/AppleAuthWrapper/index.tsx
@@ -1,0 +1,6 @@
+// No-op on Android and Web — Apple credential revocation is iOS-only.
+function AppleAuthWrapper() {
+  return null;
+}
+
+export default AppleAuthWrapper;

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -1,0 +1,79 @@
+import appleAuth, {
+  AppleButton,
+} from '@invertase/react-native-apple-authentication';
+import type {AppleError} from '@invertase/react-native-apple-authentication';
+import {OAuthProvider} from 'firebase/auth';
+import React from 'react';
+import {useFirebase} from '@context/global/FirebaseContext';
+import Log from '@libs/Log';
+import * as User from '@userActions/User';
+
+type AppleSignInProps = {
+  onPress?: () => void;
+};
+
+/**
+ * Apple Sign In button for iOS.
+ * Uses @invertase/react-native-apple-authentication to perform the native sign-in request,
+ * then passes the resulting identity token to Firebase via OAuthProvider.
+ */
+function AppleSignIn({onPress = () => {}}: AppleSignInProps) {
+  const {auth, db} = useFirebase();
+
+  const handleSignIn = async () => {
+    try {
+      const response = await appleAuth.performRequest({
+        requestedOperation: appleAuth.Operation.LOGIN,
+        // FULL_NAME must come first — see https://github.com/invertase/react-native-apple-authentication/issues/293
+        requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
+      });
+
+      const credentialState = await appleAuth.getCredentialStateForUser(
+        response.user,
+      );
+      if (credentialState !== appleAuth.State.AUTHORIZED) {
+        Log.alert(
+          '[Apple Sign In] Authentication failed. Original response: ',
+          {response},
+        );
+        return;
+      }
+
+      const {identityToken, fullName} = response;
+      // Apple only provides the full name on the very first sign-in
+      const displayName =
+        [fullName?.givenName, fullName?.familyName].filter(Boolean).join(' ') ||
+        null;
+
+      const provider = new OAuthProvider('apple.com');
+      const credential = provider.credential({idToken: identityToken ?? ''});
+
+      onPress();
+      await User.signInWithOAuth(auth, db, credential, displayName);
+    } catch (error: unknown) {
+      const e = error as {code?: AppleError};
+      if (e.code === appleAuth.Error.CANCELED) {
+        return;
+      }
+      Log.alert(
+        '[Apple Sign In] Apple authentication failed',
+        error as Record<string, unknown>,
+      );
+    }
+  };
+
+  return (
+    <AppleButton
+      buttonStyle={AppleButton.Style.WHITE}
+      buttonType={AppleButton.Type.SIGN_IN}
+      cornerRadius={22}
+      style={{height: 44, width: 44}}
+      onPress={() => {
+        handleSignIn();
+      }}
+    />
+  );
+}
+
+export default AppleSignIn;
+export type {AppleSignInProps};

--- a/src/components/SignInButtons/AppleSignIn/index.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.tsx
@@ -1,0 +1,15 @@
+// Apple Sign In is only supported on iOS.
+// Android and Web have no implementation at this time.
+
+type AppleSignInProps = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  onPress?: () => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function AppleSignIn(_: AppleSignInProps) {
+  return null;
+}
+
+export default AppleSignIn;
+export type {AppleSignInProps};

--- a/src/components/SignInButtons/GoogleSignIn/index.native.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.native.tsx
@@ -1,0 +1,72 @@
+import {
+  GoogleSignin,
+  GoogleSigninButton,
+  statusCodes,
+} from '@react-native-google-signin/google-signin';
+import {GoogleAuthProvider} from 'firebase/auth';
+import React from 'react';
+import {useFirebase} from '@context/global/FirebaseContext';
+import Log from '@libs/Log';
+import * as User from '@userActions/User';
+import CONFIG from '@src/CONFIG';
+
+type GoogleSignInProps = {
+  onPress?: () => void;
+};
+
+/**
+ * Google Sign In button for iOS and Android.
+ * Uses @react-native-google-signin/google-signin to perform the native sign-in,
+ * then passes the resulting ID token to Firebase via GoogleAuthProvider.
+ */
+function GoogleSignIn({onPress = () => {}}: GoogleSignInProps) {
+  const {auth, db} = useFirebase();
+
+  const handleSignIn = async () => {
+    try {
+      GoogleSignin.configure({
+        webClientId: CONFIG.GOOGLE_SIGN_IN.WEB_CLIENT_ID,
+        iosClientId: CONFIG.GOOGLE_SIGN_IN.IOS_CLIENT_ID,
+        offlineAccess: false,
+      });
+
+      // Sign out before signing in to always show the account picker
+      await GoogleSignin.signOut();
+
+      const response = await GoogleSignin.signIn();
+      const {idToken} = response;
+
+      if (!idToken) {
+        Log.alert('[Google Sign In] No ID token received from Google');
+        return;
+      }
+
+      const credential = GoogleAuthProvider.credential(idToken);
+      onPress();
+      await User.signInWithOAuth(auth, db, credential);
+    } catch (error: unknown) {
+      const e = error as {code?: string; message?: string};
+      if (e.code === statusCodes.SIGN_IN_CANCELLED) {
+        return;
+      }
+      Log.alert(
+        `[Google Sign In] Error code: ${e.code ?? 'unknown'}. ${e.message ?? ''}`,
+        {},
+        false,
+      );
+    }
+  };
+
+  return (
+    <GoogleSigninButton
+      color={GoogleSigninButton.Color.Light}
+      size={GoogleSigninButton.Size.Icon}
+      onPress={() => {
+        handleSignIn();
+      }}
+    />
+  );
+}
+
+export default GoogleSignIn;
+export type {GoogleSignInProps};

--- a/src/components/SignInButtons/GoogleSignIn/index.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.tsx
@@ -1,0 +1,14 @@
+// Google Sign In for web is not implemented at this time.
+
+type GoogleSignInProps = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  onPress?: () => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function GoogleSignIn(_: GoogleSignInProps) {
+  return null;
+}
+
+export default GoogleSignIn;
+export type {GoogleSignInProps};

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -13,12 +13,13 @@ import type {
   UserStatus,
 } from '@src/types/onyx';
 import type {Timestamp, UserID, UserList} from '@src/types/onyx/OnyxCommon';
-import type {Auth, User, UserCredential} from 'firebase/auth';
+import type {Auth, AuthCredential, User, UserCredential} from 'firebase/auth';
 import {
   EmailAuthProvider,
   createUserWithEmailAndPassword,
   reauthenticateWithCredential,
   sendEmailVerification,
+  signInWithCredential,
   signInWithEmailAndPassword,
   updatePassword as fbUpdatePassword,
   updateProfile,
@@ -556,6 +557,38 @@ async function setAppUpdateDismissed(timestamp: Timestamp): Promise<void> {
   await Onyx.merge(ONYXKEYS.APP_UPDATE_DISMISSED, timestamp);
 }
 
+/**
+ * Sign in (or sign up) using a Firebase OAuth credential from Apple or Google.
+ * If the user does not yet exist in the Realtime Database, creates their profile.
+ *
+ * @param auth The Firebase authentication object
+ * @param db The Firebase Realtime Database object
+ * @param credential The OAuth credential (OAuthProvider or GoogleAuthProvider)
+ * @param displayName Optional display name captured from the OAuth provider response
+ */
+async function signInWithOAuth(
+  auth: Auth,
+  db: Database,
+  credential: AuthCredential,
+  displayName?: string | null,
+): Promise<void> {
+  const userCredential = await signInWithCredential(auth, credential);
+  const {user} = userCredential;
+  const exists = await userExistsInDatabase(db, user.uid);
+  if (!exists) {
+    const name =
+      displayName ?? user.displayName ?? user.email?.split('@').at(0) ?? 'User';
+    const profileData: Profile = {
+      display_name: name,
+      photo_url: user.photoURL ?? '',
+    };
+    await pushNewUserInfo(db, user.uid, profileData);
+    await updateProfile(user, {displayName: name});
+  }
+  Session.clearSignInData();
+  Navigation.navigate(ROUTES.HOME);
+}
+
 /** Attempt to log in to the Firebase authentication service with a user's credentials
  *
  * @param auth The Firebase authentication object
@@ -680,5 +713,6 @@ export {
   updatePassword,
   userExistsInDatabase,
   logIn,
+  signInWithOAuth,
   signUp,
 };

--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -1,5 +1,8 @@
 import React, {useCallback, useRef} from 'react';
+import {View} from 'react-native';
 import {useFocusEffect} from '@react-navigation/native';
+import AppleSignIn from '@components/SignInButtons/AppleSignIn';
+import GoogleSignIn from '@components/SignInButtons/GoogleSignIn';
 import {useFirebase} from '@context/global/FirebaseContext';
 import Navigation from '@navigation/Navigation';
 import ROUTES from '@src/ROUTES';
@@ -80,15 +83,11 @@ function InitialScreen() {
     [closeAccount?.success, translate],
   );
 
-  // function getSignInWithStyles() {
-  //   return shouldUseNarrowLayout ? [styles.mt1] : [styles.mt5, styles.mb5];
-  // }
-
-  // const isSigningWithAppleOrGoogle = useRef(false);
-  // const setIsSigningWithAppleOrGoogle = useCallback(
-  //   (isPressed: boolean) => (isSigningWithAppleOrGoogle.current = isPressed),
-  //   [],
-  // );
+  const isSigningWithAppleOrGoogle = useRef(false);
+  const setIsSigningWithAppleOrGoogle = useCallback(
+    (isPressed: boolean) => (isSigningWithAppleOrGoogle.current = isPressed),
+    [],
+  );
 
   useFocusEffect(
     // Redirect to main screen if user is already logged in (from sign up screen only)
@@ -162,33 +161,16 @@ function InitialScreen() {
           )}
         </FormProvider>
         <ChangeSignUpScreenLink navigatesTo={ROUTES.LOG_IN} />
-        {/* --- OR --- */}
-        {/* {
-          // This feature has a few behavioral differences in development mode. To prevent confusion
-          // for developers about possible regressions, we won't render buttons in development mode.
-          // For more information about these differences and how to test in development mode,
-          // see`Expensify/App/contributingGuides/APPLE_GOOGLE_SIGNIN.md`
-          CONFIG.ENVIRONMENT !== CONST.ENVIRONMENT.DEV && (
-              <View style={[getSignInWithStyles()]}>
-                  <Text
-                      accessibilityElementsHidden
-                      importantForAccessibility="no-hide-descendants"
-                      style={[styles.textLabelSupporting, styles.textAlignCenter, styles.mb3, styles.mt2]}
-                  >
-                      {translate('common.signInWith')}
-                  </Text>
-
-                  <View style={shouldUseNarrowLayout ? styles.loginButtonRowSmallScreen : styles.loginButtonRow}>
-                      <View>
-                          <AppleSignIn onPress={() => setIsSigningWithAppleOrGoogle(true)} />
-                      </View>
-                      <View>
-                          <GoogleSignIn onPress={() => setIsSigningWithAppleOrGoogle(true)} />
-                      </View>
-                  </View>
-              </View>
-          )
-      } */}
+        <View
+          style={[
+            styles.flexRow,
+            styles.justifyContentCenter,
+            styles.gap3,
+            styles.mt4,
+          ]}>
+          <AppleSignIn onPress={() => setIsSigningWithAppleOrGoogle(true)} />
+          <GoogleSignIn onPress={() => setIsSigningWithAppleOrGoogle(true)} />
+        </View>
       </SignUpScreenLayout>
     </ScreenWrapper>
   );


### PR DESCRIPTION
## Summary

- Implements **Sign in with Apple** (iOS) and **Sign in with Google** (iOS + Android) using the `@invertase/react-native-apple-authentication` and `@react-native-google-signin/google-signin` packages
- OAuth tokens are passed directly to Firebase (`OAuthProvider('apple.com')` / `GoogleAuthProvider.credential()`), matching the existing Firebase-first auth pattern — no custom backend calls
- First-time OAuth users have their Realtime Database profile created automatically via the existing `pushNewUserInfo()` path in `User.ts`
- Component structure follows the Expensify pattern: `.ios.tsx` / `.native.tsx` / `.tsx` file splits for clean platform separation

## Changes

### Native config
- `package.json` — added `@invertase/react-native-apple-authentication@^2.5.1`; re-enabled `@react-native-google-signin/google-signin` in Expo autolinking
- `src/CONFIG.ts` — added `APPLE_SIGN_IN` and `GOOGLE_SIGN_IN` credential blocks (Service ID, redirect URI, Web/iOS/Android client IDs)
- `ios/kiroku/kiroku.entitlements` — added `com.apple.developer.applesignin` capability (required for App Store)
- `ios/kiroku/Info.plist` — added Google reversed client ID URL scheme so the Google SDK can redirect back after sign-in

### Action layer
- `src/libs/actions/User.ts` — added `signInWithOAuth(auth, db, credential, displayName?)`: calls `signInWithCredential()`, checks if the user exists in the DB, and creates their profile if not (handles both sign-in and sign-up in one function)

### Components (`src/components/SignInButtons/`)
| File | Platform | Purpose |
|---|---|---|
| `AppleSignIn/index.ios.tsx` | iOS | Native Apple auth via `@invertase`; passes `OAuthProvider('apple.com')` credential to Firebase |
| `AppleSignIn/index.tsx` | Android/Web | No-op |
| `GoogleSignIn/index.native.tsx` | iOS + Android | Native Google auth; passes `GoogleAuthProvider` credential to Firebase |
| `GoogleSignIn/index.tsx` | Web | No-op |
| `AppleAuthWrapper/index.ios.tsx` | iOS | Root-level listener for Apple credential revocation → signs user out (App Store requirement) |
| `AppleAuthWrapper/index.tsx` | Android/Web | No-op |

### App wiring
- `src/App.tsx` — `<AppleAuthWrapper />` mounted inside `FirebaseProvider` scope
- `src/screens/SignUp/InitialScreen.tsx` — both sign-in buttons rendered below the email form, replacing the previously commented-out block

## Before merging

- Run `pod install` in `ios/` to link the new native modules
- Verify Apple and Google providers are enabled in Firebase Console (dev project)
- Test sign-in flow on a physical iOS device (Apple Sign In does not work on simulator)

## Test plan

- [ ] Apple Sign In button appears on the initial screen (iOS device)
- [ ] Google Sign In button appears on the initial screen (iOS + Android)
- [ ] Signing in with a new Apple/Google account creates a profile in the Realtime Database
- [ ] Signing in with an existing Apple/Google account navigates to home without duplicating the profile
- [ ] Removing the app from Apple ID settings (Settings → Apple ID → Password & Security → Apps Using Apple ID) signs the user out automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)