### PR TITLE
fix(scripts): point lintChanged at origin/master

### DIFF
--- a/scripts/lintChanged.sh
+++ b/scripts/lintChanged.sh
@@ -9,10 +9,10 @@ readonly TOP
 source "${TOP}/scripts/shellUtils.sh"
 
 # Fetch the commit history to include the merge-base commit
-info "Fetching origin/main"
-git fetch origin main --no-tags
+info "Fetching origin/master"
+git fetch origin master --no-tags
 
-MERGE_BASE_SHA_HASH="$(git merge-base origin/main HEAD)"
+MERGE_BASE_SHA_HASH="$(git merge-base origin/master HEAD)"
 readonly MERGE_BASE_SHA_HASH
 
 # Check if output is empty or malformed


### PR DESCRIPTION
## Summary
- `scripts/lintChanged.sh` was fetching and computing `git merge-base` against `origin/main`, but this repo's default branch is `master`. On a fresh clone the fetch fails (no such remote ref) and locally it silently uses whatever stale `origin/main` happens to exist — producing the wrong diff set.
- Swapped all three references (`info` log, `git fetch`, `git merge-base`) over to `origin/master`.

## Test plan
- [ ] `npm run lint-changed` runs cleanly on a branch with TS/TSX changes
- [ ] Script fetches `origin/master` instead of `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)