### PR TITLE
fix(apple-signin): pass raw nonce to library which hashes internally (sign-in + account-deletion reauth)

### DIFF
--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		019BCBAE783DCC5846936DD88AB03C7C /* KirokuApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09510CCA296BCC25E8A2E7147E6746C0 /* KirokuApp.swift */; };
 		035C31412C1E2603431E7F1593EA2AF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21DD778E0182447ABC5084CA24728F34 /* Assets.xcassets */; };
 		1471B0984BB001ADC50E41AF3823C6AB /* Kiroku Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = FCC932AE708BEAD1D1F250D3CC3196F3 /* Kiroku Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		14F66261AC811B8511CB719A /* Pods_kiroku.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E25D11DFB16515309A043FB1 /* Pods_kiroku.framework */; };
 		193F7A25C49440E7ED264BE3769398DD /* ExpensifyNewKansas-MediumItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 948CE50BEBF728B21C429B720A5CF721 /* ExpensifyNewKansas-MediumItalic.otf */; };
 		1F91B5D9007998E199916D67139B5ED4 /* MainScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E902042D42637C89104374A81DCFA1D7 /* MainScreenView.swift */; };
 		2277E0348F15E2F05F9D299348664B51 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED2CAA158622481E69D1D7775C83089 /* AppDelegate.swift */; };
@@ -23,13 +22,13 @@
 		3078B470B1214DFD1DB6E9FAD333C00E /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F132D48386C9465215324CB11F83E1 /* ExpoModulesProvider.swift */; };
 		35346397021C5BB6272FEF86A02996A7 /* UnitSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732611B2ED16C157779228EEB137A4DD /* UnitSelectionView.swift */; };
 		36623FEF1D5A221A557F73AD647500ED /* ExpensifyMono-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 93A69287161165BB233810A4C9B5A2B1 /* ExpensifyMono-Bold.otf */; };
+		3ECB6456528593DA203A62E188E56513 /* Pods_kiroku_kirokuTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 014651CD44E7A06F5B009885706DF5E1 /* Pods_kiroku_kirokuTests.framework */; };
 		413CBD8FE514996619387E2F9C8595F8 /* Kiroku_Watch_AppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713C1A165F6C545FF4D8DBF61DB26122 /* Kiroku_Watch_AppUITestsLaunchTests.swift */; };
 		43B45031E9C37461A97616988D3E4910 /* SessionControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446D800DA47EC05519C25EBD2C4C1B15 /* SessionControlView.swift */; };
 		5D73DDAAC692EAB1B6F59E686222DD3A /* ExpensifyNeue-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 601DDAA52DC96A11298F6162BBD4AC76 /* ExpensifyNeue-BoldItalic.otf */; };
 		5E4ACD6C1EE6FBC1E05D75AE525E2969 /* EnglishTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757F0F7521F134C57D1F63028986A15B /* EnglishTexts.swift */; };
 		5E6F0D5CF1BB03DF159E4C2B88BAD48D /* BootSplash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93B257D6B0C1E19861DCDBEDB8A5D721 /* BootSplash.storyboard */; };
 		5F2594213B6739843D542E9AD460E687 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6C89C296C5EE51CAEA9F599877E10F /* ContentView.swift */; };
-		6655F586A7FFAD7793EDD93F /* Pods_kiroku_kirokuTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F173C83CAFA1F0297033336 /* Pods_kiroku_kirokuTests.framework */; };
 		698A9148B06F94922C213C8C768EDC59 /* Kiroku_Watch_AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E4662CD4C73E9774EEA208AAE068D /* Kiroku_Watch_AppUITests.swift */; };
 		6E05CC7FD00177EE114BE7541BE9EF1A /* UnitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF1DA67722E0F45DD9EAC0BBC5B5960 /* UnitModel.swift */; };
 		6F3319D785115B5E3BBC9021CD9C847E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C5E1ACFE4690F6678D0F721A527DB2 /* Extensions.swift */; };
@@ -45,6 +44,7 @@
 		A2831D15E1FC7975C5D17616AA4B5B50 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7215CAB6FE7E391659BEFCCEB6A930 /* ImageAssets.swift */; };
 		ACBE498C432C3C34E13F86BE6E6E3D2E /* ExpensifyNeue-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1777A343F31D8EAE6EB90ABA5CC06332 /* ExpensifyNeue-Bold.otf */; };
 		C1EBD956700E09BF2140DEC98EFAF04F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2807A7F093875785C9B9FD52DF99D726 /* PrivacyInfo.xcprivacy */; };
+		CD82A7D58DF57491E66EF28B14FE910A /* Pods_kiroku.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51753892CBE6CE9B5DAB68645B64E2DA /* Pods_kiroku.framework */; };
 		D4EB4C4B472CFB5C1C447FC0D70B6A6E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D17B18F000F10331F3702AFEF2670158 /* PrivacyInfo.xcprivacy */; };
 		D71B38A9F2A8830AA7E03D95986CE51A /* ExpensifyNeue-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = A39E3F7FF983A2F51A9E09DB690AF791 /* ExpensifyNeue-Italic.otf */; };
 		D82DC1221CC00D823D0DE5A65FAD639C /* SessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D208995320DA55DFBD5707B1041726 /* SessionModel.swift */; };
