### PR TITLE
ux(initial-screen): anchor account-deletion notice to bottom

### DIFF
--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -134,6 +134,7 @@ function InitialScreen() {
             styles.r0,
             styles.b0,
             styles.ph5,
+            styles.alignItemsCenter,
             safeAreaPaddingBottomStyle.paddingBottom
               ? safeAreaPaddingBottomStyle
               : styles.pb5,

--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -38,6 +38,7 @@ function InitialScreen() {
   const [hasCheckedAutoLogin] = useOnyx(ONYXKEYS.HAS_CHECKED_AUTO_LOGIN);
   const {isInNarrowPaneModal} = useResponsiveLayout();
   const safeAreaInsets = useStyledSafeAreaInsets();
+  const {safeAreaPaddingBottomStyle} = safeAreaInsets;
   const currentScreenLayoutRef = useRef<InitialScreenLayoutRef>(null);
 
   const welcomeHeader = translate('login.hero.header');
@@ -117,16 +118,6 @@ function InitialScreen() {
             </PressableWithFeedback>
           </View>
         )}
-        {!!closeAccount?.success && (
-          <DotIndicatorMessage
-            style={[styles.mv2]}
-            type="success"
-            messages={{
-              // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
-              0: closeAccount?.success || '',
-            }}
-          />
-        )}
       </SignUpScreenLayout>
       {/* Overlays SignUpScreenLayout's iOS narrow-layout background; alpha kept very low to avoid tinting text. */}
       <LinearGradient
@@ -134,6 +125,28 @@ function InitialScreen() {
         style={StyleSheet.absoluteFillObject}
         pointerEvents="none"
       />
+      {!!closeAccount?.success && (
+        <View
+          pointerEvents="box-none"
+          style={[
+            styles.pAbsolute,
+            styles.l0,
+            styles.r0,
+            styles.b0,
+            styles.ph5,
+            safeAreaPaddingBottomStyle.paddingBottom
+              ? safeAreaPaddingBottomStyle
+              : styles.pb5,
+          ]}>
+          <DotIndicatorMessage
+            type="success"
+            messages={{
+              // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+              0: closeAccount?.success || '',
+            }}
+          />
+        </View>
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/SignUp/InitialScreen.tsx
+++ b/src/screens/SignUp/InitialScreen.tsx
@@ -134,13 +134,16 @@ function InitialScreen() {
             styles.r0,
             styles.b0,
             styles.ph5,
-            styles.alignItemsCenter,
+            styles.flexRow,
+            styles.justifyContentCenter,
             safeAreaPaddingBottomStyle.paddingBottom
               ? safeAreaPaddingBottomStyle
               : styles.pb5,
           ]}>
           <DotIndicatorMessage
             type="success"
+            style={styles.flexShrink1}
+            textStyles={styles.textAlignCenter}
             messages={{
               // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
               0: closeAccount?.success || '',


### PR DESCRIPTION
## Summary
- Move the account-closed success `DotIndicatorMessage` out of the centered children stack on the Initial screen.
- Render it as a sibling inside `ScreenWrapper`, absolutely positioned at the bottom with the safe-area inset (or `pb5` fallback) so it clears the home indicator.

## Test plan
- [ ] Trigger the account-closed flow and confirm the success notice now appears at the bottom of the Initial screen instead of beneath the "Log in here" link.
- [ ] Verify the notice clears the home indicator on iOS and is not overlapped by anything on Android.
- [ ] Verify the Create Account button and "Log in here" link remain visually centered when the notice is absent and when it is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)