### PR TITLE
feat(build): enable Rock remote build cache via GitHub Actions

### DIFF
--- a/rock.config.mjs
+++ b/rock.config.mjs
@@ -1,12 +1,18 @@
 import {platformAndroid} from '@rock-js/platform-android';
 import {platformIOS} from '@rock-js/platform-ios';
 import {pluginMetro} from '@rock-js/plugin-metro';
+import {providerGitHub} from '@rock-js/provider-github';
 
 /** @type {import('@rock-js/config').Config} */
 export default {
-    bundler: pluginMetro(),
-    platforms: {
-        ios: platformIOS({sourceDir: './ios'}),
-        android: platformAndroid({sourceDir: './android'}),
-    },
+  remoteCacheProvider: providerGitHub(),
+  bundler: pluginMetro(),
+  platforms: {
+    ios: platformIOS({sourceDir: './ios'}),
+    android: platformAndroid({sourceDir: './android'}),
+  },
+  fingerprint: {
+    extraSources: ['ios/Podfile', 'android/build.gradle', 'package.json'],
+    env: ['APP_ENV'],
+  },
 };


### PR DESCRIPTION
## What

Enables the Rock bundler's remote build cache using the `@rock-js/provider-github` provider (already a project dependency, just not wired up).

**Changes to `rock.config.mjs`:**
- Added `remoteCacheProvider: providerGitHub()` — uses GitHub Actions artifact storage, no external infrastructure required
- Added `fingerprint.extraSources` — cache key is derived from `ios/Podfile`, `android/build.gradle`, and `package.json`; any change to these files busts the cache
- Added `fingerprint.env` — `APP_ENV` changes also bust the cache

## Why

CI builds that only change JS code currently trigger a full Xcode/Gradle native compile. With the cache enabled, Rock fingerprints the native dependency files and, on a cache hit, restores the pre-built artifact instead. This can eliminate the native compile step entirely for JS-only changes.

The `providerGitHub()` call with no arguments auto-detects the repo owner/name from the git remote and reads `GITHUB_TOKEN` automatically in GitHub Actions — no secrets to configure.

## Reviewer notes

- First run after merging is a cold miss (full build as before); subsequent CI runs benefit from the cache.
- GitHub Actions artifact storage has a 90-day retention and a ~10 GB per-repo cap — fine for this project size.
- `@rock-js/provider-github` was already listed as a dependency; this change only adds the import and configuration.
- Hermes V1 (`RCT_HERMES_V1_ENABLED`) was evaluated but ruled out: that flag is only meaningful on React Native 0.83+ (where Hermes V1 ships as `hermes-engine 250829098.x`). Kiroku is on RN 0.81.4, where the flag is silently ignored by the CocoaPods build scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)