@@ -101,74 +101,74 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		032DB00A30E23E49F905F193 /* Pods-kiroku.releasedevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releasedevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releasedevelopment.xcconfig"; sourceTree = "<group>"; };
+		0023E2B3C39E731E83A026B01F285CBA /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugproduction.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugproduction.xcconfig"; sourceTree = "<group>"; };
+		014651CD44E7A06F5B009885706DF5E1 /* Pods_kiroku_kirokuTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_kiroku_kirokuTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E1B9495EAFDC6B2FE4739336121A2C /* FirebaseConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseConfig.swift; sourceTree = "<group>"; };
+		079861F232F305189FCFB5CFCE752BF0 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releasedevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releasedevelopment.xcconfig"; sourceTree = "<group>"; };
 		09510CCA296BCC25E8A2E7147E6746C0 /* KirokuApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KirokuApp.swift; sourceTree = "<group>"; };
 		16F132D48386C9465215324CB11F83E1 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-kiroku-kirokuTests/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		1777A343F31D8EAE6EB90ABA5CC06332 /* ExpensifyNeue-Bold.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNeue-Bold.otf"; sourceTree = "<group>"; };
-		1A9BD83879B356DB1D8E5AB4 /* Pods-kiroku.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.release.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.release.xcconfig"; sourceTree = "<group>"; };
+		1B073BCE83604D59197935453ACCE810 /* Pods-kiroku-kirokuTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.release.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.release.xcconfig"; sourceTree = "<group>"; };
 		1B6C89C296C5EE51CAEA9F599877E10F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		1F173C83CAFA1F0297033336 /* Pods_kiroku_kirokuTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_kiroku_kirokuTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BC997089BCD05EFEEF7618697295B92 /* Pods-kiroku.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debug.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debug.xcconfig"; sourceTree = "<group>"; };
 		21DD778E0182447ABC5084CA24728F34 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		23D208995320DA55DFBD5707B1041726 /* SessionModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionModel.swift; sourceTree = "<group>"; };
 		23F8FAF4E5F3844745702042BF927A6B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = kiroku/Images.xcassets; sourceTree = "<group>"; };
 		2807A7F093875785C9B9FD52DF99D726 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = kiroku/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		2F116734F0500561731E173B /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releaseproduction.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releaseproduction.xcconfig"; sourceTree = "<group>"; };
+		30BFAEB5CDC561A8FC2261889B95287B /* Pods-kiroku.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.release.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.release.xcconfig"; sourceTree = "<group>"; };
+		3410A60AD738729E61AC1A5D8B207FE1 /* KirokuContainer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KirokuContainer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		36534A287E6B0F7321F76D2E4AE78B47 /* CzechTexts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CzechTexts.swift; sourceTree = "<group>"; };
 		3FC14E075100224A5C18F4B89B5FDAA8 /* RCTBootSplash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTBootSplash.h; path = kiroku/RCTBootSplash.h; sourceTree = "<group>"; };
-		41345EE1B0CA657C345B1197 /* Pods-kiroku.debugproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugproduction.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugproduction.xcconfig"; sourceTree = "<group>"; };
+		41C49860CF9CB115A5F250852F8975C8 /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releaseproduction.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releaseproduction.xcconfig"; sourceTree = "<group>"; };
+		41DA18E074548C9167CB8366E1E84FFA /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releaseadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releaseadhoc.xcconfig"; sourceTree = "<group>"; };
 		446D800DA47EC05519C25EBD2C4C1B15 /* SessionControlView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionControlView.swift; sourceTree = "<group>"; };
 		47B2D168AA0BF104AA56C9784517733C /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-kiroku/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		49139152A47AFDA44AD894FFDC4658D1 /* Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = "Kiroku Watch App/Utilities/Colors.swift"; sourceTree = SOURCE_ROOT; };
 		4FB608088F2E6A985BD942B01309E2CA /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
+		51753892CBE6CE9B5DAB68645B64E2DA /* Pods_kiroku.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_kiroku.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		579905A8BB8DCE18E94D427DC261E8D3 /* Kiroku Watch AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Kiroku Watch AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		588A590E6BED68E1F6FD0254E55C2F6C /* kirokuTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = kirokuTests.m; sourceTree = "<group>"; };
 		5AFE612BFBD88D03D71A637ED725B1C6 /* Kiroku_Watch_AppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kiroku_Watch_AppTests.swift; sourceTree = "<group>"; };
 		601DDAA52DC96A11298F6162BBD4AC76 /* ExpensifyNeue-BoldItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNeue-BoldItalic.otf"; sourceTree = "<group>"; };
+		626F52CEF3B2C5855C78BEB531BBC705 /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugadhoc.xcconfig"; sourceTree = "<group>"; };
 		672DB160CC5BB29428AC67E4E2129203 /* InitialView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialView.swift; sourceTree = "<group>"; };
 		67409ABB382975A15E2A13689AEBBF4A /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		685FF1D72D7A49104164E4BB3E1EE42F /* kirokuTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = kirokuTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6EAE7A9758B14AE6B12B6866 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugdevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugdevelopment.xcconfig"; sourceTree = "<group>"; };
 		6FC3B8C4CA38E90FD39FE96759DCF07F /* ExpensifyNewKansas-Medium.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNewKansas-Medium.otf"; sourceTree = "<group>"; };
 		713C1A165F6C545FF4D8DBF61DB26122 /* Kiroku_Watch_AppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kiroku_Watch_AppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		732611B2ED16C157779228EEB137A4DD /* UnitSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitSelectionView.swift; sourceTree = "<group>"; };
 		757F0F7521F134C57D1F63028986A15B /* EnglishTexts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnglishTexts.swift; sourceTree = "<group>"; };
 		7EAD3F577988585FEAA5C1D243A285CA /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7F0F9082C37DDC79066DFE0B03E80EE2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = kiroku/Info.plist; sourceTree = "<group>"; };
-		82C8227B2B3759DD680D978A /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releaseadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releaseadhoc.xcconfig"; sourceTree = "<group>"; };
+		808A43D92E51BAE16514C24C06578B57 /* Pods-kiroku.releaseadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releaseadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releaseadhoc.xcconfig"; sourceTree = "<group>"; };
 		8557B5A4E0FB12B8FE79BD843EED5B9B /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		8690BB807EE45F07700764C9F93DB4B1 /* Pods-kiroku.debugadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugadhoc.xcconfig"; sourceTree = "<group>"; };
 		8CF1DA67722E0F45DD9EAC0BBC5B5960 /* UnitModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitModel.swift; sourceTree = "<group>"; };
+		937610E9D0162A83E7A4284BBBD373C1 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugdevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugdevelopment.xcconfig"; sourceTree = "<group>"; };
 		93A69287161165BB233810A4C9B5A2B1 /* ExpensifyMono-Bold.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyMono-Bold.otf"; sourceTree = "<group>"; };
 		93B257D6B0C1E19861DCDBEDB8A5D721 /* BootSplash.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = BootSplash.storyboard; path = kiroku/BootSplash.storyboard; sourceTree = "<group>"; };
+		940E29BAAD0E2B39450F8DEA08D977DC /* Pods-kiroku-kirokuTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debug.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debug.xcconfig"; sourceTree = "<group>"; };
 		948CE50BEBF728B21C429B720A5CF721 /* ExpensifyNewKansas-MediumItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNewKansas-MediumItalic.otf"; sourceTree = "<group>"; };
 		94C048D5A45F93365BFB5AB6705DA84E /* StartSessionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSessionContent.swift; sourceTree = "<group>"; };
-		97AEE108FA6E954EFA2B50BB /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugadhoc.xcconfig"; sourceTree = "<group>"; };
+		9A13E951A4D63CD9FF3A57BD6E46773A /* Pods-kiroku.releasedevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releasedevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releasedevelopment.xcconfig"; sourceTree = "<group>"; };
 		9CB1138976433A90E404C5076D2F5DEC /* Kiroku-Watch-App-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Kiroku-Watch-App-Info.plist"; sourceTree = "<group>"; };
 		9D2F7B1458F4F39F476FE5D6C1F84D9D /* Translate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Translate.swift; sourceTree = "<group>"; };
 		A19095879D0F5A5F11311FBA6371E13F /* kiroku.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = kiroku.entitlements; path = kiroku/kiroku.entitlements; sourceTree = "<group>"; };
-		A2EBC8C2C3DAAB7065780169 /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debugproduction.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debugproduction.xcconfig"; sourceTree = "<group>"; };
 		A39E3F7FF983A2F51A9E09DB690AF791 /* ExpensifyNeue-Italic.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNeue-Italic.otf"; sourceTree = "<group>"; };
 		A5C5E1ACFE4690F6678D0F721A527DB2 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		AE54E40A8CDEAA1129568159 /* Pods-kiroku-kirokuTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debug.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debug.xcconfig"; sourceTree = "<group>"; };
-		B8E99795ABC9AFEF9FD9927A /* Pods-kiroku-kirokuTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.release.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.release.xcconfig"; sourceTree = "<group>"; };
 		BA6939CB91B9F4FF63C2946A0B76CF49 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BB25A7D871D3CF6578C3E000FCCE4D70 /* kiroku.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kiroku.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		BC57D7BDBD22330433BB32D58C66F350 /* KirokuContainer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KirokuContainer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD563DF2BC10EA495DB4C8CA94903344 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = kiroku/AppDelegate.h; sourceTree = "<group>"; };
 		BDE37520D28FFB693C07E6CD4B8C554D /* Kiroku Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Kiroku Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BFBAFFCE82AB72E6066806A6 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.releasedevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.releasedevelopment.xcconfig"; sourceTree = "<group>"; };
-		C45E5550581A6D12A1522D67 /* Pods-kiroku.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debug.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debug.xcconfig"; sourceTree = "<group>"; };
+		C8125522733C8CDA669574E9CD0877F9 /* Pods-kiroku.debugproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugproduction.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugproduction.xcconfig"; sourceTree = "<group>"; };
+		CBBEBF345C4A83E4EE008676C6C2ABF4 /* Pods-kiroku.releaseproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releaseproduction.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releaseproduction.xcconfig"; sourceTree = "<group>"; };
 		D17B18F000F10331F3702AFEF2670158 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../kiroku/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		D3E86EB61F1B20B8B6E08966 /* Pods-kiroku.debugadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugadhoc.xcconfig"; sourceTree = "<group>"; };
 		DA84EB4D89EE659667E5AE7A7E79CEDE /* SessionTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTabView.swift; sourceTree = "<group>"; };
+		DC58989E75FA42CFB52CFA57DD74CD6A /* Pods-kiroku.debugdevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugdevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugdevelopment.xcconfig"; sourceTree = "<group>"; };
 		DE7215CAB6FE7E391659BEFCCEB6A930 /* ImageAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		E1B02FACB14F5B45F97FCC201FB3AF24 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
-		E25D11DFB16515309A043FB1 /* Pods_kiroku.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_kiroku.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E902042D42637C89104374A81DCFA1D7 /* MainScreenView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainScreenView.swift; sourceTree = "<group>"; };
 		EED2CAA158622481E69D1D7775C83089 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		F29851E4B5EDB30B2E8D86B2 /* Pods-kiroku.releaseadhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releaseadhoc.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releaseadhoc.xcconfig"; sourceTree = "<group>"; };
-		F5B78BC07AC721240A9312B6 /* Pods-kiroku.debugdevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.debugdevelopment.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.debugdevelopment.xcconfig"; sourceTree = "<group>"; };
-		F64A62323D211C084F80CF3B /* Pods-kiroku.releaseproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku.releaseproduction.xcconfig"; path = "Target Support Files/Pods-kiroku/Pods-kiroku.releaseproduction.xcconfig"; sourceTree = "<group>"; };
 		F90E4662CD4C73E9774EEA208AAE068D /* Kiroku_Watch_AppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kiroku_Watch_AppUITests.swift; sourceTree = "<group>"; };
 		FC94F72FE31465CA8BCABD916FE6A2C6 /* RCTBootSplash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RCTBootSplash.mm; path = kiroku/RCTBootSplash.mm; sourceTree = "<group>"; };
 		FCBF9C1AD1D6D46631D118FD0EFF49A8 /* ExpensifyNeue-Regular.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNeue-Regular.otf"; sourceTree = "<group>"; };
@@ -195,7 +195,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14F66261AC811B8511CB719A /* Pods_kiroku.framework in Frameworks */,
+				CD82A7D58DF57491E66EF28B14FE910A /* Pods_kiroku.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -203,7 +203,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6655F586A7FFAD7793EDD93F /* Pods_kiroku_kirokuTests.framework in Frameworks */,
+				3ECB6456528593DA203A62E188E56513 /* Pods_kiroku_kirokuTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -229,22 +229,22 @@
 		1CDAA5A670455A257CD71C8A83C8BB60 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				C45E5550581A6D12A1522D67 /* Pods-kiroku.debug.xcconfig */,
