### PR TITLE
ci(testBuild): bump setup-ruby and setup-java to match platformDeploy

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -53,15 +53,14 @@ jobs:
         uses: ./.github/actions/composite/setupNode
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'oracle'
           java-version: '17'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@a05e47355e80e57b9a67566a813648fa67d92011
+        uses: ruby/setup-ruby@v1.190.0
         with:
-          ruby-version: '3.2.2'
           bundler-cache: true
 
       - name: Decrypt keystore
@@ -128,7 +127,7 @@ jobs:
           fi
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@a05e47355e80e57b9a67566a813648fa67d92011
+        uses: ruby/setup-ruby@v1.190.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
### Details

The Android and iOS jobs in `testBuild.yml` were failing on every PR (e.g. [run 25869334040](https://github.com/PetrCala/Kiroku/actions/runs/25869334040)) at the **Setup Ruby** step:

- **Android (`ubuntu-latest` = 24.04)** — pinned `ruby/setup-ruby@a05e4735…` misdetected the runner as self-hosted and refused to install Ruby:
  > The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image
- **iOS (`macos-26`)** — same pinned SHA didn't know about that platform:
  > Error: Unknown version 3.3.4 for ruby on macos-

`platformDeploy.yml` already uses `ruby/setup-ruby@v1.190.0`, which handles both runners correctly. This PR aligns `testBuild.yml` with that workflow:

- `ruby/setup-ruby@<old SHA>` → `@v1.190.0` (both Android and iOS jobs)
- Drop the inline `ruby-version: '3.2.2'` on Android so it reads `.ruby-version` (3.3.4), matching the iOS job and `platformDeploy.yml`
- `actions/setup-java@v3` → `@v4` for consistency with `platformDeploy.yml`

The pre-existing "Install Ruby into tool cache (self-hosted runner)" step on iOS is unchanged — it primes the cache so `bundler-cache: true` works on macos-26.

### Tests

CI-only change. Verified by inspecting the failing logs and comparing against the known-good `platformDeploy.yml` configuration. The merged PR's own `testBuild` run is the real validation.

- [ ] Android `Build and deploy Android for testing` job reaches **Setup Ruby** successfully
- [ ] iOS `Build and deploy iOS for testing` job reaches **Setup Ruby** successfully

### Offline tests

N/A — CI-only.

### QA Steps

N/A — CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)