### PR TITLE
fix(ios): resolve Google Sign-In crash on dev/adhoc builds

### DIFF
--- a/ios/config/GoogleService-Info.dev.plist
+++ b/ios/config/GoogleService-Info.dev.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>806896865950-0fnpmkppokk0epailj6u83psrfot197s.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.806896865950-0fnpmkppokk0epailj6u83psrfot197s</string>
+	<key>ANDROID_CLIENT_ID</key>
+	<string>806896865950-d0uvplo5k964gm1rpfdhojhvb6pr9o4p.apps.googleusercontent.com</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDGTMdcL1BdnBwC_q2lnKj50rFUnUH5Bnc</string>
+	<key>GCM_SENDER_ID</key>
+	<string>806896865950</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>org.reactjs.native.example.alcohol-tracker</string>
+	<key>PROJECT_ID</key>
+	<string>dev-alcohol-tracker-db</string>
+	<key>STORAGE_BUCKET</key>
+	<string>dev-alcohol-tracker-db.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:806896865950:ios:e2ccddc1f660a2cfb1618f</string>
+	<key>DATABASE_URL</key>
+	<string>https://dev-alcohol-tracker-db-default-rtdb.europe-west1.firebasedatabase.app</string>
+</dict>
+</plist>

--- a/ios/config/GoogleService-Info.prod.plist
+++ b/ios/config/GoogleService-Info.prod.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>665512857657-9jbvrm2mc02neecr5nui347vv87kr67s.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.665512857657-9jbvrm2mc02neecr5nui347vv87kr67s</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDGRd06YWNKJsEyibIhT7W_JhjaPtKH0qM</string>
+	<key>GCM_SENDER_ID</key>
+	<string>665512857657</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>org.reactjs.native.example.alcohol-tracker</string>
+	<key>PROJECT_ID</key>
+	<string>alcohol-tracker-db</string>
+	<key>STORAGE_BUCKET</key>
+	<string>alcohol-tracker-db.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:665512857657:ios:a07eeddf1f54bac2b4fde8</string>
+	<key>DATABASE_URL</key>
+	<string>https://alcohol-tracker-db-default-rtdb.europe-west1.firebasedatabase.app</string>
+</dict>
+</plist>

--- a/ios/kiroku/Info.plist
+++ b/ios/kiroku/Info.plist
@@ -30,6 +30,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.googleusercontent.apps.200327501992-07u3boj39j65sltumv2lbd2jk5nr416q</string>
+				<string>com.googleusercontent.apps.806896865950-0fnpmkppokk0epailj6u83psrfot197s</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary

Tapping **Sign up with Google** in dev simulator or adhoc builds crashes the app with `SIGABRT` from `-[GIDSignIn assertValidParameters]`.

### Root cause

Google's SDK requires the active OAuth iOS Client ID to have its reversed form registered as a `CFBundleURLScheme` in `Info.plist`. The plist only contained the **production** client ID's URL scheme:

| Env | iOS Client ID (from `.env.*`) | URL scheme registered? |
|---|---|---|
| development, adhoc | `806896865950-0fnpmkppokk0epailj6u83psrfot197s` | ❌ |
| staging, production | `200327501992-07u3boj39j65sltumv2lbd2jk5nr416q` | ✅ |

That's why prod was fine but dev/adhoc crashed the instant the validator ran.

### Fix

Add the dev/adhoc reversed client ID alongside the prod one in `ios/kiroku/Info.plist`. Multiple URL schemes coexist safely — only the one matching the active `iosClientId` is used at runtime.

### Bonus: per-environment GoogleService-Info plists

Currently `ios/GoogleService-Info.plist` is the **prod** Firebase project (`alcohol-tracker-db`), so all dev/adhoc Crashlytics events and Performance traces leak into the prod project. This PR drops the two correct plists into `ios/config/` as preparation:

- `GoogleService-Info.dev.plist` → `dev-alcohol-tracker-db` (used by dev + adhoc)
- `GoogleService-Info.prod.plist` → `alcohol-tracker-db` (used by staging + production)

**Note**: this PR does **not** yet wire them into the build — the existing `ios/GoogleService-Info.plist` is still what Xcode bundles. Follow-up work needed:

1. Remove `ios/GoogleService-Info.plist` from disk and from the Xcode target's "Copy Bundle Resources" build phase
2. Add a Run Script build phase (before "Copy Bundle Resources") that copies the right plist based on `${CONFIGURATION}`:
   ```bash
   case "${CONFIGURATION}" in
     *Development*|*AdHoc*) SRC="GoogleService-Info.dev.plist" ;;
     *Staging*|*Production*|*Release*) SRC="GoogleService-Info.prod.plist" ;;
     *) SRC="GoogleService-Info.prod.plist" ;;
   esac
   cp -v "${PROJECT_DIR}/config/${SRC}" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist"
   ```

## Test plan

- [ ] Run dev build on iOS simulator → tap **Sign up with Google** → Google sign-in sheet appears (no crash)
- [ ] Run dev build on iOS simulator → complete sign-in → user lands in app authenticated
- [ ] Run adhoc build on physical device → tap **Sign up with Google** → no crash
- [ ] Sanity check production build still works (URL scheme still present)
- [ ] Cancel mid-flow → app stays alive, returns to sign-in screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)