-				D3E86EB61F1B20B8B6E08966 /* Pods-kiroku.debugadhoc.xcconfig */,
-				41345EE1B0CA657C345B1197 /* Pods-kiroku.debugproduction.xcconfig */,
-				F5B78BC07AC721240A9312B6 /* Pods-kiroku.debugdevelopment.xcconfig */,
-				1A9BD83879B356DB1D8E5AB4 /* Pods-kiroku.release.xcconfig */,
-				F29851E4B5EDB30B2E8D86B2 /* Pods-kiroku.releaseadhoc.xcconfig */,
-				032DB00A30E23E49F905F193 /* Pods-kiroku.releasedevelopment.xcconfig */,
-				F64A62323D211C084F80CF3B /* Pods-kiroku.releaseproduction.xcconfig */,
-				AE54E40A8CDEAA1129568159 /* Pods-kiroku-kirokuTests.debug.xcconfig */,
-				97AEE108FA6E954EFA2B50BB /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */,
-				A2EBC8C2C3DAAB7065780169 /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */,
-				6EAE7A9758B14AE6B12B6866 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */,
-				B8E99795ABC9AFEF9FD9927A /* Pods-kiroku-kirokuTests.release.xcconfig */,
-				82C8227B2B3759DD680D978A /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */,
-				BFBAFFCE82AB72E6066806A6 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */,
-				2F116734F0500561731E173B /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */,
+				940E29BAAD0E2B39450F8DEA08D977DC /* Pods-kiroku-kirokuTests.debug.xcconfig */,
+				626F52CEF3B2C5855C78BEB531BBC705 /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */,
+				937610E9D0162A83E7A4284BBBD373C1 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */,
+				0023E2B3C39E731E83A026B01F285CBA /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */,
+				1B073BCE83604D59197935453ACCE810 /* Pods-kiroku-kirokuTests.release.xcconfig */,
+				41DA18E074548C9167CB8366E1E84FFA /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */,
+				079861F232F305189FCFB5CFCE752BF0 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */,
+				41C49860CF9CB115A5F250852F8975C8 /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */,
+				1BC997089BCD05EFEEF7618697295B92 /* Pods-kiroku.debug.xcconfig */,
+				8690BB807EE45F07700764C9F93DB4B1 /* Pods-kiroku.debugadhoc.xcconfig */,
+				DC58989E75FA42CFB52CFA57DD74CD6A /* Pods-kiroku.debugdevelopment.xcconfig */,
+				C8125522733C8CDA669574E9CD0877F9 /* Pods-kiroku.debugproduction.xcconfig */,
+				30BFAEB5CDC561A8FC2261889B95287B /* Pods-kiroku.release.xcconfig */,
+				808A43D92E51BAE16514C24C06578B57 /* Pods-kiroku.releaseadhoc.xcconfig */,
+				9A13E951A4D63CD9FF3A57BD6E46773A /* Pods-kiroku.releasedevelopment.xcconfig */,
+				CBBEBF345C4A83E4EE008676C6C2ABF4 /* Pods-kiroku.releaseproduction.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -357,8 +357,8 @@
 			isa = PBXGroup;
 			children = (
 				8557B5A4E0FB12B8FE79BD843EED5B9B /* JavaScriptCore.framework */,
