### PR TITLE
feat(commands): add /ship slash command for rebase-merge + delete-branch

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,25 @@
+---
+allowed-tools: Bash(gh pr merge:*),Bash(gh pr view:*),Bash(gh pr list:*)
+argument-hint: "[PR number]"
+description: Rebase-merge a PR and delete its branch. Targets the PR worked on in this session unless an argument is provided.
+---
+
+Rebase-merge a PR and delete its branch.
+
+## Target PR resolution
+
+1. **If `$ARGUMENTS` is non-empty**, treat it as the PR number and use it directly.
+2. **Otherwise**, look back through this session for PRs you opened, merged, commented on, or otherwise referenced (e.g. `gh pr create` output, `https://github.com/.../pull/<N>` links, `gh pr merge <N>` calls).
+   - **Exactly one PR in session** → use it.
+   - **Multiple distinct PRs** → STOP. Tell the user which PR numbers you saw and ask them to re-run as `/ship <number>`. Do not guess.
+   - **Zero PRs** → STOP. Tell the user to pass a PR number: `/ship <number>`.
+
+## Execute
+
+Once the target is resolved, run:
+
+```bash
+gh pr merge <N> --rebase --delete-branch
+```
+
+Report the result in one line (merged + branch deleted, or the error). Do not narrate the resolution step unless it failed.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/ship.md`, a project-level slash command that runs `gh pr merge <N> --rebase --delete-branch`.
- Resolves the target PR from the current Claude Code session's history. Falls back to requiring an explicit `/ship <number>` argument when zero or multiple PRs are referenced.

## Why

After landing #438, the user noted that "rebase-merge the PR, delete the branch" is a frequent enough action to deserve a one-token shortcut. A slash command is the right tier here — it's a single deterministic `gh` call, not a workflow that needs a skill.

## Test plan

- [ ] In a fresh session with a single PR worked on, `/ship` resolves to that PR and merges it
- [ ] With no PR in session, `/ship` (no args) stops and asks for a number
- [ ] With multiple PRs in session, `/ship` (no args) lists them and asks the user to disambiguate
- [ ] `/ship 438` works regardless of session context

🤖 Generated with [Claude Code](https://claude.com/claude-code)