### PR TITLE
fix(ci): replace unavailable runners in testBuild workflow

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -34,9 +34,7 @@ jobs:
 
   android:
     name: Build and deploy Android for testing
-    runs-on:
-      - self-hosted
-      - android-large
+    runs-on: ubuntu-latest
     needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
@@ -102,8 +100,8 @@ jobs:
     needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
-      DEVELOPER_DIR: /Applications/Xcode_15.2.0.app/Contents/Developer
-    runs-on: macos-13
+      DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,13 +117,19 @@ jobs:
         id: setup-node
         uses: ./.github/actions/composite/setupNode
 
-      - name: Setup XCode
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.0.app
+      - name: Install Ruby into tool cache (self-hosted runner)
+        run: |
+          RUBY_VERSION="3.3.4"
+          RUBY_PATH="${RUNNER_TOOL_CACHE}/Ruby/${RUBY_VERSION}/arm64"
+          if [[ ! -f "${RUBY_PATH}.complete" ]]; then
+            brew install ruby-build 2>/dev/null || true
+            ruby-build "$RUBY_VERSION" "$RUBY_PATH"
+            touch "${RUBY_PATH}.complete"
+          fi
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@a05e47355e80e57b9a67566a813648fa67d92011
         with:
-          ruby-version: '3.2.2'
           bundler-cache: true
 
       - name: Cache Pod dependencies


### PR DESCRIPTION
## What

Both jobs in `testBuild.yml` were stuck indefinitely in the queue — neither runner was available to pick them up:

| Job | Old runner | Problem |
|-----|-----------|---------|
| `android` | `[self-hosted, android-large]` | Self-hosted runner is offline |
| `iOS` | `macos-13` | Runner no longer available on GitHub's fleet |

## Why these replacements

`platformDeploy.yml` runs the same Android and iOS builds successfully. This PR brings its runner choices into `testBuild.yml`:

- **Android** → `ubuntu-latest` (identical to `platformDeploy.yml`; all setup steps are runner-agnostic)
- **iOS** → `macos-26` (identical to `platformDeploy.yml`)
  - `DEVELOPER_DIR` updated to `Xcode_26.1.1.app` to match the Xcode version on `macos-26`
  - Removed `xcode-select` step (the Xcode 15.2 path no longer exists on this runner)
  - Added ruby tool-cache pre-population step (required on `macos-26` before `ruby/setup-ruby`)
  - Removed explicit `ruby-version: '3.2.2'` pin — lets the project's ruby version file control it, consistent with `platformDeploy.yml`

## Reviewer notes

- No build step logic changed — only the runner environment and Xcode/Ruby setup alignment
- The iOS job still uses the ad-hoc provisioning profile (`Kiroku_AdHoc.mobileprovision`) and uploads to S3 via `fastlane ios build_internal`, unchanged
- Verify by triggering the workflow via `workflow_dispatch` on any open PR and confirming both jobs leave the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)