### PR TITLE
fix: replace scheduleOnRN with runOnJS to prevent worklet SIGABRT

### DIFF
--- a/src/components/CustomStatusBarAndBackground/index.tsx
+++ b/src/components/CustomStatusBarAndBackground/index.tsx
@@ -7,12 +7,12 @@ import React, {
 } from 'react';
 import {
   interpolateColor,
+  runOnJS,
   useAnimatedReaction,
   useSharedValue,
   withDelay,
   withTiming,
 } from 'react-native-reanimated';
-import {scheduleOnRN} from 'react-native-worklets';
 import usePrevious from '@hooks/usePrevious';
 import useTheme from '@hooks/useTheme';
 import {navigationRef} from '@libs/Navigation/Navigation';
@@ -73,7 +73,7 @@ function CustomStatusBarAndBackground({
         [0, 1],
         [prevStatusBarBackgroundColor.get(), statusBarBackgroundColor.get()],
       );
-      scheduleOnRN(() => updateStatusBarAppearance({backgroundColor}));
+      runOnJS(updateStatusBarAppearance)({backgroundColor});
     },
   );
 

--- a/src/components/SectionList/AnimatedSectionList.tsx
+++ b/src/components/SectionList/AnimatedSectionList.tsx
@@ -4,9 +4,7 @@ import Animated from 'react-native-reanimated';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AnimatedSectionList = Animated.createAnimatedComponent(
   RNSectionList,
-) as ReturnType<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  typeof Animated.createAnimatedComponent<any>
->;
+) as unknown as ReturnType<typeof Animated.createAnimatedComponent<any>>;
 
 export default AnimatedSectionList;

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -3,11 +3,11 @@ import type {ViewStyle} from 'react-native';
 import {StyleSheet} from 'react-native';
 import Reanimated, {
   Easing,
+  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import {scheduleOnRN} from 'react-native-worklets';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import ImageSVG from '@components/ImageSVG';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -69,7 +69,7 @@ function SplashScreenHider({
             duration: 250,
             easing: Easing.out(Easing.ease),
           },
-          () => scheduleOnRN(onHide),
+          runOnJS(onHide),
         ),
       );
     });


### PR DESCRIPTION
## Problem

After upgrading `react-native-worklets` to 0.8.3, the app still crashes with a SIGABRT after ~8 minutes of use. The crash is identical to the startup crash from the previous upgrade PR — `facebook::jsi::Function::getHostFunction()` assertion failure from inside `AnimationFrameBatchinator::flush()`.

**Root cause:** `scheduleOnRN()` expects either a `HostFunction` or a `RemoteFunction` (a JS-thread function serialised into the worklet closure). When an arrow function is created *inside* a worklet body at runtime (i.e. `scheduleOnRN(() => someJsFn(...))`), that function is a plain JSI `Function` — not a `HostFunction` — so `_scheduleHostFunctionOnJS`'s `getHostFunction()` assertion fires.

The offending call site is `CustomStatusBarAndBackground/index.tsx`:
```tsx
// BEFORE — creates a fresh arrow function inside the worklet body → SIGABRT
scheduleOnRN(() => updateStatusBarAppearance({backgroundColor}));
```
This fires on every animation frame during status-bar colour transitions (navigation events), which explains the ~8-minute delay before crash.

`SplashScreenHider` had a structurally similar pattern (`() => scheduleOnRN(onHide)`) that passed a `RemoteFunction` and may not crash in practice, but was also non-canonical.

## Fix

- Replace both `scheduleOnRN` usages with Reanimated's `runOnJS`, which is the correct and documented API for calling JS-thread functions from within a Reanimated worklet.
- Remove the `react-native-worklets` import from both files (no longer needed).
- Widen the `AnimatedSectionList` type cast through `unknown` to resolve a `TS2352` overlap error flagged by `tsgo`.

## Changes

| File | Change |
|------|--------|
| `CustomStatusBarAndBackground/index.tsx` | `scheduleOnRN(() => fn({arg}))` → `runOnJS(fn)({arg})` |
| `SplashScreenHider/index.native.tsx` | `() => scheduleOnRN(onHide)` → `runOnJS(onHide)` |
| `SectionList/AnimatedSectionList.tsx` | Add `unknown` bridge in cast to satisfy `tsgo` |

## Test plan

- [ ] Build and run iOS; navigate between screens to trigger status-bar colour transitions — confirm no crash after extended use
- [ ] Confirm splash screen animates out and `onHide` fires on app launch
- [ ] CI typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)