### PR TITLE
fix(theme): scope debounce to useColorScheme to kill cold-boot white flash

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect, useMemo} from 'react';
-import useDebouncedState from '@hooks/useDebouncedState';
 import useThemePreferenceWithStaticOverride from '@hooks/useThemePreferenceWithStaticOverride';
 import DomUtils from '@libs/DomUtils';
 // eslint-disable-next-line no-restricted-imports
@@ -18,14 +17,8 @@ function ThemeProvider({
   const themePreference = useThemePreferenceWithStaticOverride(
     staticThemePreference,
   );
-  const [, debouncedTheme, setDebouncedTheme] =
-    useDebouncedState<ThemePreferenceWithoutSystem>(themePreference);
 
-  useEffect(() => {
-    setDebouncedTheme(themePreference);
-  }, [setDebouncedTheme, themePreference]);
-
-  const theme = useMemo(() => themes[debouncedTheme], [debouncedTheme]);
+  const theme = useMemo(() => themes[themePreference], [themePreference]);
 
   useEffect(() => {
     DomUtils.addCSS(

--- a/src/hooks/useThemePreference.ts
+++ b/src/hooks/useThemePreference.ts
@@ -1,20 +1,35 @@
-import {useContext, useMemo} from 'react';
+import {useContext, useEffect, useMemo} from 'react';
+import type {ColorSchemeName} from 'react-native';
 import {useColorScheme} from 'react-native';
 import {PreferredThemeContext} from '@components/OnyxProvider';
 import CONST from '@src/CONST';
+import useDebouncedState from './useDebouncedState';
 
 function useThemePreference() {
   const preferredThemeFromStorage = useContext(PreferredThemeContext);
   const systemTheme = useColorScheme();
+
+  // iOS briefly fires transient `useColorScheme()` changes during the
+  // app-switcher gesture (see Expensify#48299). Debounce only the system
+  // appearance so those spurious flips don't reach the rendered theme. The
+  // stored preference does not flicker and must remain un-debounced — adding
+  // latency there causes a visible light->dark flash on cold launch once
+  // Onyx hydrates.
+  const [, debouncedSystemTheme, setDebouncedSystemTheme] =
+    useDebouncedState<ColorSchemeName>(systemTheme);
+
+  useEffect(() => {
+    setDebouncedSystemTheme(systemTheme);
+  }, [setDebouncedSystemTheme, systemTheme]);
 
   const themePreference = useMemo(() => {
     const theme = preferredThemeFromStorage ?? CONST.THEME.DEFAULT;
 
     // If the user chooses to use the device theme settings, set the theme preference to the system theme
     return theme === CONST.THEME.SYSTEM
-      ? systemTheme ?? CONST.THEME.FALLBACK
+      ? debouncedSystemTheme ?? CONST.THEME.FALLBACK
       : theme;
-  }, [preferredThemeFromStorage, systemTheme]);
+  }, [preferredThemeFromStorage, debouncedSystemTheme]);
 
   return themePreference;
 }


### PR DESCRIPTION
## Summary
- Move the 300ms theme debounce from `ThemeProvider` down into `useThemePreference`, applying it only to `useColorScheme()` instead of the entire theme preference.
- Restore `ThemeProvider` to its pre-debounce shape (direct `themes[themePreference]` lookup).
- Stored Onyx `PREFERRED_THEME` now reaches the rendered theme synchronously, eliminating the ~300ms white flash on cold launch for users with `dark` stored.
- The Expensify app-switcher flicker fix ([Expensify#48642](https://github.com/Expensify/App/pull/48642)) is preserved: users on `system` theme still get debounced system-appearance changes, so the original iOS gesture-flicker bug does not regress.

## Why
The debounce was copied from Expensify, where it was added specifically to suppress transient `useColorScheme()` events during iOS app-switcher gestures with the keyboard open. Globally debouncing the rendered theme also delays the initial Onyx hydration by up to 300ms — and that delay is visible in Kiroku because [Kiroku.tsx](src/Kiroku.tsx) hides the bootsplash as soon as Onyx reports `PREFERRED_THEME` loaded, while `ThemeProvider`'s `debouncedTheme` is still seeded from the first render (default `'light'`). Result: visible light → dark flash on cold launch.

The flicker source is `useColorScheme()`, not the stored Onyx preference. Stored prefs are deterministic and only change on explicit user action; debouncing them serves no purpose. This PR narrows the debounce to its actual cause.

## Test plan
- [ ] **Cold launch (primary repro)** — log out, set theme to `dark`, force-quit, relaunch. Bootsplash → app appears already dark (no white frame).
- [ ] Cold launch with theme `light` — bootsplash → light app (no regression).
- [ ] Cold launch with theme `system` while OS is in dark mode — app appears dark immediately.
- [ ] Toggle theme in Settings between light/dark/system — applies instantly.
- [ ] **Expensify regression check** — set theme to `system`, open the app with keyboard visible (focus any text input), perform iOS app-switcher swipe gesture along the bottom edge: theme should NOT flash. (Tests the path the original Expensify debounce was protecting.)
- [ ] Repeat the cold-launch flow on Android.
- [ ] `npm run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)