### PR TITLE
fix(bootsplash): wait for theme hydration before hiding splash

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -66,7 +66,9 @@ function Kiroku() {
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const [initialUrl, setInitialUrl] = useState<string | null>(null);
   const [hasCheckedAutoLogin] = useOnyx(ONYXKEYS.HAS_CHECKED_AUTO_LOGIN);
-  const [preferredTheme] = useOnyx(ONYXKEYS.PREFERRED_THEME);
+  const [preferredTheme, preferredThemeMetadata] = useOnyx(
+    ONYXKEYS.PREFERRED_THEME,
+  );
   const {config} = useConfig();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authenticationChecked, setAuthenticationChecked] = useState(false);
@@ -119,9 +121,11 @@ function Kiroku() {
 
   const shouldInit = isNavigationReady && hasCheckedAutoLogin;
 
-  // For logged-in users, wait for theme to be loaded from Firebase before hiding splash
-  // For logged-out users, theme is ready immediately (system default will be used)
-  const isThemeReady = !isAuthenticated || preferredTheme !== undefined;
+  // Wait until Onyx has finished hydrating PREFERRED_THEME from local storage
+  // before hiding the splash. Otherwise the ThemeProvider renders one frame
+  // with the default light theme and then re-renders with the stored dark
+  // preference, producing a visible white flash.
+  const isThemeReady = preferredThemeMetadata.status === 'loaded';
 
   const shouldHideSplash = !!(
     shouldInit &&


### PR DESCRIPTION
### Details

Non-logged-in users with the dark theme stored locally saw a brief white flash on iOS right after the boot splash hid. The splash gate in `Kiroku.tsx` short-circuited the `preferredTheme` check whenever the user wasn't authenticated:

```ts
const isThemeReady = !isAuthenticated || preferredTheme !== undefined;
```

So for the logged-out path the splash hid as soon as `hasCheckedAutoLogin` flipped, even though Onyx hadn't yet hydrated `PREFERRED_THEME` from local storage. `ThemeProvider` then rendered one frame with the default light theme before re-rendering with `'dark'` — the visible flash.

This PR replaces the gate with `useOnyx`'s metadata `status` field:

```ts
const isThemeReady = preferredThemeMetadata.status === 'loaded';
```

`status` flips to `'loaded'` once Onyx has read the key from storage regardless of whether a value exists, so:

- First-ever launch (no stored preference): resolves immediately, falls back to the default theme — nothing to race against.
- Returning dark-theme user (logged-in or out): splash waits for hydration, ThemeProvider renders `'dark'` on first paint, no flash.

The same path now also handles logged-in users (the previous logged-in branch already waited for `preferredTheme !== undefined`, which the new check supersedes).

### Tests

1. On iOS, set the app theme to **Dark** in preferences while signed in, then sign out so you land on the public/welcome stack.
2. Fully terminate the app and cold-launch it.
3. Verify the boot splash transitions directly into the dark public stack — there must be no white/light flash between the splash hide and the first painted screen.
4. Repeat after toggling the preference back to **Light** — splash should transition into the light public stack with no flash.
5. Sign in and cold-launch the app — splash should still hide promptly into the correct theme (no regression vs. the previous logged-in behavior).
6. Fresh install (or wipe app data) with no stored `PREFERRED_THEME` — splash should hide immediately without hanging, app renders in the default theme.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Enable airplane mode, then cold-launch the app as a signed-out dark-theme user — splash behavior should be identical (theme hydration is local-only and does not depend on the network).

### QA Steps

1. Same as the Tests section, performed on a staging build on a real iOS device.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I tested the change locally on iOS.
- [ ] Android verification still pending — change is platform-agnostic React state, but worth a quick smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)