### PR TITLE
feat(theme): default to light theme when no preference is set

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -910,7 +910,7 @@ const CONST = {
   },
   TOOLTIP_MAX_LINES: 3,
   THEME: {
-    DEFAULT: 'system',
+    DEFAULT: 'light',
     FALLBACK: 'dark',
     DARK: 'dark',
     LIGHT: 'light',


### PR DESCRIPTION
## Summary

- Changes `CONST.THEME.DEFAULT` from `'system'` to `'light'` in `src/CONST.ts`
- Users with no stored theme preference now get light mode instead of following the device OS theme
- Users who have explicitly chosen a theme in Settings are unaffected

## Test plan

- [ ] Fresh install (or clear Onyx `PREFERRED_THEME` key) → app opens in light mode
- [ ] User with an explicit dark/light/system preference stored → preference is respected, no change
- [ ] Selecting a theme in Settings → Preferences → Theme still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)