-				E25D11DFB16515309A043FB1 /* Pods_kiroku.framework */,
-				1F173C83CAFA1F0297033336 /* Pods_kiroku_kirokuTests.framework */,
+				51753892CBE6CE9B5DAB68645B64E2DA /* Pods_kiroku.framework */,
+				014651CD44E7A06F5B009885706DF5E1 /* Pods_kiroku_kirokuTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -409,7 +409,7 @@
 				FCC932AE708BEAD1D1F250D3CC3196F3 /* Kiroku Watch App.app */,
 				BDE37520D28FFB693C07E6CD4B8C554D /* Kiroku Watch AppTests.xctest */,
 				579905A8BB8DCE18E94D427DC261E8D3 /* Kiroku Watch AppUITests.xctest */,
-				BC57D7BDBD22330433BB32D58C66F350 /* KirokuContainer.app */,
+				3410A60AD738729E61AC1A5D8B207FE1 /* KirokuContainer.app */,
 				BB25A7D871D3CF6578C3E000FCCE4D70 /* kiroku.app */,
 				685FF1D72D7A49104164E4BB3E1EE42F /* kirokuTests.xctest */,
 			);
@@ -523,24 +523,24 @@
 			);
 			name = Kiroku;
 			productName = Kiroku;
-			productReference = BC57D7BDBD22330433BB32D58C66F350 /* KirokuContainer.app */;
+			productReference = 3410A60AD738729E61AC1A5D8B207FE1 /* KirokuContainer.app */;
 			productType = "com.apple.product-type.application.watchapp2-container";
 		};
 		A0F368BFB24FC009055767B843B48D83 /* kiroku */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6E44B8D3A96B9B8AAD373500F3DFBCC4 /* Build configuration list for PBXNativeTarget "kiroku" */;
 			buildPhases = (
-				1B986CB77A1C07A334AB73A0 /* [CP] Check Pods Manifest.lock */,
+				6BA8C02FF83F16AA97A53C6D1458DA30 /* [CP] Check Pods Manifest.lock */,
 				E12D80FAA2C7D4948EADD995232AC9C4 /* [Expo] Configure project */,
 				13FFCC6A33C3E3066CB0EF683CE05097 /* Sources */,
 				96EE1767D138A900D6E3A4421BAD14EF /* Frameworks */,
 				B9F8269ED055C5C64E7601A97DC265CB /* Resources */,
-				7C3F1E8B9D0A4B6E5F128A4D /* [User] Copy GoogleService-Info.plist */,
+				A93D5E4D4B3C14C35A07B0AB64D8AFE8 /* [User] Copy GoogleService-Info.plist */,
 				F3EDCA035BBAB0CF568F51A01F8CD5C4 /* Bundle React Native code and images */,
-				BD5358141F0CEAD6A6A5BB5B /* [CP] Embed Pods Frameworks */,
-				F31C6CF24AB82CE22E91127D /* [CP] Copy Pods Resources */,
-				1C438E0659B468B525E64364 /* [CP-User] [RNFB] Core Configuration */,
-				29B63FFD08D005402B92A060 /* [CP-User] [RNFB] Crashlytics Configuration */,
+				C8797D152CA0AE0A452321A15956A667 /* [CP] Embed Pods Frameworks */,
+				D5E72D27AC939E72A1D8B21BBBFF4B2F /* [CP] Copy Pods Resources */,
+				434780F6C23C23F11C55F216EF3F5161 /* [CP-User] [RNFB] Core Configuration */,
+				B3F66D10A8D53734A2A99DB51A9ABC94 /* [CP-User] [RNFB] Crashlytics Configuration */,
 			);
 			buildRules = (
 			);
@@ -555,13 +555,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 15336BC6CCD5CA0D6CBF0EB63D1E57DC /* Build configuration list for PBXNativeTarget "kirokuTests" */;
 			buildPhases = (
-				79508D10BE94B8C9D7EB64C3 /* [CP] Check Pods Manifest.lock */,
+				C0957DA537DAEC4EBA9961FD330E7891 /* [CP] Check Pods Manifest.lock */,
 				0F44606D2E0BC75B30BC4A3CB6BA1D64 /* [Expo] Configure project */,
 				A93E8CBD17A498532401C194C407014E /* Sources */,
 				AEDCC1176977E7061AB3AD52F9543639 /* Frameworks */,
 				C5520CF6175E407F067C128F87A14820 /* Resources */,
-				206D66B4C4A70E1DBB7D83D1 /* [CP] Embed Pods Frameworks */,
-				B0B7A40649805A07F8366ECA /* [CP] Copy Pods Resources */,
+				8BB43835598DD3FB89031BA763F884FB /* [CP] Embed Pods Frameworks */,
+				AF7CC9EDC1CCE41D37A63E2574E9A0E6 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -712,7 +712,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-kiroku-kirokuTests/expo-configure-project.sh\"\n";
 		};
