### PR TITLE
fix(crash): forward JS errors to Crashlytics + guard interpolateColor worklet

### DIFF
--- a/src/components/CustomStatusBarAndBackground/index.tsx
+++ b/src/components/CustomStatusBarAndBackground/index.tsx
@@ -68,10 +68,19 @@ function CustomStatusBarAndBackground({
       if (previous === null || current === null || current <= previous) {
         return;
       }
+      // interpolateColor throws on the UI runtime if either color is undefined
+      // or an unparseable string. Bail out instead of letting the worklet
+      // crash the process — this is the suspected source of the cold-start
+      // SIGABRT inside AnimationFrameBatchinator::flush().
+      const prevColor = prevStatusBarBackgroundColor.get();
+      const currColor = statusBarBackgroundColor.get();
+      if (!prevColor || !currColor) {
+        return;
+      }
       const backgroundColor = interpolateColor(
         statusBarAnimation.get(),
         [0, 1],
-        [prevStatusBarBackgroundColor.get(), statusBarBackgroundColor.get()],
+        [prevColor, currColor],
       );
       runOnJS(updateStatusBarAppearance)({backgroundColor});
     },

--- a/src/setup/platformSetup/index.native.ts
+++ b/src/setup/platformSetup/index.native.ts
@@ -4,9 +4,52 @@ import CONFIG from '@src/CONFIG';
 
 /* eslint-disable rulesdir/prefer-early-return */
 
+// Forwards uncaught JS errors to Crashlytics' log buffer before the default
+// handler runs. Worklet/Reanimated errors surface here as fatal JSErrors that
+// otherwise crash the process with only a `facebook::jsi::JSError` type tag
+// in Crashlytics — no message, no stack. Logging into the buffer first means
+// the message + stack land in the Crashlytics "Logs" tab on the next crash.
+function installCrashlyticsJSErrorBridge() {
+  const errorUtils = (
+    global as unknown as {
+      ErrorUtils?: {
+        getGlobalHandler: () => (error: Error, isFatal?: boolean) => void;
+        setGlobalHandler: (
+          handler: (error: Error, isFatal?: boolean) => void,
+        ) => void;
+      };
+    }
+  ).ErrorUtils;
+  if (!errorUtils) {
+    return;
+  }
+  const previousHandler = errorUtils.getGlobalHandler();
+  errorUtils.setGlobalHandler((error, isFatal) => {
+    try {
+      const name = error?.name ?? 'Error';
+      const message = error?.message ?? String(error);
+      crashlytics().log(
+        `[JS ${isFatal ? 'FATAL' : 'soft'}] ${name}: ${message}`,
+      );
+      const stack = error?.stack;
+      if (stack) {
+        crashlytics().log(stack.split('\n').slice(0, 30).join('\n'));
+      }
+      if (error instanceof Error) {
+        crashlytics().recordError(error);
+      }
+    } catch {
+      // Never let the bridge itself throw — fall through to the default handler.
+    }
+    previousHandler?.(error, isFatal);
+  });
+}
+
 export default function () {
   if (!CONFIG.SEND_CRASH_REPORTS) {
     crashlytics().setCrashlyticsCollectionEnabled(false);
     perf().setPerformanceCollectionEnabled(false);
+    return;
   }
+  installCrashlyticsJSErrorBridge();
 }


### PR DESCRIPTION
## Summary

- Install a global `ErrorUtils` handler on native that writes the error name, message, and top 30 stack frames into Crashlytics's log buffer (and calls `recordError`) before chaining the previous handler.
- Guard `interpolateColor` inside `CustomStatusBarAndBackground`'s `useAnimatedReaction` worklet so it bails out when either shared-value color is falsy.

## Background

Cold-start crashes from build 0.3.11.22 onward have been showing up in Crashlytics as `Fatal Exception: facebook::jsi::JSError` inside `worklets::AnimationFrameBatchinator::flush()`, with **no message and no JS stack**. The earlier reanimated 4.3.1 / worklets-core 0.8.3 upgrade ([`58043028`](https://github.com/PetrCala/Kiroku/commit/58043028)) did not fully resolve it.

Symptom pattern (cold start with restored Onyx state):

1. App restores instead of showing splash + login flow (Onyx-by-design).
2. Sometimes: bootsplash stays stuck for a few seconds, then process aborts.
3. Crashlytics: bare `facebook::jsi::JSError`, no message.

The stack pins the crash to a worklet running inside `AnimationFrameBatchinator::flush()`. `CustomStatusBarAndBackground`'s `useAnimatedReaction` is the only worklet site in our code that runs on every animation frame at the app root, calls `interpolateColor` (which throws on undefined/unparseable colors), and uses shared values derived from `theme.splashBG` / `theme.appBG` / route params — which can be undefined or malformed mid-hydration.

## What this PR does

**Diagnostic** (the primary goal): the `ErrorUtils` bridge fans Reanimated/worklet errors out to Crashlytics's `log()` buffer + `recordError()` before the runtime tears down, so the next reproduction surfaces the actual JS error message in the issue's "Logs" tab. Only installs when `CONFIG.SEND_CRASH_REPORTS` is on, chains the previous handler, and swallows internal failures so the bridge can't make crashes worse.

**Mitigation** (the educated guess): the `interpolateColor` guard in `useAnimatedReaction` returns early if either color shared-value is falsy. If the culprit is genuinely a transient undefined color, this stops the worklet from terminating the runtime. If the culprit is something else, the bridge above will tell us what.

## Out of scope

We deliberately did **not** swap `runOnJS` → `scheduleOnRN` in this PR. Expensify uses `scheduleOnRN` (the modern API in worklets-core 0.8.x), and our earlier swap *away* from it ([`cb0c7e27`](https://github.com/PetrCala/Kiroku/commit/cb0c7e27)) was a workaround for the now-fixed 0.6.1 cloning bug — so realigning would be valid. Leaving it for a separate PR to reduce risk.

## Test plan

- [ ] CI: lint, typecheck, build all green.
- [ ] After merge, a new TestFlight build is cut.
- [ ] Reproduce the cold-start crash on a device with restored state (or wait for it to recur in the wild).
- [ ] Open Firebase Crashlytics → the `facebook::jsi::JSError` issue → **Logs** tab.
- [ ] Confirm a `[JS FATAL] <Name>: <message>` entry + stack appears at the bottom of the log buffer.
- [ ] If the guard catches the bad color, the crash should stop reproducing in that path — track frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)