### PR TITLE
fix(slider): guard NumericSlider props against Android Fabric SIGSEGV

### DIFF
--- a/src/components/Popups/NumericSlider.tsx
+++ b/src/components/Popups/NumericSlider.tsx
@@ -45,6 +45,13 @@ function NumericSlider({
     setLocalValue(newValue);
   };
 
+  const safeMaxValue = Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1;
+  const safeStep =
+    Number.isFinite(step) && step > 0 && step <= safeMaxValue ? step : 1;
+  const safeValue = Math.min(Math.max(localValue, 0), safeMaxValue);
+  const tintColor =
+    typeof theme.text === 'string' && theme.text ? theme.text : '#000000';
+
   return (
     <FullScreenModal visible={visible} onClose={onRequestClose} hideCloseButton>
       <View style={styles.fullScreenCenteredContent}>
@@ -54,14 +61,14 @@ function NumericSlider({
         </View>
         <View style={styles.m4}>
           <Slider
-            value={localValue}
+            value={safeValue}
             style={styles.numericSlider}
             minimumValue={0}
-            maximumValue={maxValue}
-            step={step}
-            minimumTrackTintColor={theme.text}
-            maximumTrackTintColor={theme.text}
-            thumbTintColor={theme.text}
+            maximumValue={safeMaxValue}
+            step={safeStep}
+            minimumTrackTintColor={tintColor}
+            maximumTrackTintColor={tintColor}
+            thumbTintColor={tintColor}
             onValueChange={handleSliderChange}
             tapToSeek
           />


### PR DESCRIPTION
## Summary
- Adds defensive guards in `src/components/Popups/NumericSlider.tsx` to mitigate the Android Fabric SIGSEGV in `libreact_codegen_RNCSlider.so` reported in #422.
- Clamps the rendered `value` to `[0, maxValue]`, validates `step` is positive and `<= maxValue`, and falls back to a concrete color string when `theme.text` is missing — covering the three crash classes flagged in the issue (null/invalid color props, out-of-range value, invalid step).
- No upgrade of `@react-native-community/slider` yet; the issue recommends trying these guards first and bumping the package only if the crash persists.

Closes #422 (pending confirmation from production crash reports).

## Test plan
- [ ] Settings → Preferences → Units To Colors: open each slider row, drag to both extremes, save — no crash on Android Fabric build.
- [ ] Settings → Preferences → Drinks To Units: same flow across each drink row.
- [ ] Verify slider still uses theme color on iOS and Android in both light and dark themes.
- [ ] Monitor Crashlytics for `44ca0e62d2dbe1125c9cfd5d9de51be9` after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)