### PR TITLE
fix(boot): move DatabaseDataProvider back inside AuthScreens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {UserConnectionProvider} from '@context/global/UserConnectionContext';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {SplashScreenStateContextProvider} from '@context/global/SplashScreenStateContext';
 import {ConfigProvider} from '@context/global/ConfigContext';
-import {DatabaseDataProvider} from '@context/global/DatabaseDataContext';
 import InitialUrlContext from './libs/InitialUrlContext';
 import ColorSchemeWrapper from './components/ColorSchemeWrapper';
 import ActiveElementRoleProvider from './components/ActiveElementRoleProvider';
@@ -71,9 +70,7 @@ function App({url}: KirokuProps): React.JSX.Element {
             <CustomStatusBarAndBackground />
             <ErrorBoundary errorMessage="Kiroku crash caught by error boundary">
               <ColorSchemeWrapper>
-                <DatabaseDataProvider>
-                  <Kiroku />
-                </DatabaseDataProvider>
+                <Kiroku />
               </ColorSchemeWrapper>
             </ErrorBoundary>
           </ComposeProviders>

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -54,7 +54,7 @@ function Kiroku() {
   const appStateChangeListener = useRef<NativeEventSubscription | null>(null);
   const [isNavigationReady, setIsNavigationReady] = useState(false);
   const [isOnyxMigrated, setIsOnyxMigrated] = useState(false);
-  const {splashScreenState, setSplashScreenState} = useContext(
+  const {splashScreenState, setSplashScreenState, isAuthDataReady} = useContext(
     SplashScreenStateContext,
   );
   const [lastVisitedPath] = useOnyx(ONYXKEYS.LAST_VISITED_PATH);
@@ -121,15 +121,20 @@ function Kiroku() {
   // preference, producing a visible white flash.
   const isThemeReady = preferredThemeMetadata.status === 'loaded';
 
-  // DatabaseDataProvider lives inside AuthScreens, so we cannot wait for the
-  // user's RTDB record from up here — OnboardingGuard handles onboarding
-  // redirection downstream once the listener emits. HomeScreen and the
-  // onboarding screens render their own loading indicators while userData is
-  // still hydrating, so the brief flash is acceptable.
+  // For authenticated users, wait for the user's RTDB data (userData +
+  // preferences) to hydrate before hiding the splash, so the home screen
+  // can paint real content immediately and OnboardingGuard can redirect
+  // without flicker. The signal is set from inside AuthScreens (which
+  // lives below DatabaseDataProvider) via `setIsAuthDataReady`. For
+  // unauthenticated users this condition is bypassed — the public stack
+  // is ready as soon as nav + theme are ready.
+  const isAuthScreenReady = !isAuthenticated || isAuthDataReady;
+
   const shouldHideSplash = !!(
     shouldInit &&
     authenticationChecked &&
     isThemeReady &&
+    isAuthScreenReady &&
     splashScreenState === CONST.BOOT_SPLASH_STATE.VISIBLE
   );
 

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -9,7 +9,6 @@ import React, {
 import type {NativeEventSubscription} from 'react-native';
 import {AppState, Linking, Platform} from 'react-native';
 import Onyx, {useOnyx} from 'react-native-onyx';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import SplashScreenStateContext from '@context/global/SplashScreenStateContext';
@@ -66,7 +65,6 @@ function Kiroku() {
   const [preferredTheme, preferredThemeMetadata] = useOnyx(
     ONYXKEYS.PREFERRED_THEME,
   );
-  const {userData} = useDatabaseData();
   const {config} = useConfig();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authenticationChecked, setAuthenticationChecked] = useState(false);
@@ -123,19 +121,15 @@ function Kiroku() {
   // preference, producing a visible white flash.
   const isThemeReady = preferredThemeMetadata.status === 'loaded';
 
-  // Keep the splash up until we know whether the user needs onboarding so
-  // OnboardingGuard can route into the flow without a flicker. The signal is
-  // the user's RTDB record arriving in `useDatabaseData()`; `IS_LOADING_APP`
-  // is intentionally not consulted because `App.openApp()` (which would write
-  // that key) is not currently wired up — gating on it would deadlock the
-  // splash on every launch.
-  const isOnboardingDataReady = !isAuthenticated || userData !== undefined;
-
+  // DatabaseDataProvider lives inside AuthScreens, so we cannot wait for the
+  // user's RTDB record from up here — OnboardingGuard handles onboarding
+  // redirection downstream once the listener emits. HomeScreen and the
+  // onboarding screens render their own loading indicators while userData is
+  // still hydrating, so the brief flash is acceptable.
   const shouldHideSplash = !!(
     shouldInit &&
     authenticationChecked &&
     isThemeReady &&
-    isOnboardingDataReady &&
     splashScreenState === CONST.BOOT_SPLASH_STATE.VISIBLE
   );
 

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -1,12 +1,6 @@
 // DatabaseDataContext.tsx
 import type {ReactNode} from 'react';
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import Onyx from 'react-native-onyx';
 import type {
   DrinkingSessionList,
@@ -49,21 +43,8 @@ type DatabaseDataProviderProps = {
 
 function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const {auth} = useFirebase();
-
-  // Subscribe to auth state changes so the provider re-renders (and re-attaches
-  // listeners) when Firebase restores a persisted session, when the user signs
-  // in, or when they sign out. Reading `auth.currentUser` directly during
-  // render is not safe because the Firebase SDK mutates that property without
-  // notifying React; the provider would otherwise stay stuck with whatever
-  // value was current at mount time.
-  const [userID, setUserID] = useState<string>(
-    () => auth.currentUser?.uid ?? '',
-  );
-
-  useEffect(
-    () => auth.onAuthStateChanged(nextUser => setUserID(nextUser?.uid ?? '')),
-    [auth],
-  );
+  const user = auth.currentUser;
+  const userID = user ? user.uid : '';
 
   const dataTypes: FetchDataKeys = [
     'userStatusData',

--- a/src/context/global/SplashScreenStateContext.tsx
+++ b/src/context/global/SplashScreenStateContext.tsx
@@ -8,24 +8,38 @@ type SplashScreenStateContextType = {
   setSplashScreenState: React.Dispatch<
     React.SetStateAction<ValueOf<typeof CONST.BOOT_SPLASH_STATE>>
   >;
+  /**
+   * True once the authenticated subtree has hydrated the user's RTDB data
+   * (userData + preferences). Set from inside AuthScreens (which lives
+   * below DatabaseDataProvider) and consumed by Kiroku.tsx as one of the
+   * splash-hide preconditions for authenticated users. Has no meaning for
+   * the unauthenticated path — Kiroku gates on isAuthenticated separately.
+   */
+  isAuthDataReady: boolean;
+  setIsAuthDataReady: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const SplashScreenStateContext =
   React.createContext<SplashScreenStateContextType>({
     splashScreenState: CONST.BOOT_SPLASH_STATE.VISIBLE,
     setSplashScreenState: () => {},
+    isAuthDataReady: false,
+    setIsAuthDataReady: () => {},
   });
 
 function SplashScreenStateContextProvider({children}: ChildrenProps) {
   const [splashScreenState, setSplashScreenState] = useState<
     ValueOf<typeof CONST.BOOT_SPLASH_STATE>
   >(CONST.BOOT_SPLASH_STATE.VISIBLE);
+  const [isAuthDataReady, setIsAuthDataReady] = useState(false);
   const splashScreenStateContext = useMemo(
     () => ({
       splashScreenState,
       setSplashScreenState,
+      isAuthDataReady,
+      setIsAuthDataReady,
     }),
-    [splashScreenState],
+    [splashScreenState, isAuthDataReady],
   );
 
   return (

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -24,7 +24,11 @@ import ONYXKEYS from '@src/ONYXKEYS';
 // import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import getOnboardingModalScreenOptions from '@libs/Navigation/getOnboardingModalScreenOptions';
-import {DatabaseDataProvider} from '@context/global/DatabaseDataContext';
+import {
+  DatabaseDataProvider,
+  useDatabaseData,
+} from '@context/global/DatabaseDataContext';
+import {useSplashScreenStateContext} from '@context/global/SplashScreenStateContext';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {FirebaseApp, getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
@@ -144,6 +148,22 @@ function AuthScreensContent() {
   );
 
   const {shouldFireOnboarding} = useOnboardingFlow();
+
+  // Signal "auth data ready" to the boot splash gate in Kiroku.tsx. The
+  // splash hides only once these two fields have arrived from the live
+  // listener — matches HomeScreen's own render gate so the user sees the
+  // splash continuously until real content can paint.
+  const {userData, preferences} = useDatabaseData();
+  const {setIsAuthDataReady} = useSplashScreenStateContext();
+  useEffect(() => {
+    if (userData === undefined || preferences === undefined) {
+      return;
+    }
+    setIsAuthDataReady(true);
+  }, [userData, preferences, setIsAuthDataReady]);
+  // Reset on sign-out (AuthScreens unmounts) so a subsequent sign-in
+  // re-gates the splash on fresh data.
+  useEffect(() => () => setIsAuthDataReady(false), [setIsAuthDataReady]);
 
   const onboardingModalScreenOptions = useMemo(
     () =>

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -24,6 +24,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 // import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import getOnboardingModalScreenOptions from '@libs/Navigation/getOnboardingModalScreenOptions';
+import {DatabaseDataProvider} from '@context/global/DatabaseDataContext';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {FirebaseApp, getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
@@ -124,7 +125,7 @@ const modalScreenListeners = {
   },
 };
 
-function AuthScreens() {
+function AuthScreensContent() {
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
   const {auth} = useFirebase();
@@ -358,6 +359,16 @@ function AuthScreens() {
       <TermsReConsentGuard />
     </View>
     // </ComposeProviders>
+  );
+}
+
+AuthScreensContent.displayName = 'AuthScreensContent';
+
+function AuthScreens() {
+  return (
+    <DatabaseDataProvider>
+      <AuthScreensContent />
+    </DatabaseDataProvider>
   );
 }
 


### PR DESCRIPTION
### Details

On cold start with persisted Firebase auth, the app loads with no data: sessions are missing, preferences are not applied, and creating a new session has no effect. Sign-in flow works because the provider mounts after auth is set.

**Root cause.** The recent splash work in the onboarding rebuild hoisted `DatabaseDataProvider` above `<Kiroku />` (commit `d4c213f9`) so Kiroku could read `userData` for the splash gate. With the provider above auth, it mounts at boot when `auth.currentUser` is null, so `userID` collapses to `''`. `useListenToData` then attaches Firebase listeners on bogus root paths — [`fetchDataKeyToDbPath`](https://github.com/PetrCala/Kiroku/blob/master/src/hooks/useFetchData/utils.ts) uses `userID ?? '-1'`, which doesn't catch empty strings, producing paths like `users/`, `user_drinking_sessions/`, etc. The later `onAuthStateChanged → setUserID` re-attach is racy, and screens that read `USER_DATA_LIST` from Onyx never get populated because the live listener doesn't sync to Onyx.

**Fix.** Revert the hoist:

- `App.tsx`: drop the `<DatabaseDataProvider>` wrap.
- `Kiroku.tsx`: remove the `useDatabaseData()` call and the `isOnboardingDataReady` splash gate. Splash now hides on `shouldInit && authenticationChecked && isThemeReady`.
- `AuthScreens.tsx`: restore the inner/outer split — `AuthScreensContent` (consumer) wrapped by `AuthScreens` (provides `DatabaseDataProvider`). `useOnboardingFlow` / `OnboardingGuard` / `TermsReConsentGuard` continue to consume `useDatabaseData` from inside this subtree.
- `DatabaseDataContext.tsx`: simplify back to reading `auth.currentUser?.uid` once at render. The `useState` + `onAuthStateChanged` subscription added in `44fa29bb` was only needed because the hoisted provider had to react to async auth restoration; with the provider inside AuthScreens, auth is guaranteed present on mount.

**Tradeoff (accepted for now).** For new users on cold start, HomeScreen may briefly flash before `OnboardingGuard` redirects to onboarding. For existing users, HomeScreen already renders a `FullScreenLoadingIndicator` while `userData`/`preferences` are undefined, so they see a loading spinner — not a "no data" UI — during hydration. A flicker-free gate will be revisited later, modeled on Expensify's `onServerDataReady` pattern.

### Tests

1. Sign in with an account that has existing sessions. Force-quit the app, then cold-launch it.
2. Verify the home screen shows the user's existing sessions and preferences (theme, drinks-to-units, etc.).
3. Tap to create a new session, add a drink, save.
4. Verify the new session persists and is visible on the calendar.
5. Sign out from Settings.
6. Verify the user is returned to the public/sign-in screens with no stale data.
7. Sign up as a brand-new account.
8. Verify onboarding fires (Terms → Display name) — there may be a brief flash of the home screen before the redirect; this is expected and tracked for a follow-up.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Put the device in airplane mode.
2. Cold-launch the app while signed in.
3. Verify the app still renders cached UI (Onyx-backed) and that no crash/blank screen results from the listeners failing to connect.
4. Re-enable network and verify the listeners hydrate session/preferences/userData normally.

### QA Steps

1. On the staging build, sign in with an existing account.
2. Force-quit and cold-launch the app — confirm sessions, theme, and preferences load.
3. Create a new drinking session and save it — confirm it persists across a reload.
4. Sign out and confirm clean return to sign-in.
5. Sign up as a brand-new account on staging and confirm onboarding fires.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I ran the relevant unit tests locally (`useOnboardingFlow` — all 9 pass)
- [x] Typecheck (`npm run typecheck-tsgo`) clean on the changed files
- [x] ESLint clean on the changed files