### PR TITLE
fix(crash): use scheduleOnRN in status-bar worklet to avoid AroundLock deadlock

### DIFF
--- a/src/components/CustomStatusBarAndBackground/index.tsx
+++ b/src/components/CustomStatusBarAndBackground/index.tsx
@@ -7,12 +7,12 @@ import React, {
 } from 'react';
 import {
   interpolateColor,
-  runOnJS,
   useAnimatedReaction,
   useSharedValue,
   withDelay,
   withTiming,
 } from 'react-native-reanimated';
+import {scheduleOnRN} from 'react-native-worklets';
 import usePrevious from '@hooks/usePrevious';
 import useTheme from '@hooks/useTheme';
 import {navigationRef} from '@libs/Navigation/Navigation';
@@ -82,7 +82,7 @@ function CustomStatusBarAndBackground({
         [0, 1],
         [prevColor, currColor],
       );
-      runOnJS(updateStatusBarAppearance)({backgroundColor});
+      scheduleOnRN(updateStatusBarAppearance, {backgroundColor});
     },
   );
 


### PR DESCRIPTION
## Summary

Replace `runOnJS` (from `react-native-reanimated`) with `scheduleOnRN` (from `react-native-worklets`) in `CustomStatusBarAndBackground`'s `useAnimatedReaction` worklet. One-line behavioral change, two-line import diff.

## Why

Build 0.3.11 (54) reproduces a cold-start watchdog kill (`0x8BADF00D`) on initial install — different signature from the prior `facebook::jsi::JSError` SIGABRT, same fault domain. The `.ips` from the affected device shows:

- **Main thread**: stuck in `std::recursive_mutex::lock()`, dispatched via `_dispatch_call_block_and_release`.
- **JS thread**: stuck in `std::mutex::lock()`, called from `hermes::Runtime::drainJobs` → `HermesRuntimeImpl::drainMicrotasks`.
- Both threads share a recursion key frame at `kiroku +8731964`. Total app CPU during the 25-second hang: **0.014 seconds**. Pure lock contention.

The kiroku-binary offsets in the deadlock (`+8651872`–`+8787244`) fall in the exact ~135 KB region that Crashlytics previously symbolicated in the build-22 `.crash` as:

- `jsi::WithRuntimeDecorator<worklets::AroundLock, …>::call`
- `worklets::WorkletRuntime::runSync<double&>`
- `worklets::AnimationFrameBatchinator::flush()`

So: same `AroundLock` synchronization machinery as the prior SIGABRT, now manifesting as a deadlock rather than a throw. The earlier `interpolateColor` guard closed the throw path, exposing the deadlock underneath.

## Why this specific fix

`runOnJS` from `react-native-reanimated` is the **back-compat alias** that routes through `AroundLock` and is the documented re-entrancy hazard:

> `/** @deprecated Use \`scheduleOnRN\` instead. */`
> — [node_modules/react-native-worklets/lib/typescript/threads.native.d.ts:109](https://github.com/software-mansion/react-native-worklets)

`scheduleOnRN` from `react-native-worklets` is the post-deprecation API designed specifically to avoid re-entrant lock acquisition when scheduling work back to the JS runtime from inside a worklet that's already inside the lock.

The earlier swap *away* from `scheduleOnRN` ([`cb0c7e27`](https://github.com/PetrCala/Kiroku/commit/cb0c7e27)) was a workaround for a `worklets-core` **0.6.1** cloning bug. That bug is fixed in **0.8.x**, and we're on **0.8.3** (since [`58043028`](https://github.com/PetrCala/Kiroku/commit/58043028)) — the reason to avoid `scheduleOnRN` no longer applies.

[Expensify ships the same component](https://github.com/Expensify/App/blob/main/src/components/CustomStatusBarAndBackground/index.tsx) (we forked it) on the same `react-native-reanimated@4.x` / `react-native-worklets@0.8.x` versions using `scheduleOnRN(updateStatusBarAppearance, {backgroundColor})` and does not report this issue.

## The change

```diff
 import {
   interpolateColor,
-  runOnJS,
   useAnimatedReaction,
   useSharedValue,
   withDelay,
   withTiming,
 } from 'react-native-reanimated';
+import {scheduleOnRN} from 'react-native-worklets';

 …

-      runOnJS(updateStatusBarAppearance)({backgroundColor});
+      scheduleOnRN(updateStatusBarAppearance, {backgroundColor});
```

API mapping: `runOnJS(fn)(arg)` → `scheduleOnRN(fn, arg)`. Both schedule a JS-thread invocation of `fn(arg)`; `scheduleOnRN` is variadic and doesn't curry.

## Risk and reversibility

- Single-file, two-line behavioral change. Easy to revert.
- We deferred this swap previously precisely because it was a behavioral change in a load-bearing path. The risk profile has flipped now that the app is **unusable on initial install** — staying on `runOnJS` is now the higher-risk path.
- If the fix doesn't help, the next `.ips` will tell us within minutes whether it eliminated this particular deadlock signature.

## Test plan

- [ ] CI: lint, typecheck, build green.
- [ ] After merge, a new staging build (0.3.11 (56+)) cuts to TestFlight.
- [ ] **Cold-start initial-install repro**: uninstall Kiroku from the test device, install the new build from TestFlight, open it. Should reach login/onboarding without a frozen splash.
- [ ] Repeat the cold start 5+ times across multiple installs.
- [ ] Watch Firebase Crashlytics for any new occurrence of the SIGKILL/0x8BADF00D signature against the new build version.
- [ ] If a different crash signature appears instead, capture the `.ips` and follow up — but the previous-signature should not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)