### PR TITLE
feat(ci): trigger testBuild on "Ready To Build" PR label

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -7,6 +7,8 @@ on:
       PULL_REQUEST_NUMBER:
         description: Pull Request number for correct placement of apps
         required: true
+  pull_request:
+    types: [labeled]
 
 permissions:
   id-token: write
@@ -15,6 +17,7 @@ permissions:
 
 jobs:
   getBranchRef:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
     runs-on: ubuntu-latest
     outputs:
       REF: ${{steps.getHeadRef.outputs.REF}}
@@ -35,6 +38,7 @@ jobs:
 
   android:
     name: Build and deploy Android for testing
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
     runs-on: ubuntu-latest
     needs: [getBranchRef]
     env:
@@ -102,6 +106,7 @@ jobs:
 
   iOS:
     name: Build and deploy iOS for testing
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
     needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
@@ -204,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Post a GitHub comment with app download links for testing
     needs: [getBranchRef, android, iOS]
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build') }}
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:


### PR DESCRIPTION
## Summary

- Add `pull_request: types: [labeled]` trigger to `testBuild.yml` so a build kicks off automatically when the existing **Ready To Build** label is applied to a PR.
- Gate every job with `if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build'` so unrelated labels don't fire builds.
- No new label needed — reusing the existing **Ready To Build** label (#0226DA), whose description already matches this purpose.

## Why

Until now, building a test app for an existing PR required manually dispatching the workflow and typing the PR number. Labeling is faster, leaves an audit trail on the PR, and lets reviewers request a fresh build by removing and re-adding the label.

## Notes for reviewers

- The existing fallbacks already handle `pull_request` events, so no plumbing changes were needed:
  - PR number → `github.event.number`
  - Branch checkout → `github.event.pull_request.head.sha`
- The `getBranchRef` job becomes a no-op on the label path (its steps were already gated on `workflow_dispatch`); it still completes successfully so the downstream `needs:` chain is satisfied.
- Workflow trigger changes only take effect once this PR is merged to `master`. After merge, adding "Ready To Build" to any PR (including this one) will fire a build.

## Test plan

- [ ] Merge to master, then add **Ready To Build** to a follow-up PR and confirm the workflow fires against the PR's head SHA and posts the download links comment.
- [ ] Add a different label (e.g. `design`) and confirm no build runs.
- [ ] Re-running via manual `workflow_dispatch` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)