### PR TITLE
fix(ios): size in-process bootsplash from screen, not unsized React root

### DIFF
--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -107,9 +107,27 @@ RCT_EXPORT_MODULE();
     _loadingView = [[storyboard instantiateInitialViewController] view];
     _loadingView.autoresizingMask =
         UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _loadingView.frame = _rootView.bounds;
-    _loadingView.center = (CGPoint){CGRectGetMidX(_rootView.bounds),
-                                    CGRectGetMidY(_rootView.bounds)};
+
+    // _rootView is RCTSurfaceHostingProxyRootView (New Arch). Its bounds are
+    // CGRectZero until React reports a measured surface size — which on cold
+    // launch happens only after the JS bundle is parsed and the first render
+    // commits. If we size the loadingView from _rootView.bounds at that
+    // moment, the view is added zero-sized; the autoresizing mask only
+    // inflates it later when _rootView finally gets a real size. Between OS
+    // LaunchScreen dismissal and that first React measure, the user sees the
+    // window's yellow backgroundColor *without the logo* — the "logo
+    // disappears then reappears" gap that's especially visible in dev mode
+    // (Metro fetch + parse extends the gap to several hundred ms).
+    //
+    // Fall back to UIScreen.mainScreen.bounds so the loadingView is
+    // screen-sized from frame zero. The autoresizing mask still keeps it
+    // matched to _rootView for any later size change.
+    CGRect initialFrame = !CGRectIsEmpty(_rootView.bounds)
+                              ? _rootView.bounds
+                              : [UIScreen mainScreen].bounds;
+    _loadingView.frame = initialFrame;
+    _loadingView.center = (CGPoint){CGRectGetMidX(initialFrame),
+                                    CGRectGetMidY(initialFrame)};
     _loadingView.hidden = NO;
 
     [_rootView addSubview:_loadingView];


### PR DESCRIPTION
### Details

A minimal alternative to #404. This PR contains **only the native iOS sizing fix** — none of the JS-side overlay changes (no PNG swap, no `isImageReady` gating). Opens it standalone so we can compare the two approaches on device and pick whichever produces a cleaner cold-launch.

**The bug.** On cold launch, the user can briefly see "the logo disappear then reappear" — a moment between the OS LaunchScreen dismissal and the first frame where the in-process `RCTBootSplash` subview is visible. During that gap, only the window's yellow `backgroundColor` shows; the logo is briefly missing.

**Cause.** `RCTBootSplash.initWithStoryboard` sized the storyboard view from `_rootView.bounds`:

```objc
_loadingView.frame = _rootView.bounds;
```

`_rootView` is `RCTSurfaceHostingProxyRootView` (New Arch). On cold launch its `bounds` stay `CGRectZero` until React reports a measured surface size — which only happens after the JS bundle is parsed and the first render commits. In dev mode the Metro fetch + parse pushes that out by hundreds of milliseconds. Meanwhile iOS dismisses the OS LaunchScreen on a fixed timeline, so the user sees the window's yellow background *without the logo* until React finally lays out and the autoresizing mask inflates the (still-zero-sized) `loadingView`.

**Fix.** Fall back to `UIScreen.mainScreen.bounds` when `_rootView.bounds` is empty, so the `loadingView` is screen-sized at `addSubview` time — the logo paints in the first frame the app window becomes visible. The existing `FlexibleWidth+FlexibleHeight` autoresizing mask continues to keep it matched to `_rootView` for any later size change.

The fallback is **conditional**, so the bounds-driven sizing is preserved on the warm-launch / non-zero path. Behavior in release builds should be unchanged for end users — the visible improvement is in dev where the timing of React's first measure is slower.

### Relationship to #404

[#404](https://github.com/PetrCala/Kiroku/pull/404) is a broader splash-flicker fix that also:
- Drops the SVG logo in `SplashScreenHider` and replaces it with the same PNG asset native uses (pixel-identical handoff at `hide()`).
- Gates `BootSplash.hide()` on the JS `<Image>` firing `onLoad` so the JS overlay is paint-ready before the native cover is removed.
- Includes this same `RCTBootSplash.mm` sizing change (commit `096543cd` on that branch).

This PR contains **only the native sizing piece**, no JS changes. It's the smallest possible change that addresses the cold-launch flicker via the OS-handoff path. If the JS pieces from #404 turn out not to be needed, we can land this one alone; if both are needed, this PR's commit is already part of #404 and there's no conflict.

**Either way, the two PRs are alternatives — not meant to land together.**

### Tests

1. Force-quit the app, then cold-launch it.
2. Watch the splash from the moment the OS LaunchScreen appears.
3. Verify the logo stays visible continuously from launch through the in-process splash (no "logo disappears then reappears" gap, especially in dev builds).
4. Repeat several times to catch any race-condition variability.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Airplane mode → cold launch.
2. Verify splash behavior is unchanged from prior release.

### QA Steps

1. On staging, force-quit and cold-launch.
2. Verify the cold-launch logo handoff is smooth.
3. Verify the rest of the boot sequence (data hydration, home screen first paint) is unchanged.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] Native Obj-C++ change; will require a fresh iOS build (`npm run ios`)
- [x] No JS changes — no lint / typecheck impact