### PR TITLE
chore(auth): move Apple/Google sign-in config to env vars

### DIFF
--- a/src/CONFIG.ts
+++ b/src/CONFIG.ts
@@ -112,17 +112,13 @@ export default {
     CLUSTER: 'mt1',
   },
   APPLE_SIGN_IN: {
-    SERVICE_ID: 'org.reactjs.native.example.alcohol-tracker.signin',
-    REDIRECT_URI:
-      'https://dev-alcohol-tracker-db.firebaseapp.com/__/auth/handler',
+    SERVICE_ID: get(Config, 'APPLE_SIGN_IN_SERVICE_ID', ''),
+    REDIRECT_URI: get(Config, 'APPLE_SIGN_IN_REDIRECT_URI', ''),
   },
   GOOGLE_SIGN_IN: {
-    WEB_CLIENT_ID:
-      '665512857657-59e75jfp7p7tjt3dn6rqm8pcin0oq4p8.apps.googleusercontent.com',
-    IOS_CLIENT_ID:
-      '200327501992-07u3boj39j65sltumv2lbd2jk5nr416q.apps.googleusercontent.com',
-    ANDROID_CLIENT_ID:
-      '200327501992-dd7hj1pl6rdok1fnka4rb2utfavuj6ds.apps.googleusercontent.com',
+    WEB_CLIENT_ID: get(Config, 'GOOGLE_WEB_CLIENT_ID', ''),
+    IOS_CLIENT_ID: get(Config, 'GOOGLE_IOS_CLIENT_ID', ''),
+    ANDROID_CLIENT_ID: get(Config, 'GOOGLE_ANDROID_CLIENT_ID', ''),
   },
   SEND_CRASH_REPORTS: get(Config, 'SEND_CRASH_REPORTS', 'false') === 'true',
   IS_USING_EMULATORS: get(Config, 'USE_EMULATORS', 'false') === 'true',


### PR DESCRIPTION
### Details

`src/CONFIG.ts` had `APPLE_SIGN_IN` and `GOOGLE_SIGN_IN` hardcoded. Two problems:

- **Apple values were stale.** `SERVICE_ID` was missing the `.webandroid` suffix (the actual identifier registered in the Apple Developer portal is `org.reactjs.native.example.alcohol-tracker.signin.webandroid`), and `REDIRECT_URI` pointed at Firebase Auth's built-in handler (`/__/auth/handler`), not at the new `kiroku-web` callback page. https://github.com/PetrCala/Kiroku/pull/336 reads both values for the Android OAuth flow, so they need to be correct *per environment*.
- **Google values were prod-only.** No way to point a dev build at the dev Firebase project's OAuth clients — the same `665512857657-…` web client was used in every env.

This PR converts both blocks to `get(Config, …)` reads following the existing `FIREBASE_CONFIG` pattern. Actual values live in the gitignored `.env.*` files.

#### Required env vars (must be added to every `.env.*` file before this PR's build will sign-in successfully)

```
APPLE_SIGN_IN_SERVICE_ID
APPLE_SIGN_IN_REDIRECT_URI
GOOGLE_WEB_CLIENT_ID
GOOGLE_IOS_CLIENT_ID
GOOGLE_ANDROID_CLIENT_ID
```

Per-env recommended values:

| Var | development / adhoc | staging / production |
| --- | --- | --- |
| `APPLE_SIGN_IN_SERVICE_ID` | `org.reactjs.native.example.alcohol-tracker.signin.webandroid` | same |
| `APPLE_SIGN_IN_REDIRECT_URI` | `https://kiroku-web-dev.web.app/auth/apple/callback` | `https://kiroku-web-prod.web.app/auth/apple/callback` |
| `GOOGLE_WEB_CLIENT_ID` | dev project's web OAuth client (GCP) | `665512857657-59e75jfp7p7tjt3dn6rqm8pcin0oq4p8.apps.googleusercontent.com` |
| `GOOGLE_IOS_CLIENT_ID` | dev project's iOS OAuth client | `200327501992-07u3boj39j65sltumv2lbd2jk5nr416q.apps.googleusercontent.com` |
| `GOOGLE_ANDROID_CLIENT_ID` | dev project's Android OAuth client | `200327501992-dd7hj1pl6rdok1fnka4rb2utfavuj6ds.apps.googleusercontent.com` |

> The dev iOS / Android OAuth client IDs do not exist yet — they need to be created in the dev Firebase project (Project settings → Your apps → add iOS / Android app or use the existing one's auto-generated OAuth client). Until then, dev builds can temporarily reuse the prod values, which is what the previous hardcoded behavior did.

> The `200327501992-…` prefix on iOS/Android does not match either Firebase project number (prod: `665512857657`, dev: `806896865950`). Pre-existing oddity, not introduced by this PR — worth a separate investigation later.

### Tests

1. Add the required env vars to `.env.development` (use prod Google values as a fallback if dev OAuth clients don't exist yet).
2. Rebuild the app (`npx react-native run-android` and `run-ios`).
3. Tap **Sign in with Apple** → verify the flow proceeds normally on both platforms.
4. Tap **Sign in with Google** → verify the account picker appears and sign-in completes on both platforms.
5. Sign out and back in → verify the same Firebase user is returned (no duplicate creation).

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Toggle Airplane Mode on, tap **Sign in with Apple** → verify a sensible failure (no crash, error logged).
2. Toggle Airplane Mode on, tap **Sign in with Google** → same.
3. Toggle Airplane Mode off, retry both → verify sign-in completes normally.

### QA Steps

1. On a staging Android build, sign in with Apple → verify success.
2. On a staging iOS build, sign in with Apple → regression check.
3. Same with Google sign-in on both platforms.
4. Sign out, sign in with a different Apple/Google account → verify correct user is created.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- to be added during manual QA -->

</details>

<details>
<summary>iOS</summary>

<!-- unchanged from current behavior once env vars are populated -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)