### PR TITLE
fix(logo): keep env badge colored instead of tinting it flat

### DIFF
--- a/src/components/KirokuLogo.tsx
+++ b/src/components/KirokuLogo.tsx
@@ -1,30 +1,18 @@
 import React from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
-import AdHocLogo from '@assets/images/app-logo--adhoc.svg';
-import DevLogo from '@assets/images/app-logo--dev.svg';
-import ProductionLogo from '@assets/images/app-logo--prod.svg';
-import StagingLogo from '@assets/images/app-logo--staging.svg';
 import useEnvironment from '@hooks/useEnvironment';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
-import useTheme from '@hooks/useTheme';
-import ImageSVG from './ImageSVG';
+import KirokuLogoSvg from './KirokuLogoSvg';
 
 type KirokuLogoProps = {
   /** Additional styles to add to the component */
   style?: StyleProp<ViewStyle>;
-};
-
-const logoComponents = {
-  [CONST.ENVIRONMENT.TEST]: ProductionLogo,
-  [CONST.ENVIRONMENT.DEV]: DevLogo,
-  [CONST.ENVIRONMENT.STAGING]: StagingLogo,
-  [CONST.ENVIRONMENT.PROD]: ProductionLogo,
-  [CONST.ENVIRONMENT.ADHOC]: AdHocLogo,
 };
 
 function KirokuLogo({style}: KirokuLogoProps) {
@@ -32,8 +20,6 @@ function KirokuLogo({style}: KirokuLogoProps) {
   const theme = useTheme();
   const StyleUtils = useStyleUtils();
   const {environment} = useEnvironment();
-  // PascalCase is required for React components, so capitalize the const here
-  const LogoComponent = logoComponents[environment];
 
   const {shouldUseNarrowLayout} = useResponsiveLayout();
 
@@ -53,7 +39,7 @@ function KirokuLogo({style}: KirokuLogoProps) {
           : {},
         style,
       ]}>
-      <ImageSVG contentFit="contain" src={LogoComponent} fill={theme.appLogo} />
+      <KirokuLogoSvg fill={theme.appLogo} environment={environment} />
     </View>
   );
 }

--- a/src/components/KirokuLogoSvg.tsx
+++ b/src/components/KirokuLogoSvg.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import Svg, {Path, Polygon, Rect, Text as SvgText} from 'react-native-svg';
+import type {ValueOf} from 'type-fest';
+import CONST from '@src/CONST';
+
+type Environment = ValueOf<typeof CONST.ENVIRONMENT>;
+
+type Badge = {
+  label: string;
+  color: string;
+};
+
+// Mirror of the badge map in scripts/generate-icons.mjs — keep in sync so the
+// in-app logo matches the rasterized icon assets generated for native targets.
+const BADGES: Partial<Record<Environment, Badge>> = {
+  [CONST.ENVIRONMENT.DEV]: {label: 'DEV', color: '#007AFF'},
+  [CONST.ENVIRONMENT.STAGING]: {label: 'STG', color: '#FF9500'},
+  [CONST.ENVIRONMENT.ADHOC]: {label: 'ADHOC', color: '#AF52DE'},
+};
+
+const CANVAS = 1024;
+// Badge geometry mirrors scripts/generate-icons.mjs:variantSvg.
+const BADGE_TRI = Math.round(CANVAS * 0.38);
+const BADGE_TX = CANVAS - BADGE_TRI;
+const BADGE_TY = CANVAS - BADGE_TRI;
+const BADGE_FONT_SIZE = Math.round(BADGE_TRI * 0.28);
+const BADGE_TEXT_X = CANVAS - BADGE_TRI * 0.38;
+const BADGE_TEXT_Y = CANVAS - BADGE_TRI * 0.18;
+
+type KirokuLogoSvgProps = {
+  fill: string;
+  environment: Environment;
+};
+
+function KirokuLogoSvg({fill, environment}: KirokuLogoSvgProps) {
+  const badge = BADGES[environment];
+  return (
+    <Svg width="100%" height="100%" viewBox={`0 0 ${CANVAS} ${CANVAS}`}>
+      <Path d="M129 808L316 480L374 580L243.117 808H129Z" fill={fill} />
+      <Path d="M895.5 808L708.5 480L650.5 580L781.383 808H895.5Z" fill={fill} />
+      <Rect
+        x={523}
+        y={618}
+        width={185}
+        height={20}
+        transform="rotate(90 523 618)"
+        fill={fill}
+      />
+      <Rect
+        x={602}
+        y={808}
+        width={180}
+        height={9.99998}
+        transform="rotate(-180 602 808)"
+        fill={fill}
+      />
+      <Path d="M636.5 348L512.66 134L389 348H636.5Z" fill={fill} />
+      <Path d="M388.5 434L512.34 648L636 434L388.5 434Z" fill={fill} />
+      {badge ? (
+        <>
+          <Polygon
+            points={`${BADGE_TX},${CANVAS} ${CANVAS},${CANVAS} ${CANVAS},${BADGE_TY}`}
+            fill={badge.color}
+          />
+          <SvgText
+            x={BADGE_TEXT_X}
+            y={BADGE_TEXT_Y}
+            fontSize={BADGE_FONT_SIZE}
+            fill="white"
+            fontFamily="Arial,Helvetica,sans-serif"
+            fontWeight="bold"
+            textAnchor="middle">
+            {badge.label}
+          </SvgText>
+        </>
+      ) : null}
+    </Svg>
+  );
+}
+
+KirokuLogoSvg.displayName = 'KirokuLogoSvg';
+
+export default KirokuLogoSvg;


