### PR TITLE
fix(session): unblock InitialScreen button after sign-out

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -648,6 +648,10 @@ function setHasCheckedAutoLogin(val: boolean) {
   if (hasCheckedAutoLogin === val) {
     return;
   }
+  // Update the in-memory cache synchronously so subsequent calls in the same tick observe the new value
+  // before the Onyx.merge callback runs. Without this, a rapid false→true sequence on InitialScreen focus
+  // can collapse to false because the second call still sees the old cache and short-circuits.
+  hasCheckedAutoLogin = val;
   Onyx.merge(ONYXKEYS.HAS_CHECKED_AUTO_LOGIN, val);
 }
 


### PR DESCRIPTION
## Summary
- `setHasCheckedAutoLogin` guarded on an in-memory cache that was only updated asynchronously via `Onyx.connect`, so a rapid `false`→`true` sequence could collapse to `false`.
- After sign-out, `InitialScreen`'s focus effect calls `setHasCheckedAutoLogin(false)` and then the Firebase `onAuthStateChanged` listener fires `setHasCheckedAutoLogin(true)`. If the second call ran before Onyx propagated the first write back to the cache, the guard short-circuited and `HAS_CHECKED_AUTO_LOGIN` settled at `false` — leaving the "Create account" button on the initial screen stuck in its loading state and unclickable.
- Fix: update the cache synchronously inside the setter so the guard reflects in-flight writes.

## Root cause references
- [src/libs/actions/Session/index.ts:647](https://github.com/PetrCala/Kiroku/blob/master/src/libs/actions/Session/index.ts#L647) — `setHasCheckedAutoLogin` setter
- [src/screens/SignUp/InitialScreen.tsx:56](https://github.com/PetrCala/Kiroku/blob/master/src/screens/SignUp/InitialScreen.tsx#L56) — focus effect that drives the race
- [src/screens/SignUp/InitialScreen.tsx:112](https://github.com/PetrCala/Kiroku/blob/master/src/screens/SignUp/InitialScreen.tsx#L112) — button reads `isLoading={!hasCheckedAutoLogin}`

## Test plan (after the test build finishes)
- [ ] **Repro the original bug is gone (primary check)**
  1. Install the test build, log in with any account, land on Home.
  2. Open Settings → Sign Out (or trigger sign-out from anywhere it's exposed).
  3. You should be returned to the Initial / "Create account" screen.
  4. The **Create account** button should NOT be stuck in a spinning/loading state — it must be active and tappable within ~1 second of landing on the screen.
  5. Tapping it should navigate into the auth flow.
- [ ] **Cold-start regression check**
  1. Fully kill the app, then relaunch from a signed-out state.
  2. The Create account button should still briefly show its loading state (spinner) while the auth listener attaches, then become active. No regression in the initial render.
- [ ] **Auto-login regression check**
  1. Log in, kill the app, relaunch.
  2. App should auto-navigate to Home without ever stalling on InitialScreen.
- [ ] **Sign-out → sign-in loop**
  1. Sign out → sign in → sign out → sign in (a couple of cycles).
  2. Each return to InitialScreen should produce a tappable Create account button. Existing-account login link below it should also re-appear (it's gated on `hasCheckedAutoLogin` being true).
- [ ] **Google Sign-In path** (if accessible from this build)
  - Same sign-out flow but signed in via Google. Same expectation: button not stuck after sign-out.

If the button is still stuck after sign-out on any platform, capture a screen recording and the Onyx value of `HAS_CHECKED_AUTO_LOGIN` (via the dev tools if available) and reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)