### PR TITLE
fix: wrap withTiming completion callback so babel auto-worklets it

### DIFF
--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -69,7 +69,7 @@ function SplashScreenHider({
             duration: 250,
             easing: Easing.out(Easing.ease),
           },
-          runOnJS(onHide),
+          () => runOnJS(onHide)(),
         ),
       );
     });


### PR DESCRIPTION
## Problem

Runtime error in DevTools immediately after the splash screen hides:

\`\`\`
[Worklets] Tried to synchronously call a non-worklet anonymous function
on the UI thread.
    at step (react-native-reanimated/src/valueSetter.ts:61)
    at executeQueue / flushQueue (workletsRAF)
\`\`\`

## Root cause

[#303](https://github.com/PetrCala/Kiroku/pull/303) tightened the splash hide callback from
\`\`\`tsx
() => scheduleOnRN(onHide)
\`\`\`
to
\`\`\`tsx
runOnJS(onHide)
\`\`\`
That change was wrong. \`withTiming\`'s third argument is the **completion callback**, and Reanimated executes it on the **UI thread**, so the value must be a worklet. Reanimated's babel plugin auto-promotes inline anonymous functions in known worklet-callback positions, but it does **not** auto-promote function-call expressions like \`runOnJS(onHide)\` — that expression evaluates once at render time and returns a plain JS closure. Reanimated's animation stepper later tries to invoke it as a worklet, the worklets runtime detects the missing worklet marker, and throws.

The sibling change in \`CustomStatusBarAndBackground\` is fine — it sits inside \`useAnimatedReaction\`'s already-inline worklet callback, where \`runOnJS(fn)(arg)\` is just a worklet expression, not the worklet boundary itself.

## Fix

Restore the inline arrow-function wrapper so the babel plugin auto-worklets it, and call \`runOnJS(onHide)()\` from inside that worklet body to schedule \`onHide\` on the JS thread:

\`\`\`diff
- runOnJS(onHide),
+ () => runOnJS(onHide)(),
\`\`\`

One-line, zero ambiguity, exact pattern Reanimated's docs recommend for hopping back to JS from a worklet completion callback.

## Test plan

- [ ] Build locally, launch app, wait for splash → confirm no DevTools error
- [ ] Confirm \`onHide\` actually fires (splash overlay disappears, main UI is interactive)
- [ ] Confirm 15 s timeout safety path in \`useEffect\` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)