### PR TITLE
chore: use babel-preset-expo for metro bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -96,8 +96,13 @@ const webpack = {
 };
 
 // ─── METRO (iOS / Android bundler) ───────────────────────────────────────────
+// Use babel-preset-expo here (it extends @react-native/babel-preset) so the
+// Expo modules we ship — expo-image, expo-image-manipulator, expo-image-picker,
+// expo-modules-core — get process.env.EXPO_OS inlined at compile time. Without
+// this, Expo packages log a "process.env.EXPO_OS is not defined" warning on
+// every Platform.OS lookup and fall back to a slower runtime branch.
 const metro = {
-  presets: [require('@react-native/babel-preset')],
+  presets: [require('babel-preset-expo')],
   plugins: [
     ['babel-plugin-react-compiler', ReactCompilerConfig], // must run first!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,7 @@
         "babel-plugin-module-resolver": "^5.0.0",
         "babel-plugin-react-compiler": "1.0.0",
         "babel-plugin-transform-remove-console": "^6.9.4",
+        "babel-preset-expo": "54.0.7",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-expensify": "^2.0.60",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-react-compiler": "1.0.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
+    "babel-preset-expo": "54.0.7",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-expensify": "^2.0.60",


### PR DESCRIPTION
## Problem

Every iOS/Android dev build logs this warning the first time an Expo package is loaded:

\`\`\`
The global process.env.EXPO_OS is not defined.
This should be inlined by babel-preset-expo during transformation.
    at Platform.ts:15
    at expo-image / ExpoImage.tsx:12
\`\`\`

Expo modules (\`expo-image\`, \`expo-image-manipulator\`, \`expo-image-picker\`, \`expo-modules-core\`) assume \`babel-preset-expo\` is running and statically inlines \`process.env.EXPO_OS\` ("ios" / "android" / "web") into the bundle at build time. We're running \`@react-native/babel-preset\` instead, so the inlining never happens, the runtime fallback fires on every \`Platform.OS\` lookup inside an Expo package, and we get one warning per module on bring-up.

## Fix

Swap the metro preset:

\`\`\`diff
- presets: [require('@react-native/babel-preset')],
+ presets: [require('babel-preset-expo')],
\`\`\`

\`babel-preset-expo\` itself extends \`@react-native/babel-preset\` and adds the EXPO_OS constant inlining (plus a few other Expo-specific transforms that are no-ops if you don't use those features). All our manual plugins (\`babel-plugin-react-compiler\`, flow strip, class properties, module-resolver, worklets/plugin-last) are preserved.

Pin \`babel-preset-expo@54.0.7\` explicitly in \`devDependencies\`. It was already present transitively via \`expo@54.0.10\`; this just makes the version we depend on stable against future Expo dep changes.

### Scope

- ✅ \`metro\` config — where the warning fires, where Expo packages run on iOS/Android
- ❌ \`webpack\` config — web bundle uses its own preset stack and doesn't import \`expo-image\`
- ❌ \`testEnv\` config — Jest runs on Node; the warning is harmless and switching presets adds risk

## Verification

- [x] Babel config resolves cleanly for both \`metro\` and \`babel-jest\` callers
- [x] \`react-native-worklets/plugin\` is still last in the metro plugin list (required)
- [x] \`npm run typecheck-tsgo\` passes
- [x] Sample Jest test passes (\`__tests__/unit/StringUtils.test.ts\`)
- [ ] Local iOS dev build — confirm the EXPO_OS warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)