### PR TITLE
feat(auth): resolve OAuth sign-in collision with existing email account

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -788,7 +788,7 @@
 "src/libs/Search.ts"	"@typescript-eslint/no-base-to-string"	1
 "src/libs/ShortcutManager/index.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "src/libs/UserDataUtils.ts"	"rulesdir/no-onyx-connect"	1
-"src/libs/UserUtils.ts"	"rulesdir/no-onyx-connect"	2
+"src/libs/UserUtils.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/App.ts"	"rulesdir/no-onyx-connect"	3
 "src/libs/actions/Device/index.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/DrinkingSession.ts"	"rulesdir/no-onyx-connect"	1

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -801,7 +801,6 @@
 "src/libs/actions/PushNotification.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/Session/index.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/TestTool.ts"	"rulesdir/no-onyx-connect"	1
-"src/libs/actions/User.ts"	"arrow-body-style"	2
 "src/libs/actions/User.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/Welcome.ts"	"rulesdir/no-onyx-connect"	3
 "src/libs/compose.ts"	"@typescript-eslint/ban-types"	1

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -715,9 +715,6 @@ const CONST = {
   VERIFY_EMAIL: {
     // How often a user can request a new verification email
     COOLDOWN: 60 * 1000, // 1 minute
-
-    // How long the dismiss verify email button should hide the window for
-    DISMISS_TIME: 1000 * 60 * 60 * 24 * 1, // 1 day
   },
 
   SESSION_STORAGE_KEYS: {

--- a/src/ERRORS.ts
+++ b/src/ERRORS.ts
@@ -23,6 +23,8 @@ const ERRORS = {
     INVALID_CREDENTIAL: 'auth/invalid-credential',
     WEAK_PASSWORD: 'auth/weak-password',
     EMAIL_ALREADY_IN_USE: 'auth/email-already-in-use',
+    ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL:
+      'auth/account-exists-with-different-credential',
     USER_NOT_FOUND: 'auth/user-not-found',
     WRONG_PASSWORD: 'auth/wrong-password',
     NETWORK_REQUEST_FAILED: 'auth/network-request-failed',

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -84,10 +84,10 @@ function Kiroku() {
       setIsAuthenticated(!!user);
       setAuthenticationChecked(true);
 
-      // Check only once after the user is authenticated
-      if (UserUtils.shouldShowVerifyEmailModal(user)) {
-        setShouldShowVerifyEmailModal(true);
-      }
+      // Re-evaluate on every auth change: sign-out must drop the modal so it
+      // doesn't reappear over the public stack after the user taps "Sign out"
+      // from inside VerifyEmailModal itself.
+      setShouldShowVerifyEmailModal(UserUtils.shouldShowVerifyEmailModal(user));
     });
 
     return () => unsubscribe();

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -128,9 +128,6 @@ const ONYXKEYS = {
   /** The last time a user has sent a verification email */
   VERIFY_EMAIL_SENT: 'verifyEmailSent',
 
-  /** The last time a user dismissed the verify email value */
-  VERIFY_EMAIL_DISMISSED: 'verifyEmailDismissed',
-
   /** Is app in beta version */
   IS_BETA: 'isBeta',
 
@@ -306,7 +303,6 @@ type OnyxValuesMapping = {
   [ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT]: boolean;
   [ONYXKEYS.APP_UPDATE_DISMISSED]: Timestamp;
   [ONYXKEYS.VERIFY_EMAIL_SENT]: Timestamp;
-  [ONYXKEYS.VERIFY_EMAIL_DISMISSED]: Timestamp;
   [ONYXKEYS.IS_BETA]: boolean;
   [ONYXKEYS.HAS_CHECKED_AUTO_LOGIN]: boolean;
   [ONYXKEYS.PREFERRED_THEME]: ValueOf<typeof CONST.THEME>;

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -25,6 +25,14 @@ const ONYXKEYS = {
   CREDENTIALS: 'credentials',
   STASHED_CREDENTIALS: 'stashedCredentials',
 
+  /**
+   * Raw OAuth materials stashed when Apple/Google sign-in collides with an
+   * existing email/password account. Read by the collision-resolution modal
+   * to prompt for the existing password and call linkWithCredential.
+   * Ephemeral: cleared on link, cancel, and cleanupSession.
+   */
+  PENDING_OAUTH_CREDENTIAL: 'pendingOAuthCredential',
+
   /** Onboarding progress for the current user (completed_at, last_visited_path) */
   NVP_ONBOARDING: 'nvp_onboarding',
 
@@ -267,6 +275,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.CURRENT_DATE]: string;
   [ONYXKEYS.CREDENTIALS]: OnyxTypes.Credentials;
   [ONYXKEYS.STASHED_CREDENTIALS]: OnyxTypes.Credentials;
+  [ONYXKEYS.PENDING_OAUTH_CREDENTIAL]: OnyxTypes.PendingOAuthCredential;
   [ONYXKEYS.START_SESSION_GLOBAL_CREATE]: OnyxTypes.StartSession;
   [ONYXKEYS.MODAL]: OnyxTypes.Modal;
   [ONYXKEYS.NETWORK]: OnyxTypes.Network;

--- a/src/components/OAuthLinkModal.tsx
+++ b/src/components/OAuthLinkModal.tsx
@@ -1,0 +1,187 @@
+import {sendPasswordResetEmail} from 'firebase/auth';
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import {useFirebase} from '@context/global/FirebaseContext';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import * as ErrorUtils from '@libs/ErrorUtils';
+import * as User from '@userActions/User';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {PendingOAuthCredential} from '@src/types/onyx';
+import Button from './Button';
+import DotIndicatorMessage from './DotIndicatorMessage';
+import Modal from './Modal';
+import {PressableWithFeedback} from './Pressable';
+import Text from './Text';
+import TextInput from './TextInput';
+
+type OAuthLinkModalContentProps = {
+  pending: PendingOAuthCredential;
+};
+
+/**
+ * Inner content of the OAuth link modal. Owns the transient form state.
+ * Always rendered with a fresh instance per collision (parent supplies a
+ * `key` that changes), so state never carries over between sessions.
+ */
+function OAuthLinkModalContent({pending}: OAuthLinkModalContentProps) {
+  const {auth} = useFirebase();
+  const {translate} = useLocalize();
+  const styles = useThemeStyles();
+
+  const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorText, setErrorText] = useState('');
+  const [resetEmailSent, setResetEmailSent] = useState(false);
+
+  const isApple = pending.providerId === 'apple.com';
+  const title = translate(
+    isApple ? 'oauthLinkModal.appleTitle' : 'oauthLinkModal.googleTitle',
+  );
+  const submitText = translate(
+    isApple ? 'oauthLinkModal.appleSubmit' : 'oauthLinkModal.googleSubmit',
+  );
+  const passwordLabel = translate('common.password');
+
+  const handleCancel = () => {
+    if (isLoading) {
+      return;
+    }
+    User.clearPendingOAuthCredential();
+  };
+
+  const handleSubmit = () => {
+    (async () => {
+      setIsLoading(true);
+      setErrorText('');
+      try {
+        await User.linkPendingOAuthCredential(auth, password, pending);
+        // Success: action cleared the stash; Onyx subscription will unmount us.
+      } catch (error) {
+        const appError = ErrorUtils.getAppError(undefined, error);
+        setErrorText(appError.message);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  };
+
+  const handleForgotPassword = () => {
+    (async () => {
+      setErrorText('');
+      try {
+        await sendPasswordResetEmail(auth, pending.email);
+        setResetEmailSent(true);
+      } catch (error) {
+        const appError = ErrorUtils.getAppError(undefined, error);
+        setErrorText(appError.message);
+      }
+    })();
+  };
+
+  return (
+    <Modal
+      isVisible
+      type={CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
+      onClose={handleCancel}>
+      <View style={[styles.p5]}>
+        <Text style={[styles.textHeadlineH2, styles.mb3]}>{title}</Text>
+        <Text style={styles.mb3}>
+          {translate('oauthLinkModal.body', {email: pending.email})}
+        </Text>
+        <TextInput
+          value={password}
+          onChangeText={setPassword}
+          label={passwordLabel}
+          accessibilityLabel={passwordLabel}
+          aria-label={passwordLabel}
+          secureTextEntry
+          autoFocus
+          editable={!isLoading}
+        />
+        {!!errorText && (
+          <DotIndicatorMessage
+            style={[styles.mv2]}
+            type="error"
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            messages={{0: errorText}}
+          />
+        )}
+        {!!resetEmailSent && (
+          <DotIndicatorMessage
+            style={[styles.mv2]}
+            type="success"
+            messages={{
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              0: translate('oauthLinkModal.resetEmailSent', {
+                email: pending.email,
+              }),
+            }}
+          />
+        )}
+        {!resetEmailSent && (
+          <PressableWithFeedback
+            style={[styles.link, styles.mt3]}
+            onPress={handleForgotPassword}
+            disabled={isLoading}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={translate('password.forgot')}>
+            <Text style={styles.link}>{translate('password.forgot')}</Text>
+          </PressableWithFeedback>
+        )}
+        <Button
+          success
+          large
+          isLoading={isLoading}
+          isDisabled={!password}
+          style={styles.mt4}
+          text={submitText}
+          onPress={handleSubmit}
+        />
+        <Button
+          large
+          style={[styles.mt1, styles.bgTransparent]}
+          textStyles={styles.textAppColor}
+          text={translate('common.cancel')}
+          onPress={handleCancel}
+          isDisabled={isLoading}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+/**
+ * Collision-resolution modal for OAuth sign-in.
+ *
+ * Appears whenever `ONYXKEYS.PENDING_OAUTH_CREDENTIAL` is set — i.e. when an
+ * Apple/Google sign-in collided with an existing email/password account and
+ * the SignInButton stashed the pending credential. Prompts the user for the
+ * existing account's password, then calls `linkPendingOAuthCredential` to
+ * attach the OAuth provider so both methods sign into the same Firebase user.
+ *
+ * The keyed inner component guarantees that a new collision starts with a
+ * fresh, empty form regardless of what the previous session left behind.
+ *
+ * Post-link routing (onboarding, terms, etc.) is owned by OnboardingGuard;
+ * this modal does not navigate.
+ */
+function OAuthLinkModal() {
+  const [pending] = useOnyx(ONYXKEYS.PENDING_OAUTH_CREDENTIAL);
+
+  if (!pending) {
+    return null;
+  }
+
+  return (
+    <OAuthLinkModalContent
+      key={`${pending.providerId}:${pending.email}`}
+      pending={pending}
+    />
+  );
+}
+
+OAuthLinkModal.displayName = 'OAuthLinkModal';
+export default OAuthLinkModal;

--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -81,7 +81,7 @@ function AppleSignIn({
       onPress();
       // Shown at the Kiroku-level overlay so it stays visible across the
       // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
-      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential, displayName);

--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -5,9 +5,11 @@ import {
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useLocalize from '@hooks/useLocalize';
 import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
+import * as App from '@userActions/App';
 import * as User from '@userActions/User';
 import CONFIG from '@src/CONFIG';
 
@@ -61,8 +63,10 @@ function AppleSignIn({
   onError = () => {},
 }: AppleSignInProps) {
   const {auth, db} = useFirebase();
+  const {translate} = useLocalize();
 
   const handleSignIn = async () => {
+    let loadingShown = false;
     try {
       const result = await appleSignInRequestAndroid();
       if (!result) {
@@ -75,6 +79,10 @@ function AppleSignIn({
       const credential = provider.credential({idToken: idToken ?? ''});
 
       onPress();
+      // Shown at the Kiroku-level overlay so it stays visible across the
+      // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
+      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential, displayName);
       } catch (firebaseError: unknown) {
@@ -90,6 +98,9 @@ function AppleSignIn({
           // Collision modal will take over from here.
           return;
         }
+        Log.alert('[Apple Sign In] Firebase signInWithCredential failed', {
+          code: fe.code ?? 'unknown',
+        });
         throw firebaseError;
       }
     } catch (error: unknown) {
@@ -103,6 +114,10 @@ function AppleSignIn({
         error as Record<string, unknown>,
       );
       onError(ErrorUtils.getAppError(undefined, error).message);
+    } finally {
+      if (loadingShown) {
+        await App.setLoadingText(null);
+      }
     }
   };
 

--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -5,6 +5,7 @@ import {
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
+import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as User from '@userActions/User';
@@ -74,7 +75,23 @@ function AppleSignIn({
       const credential = provider.credential({idToken: idToken ?? ''});
 
       onPress();
-      await User.signInWithOAuth(auth, db, credential, displayName);
+      try {
+        await User.signInWithOAuth(auth, db, credential, displayName);
+      } catch (firebaseError: unknown) {
+        const fe = firebaseError as {code?: string};
+        if (
+          fe.code === ERRORS.AUTH.ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL &&
+          User.stashPendingOAuthCredential(firebaseError, {
+            providerId: 'apple.com',
+            idToken: idToken ?? '',
+            displayName,
+          })
+        ) {
+          // Collision modal will take over from here.
+          return;
+        }
+        throw firebaseError;
+      }
     } catch (error: unknown) {
       const e = error as {message?: string};
       // Android cancellation surfaces as a string message, not a code.

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -99,7 +99,7 @@ function AppleSignIn({
       onPress();
       // Shown at the Kiroku-level overlay so it stays visible across the
       // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
-      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential, displayName);

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -9,6 +9,7 @@ import {getRandomBytes} from 'expo-crypto';
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
+import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as User from '@userActions/User';
@@ -92,7 +93,24 @@ function AppleSignIn({
       });
 
       onPress();
-      await User.signInWithOAuth(auth, db, credential, displayName);
+      try {
+        await User.signInWithOAuth(auth, db, credential, displayName);
+      } catch (firebaseError: unknown) {
+        const fe = firebaseError as {code?: string};
+        if (
+          fe.code === ERRORS.AUTH.ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL &&
+          User.stashPendingOAuthCredential(firebaseError, {
+            providerId: 'apple.com',
+            idToken: identityToken ?? '',
+            rawNonce,
+            displayName,
+          })
+        ) {
+          // Collision modal will take over from here.
+          return;
+        }
+        throw firebaseError;
+      }
     } catch (error: unknown) {
       const e = error as {code?: AppleError};
       if (e.code === appleAuth.Error.CANCELED) {

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -9,9 +9,11 @@ import {getRandomBytes} from 'expo-crypto';
 import {OAuthProvider} from 'firebase/auth';
 import React from 'react';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useLocalize from '@hooks/useLocalize';
 import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
+import * as App from '@userActions/App';
 import * as User from '@userActions/User';
 
 type AppleSignInProps = {
@@ -71,8 +73,10 @@ function AppleSignIn({
   onError = () => {},
 }: AppleSignInProps) {
   const {auth, db} = useFirebase();
+  const {translate} = useLocalize();
 
   const handleSignIn = async () => {
+    let loadingShown = false;
     try {
       const result = await appleSignInRequest();
       if (!result) {
@@ -93,6 +97,10 @@ function AppleSignIn({
       });
 
       onPress();
+      // Shown at the Kiroku-level overlay so it stays visible across the
+      // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
+      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential, displayName);
       } catch (firebaseError: unknown) {
@@ -109,6 +117,9 @@ function AppleSignIn({
           // Collision modal will take over from here.
           return;
         }
+        Log.alert('[Apple Sign In] Firebase signInWithCredential failed', {
+          code: fe.code ?? 'unknown',
+        });
         throw firebaseError;
       }
     } catch (error: unknown) {
@@ -121,6 +132,10 @@ function AppleSignIn({
         error as Record<string, unknown>,
       );
       onError(ErrorUtils.getAppError(undefined, error).message);
+    } finally {
+      if (loadingShown) {
+        await App.setLoadingText(null);
+      }
     }
   };
 

--- a/src/components/SignInButtons/GoogleSignIn/index.native.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.native.tsx
@@ -94,7 +94,7 @@ function GoogleSignIn({
       onPress();
       // Shown at the Kiroku-level overlay so it stays visible across the
       // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
-      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential);

--- a/src/components/SignInButtons/GoogleSignIn/index.native.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.native.tsx
@@ -14,6 +14,7 @@ import useLocalize from '@hooks/useLocalize';
 import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
+import * as App from '@userActions/App';
 import * as User from '@userActions/User';
 import CONFIG from '@src/CONFIG';
 
@@ -80,6 +81,7 @@ function GoogleSignIn({
   const {translate} = useLocalize();
 
   const handleSignIn = async () => {
+    let loadingShown = false;
     try {
       const idToken = await googleSignInRequest();
       if (!idToken) {
@@ -90,6 +92,10 @@ function GoogleSignIn({
 
       const credential = GoogleAuthProvider.credential(idToken);
       onPress();
+      // Shown at the Kiroku-level overlay so it stays visible across the
+      // post-auth screen swap (AuthScreen → OnboardingGuard → next stack).
+      await App.setLoadingText(translate('signUpScreen.almostThere'));
+      loadingShown = true;
       try {
         await User.signInWithOAuth(auth, db, credential);
       } catch (firebaseError: unknown) {
@@ -104,6 +110,9 @@ function GoogleSignIn({
           // Collision modal will take over from here.
           return;
         }
+        Log.alert('[Google Sign In] Firebase signInWithCredential failed', {
+          code: fe.code ?? 'unknown',
+        });
         throw firebaseError;
       }
     } catch (error: unknown) {
@@ -117,6 +126,10 @@ function GoogleSignIn({
         false,
       );
       onError(ErrorUtils.getAppError(undefined, error).message);
+    } finally {
+      if (loadingShown) {
+        await App.setLoadingText(null);
+      }
     }
   };
 

--- a/src/components/SignInButtons/GoogleSignIn/index.native.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.native.tsx
@@ -11,6 +11,7 @@ import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import Text from '@components/Text';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useLocalize from '@hooks/useLocalize';
+import ERRORS from '@src/ERRORS';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as User from '@userActions/User';
@@ -89,7 +90,22 @@ function GoogleSignIn({
 
       const credential = GoogleAuthProvider.credential(idToken);
       onPress();
-      await User.signInWithOAuth(auth, db, credential);
+      try {
+        await User.signInWithOAuth(auth, db, credential);
+      } catch (firebaseError: unknown) {
+        const fe = firebaseError as {code?: string};
+        if (
+          fe.code === ERRORS.AUTH.ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL &&
+          User.stashPendingOAuthCredential(firebaseError, {
+            providerId: 'google.com',
+            idToken,
+          })
+        ) {
+          // Collision modal will take over from here.
+          return;
+        }
+        throw firebaseError;
+      }
     } catch (error: unknown) {
       const e = error as {code?: string; message?: string};
       if (e.code === statusCodes.SIGN_IN_CANCELLED) {

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -1,90 +1,109 @@
-import useThemeStyles from '@hooks/useThemeStyles';
-import * as User from '@userActions/User';
 import {useEffect, useState} from 'react';
 import {View} from 'react-native';
-import {useOnyx} from 'react-native-onyx';
-import useLocalize from '@hooks/useLocalize';
-import Navigation from '@libs/Navigation/Navigation';
-import ROUTES from '@src/ROUTES';
-import useTheme from '@hooks/useTheme';
-import {sleep} from '@libs/TimeUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import * as Session from '@libs/actions/Session';
+import {sleep} from '@libs/TimeUtils';
+import * as User from '@userActions/User';
 import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
-import Icon from './Icon';
-import SuccessAnimation from './SuccessAnimation';
-import Modal from './Modal';
-import SafeAreaConsumer from './SafeAreaConsumer';
-import DotIndicatorMessage from './DotIndicatorMessage';
-import * as KirokuIcons from './Icon/KirokuIcons';
-import Text from './Text';
 import Button from './Button';
+import DotIndicatorMessage from './DotIndicatorMessage';
+import Icon from './Icon';
+import * as KirokuIcons from './Icon/KirokuIcons';
+import Modal from './Modal';
+import {PressableWithFeedback} from './Pressable';
+import SafeAreaConsumer from './SafeAreaConsumer';
+import SuccessAnimation from './SuccessAnimation';
+import Text from './Text';
 
+type ResendStatus = 'idle' | 'success' | 'error';
+
+/**
+ * Mandatory email-verification modal. Shown immediately after signup (and on
+ * any subsequent sign-in if the email is still unverified) and stays in front
+ * of the rest of the app until the user verifies — there is no defer/dismiss
+ * affordance, because an unverified email is the exact state that triggers
+ * Firebase's silent OAuth provider takeover (see PR #439 context). The only
+ * way out without verifying is the tertiary "Sign out" link, which doesn't
+ * compromise mandatory-ness: the modal reappears on the next sign-in.
+ */
 function VerifyEmailModal() {
   const {auth} = useFirebase();
   const user = auth.currentUser;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const theme = useTheme();
-  // `VERIFY_EMAIL_SENT` is written by `User.sendVerifyEmailLink` (including the
-  // signup auto-send in `User.signUp`). When set, the modal should open in the
-  // "Check your inbox" state instead of asking the user to send an email that
-  // has already been sent. We derive `emailSent` from this so the modal
-  // updates reactively if the Onyx write lands AFTER the modal has mounted
-  // (which happens with slice D's fire-and-forget send during signup).
-  const [verifyEmailSent] = useOnyx(ONYXKEYS.VERIFY_EMAIL_SENT);
   const [isVisible, setIsVisible] = useState(true);
-  const [locallySent, setLocallySent] = useState(false);
-  const emailSent = !!verifyEmailSent || locallySent;
   const [emailVerified, setEmailVerified] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [resendStatus, setResendStatus] = useState<ResendStatus>('idle');
   const [errorText, setErrorText] = useState('');
 
-  const onVerifyEmailButtonPress = () => {
+  // On mount, reload the user to pick up any verification that happened
+  // out-of-band (e.g. user clicked the link in another tab/app before
+  // returning here).
+  useEffect(() => {
+    const checkStatus = async () => {
+      if (!user) {
+        return;
+      }
+      await user.reload();
+      setEmailVerified(user.emailVerified);
+    };
+    checkStatus();
+  }, [user, auth]);
+
+  const onVerifyButtonPress = () => {
     (async () => {
+      if (!user) {
+        return;
+      }
       try {
         setErrorText('');
+        setResendStatus('idle');
         setIsLoading(true);
-        await User.sendVerifyEmailLink(user);
-        setLocallySent(true);
+        await user.reload();
+        if (user.emailVerified) {
+          setEmailVerified(true);
+        } else {
+          setErrorText(translate('verifyEmailScreen.error.emailNotVerified'));
+        }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : '';
-        setErrorText(errorMessage);
+        setErrorText(
+          errorMessage || translate('verifyEmailScreen.error.generic'),
+        );
       } finally {
         setIsLoading(false);
       }
     })();
   };
 
-  const onChangeEmailButtonPress = () => {
+  const onResendButtonPress = () => {
     (async () => {
-      if (!emailSent) {
-        setIsVisible(false);
-        Navigation.navigate(ROUTES.SETTINGS_EMAIL);
-        return;
-      }
-      if (user) {
-        await user.reload();
-        setEmailVerified(user.emailVerified);
-        if (!user.emailVerified) {
-          setErrorText(translate('verifyEmailScreen.error.emailNotVerified'));
-        }
-      } else {
-        setErrorText(translate('verifyEmailScreen.error.emailNotVerified'));
+      try {
+        setErrorText('');
+        await User.sendVerifyEmailLink(user);
+        setResendStatus('success');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '';
+        setErrorText(
+          errorMessage || translate('verifyEmailScreen.error.sending'),
+        );
+        setResendStatus('error');
       }
     })();
   };
 
-  const onDismissVerifyEmail = () => {
-    const dismissTime = new Date().getTime();
-    User.setVerifyEmailDismissed(dismissTime)
-      .then(() => {
-        setIsVisible(false);
-      })
-      .catch(error => {
-        const errorMessage = error instanceof Error ? error.message : '';
-        setErrorText(errorMessage);
-      });
+  const onSignOutPress = () => {
+    Session.signOut(auth).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : '';
+      setErrorText(
+        errorMessage || translate('verifyEmailScreen.error.generic'),
+      );
+    });
   };
 
   const onSuccessAnimationEnd = async () => {
@@ -92,19 +111,6 @@ function VerifyEmailModal() {
       setIsVisible(false);
     });
   };
-
-  // Redirect to home screen if user is verified
-  useEffect(() => {
-    const checkStatus = async () => {
-      if (!user) {
-        return;
-      }
-
-      await user.reload();
-      setEmailVerified(user.emailVerified);
-    };
-    checkStatus();
-  }, [user, auth]);
 
   return (
     <SafeAreaConsumer>
@@ -137,22 +143,16 @@ function VerifyEmailModal() {
                   <Text
                     textAlign="center"
                     style={[styles.textHeadlineH2, styles.mt3]}>
-                    {translate(
-                      emailSent
-                        ? 'verifyEmailScreen.oneMoreStep'
-                        : 'verifyEmailScreen.youAreNotVerified',
-                    )}
+                    {translate('verifyEmailScreen.title')}
                   </Text>
                   <Text textAlign="center" style={styles.mt3}>
-                    {emailSent
-                      ? translate('verifyEmailScreen.checkYourInbox')
-                      : translate('verifyEmailScreen.wouldYouLikeToVerify', {
-                          email: user?.email ?? '',
-                        })}
+                    {translate('verifyEmailScreen.body', {
+                      email: user?.email ?? '',
+                    })}
                   </Text>
                 </View>
                 <View style={styles.pb1}>
-                  {!!emailSent && !errorText && (
+                  {resendStatus === 'success' && (
                     <DotIndicatorMessage
                       style={[styles.mv2]}
                       type="success"
@@ -167,46 +167,32 @@ function VerifyEmailModal() {
                       style={[styles.mv2]}
                       type="error"
                       // eslint-disable-next-line @typescript-eslint/naming-convention
-                      messages={{0: errorText || ''}}
+                      messages={{0: errorText}}
                     />
                   )}
                   <Button
                     success
-                    isLoading={isLoading && !emailSent}
+                    large
+                    isLoading={isLoading}
                     style={styles.mt1}
-                    text={translate(
-                      emailSent
-                        ? 'verifyEmailScreen.iHaveVerified'
-                        : 'verifyEmailScreen.verifyEmail',
-                    )}
-                    onPress={
-                      emailSent
-                        ? onChangeEmailButtonPress
-                        : onVerifyEmailButtonPress
-                    }
-                    large
+                    text={translate('verifyEmailScreen.iHaveVerified')}
+                    onPress={onVerifyButtonPress}
                   />
                   <Button
-                    style={[styles.mt1]}
-                    text={translate(
-                      emailSent
-                        ? 'verifyEmailScreen.resendEmail'
-                        : 'verifyEmailScreen.changeEmail',
-                    )}
-                    onPress={
-                      emailSent
-                        ? onVerifyEmailButtonPress
-                        : onChangeEmailButtonPress
-                    }
                     large
+                    style={styles.mt1}
+                    text={translate('verifyEmailScreen.resendEmail')}
+                    onPress={onResendButtonPress}
                   />
-                  <Button
-                    text={translate('verifyEmailScreen.illDoItLater')}
-                    style={styles.bgTransparent}
-                    textStyles={styles.textAppColor}
-                    onPress={onDismissVerifyEmail}
-                    large
-                  />
+                  <PressableWithFeedback
+                    style={[styles.mt4, styles.alignItemsCenter]}
+                    onPress={onSignOutPress}
+                    role={CONST.ROLE.BUTTON}
+                    accessibilityLabel={translate('settingsScreen.signOut')}>
+                    <Text style={styles.link}>
+                      {translate('settingsScreen.signOut')}
+                    </Text>
+                  </PressableWithFeedback>
                 </View>
               </View>
             ) : (

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -4,9 +4,12 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import Log from '@libs/Log';
 import * as Session from '@libs/actions/Session';
 import {sleep} from '@libs/TimeUtils';
+import * as UserUtils from '@libs/UserUtils';
 import * as User from '@userActions/User';
+import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import Button from './Button';
 import DotIndicatorMessage from './DotIndicatorMessage';
@@ -106,6 +109,21 @@ function VerifyEmailModal() {
     });
   };
 
+  // Non-production-only: lets QA skip past the modal without verifying.
+  // Sets a module-level flag in UserUtils so the modal also doesn't re-mount
+  // on subsequent sign-in cycles within the same app session. Cold restart
+  // clears the flag and brings the modal back.
+  const onDevSkipPress = () => {
+    UserUtils.setDevBypassEmailVerification(true);
+    setIsVisible(false);
+    Log.info(
+      '[VerifyEmailModal] dev-skip activated for this session',
+      true,
+      {},
+      true,
+    );
+  };
+
   const onSuccessAnimationEnd = async () => {
     await sleep(1000).then(() => {
       setIsVisible(false);
@@ -193,6 +211,17 @@ function VerifyEmailModal() {
                       {translate('settingsScreen.signOut')}
                     </Text>
                   </PressableWithFeedback>
+                  {!CONFIG.IS_IN_PRODUCTION && (
+                    <PressableWithFeedback
+                      style={[styles.mt2, styles.alignItemsCenter]}
+                      onPress={onDevSkipPress}
+                      role={CONST.ROLE.BUTTON}
+                      accessibilityLabel="Skip verification (dev only)">
+                      <Text style={[styles.link, styles.textSupporting]}>
+                        Skip verification (dev only)
+                      </Text>
+                    </PressableWithFeedback>
+                  )}
                 </View>
               </View>
             ) : (

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -2,6 +2,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import * as User from '@userActions/User';
 import {useEffect, useState} from 'react';
 import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
 import useLocalize from '@hooks/useLocalize';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
@@ -9,6 +10,7 @@ import useTheme from '@hooks/useTheme';
 import {sleep} from '@libs/TimeUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import Icon from './Icon';
 import SuccessAnimation from './SuccessAnimation';
 import Modal from './Modal';
@@ -24,8 +26,16 @@ function VerifyEmailModal() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const theme = useTheme();
+  // `VERIFY_EMAIL_SENT` is written by `User.sendVerifyEmailLink` (including the
+  // signup auto-send in `User.signUp`). When set, the modal should open in the
+  // "Check your inbox" state instead of asking the user to send an email that
+  // has already been sent. We derive `emailSent` from this so the modal
+  // updates reactively if the Onyx write lands AFTER the modal has mounted
+  // (which happens with slice D's fire-and-forget send during signup).
+  const [verifyEmailSent] = useOnyx(ONYXKEYS.VERIFY_EMAIL_SENT);
   const [isVisible, setIsVisible] = useState(true);
-  const [emailSent, setEmailSent] = useState(false);
+  const [locallySent, setLocallySent] = useState(false);
+  const emailSent = !!verifyEmailSent || locallySent;
   const [emailVerified, setEmailVerified] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState('');
@@ -36,7 +46,7 @@ function VerifyEmailModal() {
         setErrorText('');
         setIsLoading(true);
         await User.sendVerifyEmailLink(user);
-        setEmailSent(true);
+        setLocallySent(true);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : '';
         setErrorText(errorMessage);
@@ -147,7 +157,7 @@ function VerifyEmailModal() {
                       style={[styles.mv2]}
                       type="success"
                       messages={{
-                        // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
                         0: translate('verifyEmailScreen.emailSent'),
                       }}
                     />
@@ -156,7 +166,7 @@ function VerifyEmailModal() {
                     <DotIndicatorMessage
                       style={[styles.mv2]}
                       type="error"
-                      // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                      // eslint-disable-next-line @typescript-eslint/naming-convention
                       messages={{0: errorText || ''}}
                     />
                   )}

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -145,9 +145,14 @@ function VerifyEmailModal() {
             style={[
               styles.flex1,
               styles.mh4,
-              styles.pb1,
               styles.alignItemsCenter,
-              safeAreaPaddingBottomStyle,
+              // Match the bottom-padding pattern used by TermsScreenContent:
+              // respect the device's safe area inset, and fall back to pb5
+              // (not pb1) on devices where the inset is 0 so the buttons
+              // don't sit flush against the screen edge.
+              safeAreaPaddingBottomStyle.paddingBottom
+                ? safeAreaPaddingBottomStyle
+                : styles.pb5,
             ]}>
             {!emailVerified ? (
               <View>

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -22,7 +22,7 @@ import type {
   VerifyEmailScreenEmailParmas,
 } from './params';
 
-/* eslint-disable max-len */
+ 
 export default {
   common: {
     cancel: 'Zrušit',
@@ -966,6 +966,16 @@ export default {
     error: {
       generic: 'Při pokusu o reset hesla došlo k chybě.',
     },
+  },
+  oauthLinkModal: {
+    appleTitle: 'Propojit účet Apple',
+    googleTitle: 'Propojit účet Google',
+    body: ({email}: ForgotPasswordSuccessParams) =>
+      `Účet s adresou ${email} již existuje. Zadejte heslo pro propojení.`,
+    appleSubmit: 'Propojit účet Apple',
+    googleSubmit: 'Propojit účet Google',
+    resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
+      `Odkaz pro reset hesla byl odeslán na adresu ${email}. Zkontrolujte si schránku.`,
   },
   passwordScreen: {
     title: 'Změnit heslo',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -707,7 +707,7 @@ export default {
     iHaveVerified: 'E-mail mám ověřený',
     oneMoreStep: 'Ještě jeden krok!',
     checkYourInbox:
-      "Zkontrolujte svou e-mailovou schránku a ověřte svůj e-mail.\nPoté buď restartujte aplikaci, abyste viděli změny, nebo stiskněte tlačítko 'E-mail mám ověřený' níže.",
+      "Zkontrolujte svou e-mailovou schránku a ověřte svůj e-mail.\nNevidíte ho? Podívejte se do složky spamu.\nPoté buď restartujte aplikaci, abyste viděli změny, nebo stiskněte tlačítko 'E-mail mám ověřený' níže.",
     error: {
       generic: 'Chyba při ověřování vašeho e-mailu',
       sending: 'Chyba při odesílání ověřovacího e-mailu',
@@ -961,7 +961,7 @@ export default {
     submit: 'Resetovat heslo',
     enterEmail: 'Zadejte sem svůj e-mail',
     success: ({email}: ForgotPasswordSuccessParams) =>
-      `E-mail s pokyny pro reset hesla byl odeslán na adresu ${email}.`,
+      `E-mail s pokyny pro reset hesla byl odeslán na adresu ${email}. Nevidíte ho? Podívejte se do složky spamu.`,
     error: {
       generic: 'Při pokusu o reset hesla došlo k chybě.',
     },
@@ -974,7 +974,7 @@ export default {
     appleSubmit: 'Propojit účet Apple',
     googleSubmit: 'Propojit účet Google',
     resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
-      `Odkaz pro reset hesla byl odeslán na adresu ${email}. Zkontrolujte si schránku.`,
+      `Odkaz pro reset hesla byl odeslán na adresu ${email}. Zkontrolujte si schránku — a složku spamu, pokud ho nevidíte.`,
   },
   passwordScreen: {
     title: 'Změnit heslo',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -945,6 +945,7 @@ export default {
   },
   signUpScreen: {
     signingIn: 'Přihlašuji...',
+    almostThere: 'Už jen chvilku...',
   },
   forgotPasswordScreen: {
     title: 'Zapomenuté heslo',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1044,6 +1044,11 @@ export default {
         title: 'E-mail se již používá',
         message: 'Tato e-mailová adresa je již spojena s jiným účtem.',
       },
+      accountExistsWithDifferentCredential: {
+        title: 'Účet již existuje',
+        message:
+          'Účet s touto e-mailovou adresou již existuje. Přihlaste se prosím metodou, kterou jste použili při jeho vytvoření.',
+      },
       userNotFound: {
         title: 'Uživatel nenalezen',
         message:

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -695,23 +695,16 @@ export default {
     enterPassword: 'Zadejte heslo',
   },
   verifyEmailScreen: {
-    youAreNotVerified: 'Ověřte svůj e-mail!',
-    wouldYouLikeToVerify: ({email}: VerifyEmailScreenEmailParmas) =>
-      `Chcete ověřit e-mail ${email ?? 'vaši adresu'} rovnou?`,
-    illDoItLater: 'Udělám to později',
-    verifyEmail: 'Ověřit e-mail',
-    changeEmail: 'Změnit e-mail',
+    title: 'Ověřte svůj e-mail',
+    body: ({email}: VerifyEmailScreenEmailParmas) =>
+      `Poslali jsme ověřovací odkaz na adresu ${email ?? 'vaši adresu'}. Otevřete jej pro potvrzení a vraťte se zpět. Nevidíte ho? Podívejte se do složky spamu.`,
     resendEmail: 'Znovu odeslat e-mail',
-    emailSent: 'Ověřovací e-mail byl odeslán na vaši adresu.',
+    emailSent: 'Ověřovací e-mail byl odeslán.',
     emailVerified: 'E-mail byl ověřen!',
     iHaveVerified: 'E-mail mám ověřený',
-    oneMoreStep: 'Ještě jeden krok!',
-    checkYourInbox:
-      "Zkontrolujte svou e-mailovou schránku a ověřte svůj e-mail.\nNevidíte ho? Podívejte se do složky spamu.\nPoté buď restartujte aplikaci, abyste viděli změny, nebo stiskněte tlačítko 'E-mail mám ověřený' níže.",
     error: {
       generic: 'Chyba při ověřování vašeho e-mailu',
       sending: 'Chyba při odesílání ověřovacího e-mailu',
-      dismissing: 'Chyba při zrušení ověřovacího e-mailu',
       emailSentRecently:
         'Před odesláním dalšího ověřovacího e-mailu chvíli vyčkejte.',
       emailNotVerified: 'Váš e-mail stále nebyl ověřen.',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -945,7 +945,7 @@ export default {
   },
   signUpScreen: {
     signingIn: 'Přihlašuji...',
-    almostThere: 'Už jen chvilku...',
+    signingYouIn: 'Přihlašuji vás...',
   },
   forgotPasswordScreen: {
     title: 'Zapomenuté heslo',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -22,7 +22,6 @@ import type {
   VerifyEmailScreenEmailParmas,
 } from './params';
 
- 
 export default {
   common: {
     cancel: 'Zrušit',
@@ -1041,9 +1040,9 @@ export default {
         message: 'K pokračování je vyžadováno heslo. Zadejte prosím své heslo.',
       },
       invalidCredential: {
-        title: 'Neplatné přihlašovací údaje',
+        title: 'Nesprávný e-mail nebo heslo',
         message:
-          'Zadané údaje jsou nesprávné. Zkontrolujte je a zkuste to znovu.',
+          'Zkontrolujte e-mail a heslo. Pokud jste se zaregistrovali pomocí Apple nebo Google, přihlaste se tímto způsobem.',
       },
       weakPassword: {
         title: 'Slabé heslo',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -950,6 +950,7 @@ export default {
   },
   signUpScreen: {
     signingIn: 'Signing in...',
+    almostThere: 'Almost there...',
   },
   forgotPasswordScreen: {
     title: 'Forgotten password',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -710,7 +710,7 @@ export default {
     iHaveVerified: 'I have verified my email',
     oneMoreStep: 'One more step!',
     checkYourInbox:
-      "Please check your inbox and verify your email.\nAfterwards, either restart the app to see changes, or press the 'I have verified my email' button below.",
+      "Please check your inbox and verify your email.\nDon't see it? Check your spam folder.\nAfterwards, either restart the app to see changes, or press the 'I have verified my email' button below.",
     error: {
       generic: 'Error verifying your email',
       sending: 'Error sending verification email',
@@ -966,7 +966,7 @@ export default {
     submit: 'Reset your password',
     enterEmail: 'Enter your email here',
     success: ({email}: ForgotPasswordSuccessParams) =>
-      `An email with password reset instructions has been sent to ${email}.`,
+      `An email with password reset instructions has been sent to ${email}. Don't see it? Check your spam folder.`,
     error: {
       generic: 'There was an error when attempting to reset your password.',
     },
@@ -979,7 +979,7 @@ export default {
     appleSubmit: 'Connect Apple account',
     googleSubmit: 'Connect Google account',
     resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
-      `We sent a reset link to ${email}. Check your inbox.`,
+      `We sent a reset link to ${email}. Check your inbox — and your spam folder if you don't see it.`,
   },
   passwordScreen: {
     title: 'Change your password',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -23,7 +23,6 @@ import type {
   VerifyEmailScreenEmailParmas,
 } from './params';
 
- 
 export default {
   common: {
     cancel: 'Cancel',
@@ -1051,9 +1050,9 @@ export default {
           'A password is required to proceed. Please enter your password.',
       },
       invalidCredential: {
-        title: 'Invalid Credentials',
+        title: 'Wrong email or password',
         message:
-          'The credentials provided are incorrect. Please check and try again.',
+          'Check your email and password. If you originally signed up with Apple or Google, sign in with those instead.',
       },
       weakPassword: {
         title: 'Weak Password',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -950,7 +950,7 @@ export default {
   },
   signUpScreen: {
     signingIn: 'Signing in...',
-    almostThere: 'Almost there...',
+    signingYouIn: 'Signing you in...',
   },
   forgotPasswordScreen: {
     title: 'Forgotten password',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -23,7 +23,7 @@ import type {
   VerifyEmailScreenEmailParmas,
 } from './params';
 
-/* eslint-disable max-len */
+ 
 export default {
   common: {
     cancel: 'Cancel',
@@ -971,6 +971,16 @@ export default {
     error: {
       generic: 'There was an error when attempting to reset your password.',
     },
+  },
+  oauthLinkModal: {
+    appleTitle: 'Connect your Apple account',
+    googleTitle: 'Connect your Google account',
+    body: ({email}: ForgotPasswordSuccessParams) =>
+      `An account with ${email} already exists. Enter your password to connect.`,
+    appleSubmit: 'Connect Apple account',
+    googleSubmit: 'Connect Google account',
+    resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
+      `We sent a reset link to ${email}. Check your inbox.`,
   },
   passwordScreen: {
     title: 'Change your password',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -698,23 +698,16 @@ export default {
     enterPassword: 'Enter your password',
   },
   verifyEmailScreen: {
-    youAreNotVerified: "Let's verify your email!",
-    wouldYouLikeToVerify: ({email}: VerifyEmailScreenEmailParmas) =>
-      `Would you like to verify ${email ?? 'your email'} now?`,
-    illDoItLater: "I'll do it later",
-    verifyEmail: 'Verify email',
-    changeEmail: 'Change email',
+    title: 'Verify your email',
+    body: ({email}: VerifyEmailScreenEmailParmas) =>
+      `We sent a verification link to ${email ?? 'your email'}. Open it to confirm your address, then come back here. Don't see it? Check your spam folder.`,
     resendEmail: 'Resend email',
-    emailSent: 'A verification email has been sent to your email address.',
+    emailSent: 'Verification email sent.',
     emailVerified: 'Email verified!',
     iHaveVerified: 'I have verified my email',
-    oneMoreStep: 'One more step!',
-    checkYourInbox:
-      "Please check your inbox and verify your email.\nDon't see it? Check your spam folder.\nAfterwards, either restart the app to see changes, or press the 'I have verified my email' button below.",
     error: {
       generic: 'Error verifying your email',
       sending: 'Error sending verification email',
-      dismissing: 'Error dismissing verification email',
       emailSentRecently:
         'Please wait before sending another verification email.',
       emailNotVerified: 'Your email has not been verified yet.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1055,6 +1055,11 @@ export default {
         message:
           'The email address is already associated with another account.',
       },
+      accountExistsWithDifferentCredential: {
+        title: 'Account Already Exists',
+        message:
+          'An account with this email already exists. Please sign in with the method you originally used to create your account.',
+      },
       userNotFound: {
         title: 'User Not Found',
         message:

--- a/src/libs/Errors/ERROR_MAPPING.ts
+++ b/src/libs/Errors/ERROR_MAPPING.ts
@@ -18,6 +18,8 @@ const ERROR_MAPPING: ErrorMapping = {
   [ERRORS.AUTH.INVALID_CREDENTIAL]: 'errors.auth.invalidCredential',
   [ERRORS.AUTH.WEAK_PASSWORD]: 'errors.auth.weakPassword',
   [ERRORS.AUTH.EMAIL_ALREADY_IN_USE]: 'errors.auth.emailAlreadyInUse',
+  [ERRORS.AUTH.ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL]:
+    'errors.auth.accountExistsWithDifferentCredential',
   [ERRORS.AUTH.USER_NOT_FOUND]: 'errors.auth.userNotFound',
   [ERRORS.AUTH.WRONG_PASSWORD]: 'errors.auth.wrongPassword',
   [ERRORS.AUTH.NETWORK_REQUEST_FAILED]: 'errors.auth.networkRequestFailed',

--- a/src/libs/UserUtils.ts
+++ b/src/libs/UserUtils.ts
@@ -241,7 +241,24 @@ function getSmallSizeAvatar(
 //   return parsedLoginList.find(login => Str.isValidE164Phone(login));
 // }
 
+/**
+ * Non-production-only session bypass for the mandatory email-verification modal.
+ * Set by the "Skip verification (dev only)" affordance inside VerifyEmailModal.
+ * Module-scoped so it resets on every cold app restart — there is no Onyx
+ * persistence by design, and no clearing on logout (the bypass is per-device
+ * session, not per-user, so QA cycles don't re-trigger the modal on every
+ * sign-out/sign-in).
+ */
+let devBypassEmailVerification = false;
+
+function setDevBypassEmailVerification(bypass: boolean): void {
+  devBypassEmailVerification = bypass;
+}
+
 function shouldShowVerifyEmailModal(user: User | null): boolean {
+  if (devBypassEmailVerification) {
+    return false;
+  }
   return !!user && !user.emailVerified;
 }
 
@@ -276,6 +293,7 @@ export {
   // hasLoginListInfo,
   hashText,
   isDefaultAvatar,
+  setDevBypassEmailVerification,
   shouldShowVerifyEmailModal,
   shouldShowUpdateModal,
 };

--- a/src/libs/UserUtils.ts
+++ b/src/libs/UserUtils.ts
@@ -10,14 +10,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {User} from 'firebase/auth';
 import hashCode from './hashCode';
 
-let verifyEmailDismissed: OnyxEntry<Timestamp | null> = null;
-Onyx.connect({
-  key: ONYXKEYS.VERIFY_EMAIL_DISMISSED,
-  callback: val => {
-    verifyEmailDismissed = val;
-  },
-});
-
 let appUpdateDismissed: OnyxEntry<Timestamp | null> = null;
 Onyx.connect({
   key: ONYXKEYS.APP_UPDATE_DISMISSED,
@@ -250,13 +242,7 @@ function getSmallSizeAvatar(
 // }
 
 function shouldShowVerifyEmailModal(user: User | null): boolean {
-  if (!user || user.emailVerified) {
-    return false; // Already verified
-  }
-  if (!verifyEmailDismissed) {
-    return true; // Has not dismissed the modal yet
-  }
-  return verifyEmailDismissed < Date.now() - CONST.VERIFY_EMAIL.DISMISS_TIME;
+  return !!user && !user.emailVerified;
 }
 
 /**

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -673,11 +673,10 @@ function cleanupSession() {
   resetHomeRouteParams();
   // Drop any in-flight OAuth-link state so credentials don't leak across users.
   Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, null);
-  // Clear verification-email tracking so the next user on this device starts
-  // with a clean slate (VERIFY_EMAIL_SENT drives the modal's initial UI state;
-  // VERIFY_EMAIL_DISMISSED gates whether the modal appears at all).
+  // Clear verification-email cooldown so the next user on this device can
+  // immediately receive a fresh verification email without hitting the
+  // previous user's send timestamp.
   Onyx.set(ONYXKEYS.VERIFY_EMAIL_SENT, null);
-  Onyx.set(ONYXKEYS.VERIFY_EMAIL_DISMISSED, null);
   clearCache().then(() => {
     Log.info('Cleared all cache data', true, {}, true);
   });

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -673,6 +673,11 @@ function cleanupSession() {
   resetHomeRouteParams();
   // Drop any in-flight OAuth-link state so credentials don't leak across users.
   Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, null);
+  // Clear verification-email tracking so the next user on this device starts
+  // with a clean slate (VERIFY_EMAIL_SENT drives the modal's initial UI state;
+  // VERIFY_EMAIL_DISMISSED gates whether the modal appears at all).
+  Onyx.set(ONYXKEYS.VERIFY_EMAIL_SENT, null);
+  Onyx.set(ONYXKEYS.VERIFY_EMAIL_DISMISSED, null);
   clearCache().then(() => {
     Log.info('Cleared all cache data', true, {}, true);
   });

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -671,6 +671,8 @@ function cleanupSession() {
   // NetworkConnection.clearReconnectionCallbacks();
   // SessionUtils.resetDidUserLogInDuringSession();
   resetHomeRouteParams();
+  // Drop any in-flight OAuth-link state so credentials don't leak across users.
+  Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, null);
   clearCache().then(() => {
     Log.info('Cleared all cache data', true, {}, true);
   });

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -5,6 +5,7 @@ import type {
   DrinkingSessionList,
   FriendRequestList,
   NicknameToId,
+  PendingOAuthCredential,
   Preferences,
   Profile,
   ReasonForLeaving,
@@ -16,7 +17,10 @@ import type {Timestamp, UserID, UserList} from '@src/types/onyx/OnyxCommon';
 import type {Auth, AuthCredential, User, UserCredential} from 'firebase/auth';
 import {
   EmailAuthProvider,
+  GoogleAuthProvider,
+  OAuthProvider,
   createUserWithEmailAndPassword,
+  linkWithCredential,
   reauthenticateWithCredential,
   sendEmailVerification,
   signInWithCredential,
@@ -54,25 +58,23 @@ Onyx.connect({
   },
 });
 
-const getDefaultPreferences = (): Preferences => {
-  return {
-    first_day_of_week: 'Monday',
-    units_to_colors: {
-      orange: 10,
-      yellow: 5,
-    },
-    drinks_to_units: {
-      small_beer: 0.5,
-      beer: 1,
-      cocktail: 1.5,
-      other: 1,
-      strong_shot: 1,
-      weak_shot: 0.5,
-      wine: 1,
-    },
-    theme: CONST.THEME.SYSTEM,
-  };
-};
+const getDefaultPreferences = (): Preferences => ({
+  first_day_of_week: 'Monday',
+  units_to_colors: {
+    orange: 10,
+    yellow: 5,
+  },
+  drinks_to_units: {
+    small_beer: 0.5,
+    beer: 1,
+    cocktail: 1.5,
+    other: 1,
+    strong_shot: 1,
+    weak_shot: 0.5,
+    wine: 1,
+  },
+  theme: CONST.THEME.SYSTEM,
+});
 
 const getDefaultUserData = (profileData: Profile): UserData => {
   const userRole = 'open_beta_user';
@@ -88,11 +90,9 @@ const getDefaultUserData = (profileData: Profile): UserData => {
   };
 };
 
-const getDefaultUserStatus = (): {last_online: number} => {
-  return {
-    last_online: new Date().getTime(),
-  };
-};
+const getDefaultUserStatus = (): {last_online: number} => ({
+  last_online: new Date().getTime(),
+});
 
 /**
  * Check if a user exists in the realtime database.
@@ -604,6 +604,83 @@ async function signInWithOAuth(
   // just created with `username_chosen: false`).
 }
 
+/**
+ * Stash the raw OAuth materials when Firebase reports that the email already
+ * belongs to a different account (`auth/account-exists-with-different-credential`).
+ * The caller extracts the idToken/rawNonce/displayName from the OAuth response;
+ * this helper extracts the existing-account email from the FirebaseError and
+ * writes the combined record so the collision-resolution modal can pick it up.
+ *
+ * Returns true if the stash was written, false if the error did not carry an
+ * email (caller should fall back to the generic error path).
+ */
+function stashPendingOAuthCredential(
+  error: unknown,
+  data: {
+    providerId: PendingOAuthCredential['providerId'];
+    idToken: string;
+    rawNonce?: string;
+    displayName?: string | null;
+  },
+): boolean {
+  const email = (error as {customData?: {email?: string}}).customData?.email;
+  if (!email) {
+    return false;
+  }
+  Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, {email, ...data});
+  return true;
+}
+
+/** Drop the stashed OAuth credential — call on cancel, successful link, or unrecoverable error. */
+function clearPendingOAuthCredential(): void {
+  Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, null);
+}
+
+/**
+ * Resolve an OAuth sign-in collision by signing the user in with their existing
+ * email/password account and linking the pending OAuth credential to it. After
+ * this completes, both methods sign into the same Firebase account.
+ *
+ * The caller passes in the pending credential (read via `useOnyx` in the
+ * collision modal) so this action stays pure and doesn't depend on module
+ * state.
+ *
+ * - Wrong password → throws Firebase's wrong-password error; the caller should
+ *   keep the pending credential stash so the user can retry.
+ * - linkWithCredential failure → clears the stash and re-throws; the user must
+ *   re-OAuth because the token is likely stale.
+ */
+async function linkPendingOAuthCredential(
+  auth: Auth,
+  password: string,
+  pending: PendingOAuthCredential,
+): Promise<void> {
+  const userCredential = await signInWithEmailAndPassword(
+    auth,
+    pending.email,
+    password,
+  );
+
+  const credential: AuthCredential =
+    pending.providerId === 'apple.com'
+      ? new OAuthProvider('apple.com').credential({
+          idToken: pending.idToken,
+          rawNonce: pending.rawNonce,
+        })
+      : GoogleAuthProvider.credential(pending.idToken);
+
+  try {
+    await linkWithCredential(userCredential.user, credential);
+  } catch (linkError) {
+    // Stale/invalid token — drop the stash; the user must re-OAuth.
+    clearPendingOAuthCredential();
+    throw linkError;
+  }
+
+  clearPendingOAuthCredential();
+  Session.clearSignInData();
+}
+
 /** Attempt to log in to the Firebase authentication service with a user's credentials
  *
  * @param auth The Firebase authentication object
@@ -724,5 +801,8 @@ export {
   userExistsInDatabase,
   logIn,
   signInWithOAuth,
+  stashPendingOAuthCredential,
+  clearPendingOAuthCredential,
+  linkPendingOAuthCredential,
   signUp,
 };

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -749,6 +749,22 @@ async function signUp(
   const newUser = userCredential.user;
   const newUserID = newUser.uid;
 
+  // Fire-and-forget the verification email. Without this, the account's
+  // email stays unverified — and Firebase's "single account per email"
+  // policy will then silently OVERWRITE the password provider if the same
+  // user later signs in via Apple/Google with the same email (because
+  // OAuth verifies the email and Firebase trusts the verified claim over
+  // the unverified password account). The takeover is irreversible: the
+  // user gets locked out of email/password sign-in with no error. Sending
+  // verification immediately on signup means the collision path goes
+  // through `auth/account-exists-with-different-credential` instead and
+  // triggers the OAuthLinkModal.
+  sendEmailVerification(newUser).catch(error => {
+    Log.alert('[signUp] failed to send verification email', {
+      error,
+    });
+  });
+
   try {
     // Realtime Database updates
     await pushNewUserInfo(db, newUserID, newProfileData);

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -532,11 +532,6 @@ async function saveSelectedTimezone(
   });
 }
 
-/** Set the information about when the verify email modal was last dismissed */
-async function setVerifyEmailDismissed(timestamp: Timestamp): Promise<void> {
-  await Onyx.merge(ONYXKEYS.VERIFY_EMAIL_DISMISSED, timestamp);
-}
-
 /** Set the information about when the app update was last dimmissed */
 async function setAppUpdateDismissed(timestamp: Timestamp): Promise<void> {
   await Onyx.merge(ONYXKEYS.APP_UPDATE_DISMISSED, timestamp);
@@ -824,7 +819,6 @@ export {
   sendVerifyEmailLink,
   setAppUpdateDismissed,
   setUsername,
-  setVerifyEmailDismissed,
   synchronizeUserStatus,
   updateAutomaticTimezone,
   updatePassword,

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -322,21 +322,30 @@ async function updatePassword(
 /**
  * Send an email verification link to a user.
  *
- * @params user The user to send the email to
+ * @param user The user to send the email to
+ * @param options Optional behavior overrides:
+ *   - `bypassCooldown`: skip the per-device cooldown check. Used by `signUp` so
+ *     the very first verification email always fires regardless of a prior
+ *     user's send timestamp on the same device.
  * @returns A promise that resolves when the email is sent.
  */
-async function sendVerifyEmailLink(user: User | null): Promise<void> {
+async function sendVerifyEmailLink(
+  user: User | null,
+  options: {bypassCooldown?: boolean} = {},
+): Promise<void> {
   if (!user) {
     throw new Error(Localize.translateLocal('common.error.userNull'));
   }
-  const hasSentEmailRecently =
-    verifyEmailSent &&
-    verifyEmailSent > Date.now() - CONST.VERIFY_EMAIL.COOLDOWN;
+  if (!options.bypassCooldown) {
+    const hasSentEmailRecently =
+      verifyEmailSent &&
+      verifyEmailSent > Date.now() - CONST.VERIFY_EMAIL.COOLDOWN;
 
-  if (hasSentEmailRecently) {
-    throw new Error(
-      Localize.translateLocal('verifyEmailScreen.error.emailSentRecently'),
-    );
+    if (hasSentEmailRecently) {
+      throw new Error(
+        Localize.translateLocal('verifyEmailScreen.error.emailSentRecently'),
+      );
+    }
   }
   await sendEmailVerification(user);
   await Onyx.set(ONYXKEYS.VERIFY_EMAIL_SENT, new Date().getTime());
@@ -758,8 +767,13 @@ async function signUp(
   // user gets locked out of email/password sign-in with no error. Sending
   // verification immediately on signup means the collision path goes
   // through `auth/account-exists-with-different-credential` instead and
-  // triggers the OAuthLinkModal.
-  sendEmailVerification(newUser).catch(error => {
+  // triggers the OAuthLinkModal. We bypass the cooldown because this is
+  // the canonical first send for a brand-new account; the cooldown is
+  // device-global and otherwise blocks first-sends after a different user
+  // recently sent on this device. Routing through the wrapper (instead of
+  // the bare Firebase call) ensures `VERIFY_EMAIL_SENT` is written so the
+  // VerifyEmailModal opens in the truthful "Check your inbox" state.
+  sendVerifyEmailLink(newUser, {bypassCooldown: true}).catch(error => {
     Log.alert('[signUp] failed to send verification email', {
       error,
     });

--- a/src/screens/SignUp/AuthScreen.tsx
+++ b/src/screens/SignUp/AuthScreen.tsx
@@ -30,6 +30,7 @@ import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import AppleSignIn from '@components/SignInButtons/AppleSignIn';
 import GoogleSignIn from '@components/SignInButtons/GoogleSignIn';
+import OAuthLinkModal from '@components/OAuthLinkModal';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import type {TranslationPaths} from '@src/languages/types';
 import OrDelimiter from './OrDelimiter';
@@ -175,6 +176,7 @@ function AuthScreen({route}: AuthScreenProps) {
             <AppleSignIn onError={setServerErrorMessage} />
             <GoogleSignIn onError={setServerErrorMessage} />
           </View>
+          <OAuthLinkModal />
           <OrDelimiter containerStyle={styles.mb4} />
           <FormProvider
             formID={ONYXKEYS.FORMS.AUTH_FORM}
@@ -227,7 +229,7 @@ function AuthScreen({route}: AuthScreenProps) {
               <DotIndicatorMessage
                 style={[styles.mv2]}
                 type="error"
-                // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 messages={{0: serverErrorMessage || ''}}
               />
             )}

--- a/src/types/onyx/PendingOAuthCredential.ts
+++ b/src/types/onyx/PendingOAuthCredential.ts
@@ -1,0 +1,29 @@
+/**
+ * Raw OAuth sign-in materials stashed when Firebase reports that the email
+ * already belongs to an existing email/password account
+ * (`auth/account-exists-with-different-credential`). The collision-resolution
+ * modal reads this to prompt the user for their existing password, then
+ * reconstructs the credential and calls `linkWithCredential`.
+ *
+ * Stored in Onyx for reactivity, but treated as ephemeral: cleared on
+ * successful link, on user cancel, and on `cleanupSession()`. The idToken is
+ * short-lived, so a stale stash on disk is not exploitable for long.
+ */
+type PendingOAuthCredential = {
+  /** Which OAuth provider produced the credential */
+  providerId: 'apple.com' | 'google.com';
+
+  /** Email of the existing account — used as the login for the password prompt */
+  email: string;
+
+  /** Apple/Google identity token; required to reconstruct the credential */
+  idToken: string;
+
+  /** Raw nonce — required to reconstruct Apple credentials; absent for Google */
+  rawNonce?: string;
+
+  /** Best-effort display name captured from the OAuth provider response */
+  displayName?: string | null;
+};
+
+export default PendingOAuthCredential;

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -28,6 +28,7 @@ import type Login from './Login';
 import type Modal from './Modal';
 import type Network from './Network';
 import type NicknameToId from './NicknameToId';
+import type PendingOAuthCredential from './PendingOAuthCredential';
 import type {Nickname, NicknameKey, NicknameToIdList} from './NicknameToId';
 import type {
   OnyxUpdateEvent,
@@ -111,6 +112,7 @@ export type {
   NicknameKey,
   NicknameToId,
   NicknameToIdList,
+  PendingOAuthCredential,
   OnboardingData,
   OnyxUpdateEvent,
   OnyxUpdatesFromServer,


### PR DESCRIPTION
### Details

Closes the full collision-resolution story from [#297](https://github.com/PetrCala/Kiroku/issues/297). Ships in four layered commits:

- **Slice A — `fix(auth): surface OAuth account-collision error instead of "unknown"`** — adds the missing Firebase error code to `ERRORS.AUTH`, `ERROR_MAPPING`, and en/cs translations. Stops the silent failure; the user now sees "Account Already Exists" with a real instruction.
- **Slice B — `feat(auth): stash OAuth credential on collision and add link/clear actions`** — adds the `PENDING_OAUTH_CREDENTIAL` Onyx key + `PendingOAuthCredential` type, three pure action functions (`stashPendingOAuthCredential`, `clearPendingOAuthCredential`, `linkPendingOAuthCredential`), and wires the three SignInButton catch blocks (Apple iOS, Apple Android, Google) to stash on collision instead of showing the error. Logout clears the stash.
- **Slice C — `feat(auth): collision-resolution modal that links OAuth to existing account`** — adds `OAuthLinkModal` mounted in `AuthScreen`. Reads the stash via `useOnyx`, prompts for the existing-account password, and calls `linkPendingOAuthCredential` (which signs in with email/password + calls Firebase's `linkWithCredential`). Includes a "Forgot password?" link that fires `sendPasswordResetEmail` and shows inline confirmation. Post-link routing is owned by `OnboardingGuard` — no manual navigation.
- **Slice D — `fix(auth): send verification email on signup to prevent OAuth takeover`** — added after on-device testing surfaced a critical Firebase behavior gap: Firebase silently **overwrites** the password provider when an OAuth sign-in matches an existing **unverified** email/password account (security-trade-off; Firebase trusts the OAuth-verified email over the unverified password account). The takeover is irreversible — the user gets locked out of email/password with no error. Fix: fire `sendEmailVerification` immediately after `createUserWithEmailAndPassword` so the email becomes verifiable. Once verified, the collision path goes through `auth/account-exists-with-different-credential` as expected and slices A–C handle it. Also reworded the `auth/invalid-credential` translation to hint at trying Apple/Google, because Firebase's Email Enumeration Protection collapses wrong-password / user-not-found / takeover-victim into the same generic code.

### Design notes

- **Firebase-idiomatic flow, not Expensify's**: looked at Expensify's `UnlinkLoginForm` and concluded the email-validation step it does isn't needed for us — Firebase already trusts Apple/Google's verified email, so the only proof the user owes is their existing password. Single modal, no inbox round-trip.
- **OAuth idToken in Onyx**: the stash hits AsyncStorage on disk. Risk is bounded — Apple/Google idTokens are short-lived (~minutes), the stash is cleared on success, cancel, and `cleanupSession`, and AsyncStorage is sandboxed per app. Acceptable for v1.
- **Pure action**: `linkPendingOAuthCredential(auth, password, pending)` takes the stash as a parameter (the modal reads it via `useOnyx` and passes it in). This avoided introducing a new grandfathered `Onyx.connect` violation.
- **Keyed modal content**: the inner modal content is split into a keyed component (`key=${providerId}:${email}`), so each new collision remounts with a fresh form. Avoids carrying a stale password across sessions and a `react-hooks/set-state-in-effect` warning.
- **Verification email is fire-and-forget**: in slice D, the `sendEmailVerification` call is not awaited and errors only log. The verification flow shouldn't block account creation, and Firebase's per-user rate-limit doesn't apply to the first send.
- **Out of scope**: settings-side "Connected Accounts" screen tracked separately as [#441](https://github.com/PetrCala/Kiroku/issues/441) — that's where users who already got bitten by the takeover can add a password back (`linkWithCredential` from a signed-in session). Apple Hide-My-Email private-relay collision documented as a known limitation. Phone-number / SMS provider not planned.

### Tests

Requires real Apple/Google test accounts; cannot validate without a device.

**Primary flow — collision triggers the modal:**
1. Create an email/password account using a real email you control (e.g. `test@example.com`)
2. **Click the verification link** Firebase emails you (slice D wires this) — this is what makes the takeover NOT happen
3. Sign out
4. From the login screen, tap **"Sign in with Apple"** using an Apple ID associated with `test@example.com`
5. **Expected:** modal appears titled "Connect your Apple account", body shows the email, password field is focused
6. Type the **wrong** password → submit → modal stays open, error appears inline, can retry
7. Type the **correct** password → submit → modal closes, you land signed in
8. Sign out, sign in again with Apple → no modal, OAuth is now linked to the existing account
9. Repeat steps 1–8 with **"Sign in with Google"**
10. Tap "Forgot password?" inside the modal → inline "We sent a reset link…" appears, the Forgot link disappears, modal stays open, reset email arrives
11. Tap Cancel or the backdrop → modal closes, can re-tap the OAuth button

**Failure path — verification skipped:**
1. Create email/password account
2. **Do NOT click the verification link**
3. Sign out, sign in with Apple/Google using the same email
4. **Expected:** Firebase silently overwrites the password provider (this is the documented Firebase behavior we cannot prevent client-side). User is signed into the OAuth-only account. The email/password sign-in path is dead until they reset/re-link via [#441](https://github.com/PetrCala/Kiroku/issues/441). The `invalid-credential` error message now points them toward the OAuth buttons as a fallback.

**Regression check:**
- Sign up via Apple/Google with a brand-new email (no collision) — still works end-to-end, no modal appears.

### Offline tests

- Login screen offline → tapping Apple/Google fails before reaching Firebase; existing error handling unchanged
- Modal open, network drops, submit pressed → `signInWithEmailAndPassword` throws network error, inline message shown, stash preserved for retry
- Signup offline → `createUserWithEmailAndPassword` rejects with network error; `sendEmailVerification` is never reached (account never created)

### QA Steps

Same as Tests above, on the staging build. After the primary flow's step 8, additionally:

- Verify in Firebase console that the user shows two linked providers (email + apple.com or google.com)
- Verify only one user UID exists for that email (no orphan duplicate account)

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] All UI copy localized in en + cs
- [x] Typecheck (`npm run typecheck-tsgo`) passes
- [x] Prettier passes on all changed files
- [x] `eslint --fix` clean on changed files (0 errors; pre-existing `Onyx.connect` warnings on unrelated lines)
- [ ] Manual end-to-end verification on a build (cannot delegate; needs real Firebase + real Apple/Google accounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Follow-up fixes (review round) — to test

Three review fixes pushed on top: `aff4d556`, `fb0f7d24`, `25e31d03`.

**1. Sign-out from VerifyEmailModal (`aff4d556`)**
- [x] Sign up with a new email → VerifyEmailModal appears → tap "Sign out" → user lands on AuthScreen, modal does **not** flash back
- [x] Sign in elsewhere (e.g. settings) → sign out → no VerifyEmailModal appears over the public stack
- [x] Cold-restart app while signed out → no VerifyEmailModal at launch

**2. Loading indicator after Apple/Google sign-in (`fb0f7d24`)**
- [x] Tap Apple Sign In (iOS) on a fresh account → after Apple sheet dismisses, "Signing you in…" overlay covers the screen continuously until the next screen paints (no blank window)
- [ ] Same, on Android (Apple web flow)
- [x] Same, Google Sign In
- [x] Cancel the OAuth sheet → no spinner left pinned, can re-tap the button
- [ ] Trigger an error path (e.g. airplane mode mid-sign-in) → spinner clears, error surfaces on AuthScreen
- [ ] cs locale: text reads "Přihlašuji vás…"

**3. VerifyEmailModal bottom padding (`25e31d03`)**
- [ ] On a device **with** a notch / bottom inset (e.g. iPhone 14): bottom controls clear the home indicator (visually identical to before)
- [ ] On a device **without** a bottom inset (e.g. older iPhone SE, most Android): "Sign out" link is no longer flush against the screen edge; visually comparable to the onboarding Terms / Display Name screens

**4. OAuth collision modal — verification flow (PR slice C)**

The earlier review noted the collision modal doesn't appear. Most likely cause is the documented Firebase silent-takeover path (unverified email). New diagnostic logging added in `fb0f7d24` will print the actual error code if `signInWithCredential` fails with something other than `auth/account-exists-with-different-credential`.

- [ ] **Primary** — follow the original test plan strictly, including step 2 (click the verification link **before** signing out). Confirm the modal appears titled "Connect your Apple/Google account".
- [ ] **Diagnostic** — if the modal still doesn't appear, capture the `[Apple Sign In] Firebase signInWithCredential failed` / `[Google Sign In] Firebase signInWithCredential failed` log line and report the `code` field — that will tell us whether Firebase is returning a different code (e.g. Email Enumeration Protection) or whether the silent takeover is happening (no error at all).

