### PR TITLE
feat(auth): add Sign in with Apple on Android (#332)

### DIFF
--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -1,0 +1,100 @@
+import {
+  appleAuthAndroid,
+  AppleButton,
+} from '@invertase/react-native-apple-authentication';
+import {OAuthProvider} from 'firebase/auth';
+import React from 'react';
+import {useFirebase} from '@context/global/FirebaseContext';
+import Log from '@libs/Log';
+import * as User from '@userActions/User';
+import CONFIG from '@src/CONFIG';
+
+type AppleSignInProps = {
+  onPress?: () => void;
+};
+
+type AppleAndroidSignInResult = {
+  idToken: string | undefined;
+  displayName: string | null;
+};
+
+/**
+ * Performs the web-based Apple Sign In request on Android via appleAuthAndroid.
+ * Returns the identity token and a best-effort display name (Apple only sends
+ * the user's name on the very first sign-in).
+ */
+async function appleSignInRequestAndroid(): Promise<AppleAndroidSignInResult | null> {
+  appleAuthAndroid.configure({
+    clientId: CONFIG.APPLE_SIGN_IN.SERVICE_ID,
+    redirectUri: CONFIG.APPLE_SIGN_IN.REDIRECT_URI,
+    responseType: appleAuthAndroid.ResponseType.ALL,
+    scope: appleAuthAndroid.Scope.ALL,
+  });
+
+  const response = await appleAuthAndroid.signIn();
+
+  if (!response.id_token) {
+    Log.alert(
+      '[Apple Sign In] Android response missing id_token. Original response: ',
+      {response},
+    );
+    return null;
+  }
+
+  const name = response.user?.name;
+  const displayName =
+    [name?.firstName, name?.lastName].filter(Boolean).join(' ') || null;
+
+  return {idToken: response.id_token, displayName};
+}
+
+/**
+ * Apple Sign In button for Android.
+ * Drives Apple's web-based OAuth flow via appleAuthAndroid, then passes the
+ * resulting identity token to Firebase the same way the iOS variant does.
+ */
+function AppleSignIn({onPress = () => {}}: AppleSignInProps) {
+  const {auth, db} = useFirebase();
+
+  const handleSignIn = async () => {
+    try {
+      const result = await appleSignInRequestAndroid();
+      if (!result) {
+        return;
+      }
+
+      const {idToken, displayName} = result;
+
+      const provider = new OAuthProvider('apple.com');
+      const credential = provider.credential({idToken: idToken ?? ''});
+
+      onPress();
+      await User.signInWithOAuth(auth, db, credential, displayName);
+    } catch (error: unknown) {
+      const e = error as {message?: string};
+      // Android cancellation surfaces as a string message, not a code.
+      if (e.message === appleAuthAndroid.Error.SIGNIN_CANCELLED) {
+        return;
+      }
+      Log.alert(
+        '[Apple Sign In] Apple authentication failed',
+        error as Record<string, unknown>,
+      );
+    }
+  };
+
+  return (
+    <AppleButton
+      buttonStyle={AppleButton.Style.BLACK}
+      buttonType={AppleButton.Type.SIGN_IN}
+      cornerRadius={8}
+      style={{height: 48, width: '100%'}}
+      onPress={() => {
+        handleSignIn();
+      }}
+    />
+  );
+}
+
+export default AppleSignIn;
+export type {AppleSignInProps};


### PR DESCRIPTION
Resolves https://github.com/PetrCala/Kiroku/issues/332

### Details

Apple Sign-in was iOS-only — on Android, `src/components/SignInButtons/AppleSignIn/index.tsx` returned `null`, so Android users only had Google + email/password on the auth screen.

This PR adds `src/components/SignInButtons/AppleSignIn/index.android.tsx`, which:

- Drives Apple's web-based OAuth flow via `appleAuthAndroid.configure(...).signIn()` using the existing `CONFIG.APPLE_SIGN_IN.SERVICE_ID` / `REDIRECT_URI` (already wired up in `src/CONFIG.ts`).
- Hands the returned `id_token` to Firebase via `OAuthProvider('apple.com').credential(...)` and calls the same `User.signInWithOAuth(auth, db, credential, displayName)` as iOS, so the Firebase user creation/linking path is identical across platforms.
- Pulls a best-effort `displayName` from `response.user.name.{firstName,lastName}` (Apple only sends the name on first sign-in).
- Treats the Android-specific cancel error (`error.message === appleAuthAndroid.Error.SIGNIN_CANCELLED`, a string rather than iOS's numeric code) as a silent no-op.
- Renders the same `AppleButton` (BLACK / SIGN_IN / `cornerRadius={8}` / `height: 48, width: '100%'`) for visual parity with iOS.

`@invertase/react-native-apple-authentication` was already a dependency, so no `package.json` change. iOS, web, and the `AppleAuthWrapper` no-op remain untouched.

Out of scope (per the linked issue): web Apple Sign-in, and Android revocation handling (the library has no Android equivalent of `appleAuth.onCredentialRevoked`).

### Tests

1. On a fresh Android install, open the auth screen.
2. Tap the Apple Sign-in button.
3. Complete the Apple web sign-in sheet with a test Apple ID.
4. Verify the app proceeds into the authenticated flow and the Firebase user matches what iOS produces (same UID for the same Apple ID).
5. Re-launch the app, sign out, and sign in again with the same Apple ID — verify the user is reused (no duplicate profile creation in the database).
6. Tap the Apple Sign-in button again and cancel the Apple web sheet — verify no error alert / no JS console error.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Toggle Airplane Mode on, then tap the Apple Sign-in button — verify a sensible failure (`Log.alert` fires, no crash).
2. Toggle Airplane Mode off and retry — sign-in completes normally.

### QA Steps

1. On staging Android build, open the auth screen.
2. Sign in with Apple — verify the user lands in the app and the Firebase record is created correctly.
3. Sign out, sign back in — verify the same user is reused.
4. Cancel the Apple web sheet — verify no crash and no error alert.
5. On staging iOS build, sign in with Apple — regression check that the iOS flow is unchanged.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- to be added during manual QA -->

</details>

<details>
<summary>iOS</summary>

<!-- unchanged from previous releases -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)