### PR TITLE
fix(onboarding): animate modal dismissal by always mounting the screen

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -31,7 +31,6 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {useFirebase} from '@context/global/FirebaseContext';
 import OnboardingGuard from '@libs/Navigation/guards/OnboardingGuard';
 import TermsReConsentGuard from '@libs/Navigation/guards/TermsReConsentGuard';
-import useOnboardingFlow from '@hooks/useOnboardingFlow';
 import createCustomStackNavigator from './createCustomStackNavigator';
 import getRootNavigatorScreenOptions from './getRootNavigatorScreenOptions';
 import BottomTabNavigator from './Navigators/BottomTabNavigator';
@@ -141,8 +140,6 @@ function AuthScreens() {
     styles,
     StyleUtils,
   );
-
-  const {shouldFireOnboarding} = useOnboardingFlow();
 
   const onboardingModalScreenOptions = useMemo(
     () =>
@@ -323,19 +320,17 @@ function AuthScreens() {
           options={screenOptions.fullScreen}
           component={DesktopSignInRedirectPage}
         /> */}
-        {shouldFireOnboarding && (
-          <RootStack.Screen
-            name={NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR}
-            options={onboardingModalScreenOptions}
-            component={OnboardingModalNavigator}
-            listeners={{
-              focus: () => {
-                Modal.setDisableDismissOnEscape(true);
-              },
-              beforeRemove: () => Modal.setDisableDismissOnEscape(false),
-            }}
-          />
-        )}
+        <RootStack.Screen
+          name={NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR}
+          options={onboardingModalScreenOptions}
+          component={OnboardingModalNavigator}
+          listeners={{
+            focus: () => {
+              Modal.setDisableDismissOnEscape(true);
+            },
+            beforeRemove: () => Modal.setDisableDismissOnEscape(false),
+          }}
+        />
         {/* {Object.entries(CENTRAL_PANE_SCREENS).map(
             ([screenName, componentGetter]) => {
               const centralPaneName = screenName as CentralPaneName;


### PR DESCRIPTION
### Details

Follow-up polish on top of the onboarding rebuild (#390): make the post-completion transition out of the onboarding modal animate properly instead of flashing Home before the navigation animation plays.

**Root cause.** [AuthScreens.tsx](https://github.com/PetrCala/Kiroku/blob/master/src/libs/Navigation/AppNavigator/AuthScreens.tsx) was conditionally mounting the `ONBOARDING_MODAL_NAVIGATOR` screen via `{shouldFireOnboarding && <RootStack.Screen ... />}`. The moment `completed_at` landed in Onyx, React removed the screen from the JSX tree synchronously — React Navigation never got a chance to play a close transition, so Home appeared instantly underneath and the subsequent `Navigation.navigate(ROUTES.HOME)` looked like an extraneous post-hoc shuffle.

**Fix.** Always mount the screen. Visibility is now driven entirely by navigation actions:
- `OnboardingGuard` navigates *into* the modal when `shouldFireOnboarding` flips true (unchanged).
- `navigateAfterOnboarding()` in `DisplayNameScreen` calls `Navigation.navigate(ROUTES.HOME)` to leave — this now drives a real stack transition.
- `OnboardingModalNavigator`'s existing `isOnboardingCompleted ? null` early return keeps the content collapsed once focus has moved to Home.

**Account-deletion T&C flash safety is preserved.** That fix (commit `37be66d9`) lives in `useOnboardingFlow`'s readiness gate, not in the AuthScreens conditional. With `userData === null`, `shouldFireOnboarding` still returns false, so `OnboardingGuard` won't navigate to the modal, and the always-mounted-but-unfocused screen stays invisible.

This is a single-file change (11 insertions, 16 deletions in `AuthScreens.tsx`).

### Tests

1. Sign up with a new email (or wipe a test account's `onboarding.completed_at` in Firebase).
2. Complete the onboarding flow (Terms → Display name).
3. Submit the display-name screen.
4. Verify the modal **slides out** smoothly to reveal Home, instead of Home flashing in first and a transition playing afterward.
5. Open the JS console — verify no `POP_TO_TOP was not handled by any navigator` warning and no other React Navigation warnings.
6. Existing account (already onboarded): verify the app still goes straight to Home with no flash of the modal.
7. T&C re-consent: bump `CURRENT_TERMS_VERSION` locally → verify only the re-consent guard fires, not the full onboarding flow.
8. Account deletion: from a signed-in account, tap "Close account" → verify no T&C screen flashes during the sign-out window.
9. `CONFIG.SKIP_ONBOARDING=true` → verify the flow is bypassed entirely.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Put the device in airplane mode after signing up but before completing onboarding.
2. Complete the Terms and Display-name screens.
3. Verify the modal dismisses with a transition and lands on Home (the `completed_at` write is queued by Firebase RTDB; the modal close is driven by the Onyx optimistic merge).
4. Re-enable connectivity → verify the queued Firebase write replays and `onboarding.completed_at` lands on the user record.

### QA Steps

1. On staging, complete onboarding from a fresh account on iOS narrow layout → verify the modal slides out and lands on Home with no flash.
2. Repeat on Android.
3. Repeat on a wider iPad / desktop layout → verify the modal dismissal still animates correctly.
4. Sign in to an existing onboarded account → verify the app goes directly to Home.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [x] I verified there are no console errors
- [x] I followed proper code patterns

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)