### PR TITLE
ux(initial-screen): move account-deletion announcement below log-in link

### DIFF
--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -94,16 +94,6 @@ function InitialScreen() {
         welcomeText=""
         ref={currentScreenLayoutRef}
         navigateFocus={navigateFocus}>
-        {!!closeAccount?.success && (
-          <DotIndicatorMessage
-            style={[styles.mv2]}
-            type="success"
-            messages={{
-              // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
-              0: closeAccount?.success || '',
-            }}
-          />
-        )}
         <Button
           large
           success
@@ -124,6 +114,16 @@ function InitialScreen() {
               <Text style={[styles.link]}>{logInActionText}</Text>
             </PressableWithFeedback>
           </View>
+        )}
+        {!!closeAccount?.success && (
+          <DotIndicatorMessage
+            style={[styles.mv2]}
+            type="success"
+            messages={{
+              // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+              0: closeAccount?.success || '',
+            }}
+          />
         )}
       </SignUpScreenLayout>
       {/* Overlays SignUpScreenLayout's iOS narrow-layout background; alpha kept very low to avoid tinting text. */}


### PR DESCRIPTION
## Summary

- The success announcement (e.g. *"Your account has been successfully deleted"*) on `InitialScreen` was sitting between the hero heading and the **Create Account** button, visually breaking up the primary call-to-action flow.
- Moved it to below the **Log in here** link so it reads as a contextual footnote rather than an interruption.

## What changed

`src/screens/SignUp/InitialScreen.tsx` — the `DotIndicatorMessage` block was relocated from above `<Button>` to after the log-in `<View>`. No logic changes.

**New order:**
1. Hero heading
2. Create Account button
3. "Already have an account? Log in here" link
4. *(conditional)* Account-deletion success message

## Reviewer notes

- Only a render-order change — no logic, styling, or translation keys were modified.
- The message still clears correctly when the user navigates to sign-up or log-in (handled by `CloseAccount.setDefaultData()` in `navigateToAuth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)