### PR TITLE
fix(tests): remove unsupported haste.blockList and update baseline-browser-mapping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,9 +17,6 @@ module.exports = {
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/.claude/'],
   watchPathIgnorePatterns: ['<rootDir>/.claude/'],
   modulePathIgnorePatterns: ['<rootDir>/.claude/'],
-  haste: {
-    blockList: [/\.claude\//],
-  },
   globals: {
     __DEV__: true,
     WebSocket: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "babel-preset-expo": "54.0.7",
+        "baseline-browser-mapping": "^2.10.29",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-expensify": "^2.0.60",
@@ -9917,11 +9918,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
-      "integrity": "sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/before-after-hook": {

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-expo": "54.0.7",
+    "baseline-browser-mapping": "^2.10.29",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-expensify": "^2.0.60",


### PR DESCRIPTION
## Summary

- Removes `haste: { blockList: [/\.claude\//] }` from `jest.config.js` — `blockList` is not a recognized option in Jest 29's `haste` config (valid in older `jest-haste-map`, since removed), so it silently did nothing but printed a validation warning on every test run. The `.claude/` directory is already excluded by `testPathIgnorePatterns`, `watchPathIgnorePatterns`, and `modulePathIgnorePatterns`.
- Pins `baseline-browser-mapping@^2.10.29` as a direct `devDependency` to silence the staleness warning emitted at runtime by the transitive install via `browserslist`.

## Test plan

- [ ] CI Jest workflow runs without the two validation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)