-		1B986CB77A1C07A334AB73A0 /* [CP] Check Pods Manifest.lock */ = {
+		6BA8C02FF83F16AA97A53C6D1458DA30 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -734,7 +734,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1C438E0659B468B525E64364 /* [CP-User] [RNFB] Core Configuration */ = {
+		434780F6C23C23F11C55F216EF3F5161 /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -747,7 +747,7 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n##########################################################################\n##########################################################################\n#\n#  NOTE THAT IF YOU CHANGE THIS FILE YOU MUST RUN pod install AFTERWARDS\n#\n#  This file is installed as an Xcode build script in the project file\n#  by cocoapods, and you will not see your changes until you pod install\n#\n##########################################################################\n##########################################################################\n\nset -e\n\n_MAX_LOOKUPS=2;\n_SEARCH_RESULT=''\n_RN_ROOT_EXISTS=''\n_CURRENT_LOOKUPS=1\n_JSON_ROOT=\"'react-native'\"\n_JSON_FILE_NAME='firebase.json'\n_JSON_OUTPUT_BASE64='e30=' # { }\n_CURRENT_SEARCH_DIR=${PROJECT_DIR}\n_PLIST_BUDDY=/usr/libexec/PlistBuddy\n_TARGET_PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n_DSYM_PLIST=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n# plist arrays\n_PLIST_ENTRY_KEYS=()\n_PLIST_ENTRY_TYPES=()\n_PLIST_ENTRY_VALUES=()\n\nfunction setPlistValue {\n  echo \"note:      setting plist entry '$1' of type '$2' in file '$4'\"\n  ${_PLIST_BUDDY} -c \"Add :$1 $2 '$3'\" $4 || echo \"note:      '$1' already exists\"\n}\n\nfunction getFirebaseJsonKeyValue () {\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']\"\n  else\n    echo \"\"\n  fi;\n}\n\nfunction jsonBoolToYesNo () {\n  if [[ $1 == \"false\" ]]; then\n    echo \"NO\"\n  elif [[ $1 == \"true\" ]]; then\n    echo \"YES\"\n  else echo \"NO\"\n  fi\n}\n\necho \"note: -> RNFB build script started\"\necho \"note: 1) Locating ${_JSON_FILE_NAME} file:\"\n\nif [[ -z ${_CURRENT_SEARCH_DIR} ]]; then\n  _CURRENT_SEARCH_DIR=$(pwd)\nfi;\n\nwhile true; do\n  _CURRENT_SEARCH_DIR=$(dirname \"$_CURRENT_SEARCH_DIR\")\n  if [[ \"$_CURRENT_SEARCH_DIR\" == \"/\" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;\n  echo \"note:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file.\"\n  _SEARCH_RESULT=$(find \"$_CURRENT_SEARCH_DIR\" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | /usr/bin/head -n 1)\n  if [[ ${_SEARCH_RESULT} ]]; then\n    echo \"note:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT\"\n    break;\n  fi;\n  _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))\ndone\n\nif [[ ${_SEARCH_RESULT} ]]; then\n  _JSON_OUTPUT_RAW=$(cat \"${_SEARCH_RESULT}\")\n  if ! _RN_ROOT_EXISTS=$(ruby -Ku -e \"require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]\"); then\n    echo \"error: Failed to parse firebase.json, check for syntax errors.\"\n    exit 1\n  fi\n\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    if ! python3 --version >/dev/null 2>&1; then echo \"error: python3 not found, firebase.json file processing error.\" && exit 1; fi\n    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('\"'${_SEARCH_RESULT}'\"', '\"'rb'\"').read())['${_JSON_ROOT}']), '\"'utf-8'\"')).decode())' || echo \"e30=\")\n  fi\n\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n\n  # config.app_data_collection_default_enabled\n  _APP_DATA_COLLECTION_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_data_collection_default_enabled\")\n  if [[ $_APP_DATA_COLLECTION_ENABLED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseDataCollectionDefaultEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_DATA_COLLECTION_ENABLED\")\")\n  fi\n\n  # config.analytics_auto_collection_enabled\n  _ANALYTICS_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_auto_collection_enabled\")\n  if [[ $_ANALYTICS_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_COLLECTION\")\")\n  fi\n\n  # config.analytics_collection_deactivated\n  _ANALYTICS_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_collection_deactivated\")\n  if [[ $_ANALYTICS_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_DEACTIVATED\")\")\n  fi\n\n  # config.analytics_idfv_collection_enabled\n  _ANALYTICS_IDFV_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_idfv_collection_enabled\")\n  if [[ $_ANALYTICS_IDFV_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_IDFV_COLLECTION\")\")\n  fi\n\n  # config.analytics_default_allow_analytics_storage\n  _ANALYTICS_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_analytics_storage\")\n  if [[ $_ANALYTICS_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_storage\n  _ANALYTICS_AD_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_storage\")\n  if [[ $_ANALYTICS_AD_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_user_data\n  _ANALYTICS_AD_USER_DATA=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_user_data\")\n  if [[ $_ANALYTICS_AD_USER_DATA ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_USER_DATA\")\")\n  fi\n\n  # config.analytics_default_allow_ad_personalization_signals\n  _ANALYTICS_PERSONALIZATION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_personalization_signals\")\n  if [[ $_ANALYTICS_PERSONALIZATION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_PERSONALIZATION\")\")\n  fi\n\n  # config.analytics_registration_with_ad_network_enabled\n  _ANALYTICS_REGISTRATION_WITH_AD_NETWORK=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_registration_with_ad_network_enabled\")\n  if [[ $_ANALYTICS_REGISTRATION_WITH_AD_NETWORK ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_REGISTRATION_WITH_AD_NETWORK\")\")\n  fi\n\n  # config.google_analytics_automatic_screen_reporting_enabled\n  _ANALYTICS_AUTO_SCREEN_REPORTING=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_automatic_screen_reporting_enabled\")\n  if [[ $_ANALYTICS_AUTO_SCREEN_REPORTING ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAutomaticScreenReportingEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_SCREEN_REPORTING\")\")\n  fi\n\n  # config.perf_auto_collection_enabled\n  _PERF_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_auto_collection_enabled\")\n  if [[ $_PERF_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_enabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_AUTO_COLLECTION\")\")\n  fi\n\n  # config.perf_collection_deactivated\n  _PERF_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_collection_deactivated\")\n  if [[ $_PERF_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_deactivated\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_DEACTIVATED\")\")\n  fi\n\n  # config.messaging_auto_init_enabled\n  _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"messaging_auto_init_enabled\")\n  if [[ $_MESSAGING_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseMessagingAutoInitEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_MESSAGING_AUTO_INIT\")\")\n  fi\n\n  # config.in_app_messaging_auto_colllection_enabled\n  _FIAM_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"in_app_messaging_auto_collection_enabled\")\n  if [[ $_FIAM_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseInAppMessagingAutomaticDataCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_FIAM_AUTO_INIT\")\")\n  fi\n\n  # config.app_check_token_auto_refresh\n  _APP_CHECK_TOKEN_AUTO_REFRESH=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_check_token_auto_refresh\")\n  if [[ $_APP_CHECK_TOKEN_AUTO_REFRESH ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAppCheckTokenAutoRefreshEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_CHECK_TOKEN_AUTO_REFRESH\")\")\n  fi\n\n  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes useful\n  _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"crashlytics_disable_auto_disabler\")\n  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == \"true\" ]]; then\n    echo \"Disabled Crashlytics auto disabler.\" # do nothing\n  else\n    _PLIST_ENTRY_KEYS+=(\"FirebaseCrashlyticsCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"NO\")\n  fi\nelse\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n  echo \"warning:   A firebase.json file was not found, whilst this file is optional it is recommended to include it to configure firebase services in React Native Firebase.\"\nfi;\n\necho \"note: 2) Injecting Info.plist entries: \"\n\n# Log out the keys we're adding\nfor i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n  echo \"    ->  $i) ${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\"\ndone\n\nfor plist in \"${_TARGET_PLIST}\" \"${_DSYM_PLIST}\" ; do\n  if [[ -f \"${plist}\" ]]; then\n\n    # paths with spaces break the call to setPlistValue. temporarily modify\n    # the shell internal field separator variable (IFS), which normally\n    # includes spaces, to consist only of line breaks\n    oldifs=$IFS\n    IFS=\"\n\"\n\n    for i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n      setPlistValue \"${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\" \"${plist}\"\n    done\n\n    # restore the original internal field separator value\n    IFS=$oldifs\n  else\n    echo \"warning:   A Info.plist build output file was not found (${plist})\"\n  fi\ndone\n\necho \"note: <- RNFB build script finished\"\n";
 		};
-		206D66B4C4A70E1DBB7D83D1 /* [CP] Embed Pods Frameworks */ = {
+		8BB43835598DD3FB89031BA763F884FB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -764,7 +764,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		29B63FFD08D005402B92A060 /* [CP-User] [RNFB] Crashlytics Configuration */ = {
+		B3F66D10A8D53734A2A99DB51A9ABC94 /* [CP-User] [RNFB] Crashlytics Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -778,7 +778,7 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\nset -e\n\nif [[ ${PODS_ROOT} ]]; then\n  echo \"info: Exec FirebaseCrashlytics Run from Pods\"\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\"\nelse\n  echo \"info: Exec FirebaseCrashlytics Run from framework\"\n  \"${PROJECT_DIR}/FirebaseCrashlytics.framework/run\"\nfi\n";
 		};
-		79508D10BE94B8C9D7EB64C3 /* [CP] Check Pods Manifest.lock */ = {
+		C0957DA537DAEC4EBA9961FD330E7891 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -800,7 +800,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7C3F1E8B9D0A4B6E5F128A4D /* [User] Copy GoogleService-Info.plist */ = {
+		A93D5E4D4B3C14C35A07B0AB64D8AFE8 /* [User] Copy GoogleService-Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -818,7 +818,7 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n# Copy the GoogleService-Info.plist that matches the active Xcode\n# configuration into the built .app bundle. Source files live under\n# ios/config/ and are committed to the repo.\nset -euo pipefail\n\ncase \"${CONFIGURATION}\" in\n  *Development*|*AdHoc*)\n    SRC_NAME=\"GoogleService-Info.dev.plist\"\n    ;;\n  *Production*)\n    SRC_NAME=\"GoogleService-Info.prod.plist\"\n    ;;\n  Debug)\n    SRC_NAME=\"GoogleService-Info.dev.plist\"\n    ;;\n  Release)\n    SRC_NAME=\"GoogleService-Info.prod.plist\"\n    ;;\n  *)\n    echo \"warning: Unknown CONFIGURATION '${CONFIGURATION}', defaulting to prod plist\"\n    SRC_NAME=\"GoogleService-Info.prod.plist\"\n    ;;\nesac\n\nSRC=\"${SRCROOT}/config/${SRC_NAME}\"\nDEST=\"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\n\nif [[ ! -f \"${SRC}\" ]]; then\n  echo \"error: GoogleService-Info source plist not found at ${SRC}\"\n  exit 1\nfi\n\nmkdir -p \"$(dirname \"${DEST}\")\"\ncp -v \"${SRC}\" \"${DEST}\"\necho \"info: Copied ${SRC_NAME} into .app for configuration ${CONFIGURATION}\"\n";
 		};
-		B0B7A40649805A07F8366ECA /* [CP] Copy Pods Resources */ = {
+		AF7CC9EDC1CCE41D37A63E2574E9A0E6 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -835,7 +835,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BD5358141F0CEAD6A6A5BB5B /* [CP] Embed Pods Frameworks */ = {
+		C8797D152CA0AE0A452321A15956A667 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -876,7 +876,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-kiroku/expo-configure-project.sh\"\n";
 		};
-		F31C6CF24AB82CE22E91127D /* [CP] Copy Pods Resources */ = {
+		D5E72D27AC939E72A1D8B21BBBFF4B2F /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1155,7 +1155,7 @@
 		};
 		10755F4913B366E1F51A7CFDF6DAC002 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8E99795ABC9AFEF9FD9927A /* Pods-kiroku-kirokuTests.release.xcconfig */;
+			baseConfigurationReference = 1B073BCE83604D59197935453ACCE810 /* Pods-kiroku-kirokuTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -1181,7 +1181,7 @@
 		};
 		1A2B7D80135952A11CFB9B79B3003F00 /* ReleaseDevelopment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 032DB00A30E23E49F905F193 /* Pods-kiroku.releasedevelopment.xcconfig */;
+			baseConfigurationReference = 9A13E951A4D63CD9FF3A57BD6E46773A /* Pods-kiroku.releasedevelopment.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -1291,7 +1291,7 @@
 		};
 		2623219C899386B07E5E1732D12218E9 /* DebugAdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D3E86EB61F1B20B8B6E08966 /* Pods-kiroku.debugadhoc.xcconfig */;
+			baseConfigurationReference = 8690BB807EE45F07700764C9F93DB4B1 /* Pods-kiroku.debugadhoc.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconAdHoc;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -1380,7 +1380,7 @@
 		};
 		2D3BEC61D1B53827C79B8A2B0420605E /* DebugProduction */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A2EBC8C2C3DAAB7065780169 /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */;
+			baseConfigurationReference = 0023E2B3C39E731E83A026B01F285CBA /* Pods-kiroku-kirokuTests.debugproduction.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = L357YP9W28;
@@ -1600,7 +1600,7 @@
 		};
 		3A387BBC63D0E63106722FB267FB04B3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AE54E40A8CDEAA1129568159 /* Pods-kiroku-kirokuTests.debug.xcconfig */;
+			baseConfigurationReference = 940E29BAAD0E2B39450F8DEA08D977DC /* Pods-kiroku-kirokuTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = L357YP9W28;
@@ -1629,7 +1629,7 @@
 		};
 		4084784CF9E3019F5086662585D44528 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C45E5550581A6D12A1522D67 /* Pods-kiroku.debug.xcconfig */;
+			baseConfigurationReference = 1BC997089BCD05EFEEF7618697295B92 /* Pods-kiroku.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -1845,7 +1845,7 @@
 		};
 		692CD12082DDDD205B480E167CE902DF /* DebugDevelopment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5B78BC07AC721240A9312B6 /* Pods-kiroku.debugdevelopment.xcconfig */;
+			baseConfigurationReference = DC58989E75FA42CFB52CFA57DD74CD6A /* Pods-kiroku.debugdevelopment.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -1885,7 +1885,7 @@
 		};
 		6BE29CF28E5375E92A25DCA2F4EB7505 /* ReleaseDevelopment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BFBAFFCE82AB72E6066806A6 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */;
+			baseConfigurationReference = 079861F232F305189FCFB5CFCE752BF0 /* Pods-kiroku-kirokuTests.releasedevelopment.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -2015,7 +2015,7 @@
 		};
 		7A0BE35C0C4295BCE6B147E0C502631A /* ReleaseProduction */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F64A62323D211C084F80CF3B /* Pods-kiroku.releaseproduction.xcconfig */;
+			baseConfigurationReference = CBBEBF345C4A83E4EE008676C6C2ABF4 /* Pods-kiroku.releaseproduction.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -2399,7 +2399,7 @@
 		};
 		8ED207EF2A175948388B591C0419BFAA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1A9BD83879B356DB1D8E5AB4 /* Pods-kiroku.release.xcconfig */;
+			baseConfigurationReference = 30BFAEB5CDC561A8FC2261889B95287B /* Pods-kiroku.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -2790,7 +2790,7 @@
 		};
 		B07FB74358F681373842C282CCBEB0A9 /* ReleaseAdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82C8227B2B3759DD680D978A /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */;
+			baseConfigurationReference = 41DA18E074548C9167CB8366E1E84FFA /* Pods-kiroku-kirokuTests.releaseadhoc.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -2850,7 +2850,7 @@
 		};
 		B93762027BD8243C332E02FA0EA80341 /* DebugDevelopment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6EAE7A9758B14AE6B12B6866 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */;
+			baseConfigurationReference = 937610E9D0162A83E7A4284BBBD373C1 /* Pods-kiroku-kirokuTests.debugdevelopment.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = L357YP9W28;
@@ -2879,7 +2879,7 @@
 		};
 		B9EBB5A80324C58EDA4473433F66B39D /* ReleaseProduction */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F116734F0500561731E173B /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */;
+			baseConfigurationReference = 41C49860CF9CB115A5F250852F8975C8 /* Pods-kiroku-kirokuTests.releaseproduction.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -2905,7 +2905,7 @@
 		};
 		BAEC72649D289DD70E5968F93A0AB2B2 /* ReleaseAdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F29851E4B5EDB30B2E8D86B2 /* Pods-kiroku.releaseadhoc.xcconfig */;
+			baseConfigurationReference = 808A43D92E51BAE16514C24C06578B57 /* Pods-kiroku.releaseadhoc.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconAdHoc;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -3128,7 +3128,7 @@
 		};
 		CE7D307830464E8A54882504A8D81C22 /* DebugProduction */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 41345EE1B0CA657C345B1197 /* Pods-kiroku.debugproduction.xcconfig */;
+			baseConfigurationReference = C8125522733C8CDA669574E9CD0877F9 /* Pods-kiroku.debugproduction.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -3403,7 +3403,7 @@
 		};
 		D7FF3050E03151EE682DA4EBA96FFDC4 /* DebugAdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 97AEE108FA6E954EFA2B50BB /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */;
+			baseConfigurationReference = 626F52CEF3B2C5855C78BEB531BBC705 /* Pods-kiroku-kirokuTests.debugadhoc.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = L357YP9W28;

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -9,7 +9,6 @@ import * as Crypto from 'expo-crypto';
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
-import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as User from '@userActions/User';
 
@@ -102,7 +101,11 @@ function AppleSignIn({
       onPress();
       await User.signInWithOAuth(auth, db, credential, displayName);
     } catch (error: unknown) {
-      const e = error as {code?: AppleError};
+      const e = error as {
+        code?: AppleError | string;
+        message?: string;
+        name?: string;
+      };
       if (e.code === appleAuth.Error.CANCELED) {
         return;
       }
@@ -110,7 +113,22 @@ function AppleSignIn({
         '[Apple Sign In] Apple authentication failed',
         error as Record<string, unknown>,
       );
-      onError(ErrorUtils.getAppError(undefined, error).message);
+      // DEBUG: surface raw error so we can diagnose the "unknown error" wrapper.
+      // Revert before shipping.
+      const rawJson = (() => {
+        try {
+          const keys =
+            error && typeof error === 'object'
+              ? Object.getOwnPropertyNames(error)
+              : [];
+          return JSON.stringify(error, keys);
+        } catch {
+          return String(error);
+        }
+      })();
+      onError(
+        `[DEBUG] name=${e.name ?? '?'} code=${e.code ?? '?'} msg=${e.message ?? '?'} raw=${rawJson}`,
+      );
     }
   };
 

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -5,10 +5,11 @@ import type {
   AppleError,
   AppleRequestResponse,
 } from '@invertase/react-native-apple-authentication';
-import * as Crypto from 'expo-crypto';
+import {getRandomBytes} from 'expo-crypto';
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
+import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as User from '@userActions/User';
 
@@ -22,21 +23,11 @@ type AppleSignInResult = {
   rawNonce: string;
 };
 
-/**
- * Generates a cryptographically random nonce and its SHA-256 hash.
- * Firebase requires the raw nonce to verify the hashed nonce claim Apple embeds
- * in the identity token — without it, signInWithCredential rejects the credential.
- */
-async function generateNonce(): Promise<{raw: string; hashed: string}> {
-  const bytes = Crypto.getRandomBytes(32);
-  const raw = Array.from(bytes)
+function generateRawNonce(): string {
+  const bytes = getRandomBytes(32);
+  return Array.from(bytes)
     .map(b => b.toString(16).padStart(2, '0'))
     .join('');
-  const hashed = await Crypto.digestStringAsync(
-    Crypto.CryptoDigestAlgorithm.SHA256,
-    raw,
-  );
-  return {raw, hashed};
 }
 
 /**
@@ -45,13 +36,15 @@ async function generateNonce(): Promise<{raw: string; hashed: string}> {
  * must be forwarded to Firebase, or null on failure.
  */
 async function appleSignInRequest(): Promise<AppleSignInResult | null> {
-  const {raw: rawNonce, hashed: hashedNonce} = await generateNonce();
+  const rawNonce = generateRawNonce();
 
   const response = await appleAuth.performRequest({
     requestedOperation: appleAuth.Operation.LOGIN,
     // FULL_NAME must come first — see https://github.com/invertase/react-native-apple-authentication/issues/293
     requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
-    nonce: hashedNonce,
+    // The library SHA-256 hashes this before passing to Apple — pass raw, NOT pre-hashed.
+    // See node_modules/@invertase/react-native-apple-authentication/ios/RNAppleAuthentication/RNAppleAuthModule.m
+    nonce: rawNonce,
   });
 
   const credentialState = await appleAuth.getCredentialStateForUser(
@@ -101,11 +94,7 @@ function AppleSignIn({
       onPress();
       await User.signInWithOAuth(auth, db, credential, displayName);
     } catch (error: unknown) {
-      const e = error as {
-        code?: AppleError | string;
-        message?: string;
-        name?: string;
-      };
+      const e = error as {code?: AppleError};
       if (e.code === appleAuth.Error.CANCELED) {
         return;
       }
@@ -113,22 +102,7 @@ function AppleSignIn({
         '[Apple Sign In] Apple authentication failed',
         error as Record<string, unknown>,
       );
-      // DEBUG: surface raw error so we can diagnose the "unknown error" wrapper.
-      // Revert before shipping.
-      const rawJson = (() => {
-        try {
-          const keys =
-            error && typeof error === 'object'
-              ? Object.getOwnPropertyNames(error)
-              : [];
-          return JSON.stringify(error, keys);
-        } catch {
-          return String(error);
-        }
-      })();
-      onError(
-        `[DEBUG] name=${e.name ?? '?'} code=${e.code ?? '?'} msg=${e.message ?? '?'} raw=${rawJson}`,
-      );
+      onError(ErrorUtils.getAppError(undefined, error).message);
     }
   };
 

--- a/src/libs/OAuthCredential/index.ios.ts
+++ b/src/libs/OAuthCredential/index.ios.ts
@@ -1,6 +1,6 @@
 import appleAuth from '@invertase/react-native-apple-authentication';
 import type {AppleError} from '@invertase/react-native-apple-authentication';
-import * as Crypto from 'expo-crypto';
+import {getRandomBytes} from 'expo-crypto';
 import {GoogleAuthProvider, OAuthProvider} from 'firebase/auth';
 import type {AuthCredential} from 'firebase/auth';
 import {
@@ -34,33 +34,24 @@ async function getGoogleCredential(): Promise<AuthCredential | null> {
   }
 }
 
-/**
- * Generates a cryptographically random nonce and its SHA-256 hash.
- * Firebase requires the raw nonce to verify the hashed nonce claim Apple
- * embeds in the identity token — without it, reauthenticateWithCredential
- * rejects the credential.
- */
-async function generateNonce(): Promise<{raw: string; hashed: string}> {
-  const bytes = Crypto.getRandomBytes(32);
-  const raw = Array.from(bytes)
+function generateRawNonce(): string {
+  const bytes = getRandomBytes(32);
+  return Array.from(bytes)
     .map(b => b.toString(16).padStart(2, '0'))
     .join('');
-  const hashed = await Crypto.digestStringAsync(
-    Crypto.CryptoDigestAlgorithm.SHA256,
-    raw,
-  );
-  return {raw, hashed};
 }
 
 async function getAppleCredential(): Promise<AuthCredential | null> {
   try {
-    const {raw: rawNonce, hashed: hashedNonce} = await generateNonce();
+    const rawNonce = generateRawNonce();
 
     const response = await appleAuth.performRequest({
       requestedOperation: appleAuth.Operation.LOGIN,
       // FULL_NAME must come first — see https://github.com/invertase/react-native-apple-authentication/issues/293
       requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
-      nonce: hashedNonce,
+      // The library SHA-256 hashes this before passing to Apple — pass raw, NOT pre-hashed.
+      // See node_modules/@invertase/react-native-apple-authentication/ios/RNAppleAuthentication/RNAppleAuthModule.m
+      nonce: rawNonce,
     });
     const credentialState = await appleAuth.getCredentialStateForUser(
       response.user,


### PR DESCRIPTION
## Summary

Fixes Sign in with Apple on iOS, **and** the matching Apple re-auth flow used by account deletion. Both were failing with `auth/missing-or-invalid-nonce` from Firebase.

## Root cause

`@invertase/react-native-apple-authentication` **already SHA-256 hashes** the `nonce` we hand it before forwarding to `ASAuthorizationAppleIDRequest`:

```objc
// node_modules/@invertase/react-native-apple-authentication/ios/RNAppleAuthentication/RNAppleAuthModule.m:105-107
if (appleIdRequest.nonce) {
  rawNonce = appleIdRequest.nonce;
  appleIdRequest.nonce = [RNAppleAuthUtils stringBySha256HashingString:rawNonce];
}
```

And the library types document the contract: `"This value will be SHA256 hashed by the library before being sent to Apple."` (`lib/index.d.ts:535`).

Two call sites — `src/components/SignInButtons/AppleSignIn/index.ios.tsx` (sign-in) and `src/libs/OAuthCredential/index.ios.ts` (account-deletion re-auth) — were each generating a raw nonce, **pre-hashing it in JS via `expo-crypto`**, and passing that hash to the library. The library hashed again, so Apple's ID token `nonce` claim contained `SHA256(SHA256(raw))`. We then forwarded the original `raw` to Firebase via `OAuthProvider.credential({idToken, rawNonce})`. Firebase computed `SHA256(raw)` and compared it against the ID token nonce — they never matched, so every credential exchange (sign-in *and* re-auth) was rejected.

The mismatch was verified arithmetically against the failing nonces captured from the on-device debug build:
- `raw = dffd1ccf…80c8`
- `SHA256(raw) = 1efad6a9…9300`  ← what we sent to the library
- `SHA256(SHA256(raw)) = 6014365547…01e22`  ← what Apple actually stored in the ID token ✓

## Fix

In both files:

- Generate the raw nonce in JS (32 random bytes, hex-encoded).
- Pass that **raw** value to `appleAuth.performRequest({nonce: rawNonce})`; the library hashes it for Apple.
- Forward the same raw value to Firebase via `OAuthProvider.credential({idToken, rawNonce})`.
- Drop the JS-side SHA-256 step entirely (`expo-crypto.digestStringAsync` and `CryptoDigestAlgorithm` import).

Sign-in commit also reverts the debug `[DEBUG] name=… code=… msg=… raw=…` toast added earlier in this branch — it had served its purpose surfacing the underlying Firebase error code. The original `ErrorUtils.getAppError(...)` wrapper is restored for the production user-facing message.

A short code comment in each `performRequest` call flags the library's internal hashing so the next person doesn't reintroduce the double-hash.

## Test plan

- [x] `npx prettier --write` — clean
- [x] `npx eslint` — 0 errors
- [x] Local iOS device build (Production scheme): tap Sign in with Apple → confirm credential exchange succeeds and you land authenticated (no `auth/missing-or-invalid-nonce` toast)
- [x] Tap Sign in with Apple then cancel the Apple sheet → confirm no error toast (cancellation path preserved)
- [x] Settings → Close account, choose Apple re-auth → confirm account deletion completes (no "account deletion failed" toast)
- [x] Start the Apple re-auth sheet for account deletion then cancel → confirm the flow silently aborts (no error)

## Out of scope

- Sign in with Google (separate code path, not affected).
- The Android Apple Sign In stub (`index.android.tsx`) is unchanged — Android Apple Sign In goes through the web-redirect path, which doesn't use this library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)