### PR DESCRIPTION
### Details

The in-app `KirokuLogo` renders the env-specific logo (`app-logo--dev.svg`, `--staging.svg`, `--adhoc.svg`) through `ImageSVG`, which on iOS and Android pipes the `fill` prop into expo-image's `tintColor`. `tintColor` recolors every non-transparent pixel to one solid color, so the env badge (blue/orange/purple corner triangle + white label) collapses into the same silhouette as the main glyph. In dark theme `theme.appLogo` is near-white, so the badge ended up reading as "a white triangle in the bottom-right."

This PR adds a hand-built `KirokuLogoSvg` component that renders the master glyph paths using `react-native-svg` primitives. The theme color is applied only to the main glyph paths via SVG `fill` attributes (not `tintColor`), so the badge keeps its own hardcoded colors. Badge geometry mirrors the formula in `scripts/generate-icons.mjs:variantSvg`, so the in-app logo stays visually aligned with the rasterized native-icon assets.

Scope is deliberately narrow:
- `ImageSVG` is untouched — every other consumer still uses `expo-image` + `tintColor`.
- The icon-generation pipeline (`scripts/generate-icons.mjs`) and the `app-logo--*.svg` variant files are untouched — they remain the source of truth for native iOS / Android / web icon assets.
- No metro / babel / jest config changes; no `react-native-svg-transformer` introduced.

### Tests

1. Build the app on iOS (`npm run ios`) and Android (`npm run android`) against the **DEV** environment.
2. On the sign-up screen, verify the logo's bottom-right corner shows a blue triangle with readable white "DEV" text — in both light and dark themes.
3. Toggle theme (Settings → Theme) and re-open the sign-up flow; verify the main glyph recolors with the theme but the badge stays blue/white.
4. Repeat on a **staging** build (badge should be orange with "STG") and an **adhoc** build (badge should be purple with "ADHOC").
5. Build a **production** build and verify the logo renders the main glyph only — no badge at all.
6. Verify the logo's overall size, aspect ratio, and positioning on the sign-up screen match what was rendered before this change (narrow + wide layouts).

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A — logo rendering is fully offline; this change does not interact with network state.

### QA Steps

1. On the **staging** build, open the app to the sign-up screen.
2. Verify the bottom-right corner of the logo shows an orange triangle with white "STG" text (not a solid silhouette).
3. Toggle dark and light themes; verify the main glyph recolors but the badge keeps its orange/white colors.
4. Confirm overall logo size and aspect ratio look identical to the pre-change build.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)