### PR TITLE
feat(auth): polish welcome screen with gradient, haptic, and auth-check spinner

### DIFF
--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -1,5 +1,6 @@
 import React, {useRef} from 'react';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import {useFocusEffect} from '@react-navigation/native';
 import {useFirebase} from '@context/global/FirebaseContext';
 import Navigation from '@navigation/Navigation';
@@ -8,6 +9,7 @@ import ROUTES from '@src/ROUTES';
 import CONST from '@src/CONST';
 import * as CloseAccount from '@userActions/CloseAccount';
 import * as Session from '@userActions/Session';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -29,9 +31,11 @@ type InitialScreenLayoutRef = {
 function InitialScreen() {
   const {auth} = useFirebase();
   const {translate} = useLocalize();
+  const theme = useTheme();
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
   const [closeAccount] = useOnyx(ONYXKEYS.FORMS.CLOSE_ACCOUNT_FORM);
+  const [hasCheckedAutoLogin] = useOnyx(ONYXKEYS.HAS_CHECKED_AUTO_LOGIN);
   const {isInNarrowPaneModal} = useResponsiveLayout();
   const safeAreaInsets = useStyledSafeAreaInsets();
   const currentScreenLayoutRef = useRef<InitialScreenLayoutRef>(null);
@@ -52,6 +56,8 @@ function InitialScreen() {
   useFocusEffect(
     React.useCallback(() => {
       Session.clearSignInData();
+      // Reset on each focus so the spinner reflects the current auth check, not a stale value from a previous mount.
+      Session.setHasCheckedAutoLogin(false);
       const stopListening = auth.onAuthStateChanged(user => {
         if (!user) {
           Session.setHasCheckedAutoLogin(true);
@@ -101,21 +107,31 @@ function InitialScreen() {
         <Button
           large
           success
-          text={translate('common.getStarted')}
+          text={translate('common.createAccount')}
           onPress={onGetStarted}
+          isLoading={!hasCheckedAutoLogin}
+          shouldEnableHapticFeedback
           style={[styles.mt5]}
         />
-        <View style={[styles.changeSignUpScreenLinkContainer, styles.mt4]}>
-          <Text style={styles.mr1}>{translate('login.existingAccount')}</Text>
-          <PressableWithFeedback
-            style={[styles.link]}
-            onPress={onLogIn}
-            role={CONST.ROLE.LINK}
-            accessibilityLabel={logInActionText}>
-            <Text style={[styles.link]}>{logInActionText}</Text>
-          </PressableWithFeedback>
-        </View>
+        {!!hasCheckedAutoLogin && (
+          <View style={[styles.changeSignUpScreenLinkContainer, styles.mt4]}>
+            <Text style={styles.mr1}>{translate('login.existingAccount')}</Text>
+            <PressableWithFeedback
+              style={[styles.link]}
+              onPress={onLogIn}
+              role={CONST.ROLE.LINK}
+              accessibilityLabel={logInActionText}>
+              <Text style={[styles.link]}>{logInActionText}</Text>
+            </PressableWithFeedback>
+          </View>
+        )}
       </SignUpScreenLayout>
+      {/* Overlays SignUpScreenLayout's iOS narrow-layout background; alpha kept very low to avoid tinting text. */}
+      <LinearGradient
+        colors={[`${theme.success}00`, `${theme.success}0A`]}
+        style={StyleSheet.absoluteFillObject}
+        pointerEvents="none"
+      />
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
### Details

Small UX upgrade to the logged-out welcome screen (`src/screens/SignUp/InitialScreen.tsx`) so it feels more polished and professional without restructuring layout or touching shared sign-up components.

**What changed:**

- **CTA copy**: primary button now reads "Create account" (via the existing `common.createAccount` translation key — both `en.ts` and `cs_cz.ts` already had it). The `common.getStarted` key is left intact for any future re-use.
- **Soft brand-tint gradient**: a `LinearGradient` overlay using `theme.success` (Kiroku brand yellow `#F5C400`) at 0% → ~4% alpha, absolutely positioned with `pointerEvents="none"`. It sits *after* `SignUpScreenLayout` because that shared component applies an opaque `theme.signInPage` background on iOS narrow layout ([`getSignInBgStyles/index.ios.ts`](https://github.com/PetrCala/Kiroku/blob/master/src/styles/utils/getSignInBgStyles/index.ios.ts)) that would otherwise hide an underlay. Alpha is intentionally tiny so it doesn't tint text.
- **Haptic on press**: the existing `Button` component already supports `shouldEnableHapticFeedback` (wired into `react-native-haptic-feedback`), but it defaults to `false`. One prop turns it on for this CTA.
- **Auto-login flicker fix**: a `useOnyx(ONYXKEYS.HAS_CHECKED_AUTO_LOGIN)` gate on the CTA's `isLoading` state and on the "Log in here" link. The `useFocusEffect` now resets the flag to `false` before subscribing to `auth.onAuthStateChanged`, so the spinner reflects the *current* check rather than a stale `true` from a previous mount (e.g. logout → welcome). The boot splash already masks this on cold boot — the fix matters for navigations into the screen post-boot.

`Button` natively disables presses while `isLoading={true}` and renders an `ActivityIndicator`, so no extra disable logic was needed.

**Not changed:**

- No new components; no edits to `SignUpScreenLayout` / `SignUpScreenContent` (shared with `AuthScreen`).
- No translation file edits.
- No theme, Session-action, or Onyx-key changes.

### Tests

1. **Cold boot, logged out.** Force-quit and relaunch the app. Boot splash hides on the welcome screen with: subtle bottom yellow tint visible, "Create account" CTA showing (not a spinner, because by the time the splash hides `hasCheckedAutoLogin` is already true). Press the CTA — verify a light haptic fires (device only — simulators don't emit haptics). Confirm navigation to `/auth?mode=signUp`.
2. **Cold boot, logged in.** Should redirect to HOME without a welcome flash. (Unchanged behavior.)
3. **Logout flow.** From the home screen, log out. You should land on the welcome screen. Watch the CTA: it should briefly show the `ActivityIndicator` spinner while the auth listener re-resolves, then settle into "Create account". The "Log in here" link should appear only after the spinner resolves — no flash of the live CTA followed by a redirect.
4. **i18n.** Switch device language to Czech (Settings → Preferences → Language) and confirm the CTA renders "Vytvořit účet".
5. **Theme.** Toggle light/dark theme. The gradient should adapt — readable in both, more subtle in dark mode. Verify it doesn't muddy the background.

- [ ] Verify that no errors appear in the JS console

### Offline tests

The welcome screen has no network calls of its own beyond the existing Firebase `onAuthStateChanged` listener. Behavior offline is identical to today — the auth listener simply doesn't fire until connectivity returns, in which case the spinner stays visible. No regression vector here.

1. Toggle airplane mode before launching the app from a logged-out state.
2. Confirm the welcome screen renders the gradient and header, with the CTA in the spinner state.
3. Restore connectivity — within a few seconds the CTA resolves to "Create account" (or the screen redirects to HOME if you were logged in).

### QA Steps

1. On staging, install a fresh build and launch the app from a logged-out state.
2. Verify the welcome screen shows the new "Create account" button with a subtle yellow tint near the bottom of the screen.
3. Tap the button on a physical device — confirm a light haptic fires.
4. Sign in, then sign out from the account screen. Verify the welcome screen returns with a brief spinner in place of the CTA before it resolves to "Create account".
5. Repeat on both iOS and Android.

- [ ] Verify that no errors appear in the JS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)