### PR TITLE
ci(ios): stash dSYM as workflow artifact

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -205,6 +205,23 @@ jobs:
           VERSION: ${{ env.IOS_VERSION }}
           TESTFLIGHT_CHANGELOG: ${{ env.TESTFLIGHT_CHANGELOG }}
 
+      # Preserve the dSYM as a workflow artifact so we can symbolicate native
+      # crash reports later without trips to App Store Connect. Fastlane's
+      # build_app emits *.app.dSYM.zip next to the IPA in the workspace; the
+      # path glob also catches ios/ in case future changes move the output.
+      # Runs on always() so failures in upload_to_testflight still preserve
+      # the dSYM for debugging.
+      - name: Stash iOS dSYM as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-dsym-${{ inputs.APP_VERSION }}
+          path: |
+            ./*.app.dSYM.zip
+            ios/*.app.dSYM.zip
+          retention-days: 90
+          if-no-files-found: warn
+
       # - name: Upload iOS build to Browser Stack
       #   if: ${{ !inputs.SHOULD_DEPLOY_PRODUCTION }}
       #   run: curl -u "$BROWSERSTACK" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@/Users/runner/work/App/App/kiroku.ipa"


### PR DESCRIPTION
## Summary

Add an `actions/upload-artifact` step to the iOS deploy job so the dSYM zip produced by Fastlane is preserved as a workflow artifact, downloadable via `gh run download` for 90 days.

## Background

The iOS deploy lane (`fastlane/Fastfile`) produces a `*.app.dSYM.zip` next to the IPA on the macOS runner. Today it's shipped to two destinations only:

- App Store Connect (via `upload_to_testflight`)
- Firebase Crashlytics (via `upload_symbols_to_crashlytics`)

After the lane finishes, the runner is torn down and the dSYM is gone from CI. When we need to symbolicate a crash log locally (e.g. `atos` against a TestFlight `.ips`), the only remaining source is App Store Connect — which requires logging in, navigating to the build, and clicking Download. This was painful enough to come up during a live crash investigation today.

Stashing the dSYM as a workflow artifact means the next time we need it: `gh run download <run-id> -n ios-dsym-<version>`.

## Changes

Adds one step right after the existing **Run Fastlane** step in [.github/workflows/platformDeploy.yml](.github/workflows/platformDeploy.yml):

```yaml
- name: Stash iOS dSYM as workflow artifact
  if: always()
  uses: actions/upload-artifact@v4
  with:
    name: ios-dsym-${{ inputs.APP_VERSION }}
    path: |
      ./*.app.dSYM.zip
      ios/*.app.dSYM.zip
    retention-days: 90
    if-no-files-found: warn
```

Design choices:

- **`if: always()`** so that even if a later step in the Fastlane lane fails (most likely `upload_to_testflight`), we still preserve the dSYM — that's the scenario where we most need it for debugging.
- **Glob path** covers the workspace root (current Fastlane output location) and `ios/` (in case future config changes move it). `if-no-files-found: warn` keeps the workflow green if neither produces a file, instead of failing.
- **`retention-days: 90`** — long enough to cover most retroactive crash investigations without bloating storage. (Default is 90 anyway, explicit for clarity.)
- **Artifact name includes `APP_VERSION`** so multiple builds in the same workflow run wouldn't collide and so it's obvious which build a downloaded artifact corresponds to.

## Test plan

- [ ] CI: workflow YAML lint passes.
- [ ] After merge, the next staging deploy (`deploy.yml` → `platformDeploy.yml`) runs to completion.
- [ ] On the resulting GitHub Actions run page, verify the **Artifacts** section lists `ios-dsym-<version>`.
- [ ] Run `gh run download <run-id> -n ios-dsym-<version>` locally and confirm a `kiroku.app.dSYM.zip` (or similar) lands.
- [ ] Verify the dSYM's UUID matches the kiroku binary UUID from a TestFlight `.ips` for that build (`dwarfdump --uuid path/to/kiroku.app.dSYM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)