### PR TITLE
ci(testBuild): platform-specific Ready To Build labels

### DIFF
--- a/.github/actions/javascript/postTestBuildComment/index.js
+++ b/.github/actions/javascript/postTestBuildComment/index.js
@@ -33743,20 +33743,32 @@ const core = __importStar(__nccwpck_require__(2481));
 const github_1 = __nccwpck_require__(707);
 const CONST_1 = __importDefault(__nccwpck_require__(4780));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(4615));
+function renderLinkCell(result, link) {
+    if (result === 'success') {
+        return link;
+    }
+    if (result === 'skipped') {
+        return '⏭️ Not built';
+    }
+    return '❌ FAILED ❌';
+}
+function renderQRCell(result, link, platformLabel) {
+    if (result === 'success') {
+        return `![${platformLabel}](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${link})`;
+    }
+    if (result === 'skipped') {
+        return '—';
+    }
+    return `The QR code can't be generated, because the ${platformLabel} build failed`;
+}
 function getTestBuildMessage() {
     console.log('Input for android', core.getInput('ANDROID', { required: true }));
-    const androidSuccess = core.getInput('ANDROID', { required: true }) === 'success';
-    const iOSSuccess = core.getInput('IOS', { required: true }) === 'success';
-    const androidLink = androidSuccess
-        ? core.getInput('ANDROID_LINK')
-        : '❌ FAILED ❌';
-    const iOSLink = iOSSuccess ? core.getInput('IOS_LINK') : '❌ FAILED ❌';
-    const androidQRCode = androidSuccess
-        ? `![Android](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${androidLink})`
-        : "The QR code can't be generated, because the android build failed";
-    const iOSQRCode = iOSSuccess
-        ? `![iOS](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${iOSLink})`
-        : "The QR code can't be generated, because the iOS build failed";
+    const androidResult = core.getInput('ANDROID', { required: true });
+    const iOSResult = core.getInput('IOS', { required: true });
+    const androidLink = renderLinkCell(androidResult, core.getInput('ANDROID_LINK'));
+    const iOSLink = renderLinkCell(iOSResult, core.getInput('IOS_LINK'));
+    const androidQRCode = renderQRCell(androidResult, core.getInput('ANDROID_LINK'), 'android');
+    const iOSQRCode = renderQRCell(iOSResult, core.getInput('IOS_LINK'), 'iOS');
     const message = `:test_tube::test_tube: Use the links below to test this adhoc build on Android and iOS. Happy testing! :test_tube::test_tube:
 | Android :robot:  | iOS :apple: |
 | ------------- | ------------- |

--- a/.github/actions/javascript/postTestBuildComment/postTestBuildComment.ts
+++ b/.github/actions/javascript/postTestBuildComment/postTestBuildComment.ts
@@ -3,23 +3,47 @@ import {context} from '@actions/github';
 import CONST from '@github/libs/CONST';
 import GithubUtils from '@github/libs/GithubUtils';
 
+function renderLinkCell(result: string, link: string): string {
+  if (result === 'success') {
+    return link;
+  }
+  if (result === 'skipped') {
+    return '⏭️ Not built';
+  }
+  return '❌ FAILED ❌';
+}
+
+function renderQRCell(
+  result: string,
+  link: string,
+  platformLabel: string,
+): string {
+  if (result === 'success') {
+    return `![${platformLabel}](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${link})`;
+  }
+  if (result === 'skipped') {
+    return '—';
+  }
+  return `The QR code can't be generated, because the ${platformLabel} build failed`;
+}
+
 function getTestBuildMessage(): string {
   console.log('Input for android', core.getInput('ANDROID', {required: true}));
-  const androidSuccess =
-    core.getInput('ANDROID', {required: true}) === 'success';
-  const iOSSuccess = core.getInput('IOS', {required: true}) === 'success';
+  const androidResult = core.getInput('ANDROID', {required: true});
+  const iOSResult = core.getInput('IOS', {required: true});
 
-  const androidLink = androidSuccess
-    ? core.getInput('ANDROID_LINK')
-    : '❌ FAILED ❌';
-  const iOSLink = iOSSuccess ? core.getInput('IOS_LINK') : '❌ FAILED ❌';
+  const androidLink = renderLinkCell(
+    androidResult,
+    core.getInput('ANDROID_LINK'),
+  );
+  const iOSLink = renderLinkCell(iOSResult, core.getInput('IOS_LINK'));
 
-  const androidQRCode = androidSuccess
-    ? `![Android](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${androidLink})`
-    : "The QR code can't be generated, because the android build failed";
-  const iOSQRCode = iOSSuccess
-    ? `![iOS](https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${iOSLink})`
-    : "The QR code can't be generated, because the iOS build failed";
+  const androidQRCode = renderQRCell(
+    androidResult,
+    core.getInput('ANDROID_LINK'),
+    'android',
+  );
+  const iOSQRCode = renderQRCell(iOSResult, core.getInput('IOS_LINK'), 'iOS');
 
   const message = `:test_tube::test_tube: Use the links below to test this adhoc build on Android and iOS. Happy testing! :test_tube::test_tube:
 | Android :robot:  | iOS :apple: |

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   getBranchRef:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(fromJson('["Ready To Build", "Ready To Build - iOS", "Ready To Build - Android"]'), github.event.label.name) }}
     runs-on: ubuntu-latest
     outputs:
       REF: ${{steps.getHeadRef.outputs.REF}}
@@ -38,7 +38,7 @@ jobs:
 
   android:
     name: Build and deploy Android for testing
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(fromJson('["Ready To Build", "Ready To Build - Android"]'), github.event.label.name) }}
     runs-on: ubuntu-latest
     needs: [getBranchRef]
     env:
@@ -106,7 +106,7 @@ jobs:
 
   iOS:
     name: Build and deploy iOS for testing
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(fromJson('["Ready To Build", "Ready To Build - iOS"]'), github.event.label.name) }}
     needs: [getBranchRef]
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Post a GitHub comment with app download links for testing
     needs: [getBranchRef, android, iOS]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event.label.name == 'Ready To Build') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || contains(fromJson('["Ready To Build", "Ready To Build - iOS", "Ready To Build - Android"]'), github.event.label.name)) }}
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:


### PR DESCRIPTION
### Details

Adds platform-specific variants of the `Ready To Build` label so a single platform can be built without spending CI minutes on the other. The base `Ready To Build` label is unchanged.

| Label | Effect |
|---|---|
| `Ready To Build` | Build iOS + Android (unchanged) |
| `Ready To Build - iOS` | Build iOS only; Android skipped |
| `Ready To Build - Android` | Build Android only; iOS skipped |
| `Ready To Build - Web` | No-op for now (no web job exists) |

The four `if:` gates in [.github/workflows/testBuild.yml](.github/workflows/testBuild.yml) now match against an allowlist instead of an exact label name:
- `getBranchRef` and `postGithubComment` run for any of the three iOS/Android/base labels (so the comment job still posts on single-platform builds).
- `android` runs for `Ready To Build` or `Ready To Build - Android`.
- `iOS` runs for `Ready To Build` or `Ready To Build - iOS`.

`Ready To Build - Web` is intentionally **not** in the workflow gates yet — without a web job, including it would only spin the workflow up to skip both platforms. When a web build job is added, extend the `getBranchRef` and `postGithubComment` gates and add a web-only job.

[postTestBuildComment.ts](.github/actions/javascript/postTestBuildComment/postTestBuildComment.ts) now distinguishes three job results — `success`, `skipped`, and failure. Skipped platforms render `⏭️ Not built` in the link cell and `—` in the QR cell, rather than `❌ FAILED ❌` (which would be misleading when the platform was intentionally not built). `index.js` was rebuilt with `npm run gh-actions-build -- postTestBuildComment`.

### Follow-up (manual)

Three labels need to be created in the repo before the new gates do anything:

```bash
gh label create "Ready To Build - iOS"     --color 0226DA --description "Trigger an iOS-only ad-hoc test build"
gh label create "Ready To Build - Android" --color 0226DA --description "Trigger an Android-only ad-hoc test build"
gh label create "Ready To Build - Web"     --color 0226DA --description "Trigger a web-only test build (no-op until a web build job is added)"
```

Color matches the existing `Ready To Build` label (`#0226DA`).

### Tests

1. Apply `Ready To Build - iOS` to a draft PR → only the iOS job runs; the comment shows the iOS link and `⏭️ Not built` for Android.
2. Apply `Ready To Build - Android` to a draft PR → mirrored: only Android job runs; iOS column shows `⏭️ Not built`.
3. Apply the existing `Ready To Build` label → both jobs run, comment shows both links (unchanged behavior).
4. Apply `Ready To Build - Web` → workflow does not start (label is not in any job's gate).
5. `workflow_dispatch` trigger continues to run both platforms.

### Offline tests

N/A — CI-only change.

### QA Steps

N/A — CI-only change. Validate on the steps above using a throwaway PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)