### PR TITLE
fix(preferences): make full rows tappable on drinks→units and units→colors

### DIFF
--- a/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
+++ b/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
@@ -125,41 +125,44 @@ function DrinksToUnitsScreen() {
       },
     ];
 
-    return drinksHelperData.map((detail, index) => (
-      <MenuItem
-        // eslint-disable-next-line react/no-array-index-key
-        key={`${detail.title}_${index}`}
-        title={detail.title}
-        titleStyle={styles.plainSectionTitle}
-        wrapperStyle={styles.sectionMenuItemTopDescription}
-        disabled
-        shouldGreyOutWhenDisabled={false}
-        shouldUseRowFlexDirection
-        shouldShowRightIcon={false}
-        shouldShowRightComponent
-        rightComponent={
-          <Button
-            text={detail.currentValue.toString()}
-            style={styles.settingValueButton}
-            onPress={() => {
-              setSliderConfig(prev => ({
-                ...prev,
-                visible: true,
-                heading: detail.title ?? '',
-                value: detail.currentValue ?? 0,
-                key: detail.key ?? '',
-                onSave: (value: number) => {
-                  setCurrentValues(prevVal => ({
-                    ...prevVal,
-                    [detail.key]: value,
-                  }));
-                },
-              }));
-            }}
-          />
-        }
-      />
-    ));
+    return drinksHelperData.map((detail, index) => {
+      const openSlider = () => {
+        setSliderConfig(prev => ({
+          ...prev,
+          visible: true,
+          heading: detail.title ?? '',
+          value: detail.currentValue ?? 0,
+          key: detail.key ?? '',
+          onSave: (value: number) => {
+            setCurrentValues(prevVal => ({
+              ...prevVal,
+              [detail.key]: value,
+            }));
+          },
+        }));
+      };
+
+      return (
+        <MenuItem
+          // eslint-disable-next-line react/no-array-index-key
+          key={`${detail.title}_${index}`}
+          title={detail.title}
+          titleStyle={styles.plainSectionTitle}
+          wrapperStyle={styles.sectionMenuItemTopDescription}
+          shouldUseRowFlexDirection
+          shouldShowRightIcon={false}
+          shouldShowRightComponent
+          onPress={openSlider}
+          rightComponent={
+            <Button
+              text={detail.currentValue.toString()}
+              style={styles.settingValueButton}
+              onPress={openSlider}
+            />
+          }
+        />
+      );
+    });
   }, [
     currentValues.beer,
     currentValues.cocktail,

--- a/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
+++ b/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
@@ -100,41 +100,44 @@ function UnitsToColorsScreen() {
       },
     ];
 
-    return unitsHelperData.map((detail, index) => (
-      <MenuItem
-        // eslint-disable-next-line react/no-array-index-key
-        key={`${detail.title}_${index}`}
-        title={detail.title}
-        titleStyle={styles.plainSectionTitle}
-        wrapperStyle={styles.sectionMenuItemTopDescription}
-        disabled
-        shouldGreyOutWhenDisabled={false}
-        shouldUseRowFlexDirection
-        shouldShowRightIcon={false}
-        shouldShowRightComponent
-        rightComponent={
-          <Button
-            text={detail.currentValue.toString()}
-            style={styles.settingValueButton}
-            onPress={() => {
-              setSliderConfig(prev => ({
-                ...prev,
-                visible: true,
-                heading: detail.title ?? '',
-                value: detail.currentValue ?? 0,
-                key: detail.key ?? '',
-                onSave: (value: number) => {
-                  setCurrentValues(prevVal => ({
-                    ...prevVal,
-                    [detail.key]: value,
-                  }));
-                },
-              }));
-            }}
-          />
-        }
-      />
-    ));
+    return unitsHelperData.map((detail, index) => {
+      const openSlider = () => {
+        setSliderConfig(prev => ({
+          ...prev,
+          visible: true,
+          heading: detail.title ?? '',
+          value: detail.currentValue ?? 0,
+          key: detail.key ?? '',
+          onSave: (value: number) => {
+            setCurrentValues(prevVal => ({
+              ...prevVal,
+              [detail.key]: value,
+            }));
+          },
+        }));
+      };
+
+      return (
+        <MenuItem
+          // eslint-disable-next-line react/no-array-index-key
+          key={`${detail.title}_${index}`}
+          title={detail.title}
+          titleStyle={styles.plainSectionTitle}
+          wrapperStyle={styles.sectionMenuItemTopDescription}
+          shouldUseRowFlexDirection
+          shouldShowRightIcon={false}
+          shouldShowRightComponent
+          onPress={openSlider}
+          rightComponent={
+            <Button
+              text={detail.currentValue.toString()}
+              style={styles.settingValueButton}
+              onPress={openSlider}
+            />
+          }
+        />
+      );
+    });
   }, [
     currentValues.orange,
     currentValues.yellow,


### PR DESCRIPTION
## Summary
- Tapping anywhere on a row in the **Drinks → Units** and **Units → Colors** preference screens now opens the value slider.
- Previously only the small value Button on the right edge was clickable, which felt clunky.

## Changes
- `src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx`: removed `disabled` / `shouldGreyOutWhenDisabled` on the `MenuItem`, extracted an `openSlider` helper, and wired it to both `MenuItem.onPress` and the right-side `Button.onPress`.
- `src/screens/Settings/Preferences/UnitsToColorsScreen.tsx`: same change applied symmetrically.

## Test plan
- [ ] Open Settings → Preferences → **Drinks to units**, tap each row (not just the value button) and confirm the slider opens with the correct heading and current value.
- [ ] Edit a value, save, and confirm it persists.
- [ ] Repeat for Settings → Preferences → **Units to colors**.
- [ ] Confirm the right-side value Button still works on its own.
- [ ] Confirm unsaved-changes leave-confirmation still triggers when navigating back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)