### PR TITLE
fix(scripts): use stdin and .env.development for env-secret upload

### DIFF
--- a/scripts/updateEnvSecrets.sh
+++ b/scripts/updateEnvSecrets.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Update GitHub repository secrets from local .env.* files.
 #
-# Mapping:
-#   .env.adhoc      -> ADHOC_ENV_FILE
-#   .env.dev        -> DEV_ENV_FILE
-#   .env.production -> PRODUCTION_ENV_FILE
-#   .env.staging    -> STAGING_ENV_FILE
+# Mapping (env arg -> local file -> GitHub secret):
+#   adhoc      -> .env.adhoc       -> ADHOC_ENV_FILE
+#   dev        -> .env.development -> DEV_ENV_FILE
+#   production -> .env.production  -> PRODUCTION_ENV_FILE
+#   staging    -> .env.staging     -> STAGING_ENV_FILE
 #
 # Usage:
 #   scripts/updateEnvSecrets.sh              # update all four
@@ -20,12 +20,34 @@ ROOT_DIR=$(cd "$SCRIPTS_DIR/.." && pwd)
 
 ALL_ENVS=(adhoc dev production staging)
 
+# Maps an env arg to its local filename suffix (the part after `.env.`).
+env_file_suffix() {
+  case "$1" in
+  adhoc) echo "adhoc" ;;
+  dev) echo "development" ;;
+  production) echo "production" ;;
+  staging) echo "staging" ;;
+  *) return 1 ;;
+  esac
+}
+
+# Maps an env arg to its GitHub secret name.
+env_secret_name() {
+  case "$1" in
+  adhoc) echo "ADHOC_ENV_FILE" ;;
+  dev) echo "DEV_ENV_FILE" ;;
+  production) echo "PRODUCTION_ENV_FILE" ;;
+  staging) echo "STAGING_ENV_FILE" ;;
+  *) return 1 ;;
+  esac
+}
+
 usage() {
   cat <<EOF
 Usage: $0 [env ...]
 
-Updates the GitHub repository secret <ENV>_ENV_FILE from the matching
-local .env.<env> file. With no arguments, all four envs are updated:
+Updates the matching GitHub repository secret from the local .env file.
+With no arguments, all four envs are updated:
   ${ALL_ENVS[*]}
 EOF
   exit 1
@@ -63,10 +85,11 @@ info "Target repository: $REPO"
 
 FAILED=()
 for env_name in "${SELECTED[@]}"; do
-  file="$ROOT_DIR/.env.$env_name"
-  secret_name="$(echo "$env_name" | tr '[:lower:]' '[:upper:]')_ENV_FILE"
+  suffix=$(env_file_suffix "$env_name")
+  secret_name=$(env_secret_name "$env_name")
+  file="$ROOT_DIR/.env.$suffix"
 
-  title "Updating $secret_name from .env.$env_name"
+  title "Updating $secret_name from .env.$suffix"
 
   if [[ ! -f "$file" ]]; then
     error "Missing file: $file"
@@ -80,7 +103,7 @@ for env_name in "${SELECTED[@]}"; do
     continue
   fi
 
-  if gh secret set "$secret_name" --repo "$REPO" --body-file "$file"; then
+  if gh secret set "$secret_name" --repo "$REPO" <"$file"; then
     success "Updated $secret_name"
   else
     error "Failed to update $secret_name"


### PR DESCRIPTION
### Details

Follow-up to [#347](https://github.com/PetrCala/Kiroku/pull/347). Two fixes to `scripts/updateEnvSecrets.sh`:

1. **Use stdin instead of `--body-file`.** That flag isn't available in older `gh` versions and was causing `unknown flag: --body-file` errors. The neighboring `--env-file` flag is *not* a drop-in replacement — it splits a dotenv file into one secret per `KEY=VALUE` line. We want the entire file content stored as a single secret, so pipe via stdin (`gh secret set NAME < file`), which is what `gh` reads from when no `--body` is given.
2. **Decouple env name from filename suffix.** The dev env's local file is `.env.development` (not `.env.dev`), but the GitHub secret is still `DEV_ENV_FILE`. Replaced the "uppercase the arg" derivation with explicit `env_file_suffix` / `env_secret_name` mapping functions so each env's file path and secret name are looked up independently.

Final mapping:

| Arg          | Local file        | GitHub secret         |
| ------------ | ----------------- | --------------------- |
| `adhoc`      | `.env.adhoc`      | `ADHOC_ENV_FILE`      |
| `dev`        | `.env.development`| `DEV_ENV_FILE`        |
| `production` | `.env.production` | `PRODUCTION_ENV_FILE` |
| `staging`    | `.env.staging`    | `STAGING_ENV_FILE`    |

### Tests

1. Run `scripts/updateEnvSecrets.sh adhoc` with `.env.adhoc` present — verify it no longer prints `unknown flag: --body-file` and that `ADHOC_ENV_FILE` is updated (`gh secret list`).
2. Run `scripts/updateEnvSecrets.sh dev` with `.env.development` present — verify it reads from `.env.development` (not `.env.dev`) and updates `DEV_ENV_FILE`.
3. Run `scripts/updateEnvSecrets.sh` with no args and all four `.env.*` files present — verify all four secrets are updated.
4. Run `scripts/updateEnvSecrets.sh dev` with `.env.development` missing — verify it reports the missing file and exits non-zero.
5. Run `scripts/updateEnvSecrets.sh bogus` — verify it prints usage and exits non-zero.

- [ ] Verify that no errors appear in the JS console (N/A — tooling-only change)

### Offline tests

N/A — script requires network to call the GitHub API; no offline behavior.

### QA Steps

N/A — does not ship in the app bundle, no user-facing behavior to QA.

- [ ] Verify that no errors appear in the JS console (N/A)

### PR Author Checklist

- [x] `bash -n` passes on the updated script.
- [x] No application code, native projects, or workflows touched.
- [x] Documented the env-arg / file / secret mapping in the script header and PR body.

### Screenshots/Videos

N/A — CLI helper script, no UI.