### PR TITLE
feat(session): disable Save button when session has no units

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -63,6 +63,8 @@ function DrinkingSessionWindow({
     return !isEqual(sessionRef.current, session);
   };
 
+  const isSaveDisabled = totalUnits <= 0;
+
   const saveSession = (database: Database, usr: User | null) => {
     (async () => {
       if (!session || !usr) {
@@ -72,8 +74,7 @@ function DrinkingSessionWindow({
         Log.warn('DrinkingSessionWindow - saveSession - Max units exceeded');
         return null;
       }
-      if (totalUnits <= 0) {
-        // TODO inform the user why the they can not save their session - 0 units
+      if (isSaveDisabled) {
         return;
       }
 
@@ -252,6 +253,7 @@ function DrinkingSessionWindow({
         <Button
           success
           large
+          isDisabled={isSaveDisabled}
           text={translate('liveSessionScreen.saveSession')}
           style={styles.buttonLargeSuccess}
           onPress={() => saveSession(db, user)}


### PR DESCRIPTION
### Details

The save handler already short-circuited when `totalUnits <= 0`, but the Save button remained visually active, giving the user no signal that pressing it would do nothing. This adds a derived `isSaveDisabled` flag and wires it into the Button's `isDisabled` prop so the UI reflects the same guard the press handler uses.

### Tests

1. Start a new drinking session and navigate to the session window before adding any drinks.
2. Verify the **Save Session** button renders in the disabled style.
3. Tap it and verify nothing happens (session is not saved, no navigation).
4. Add at least one drink so `totalUnits > 0` and verify the button becomes enabled again.
5. Tap **Save Session** and verify the session saves normally.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Repeat the test steps above while offline — the disabled-state behaviour should be identical (it is purely client-side and does not depend on network).

### QA Steps

1. On staging, open a live or edit session with zero units and confirm the Save button is visibly disabled and non-functional.
2. Add units and confirm Save becomes active and persists the session as before.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)