### PR TITLE
ci(ios): upload dSYMs to Firebase Crashlytics after TestFlight upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,18 +211,21 @@ platform :ios do
         }
     )
 
-    begin
-      upload_to_testflight(
-          api_key_path: "./ios/ios-fastlane-json-key.json",
-          distribute_external: false,
-      )
+    upload_to_testflight(
+        api_key_path: "./ios/ios-fastlane-json-key.json",
+        distribute_external: false,
+    )
 
-    # upload_symbols_to_crashlytics(
-    #   app_id: "1:665512857657:ios:a07eeddf1f54bac2b4fde8",
-    #   dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
-    #   gsp_path: "./ios/GoogleService-Info.plist",
-    #   binary_path: "./ios/Pods/FirebaseCrashlytics/upload-symbols"
-    # )
+    begin
+      upload_symbols_to_crashlytics(
+        app_id: "1:665512857657:ios:a07eeddf1f54bac2b4fde8",
+        dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+        gsp_path: "./ios/GoogleService-Info.plist",
+        binary_path: "./ios/Pods/FirebaseCrashlytics/upload-symbols",
+      )
+    rescue => e
+      UI.error("Failed to upload dSYMs to Crashlytics: #{e.message}")
+      UI.important("Continuing — TestFlight upload already succeeded. Symbolicate the affected build manually if needed.")
     end
 
   end


### PR DESCRIPTION
## Problem

When TestFlight build 0.3.11.22 crashed, we had no way to symbolicate the native frames in the crash log because the dSYMs produced during the iOS \`beta\` lane were not published anywhere:

- ❌ Not uploaded to Crashlytics — the \`upload_symbols_to_crashlytics\` call in the Fastfile was commented out
- ❌ Not uploaded to GitHub Releases — only \`kiroku.ipa\` and \`main.jsbundle.map\` are
- ❌ Not retained as a GitHub Actions artifact
- ❌ Gone from the runner once CI finished

Without dSYMs we cannot turn binary addresses like \`0x101431d64\` into function names, which means every native-side crash report comes back unactionable until someone manually grabs the dSYM from App Store Connect.

## Fix

Uncomment the existing \`upload_symbols_to_crashlytics\` block in the iOS \`beta\` lane so dSYMs are pushed to Firebase Crashlytics' dSYM bucket on every TestFlight upload.

### Why this works without any other changes

| Check | Result |
|---|---|
| \`@react-native-firebase/crashlytics\` installed | ✅ v24.0.0 in \`package.json\` |
| \`FirebaseCrashlytics\` Pod installed | ✅ v12.10.0 in \`Podfile.lock\` |
| \`upload-symbols\` binary present at the hardcoded path | ✅ \`ios/Pods/FirebaseCrashlytics/upload-symbols\` |
| Hardcoded \`app_id\` matches \`GOOGLE_APP_ID\` | ✅ \`1:665512857657:ios:a07eeddf1f54bac2b4fde8\` |
| \`DSYM_OUTPUT_PATH\` set by \`build_app\` | ✅ gym always exports a dSYM when \`DEBUG_INFORMATION_FORMAT = dwarf-with-dsym\` (the Release config sets it — \`project.pbxproj:1011, 1333, 1462, 1496, 1530\`) |
| Fastfile syntax | ✅ \`ruby -c fastlane/Fastfile\` passes |

### Resilience

Wrapped in \`begin/rescue\` so a Crashlytics-side failure (network blip, expired credential, transient API error) does not break a TestFlight deploy that has already succeeded. On failure we log a clear message and continue; the build has been delivered, we just have to symbolicate by hand for that single release.

## Test plan

- [ ] Merge and trigger a beta deploy
- [ ] Confirm fastlane log shows \`upload_symbols_to_crashlytics\` running after the TestFlight upload
- [ ] Confirm the dSYM shows up in Firebase Console → Crashlytics → dSYMs for the new build UUID
- [ ] Crash the new build deliberately and verify the report appears symbolicated in Crashlytics

## Follow-ups (not in this PR)

- Consider also uploading the dSYM as a \`actions/upload-artifact\` so it's downloadable from the GitHub Actions run page — useful as a secondary source if Crashlytics is ever unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)