### PR TITLE
style(theme): use Expensify Neue Bold for headline font

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -159,8 +159,8 @@ const baseCodeTagStyles = (theme: ThemeColors) =>
   }) satisfies ViewStyle & MixedStyleDeclaration;
 
 const headlineFont = {
-  ...FontUtils.fontFamily.platform.EXP_NEW_KANSAS_MEDIUM,
-  fontWeight: '500',
+  ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
+  fontWeight: '700',
 } satisfies TextStyle;
 
 // const modalNavigatorContainer = (isSmallScreenWidth: boolean) =>


### PR DESCRIPTION
## Summary
- Switches the shared `headlineFont` constant in [src/styles/index.ts:161](src/styles/index.ts#L161) from `EXP_NEW_KANSAS_MEDIUM` (weight 500) to `EXP_NEUE_BOLD` (weight 700).
- Affects `textHeadline`, `textHeadlineH1`, and `textHeadlineXXXLarge` — they now match `textHeadlineH2` and the rest of the app, which already use Expensify Neue.
- `textHero` and `loginHeroHeader` still use Kansas; the font file remains shipped.

## Why
`textHeadlineH1` was the odd one out — used for screen titles like the MM-DD date on the day overview screen and onboarding step headers, but rendered in Kansas while H2 and surrounding text used Neue. Unifying on Neue Bold gives consistent heading styling app-wide.

## Test plan
- [ ] Day overview screen: MM-DD date heading renders in Neue Bold
- [ ] Onboarding display-name screen: heading renders in Neue Bold
- [ ] T&C screen title renders in Neue Bold
- [ ] Success animation title renders in Neue Bold
- [ ] Login hero header still uses Kansas (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)