### PR TITLE
fix(android): prevent image dimension distortion on upload

### DIFF
--- a/src/components/UploadImage.tsx
+++ b/src/components/UploadImage.tsx
@@ -66,32 +66,40 @@ function UploadImageComponent({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const selectedImage: ImagePickerAsset = result.assets[0];
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const imageUri: string | undefined = selectedImage?.uri;
+      const {uri: imageUri, width: srcWidth, height: srcHeight} = selectedImage;
       if (!imageUri || typeof imageUri !== 'string') {
         ErrorUtils.raiseAppError(ERRORS.IMAGE_UPLOAD.FETCH_FAILED);
         return;
       }
 
-      // Crop and resize the image using expo-image-manipulator
-      const manipulatorActions: ImageManipulator.Action[] = [];
+      // Compute a center-crop rectangle that matches the target aspect ratio.
+      // This is necessary because Android's native crop intent (used by allowsEditing)
+      // does not reliably enforce the aspect constraint — the picker may return an image
+      // with arbitrary dimensions. Cropping in ImageManipulator before resizing ensures
+      // the output is never stretched regardless of platform behaviour.
+      const [ratioW, ratioH] = isProfilePicture ? [1, 1] : [3, 4];
+      const targetRatio = ratioW / ratioH;
+      const srcRatio = srcWidth / srcHeight;
 
-      // For profile pictures, ensure square crop
-      if (isProfilePicture) {
-        manipulatorActions.push({
-          resize: {
-            width: 300,
-            height: 300,
-          },
-        });
-      } else {
-        // Resize to target dimensions (300x400)
-        manipulatorActions.push({
-          resize: {
-            width: 300,
-            height: 400,
-          },
-        });
+      let originX = 0;
+      let originY = 0;
+      let cropWidth = srcWidth;
+      let cropHeight = srcHeight;
+
+      if (srcRatio > targetRatio) {
+        cropWidth = Math.round(srcHeight * targetRatio);
+        originX = Math.round((srcWidth - cropWidth) / 2);
+      } else if (srcRatio < targetRatio) {
+        cropHeight = Math.round(srcWidth / targetRatio);
+        originY = Math.round((srcHeight - cropHeight) / 2);
       }
+
+      // Crop to the exact target ratio first, then resize with only width so
+      // ImageManipulator infers height proportionally — distortion is impossible.
+      const manipulatorActions: ImageManipulator.Action[] = [
+        {crop: {originX, originY, width: cropWidth, height: cropHeight}},
+        {resize: {width: 300}},
+      ];
 
       const manipulatedImage = await ImageManipulator.manipulateAsync(
         imageUri,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Fixes #214

On Android, `expo-image-picker`'s `allowsEditing` delegates cropping to the device's native crop intent. Unlike iOS (which enforces the `aspect` constraint precisely), Android's native crop UI does not reliably honour the specified ratio — the image returned by the picker can have arbitrary dimensions.

The previous code then passed both `width` and `height` to `ImageManipulator.resize`, which unconditionally stretches the image to the exact target size regardless of the input ratio. This is the direct cause of the distortion.

**Fix:** After the picker returns, read the actual source dimensions from `ImagePickerAsset.width` / `.height` (they were available but unused). Compute a center-crop rectangle in code that produces the exact target ratio (`[1,1]` for profile pictures, `[3,4]` otherwise). Pass that as an explicit `crop` action to `ImageManipulator` before the resize, and change the resize to specify only `width` — `height` is then inferred proportionally, making distortion structurally impossible.

Android EXIF orientation inconsistencies are also resolved as a side effect: `manipulateAsync` bakes in EXIF rotation automatically whenever any action is applied.

No platform-specific files are needed — the fix is safe and correct on both Android and iOS (on iOS the computed crop box matches what the picker already produced, so it is effectively a no-op).

Only `src/components/UploadImage.tsx` is modified.

### Tests

1. On an Android device/emulator, navigate to the profile picture upload flow
2. Select a landscape photo (wider than square)
3. Verify the resulting profile picture is square (1:1) with no stretching or squashing
4. Repeat with a portrait photo (taller than square) — verify same correct 1:1 result
5. Upload a non-profile image; verify the result is 3:4 and undistorted
6. Repeat steps 1–5 on iOS to verify no regression

### Offline tests

Image manipulation runs entirely on-device before upload — no network required. Offline behaviour is unchanged.

### QA Steps

1. On Android staging, go to profile → tap the camera/upload button
2. Select any photo from the gallery (try both landscape and portrait originals)
3. Verify the uploaded profile picture appears square and undistorted
4. Verify no JS console errors appear during the flow

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I wrote clear testing steps that cover the changes made in this PR
  - [ ] I added steps for local testing in the `Tests` section
  - [ ] I added steps for the expected offline behavior in the `Offline steps` section
  - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
  - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
  - [ ] I verified that comments were added to code that is not self explanatory
  - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing
  - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method of the `LocaleContextProvider`
    - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in the Discord and approved by a Kiroku head developer team
  - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods from the `LocaleContextProvider`
  - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized).
  - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Kiroku head development team members
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `ProfileImage`, I verified the components using `ProfileImage` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified that all code follows the ETC (easy-to-change) principle
- [ ] I verified any variables that can be defined as constants (i.e., in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages and relevant docstrings have also been updated correctly
- [ ] If any new file was added I verified that:
  - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
  - [ ] A similar style doesn't already exist
  - [ ] The style can't be created with an existing `StyleUtils` function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `ProfileImage` is modified, I verified that `ProfileImage` is working as expected in all cases)
- [ ] If the PR modifies a component or screen that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [ ] I verified that all the inputs inside a form are aligned with each other.
  - [ ] I added `design` label and/or tagged `@Kiroku/design` so the design team can review the changes.
- [ ] If a new screen is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the screen.
- [ ] If the `master` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>