### PR TITLE
feat(onboarding): anchor Terms controls to bottom of screen

### DIFF
--- a/src/components/TermsScreenContent.tsx
+++ b/src/components/TermsScreenContent.tsx
@@ -7,6 +7,7 @@ import * as ErrorUtils from '@libs/ErrorUtils';
 import CONST from '@src/CONST';
 import Button from './Button';
 import CheckboxWithLabel from './CheckboxWithLabel';
+import SafeAreaConsumer from './SafeAreaConsumer';
 import ScrollView from './ScrollView';
 import Text from './Text';
 import TextLink from './TextLink';
@@ -108,15 +109,26 @@ function TermsScreenContent({
 
   if (fillContainer) {
     return (
-      <View style={[styles.flex1, styles.mt3, styles.mh5]}>
-        <ScrollView
-          style={[styles.flex1]}
-          contentContainerStyle={styles.mb4}
-          showsVerticalScrollIndicator={false}>
-          {textBlock}
-        </ScrollView>
-        <View>{controls}</View>
-      </View>
+      <SafeAreaConsumer>
+        {({safeAreaPaddingBottomStyle}) => (
+          <View style={[styles.flex1, styles.mt3, styles.mh5]}>
+            <ScrollView
+              style={[styles.flex1]}
+              contentContainerStyle={styles.mb4}
+              showsVerticalScrollIndicator={false}>
+              {textBlock}
+            </ScrollView>
+            <View
+              style={
+                safeAreaPaddingBottomStyle.paddingBottom
+                  ? safeAreaPaddingBottomStyle
+                  : styles.pb5
+              }>
+              {controls}
+            </View>
+          </View>
+        )}
+      </SafeAreaConsumer>
     );
   }
 

--- a/src/components/TermsScreenContent.tsx
+++ b/src/components/TermsScreenContent.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import type {StyleProp, TextStyle} from 'react-native';
-import {View} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as ErrorUtils from '@libs/ErrorUtils';
@@ -19,12 +19,19 @@ type TermsScreenContentProps = {
 
   /** Called when the user confirms acceptance. May be async. */
   onAccept: () => Promise<void> | void;
+
+  /**
+   * When true, the component grows to fill its parent and pushes the
+   * checkbox + Confirm button to the bottom. Default false (modal-friendly).
+   */
+  fillContainer?: boolean;
 };
 
 function TermsScreenContent({
   title,
   description,
   onAccept,
+  fillContainer = false,
 }: TermsScreenContentProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -61,20 +68,23 @@ function TermsScreenContent({
     })();
   }, [isChecked, onAccept, translate]);
 
-  return (
-    <View style={[styles.mt3, styles.mh5]}>
-      <View style={styles.mb4}>
-        <Text style={[styles.textHeadlineH1]}>{title}</Text>
-        <Text style={[styles.mv4, styles.textNormal]}>
-          {description ?? translate('agreeToTerms.description')}
-        </Text>
-        <TextLink style={linkStyles} href={CONST.TERMS_URL}>
-          {translate('common.termsOfService')}
-        </TextLink>
-        <TextLink style={linkStyles} href={CONST.PRIVACY_URL}>
-          {translate('common.privacyPolicy')}
-        </TextLink>
-      </View>
+  const textBlock = (
+    <>
+      <Text style={[styles.textHeadlineH1]}>{title}</Text>
+      <Text style={[styles.mv4, styles.textNormal]}>
+        {description ?? translate('agreeToTerms.description')}
+      </Text>
+      <TextLink style={linkStyles} href={CONST.TERMS_URL}>
+        {translate('common.termsOfService')}
+      </TextLink>
+      <TextLink style={linkStyles} href={CONST.PRIVACY_URL}>
+        {translate('common.privacyPolicy')}
+      </TextLink>
+    </>
+  );
+
+  const controls = (
+    <>
       <CheckboxWithLabel
         label={translate('agreeToTerms.iHaveRead')}
         accessibilityLabel={translate('agreeToTerms.iHaveRead')}
@@ -92,6 +102,27 @@ function TermsScreenContent({
         onPress={onConfirm}
         text={translate('common.confirm')}
       />
+    </>
+  );
+
+  if (fillContainer) {
+    return (
+      <View style={[styles.flex1, styles.mt3, styles.mh5]}>
+        <ScrollView
+          style={[styles.flex1]}
+          contentContainerStyle={styles.mb4}
+          showsVerticalScrollIndicator={false}>
+          {textBlock}
+        </ScrollView>
+        <View>{controls}</View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.mt3, styles.mh5]}>
+      <View style={styles.mb4}>{textBlock}</View>
+      {controls}
     </View>
   );
 }

--- a/src/components/TermsScreenContent.tsx
+++ b/src/components/TermsScreenContent.tsx
@@ -1,12 +1,13 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import type {StyleProp, TextStyle} from 'react-native';
-import {ScrollView, View} from 'react-native';
+import {View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import CONST from '@src/CONST';
 import Button from './Button';
 import CheckboxWithLabel from './CheckboxWithLabel';
+import ScrollView from './ScrollView';
 import Text from './Text';
 import TextLink from './TextLink';
 

--- a/src/screens/Onboarding/TermsScreen.tsx
+++ b/src/screens/Onboarding/TermsScreen.tsx
@@ -38,6 +38,7 @@ function TermsScreen({navigation}: TermsScreenProps) {
         title={translate('onboarding.terms.heading')}
         description={translate('onboarding.terms.description')}
         onAccept={handleAccept}
+        fillContainer
       />
     </OnboardingScreenLayout>
   );


### PR DESCRIPTION
### Details

Resolves https://github.com/PetrCala/Kiroku/issues/393.

On the onboarding Terms step (step 1 of 2), the "I have read" checkbox and the "Confirm" button hugged the top of the screen, right under the Terms / Privacy links, leaving the bottom half of the screen blank. The same `TermsScreenContent` component is reused by `TermsReConsentGuard` as a bottom-docked modal that must stay sized to its content — so we couldn't unconditionally restructure the layout.

This adds an opt-in `fillContainer` prop to `TermsScreenContent`:

- **`fillContainer={true}`** (onboarding): the outer view becomes `flex: 1`. The title + description + links sit at the top inside a `ScrollView` (so long copy / Czech / large dynamic type doesn't push the controls off-screen), and the checkbox + Confirm button get pushed to the bottom edge.
- **`fillContainer` omitted** (re-consent modal): default branch — original layout preserved exactly, modal still sizes to content.

`OnboardingScreenLayout` didn't need a change: `ScreenWrapper`'s inner container is already `flex: 1`, so giving the variant's outer view `flex: 1` is enough for it to consume the space below the header.

### Tests

1. Sign up a brand-new account → reach the onboarding Terms step.
2. Verify the title, description, and TOS / Privacy links sit at the top of the screen.
3. Verify the "I have read" checkbox + Confirm button are anchored at the bottom, above the safe-area inset.
4. Tap Confirm without checking the box → error appears under the checkbox; controls remain anchored.
5. Switch the device language to Czech (or any longer translation) and / or crank dynamic type to max → verify the text block scrolls inside its area instead of pushing the controls off-screen, and the controls stay pinned to the bottom.
6. Bump `CONST.CURRENT_TERMS_VERSION` locally, sign in as a previously-onboarded user → the re-consent modal appears with the **unchanged** layout (controls directly under the links, modal sized to content, same height as before this PR).
7. - [ ] Verify that no errors appear in the JS console

### Offline tests

1. Reach the onboarding Terms step online, then go offline.
2. Tap Confirm with the box checked → the request queues; layout doesn't shift or flicker.
3. Go back online → confirm the request replays and the flow advances to the Display Name step.

### QA Steps

1. Install the staging build on a small device (iPhone SE / small Android) and a large device (iPhone Pro Max / large Android).
2. Sign up a new account → on the Terms step, the Confirm button should sit at the bottom safe-area edge on both device sizes.
3. Repeat with the device language set to Czech and dynamic type maxed → text block scrolls, controls stay pinned.
4. Existing users on the current Terms version see no change at app launch.
5. After QA bumps `CURRENT_TERMS_VERSION` for testing, existing users see the re-consent modal with its previous layout intact.
6. - [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>