### PR TITLE
fix(scripts): set UTF-8 locale in podReset.sh to avoid CocoaPods encoding crash

### DIFF
--- a/scripts/podReset.sh
+++ b/scripts/podReset.sh
@@ -12,6 +12,11 @@
 
 set -e
 
+# CocoaPods 1.16.2 + Ruby 3.3 crashes on Encoding::CompatibilityError when
+# LANG/LC_ALL aren't UTF-8. Set them defensively before any `pod` call.
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
 SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SCRIPTS_DIR/shellUtils.sh"
 


### PR DESCRIPTION
## Summary

- Export `LANG`/`LC_ALL` defensively at the top of `scripts/podReset.sh` so `pod deintegrate` / `pod install` don't crash with `Encoding::CompatibilityError` on CocoaPods 1.16.2 + Ruby 3.3.
- Uses `${VAR:-en_US.UTF-8}` so anything the user already has set in their environment wins.

## Context

Running `npm run ios:pod:reset` on a shell without UTF-8 locale vars crashes inside CocoaPods:

```
/Users/.../ruby/3.3.0/unicode_normalize/normalize.rb:141:in `normalize':
Unicode Normalization not appropriate for ASCII-8BIT (Encoding::CompatibilityError)
	from .../cocoapods-1.16.2/lib/cocoapods/config.rb:167:in `unicode_normalize'
	from .../cocoapods-1.16.2/lib/cocoapods/config.rb:167:in `installation_root'
```

CocoaPods reads path strings as ASCII-8BIT instead of UTF-8 when `LANG`/`LC_ALL` aren't set to a UTF-8 locale. Because the script runs under `set -e`, the failure happens *after* it's already deleted `Pods/`, `Podfile.lock`, `*.xcworkspace/`, and `build/` — leaving the worktree half-broken until someone manually re-runs `pod install` with the right env.

Out of scope (intentionally not touched): the destructive ordering in the script (deleting Pods before `pod deintegrate`) and `Podfile` itself.

## Test plan

- [ ] `unset LANG LC_ALL; npm run ios:pod:reset` from the repo root completes without the `Encoding::CompatibilityError` traceback
- [ ] Resulting `ios/Podfile.lock` and `ios/kiroku.xcodeproj/project.pbxproj` produce no semantic diff (xUnique UUID churn at most)
- [ ] Existing UTF-8 env vars (if the user has them) are still respected — verify by setting `LANG=C.UTF-8 LC_ALL=C.UTF-8` and confirming they aren't overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)