### PR TITLE
chore(scripts): add helper to sync .env.* files to GitHub secrets

### DIFF
--- a/scripts/updateEnvSecrets.sh
+++ b/scripts/updateEnvSecrets.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Update GitHub repository secrets from local .env.* files.
+#
+# Mapping:
+#   .env.adhoc      -> ADHOC_ENV_FILE
+#   .env.dev        -> DEV_ENV_FILE
+#   .env.production -> PRODUCTION_ENV_FILE
+#   .env.staging    -> STAGING_ENV_FILE
+#
+# Usage:
+#   scripts/updateEnvSecrets.sh              # update all four
+#   scripts/updateEnvSecrets.sh adhoc dev    # update only the named envs
+
+set -e
+
+SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "$SCRIPTS_DIR/shellUtils.sh"
+
+ROOT_DIR=$(cd "$SCRIPTS_DIR/.." && pwd)
+
+ALL_ENVS=(adhoc dev production staging)
+
+usage() {
+  cat <<EOF
+Usage: $0 [env ...]
+
+Updates the GitHub repository secret <ENV>_ENV_FILE from the matching
+local .env.<env> file. With no arguments, all four envs are updated:
+  ${ALL_ENVS[*]}
+EOF
+  exit 1
+}
+
+if ! command -v gh &>/dev/null; then
+  error "gh CLI is not installed. See https://cli.github.com/"
+  exit 1
+fi
+
+if ! gh auth status &>/dev/null; then
+  error "gh CLI is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+# Validate selection
+SELECTED=()
+if [[ $# -eq 0 ]]; then
+  SELECTED=("${ALL_ENVS[@]}")
+else
+  for arg in "$@"; do
+    case "$arg" in
+    -h | --help) usage ;;
+    adhoc | dev | production | staging) SELECTED+=("$arg") ;;
+    *)
+      error "Unknown env: $arg"
+      usage
+      ;;
+    esac
+  done
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+info "Target repository: $REPO"
+
+FAILED=()
+for env_name in "${SELECTED[@]}"; do
+  file="$ROOT_DIR/.env.$env_name"
+  secret_name="$(echo "$env_name" | tr '[:lower:]' '[:upper:]')_ENV_FILE"
+
+  title "Updating $secret_name from .env.$env_name"
+
+  if [[ ! -f "$file" ]]; then
+    error "Missing file: $file"
+    FAILED+=("$env_name")
+    continue
+  fi
+
+  if [[ ! -s "$file" ]]; then
+    error "File is empty: $file"
+    FAILED+=("$env_name")
+    continue
+  fi
+
+  if gh secret set "$secret_name" --repo "$REPO" --body-file "$file"; then
+    success "Updated $secret_name"
+  else
+    error "Failed to update $secret_name"
+    FAILED+=("$env_name")
+  fi
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  error "Failed: ${FAILED[*]}"
+  exit 1
+fi
+
+success "All selected secrets updated."


### PR DESCRIPTION
### Details

Adds `scripts/updateEnvSecrets.sh`, a small helper that uploads the local `.env.*` files to their matching GitHub repository secrets using the `gh` CLI, so the secrets consumed by `deploy.yml` / `platformDeploy.yml` / `testBuild.yml` can be kept in sync without clicking through the GitHub UI.

Mapping (matches existing workflow usage):

| Local file        | GitHub secret           |
| ----------------- | ----------------------- |
| `.env.adhoc`      | `ADHOC_ENV_FILE`        |
| `.env.dev`        | `DEV_ENV_FILE`          |
| `.env.production` | `PRODUCTION_ENV_FILE`   |
| `.env.staging`    | `STAGING_ENV_FILE`      |

Behavior:

- No-arg form (`scripts/updateEnvSecrets.sh`) updates all four secrets.
- Pass one or more env names to update a subset, e.g. `scripts/updateEnvSecrets.sh adhoc staging`.
- Auto-detects the target repo via `gh repo view`.
- Verifies `gh` is installed and authenticated before doing anything.
- Skips missing/empty files (reports them) instead of uploading garbage, and exits non-zero if any upload failed.

No application code is touched — this is tooling only.

### Tests

1. With `gh` logged out, run `scripts/updateEnvSecrets.sh` — verify it errors with an auth message and exits non-zero.
2. With `gh` logged in but no `.env.*` files present, run the script — verify each env is reported as missing and the script exits non-zero.
3. Create dummy `.env.adhoc` (single line, e.g. `FOO=bar`) and run `scripts/updateEnvSecrets.sh adhoc` — verify only `ADHOC_ENV_FILE` is updated on GitHub (check via `gh secret list`).
4. Run `scripts/updateEnvSecrets.sh` with all four files present — verify all four secrets are updated and the script reports success.
5. Run `scripts/updateEnvSecrets.sh bogus` — verify it prints usage and exits non-zero.

- [ ] Verify that no errors appear in the JS console (N/A — tooling-only change)

### Offline tests

N/A — this script requires network access to talk to the GitHub API; there is no offline behavior to validate.

### QA Steps

N/A — does not ship in the app bundle, no staging/production user-visible behavior to QA.

- [ ] Verify that no errors appear in the JS console (N/A)

### PR Author Checklist

- [x] Script is executable (`chmod +x`) and passes `bash -n` syntax check.
- [x] Reuses existing `scripts/shellUtils.sh` helpers (`info`, `success`, `error`, `title`) for consistency with sibling scripts.
- [x] Does not touch application code, native projects, or CI workflows.

### Screenshots/Videos

N/A — CLI helper script, no UI.