### PR TITLE
feat(session): haptic feedback on ending a live session

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -22,6 +22,7 @@ import {convertUnitsToColors} from '@libs/DataHandling';
 import ScrollView from '@components/ScrollView';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import SuccessIndicator from '@components/SuccessIndicator';
+import HapticFeedback from '@libs/HapticFeedback';
 import Log from '@libs/Log';
 import DateUtils from '@libs/DateUtils';
 import {isEqual} from 'lodash';
@@ -75,6 +76,10 @@ function DrinkingSessionWindow({
       if (totalUnits <= 0) {
         // TODO inform the user why the they can not save their session - 0 units
         return;
+      }
+
+      if (sessionIsLive) {
+        HapticFeedback.success();
       }
 
       await App.setLoadingText(translate('liveSessionScreen.saving'));


### PR DESCRIPTION
## Summary
- Fire a success notification haptic when the user taps **Save** on a live (ongoing) drinking session, signalling that the session has been ended
- Gated behind the existing units-valid / signed-in guards in `saveSession`, so an invalid tap doesn't buzz
- Edit-session saves stay silent — only live → completed transitions trigger it

## Test plan
- [ ] Start a new live session, add at least one drink, tap **Save** → device emits the success haptic
- [ ] Open an existing (non-live) session, edit it, tap **Save** → no haptic
- [ ] Tap **Save** with zero units → no haptic (early return)
- [ ] Verify on both iOS and Android physical devices (simulator has no haptics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)