### PR TITLE
feat(testing): scaffold Maestro E2E for sign-up flows (v1, Android)

### DIFF
--- a/.github/workflows/e2eAndroid.yml
+++ b/.github/workflows/e2eAndroid.yml
@@ -1,0 +1,95 @@
+name: E2E Android (Maestro)
+
+# Runs Maestro flows in .maestro/flows/ on every PR. Targets the staging
+# Android variant against the dev Firebase project. iOS coverage and
+# additional flows (email verification, OAuth providers) are tracked
+# separately — see contributingGuides/E2E_TESTING.md.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+# Cancel in-progress runs when a new commit is pushed to the same PR.
+concurrency:
+  group: e2e-android-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  maestro:
+    name: Run Maestro flows on Android emulator
+    if: github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Reuse the staging .env so the build talks to the dev Firebase project.
+      STAGING_ENV_FILE: ${{ secrets.STAGING_ENV_FILE }}
+      FIREBASE_DEV_ADMIN_SA: ${{ secrets.FIREBASE_DEV_ADMIN_SA }}
+      MAESTRO_RUN_ID: pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'oracle'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Hydrate .env.staging
+        run: |
+          if [ -z "$STAGING_ENV_FILE" ]; then
+            echo "::error::STAGING_ENV_FILE secret is not set"
+            exit 1
+          fi
+          echo "$STAGING_ENV_FILE" > .env.staging
+
+      - name: Install Maestro CLI
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Build staging debug APK
+        run: |
+          cd android
+          ./gradlew :app:assembleStagingDebug --no-daemon
+
+      - name: Run Maestro flows on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            adb install -r android/app/build/outputs/apk/staging/debug/app-staging-debug.apk
+            npm run e2e:android
+
+      - name: Upload Maestro artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-debug-${{ github.run_attempt }}
+          path: |
+            ~/.maestro/tests/**/*.png
+            ~/.maestro/tests/**/*.mp4
+            ~/.maestro/tests/**/*.xml
+            ~/.maestro/tests/**/commands*.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,45 @@
+# Maestro end-to-end tests
+
+End-to-end coverage for the Kiroku sign-up and onboarding flows, run via
+[Maestro](https://maestro.mobile.dev). v1 targets Android only against the
+**staging** build, which points at the **dev** Firebase project.
+
+## Local setup
+
+```bash
+npm run e2e:setup            # installs Maestro CLI (curl from mobile.dev)
+npm run android              # produces a stagingDebug APK on a running emulator
+npm run e2e:android          # runs all flows via scripts/maestro/run.ts
+FLOWS=signup-email-password npm run e2e:android   # single flow
+```
+
+You need a running Android emulator (`npm run startAndroidEmulator`) and the
+staging APK installed before running flows. `FIREBASE_DEV_ADMIN_SA` must be
+exported in your environment (single-line service-account JSON for the dev
+Firebase project) so the orchestrator can seed and tear down test users.
+
+## Layout
+
+- `flows/` — YAML flow files, one per scenario. Each consumes `EMAIL`,
+  `PASSWORD` env vars injected by the orchestrator.
+- `config.yaml` — Maestro workspace config.
+- The orchestrator lives at `scripts/maestro/run.ts`. It generates a unique
+  `maestro+<runId>-<flow>@kiroku.test` per flow, seeds Firebase Auth for
+  flows that need an existing user, runs the flow, and tears the user down
+  in a `finally` so failures don't leak state.
+
+## Maestro YAML conventions
+
+- Reference elements by `id:` matching a key in `CONST.TEST_IDS`. Use text
+  matching only for buttons rendered by shared form components (e.g.
+  `tapOn: "Create account"`) until we thread testID through `FormWrapper`.
+- New flows: add a `tags:` block (`smoke`, `signup`, `login`, …) so we can
+  filter in CI as the suite grows.
+
+## Out of scope for v1
+
+- iOS (planned for PR 2).
+- Email verification flow (needs Admin-SDK link generation — PR 2).
+- Google and Apple Sign-In (system-modal native UI; will need mocked
+  providers in a separate build flavor).
+- Locale variants (flows assume English defaults).

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,7 @@
+# Maestro workspace config. Flows in flows/ default to the staging build's
+# Android applicationId (com.alcohol_tracker.staging). Override per-flow if
+# you need to target a different variant or platform.
+#
+# Docs: https://maestro.mobile.dev/cli/test-suites-and-reports#flow-configuration
+flows:
+  - flows/

--- a/.maestro/flows/forgot-password-flow.yaml
+++ b/.maestro/flows/forgot-password-flow.yaml
@@ -1,0 +1,32 @@
+# Password reset request:
+#   AuthScreen (logIn) -> "Forgot password?" -> submit email.
+#
+# Verifies the UI path and that Firebase accepts the reset request. We do
+# NOT assert the reset email is received — that lands in PR 2 with the
+# Admin-SDK inbox-free verification.
+appId: com.alcohol_tracker.staging
+env:
+  EMAIL: ''
+tags:
+  - reset
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: 'Auth Screen'
+
+- tapOn:
+    id: 'auth-toggle-mode'
+- tapOn:
+    id: 'auth-forgot-password-link'
+
+- assertVisible:
+    id: 'ForgotPasswordScreen'
+- tapOn:
+    id: 'forgot-password-email-input'
+- inputText: ${EMAIL}
+- hideKeyboard
+- tapOn: 'Send reset link'
+
+# Success message contains the email address we submitted
+- assertVisible: ${EMAIL}

--- a/.maestro/flows/login-existing-user.yaml
+++ b/.maestro/flows/login-existing-user.yaml
@@ -1,0 +1,30 @@
+# Existing user log-in:
+#   Pre-seeded user (scripts/maestro/run.ts uses Admin SDK to create +
+#   mark verified before this flow runs) -> AuthScreen (logIn) -> Home.
+appId: com.alcohol_tracker.staging
+env:
+  EMAIL: ''
+  PASSWORD: ''
+tags:
+  - login
+  - smoke
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: 'Auth Screen'
+
+# Switch from sign-up to log-in mode
+- tapOn:
+    id: 'auth-toggle-mode'
+
+- tapOn:
+    id: 'auth-email-input'
+- inputText: ${EMAIL}
+- tapOn:
+    id: 'auth-password-input'
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn: 'Log in'
+
+- assertVisible: 'Today'

--- a/.maestro/flows/signup-email-password.yaml
+++ b/.maestro/flows/signup-email-password.yaml
@@ -1,0 +1,45 @@
+# Email/password sign-up happy path:
+#   AuthScreen (signUp mode) -> Onboarding Terms -> Display Name -> Home
+#
+# Disposable user. Created via the UI, torn down by the orchestrator
+# (scripts/maestro/run.ts) after the flow finishes.
+appId: com.alcohol_tracker.staging
+env:
+  EMAIL: '' # injected by scripts/maestro/run.ts (unique per run)
+  PASSWORD: ''
+  DISPLAY_NAME: 'Maestro Tester'
+tags:
+  - signup
+  - smoke
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: 'Auth Screen'
+
+# Sign-up form (default mode on AuthScreen is 'signUp')
+- tapOn:
+    id: 'auth-email-input'
+- inputText: ${EMAIL}
+- tapOn:
+    id: 'auth-password-input'
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn: 'Create account'
+
+# Terms screen
+- assertVisible:
+    id: 'TermsScreen'
+- tapOn: 'Accept'
+
+# Display name screen
+- assertVisible:
+    id: 'DisplayNameScreen'
+- tapOn:
+    id: 'onboarding-display-name-input'
+- inputText: ${DISPLAY_NAME}
+- hideKeyboard
+- tapOn: 'Continue'
+
+# Landed on the authenticated home surface
+- assertVisible: 'Today'

--- a/contributingGuides/E2E_TESTING.md
+++ b/contributingGuides/E2E_TESTING.md
@@ -1,0 +1,81 @@
+# End-to-end testing (Maestro)
+
+Kiroku's E2E suite uses [Maestro](https://maestro.mobile.dev) to drive the
+real app on an Android emulator. Flows live in `.maestro/flows/`. The
+suite runs on every PR via `.github/workflows/e2eAndroid.yml` against the
+**staging** Android variant pointed at the **dev** Firebase project.
+
+## Why Maestro
+
+- YAML flows are an order of magnitude less code than Detox tests and
+  don't compile against app source, so they don't break on TypeScript
+  refactors.
+- Free and open source. No Maestro Cloud dependency for the suite to run.
+- The Maestro CLI ships with screenshot/video capture, which lands as
+  GitHub Actions artifacts when a flow fails.
+
+## Running locally
+
+```bash
+# One-time
+npm run e2e:setup
+
+# Bring up an emulator and install a staging build
+npm run startAndroidEmulator
+cd android && ./gradlew :app:assembleStagingDebug && cd ..
+adb install -r android/app/build/outputs/apk/staging/debug/app-staging-debug.apk
+
+# Export the dev Firebase admin service-account JSON as a single line
+export FIREBASE_DEV_ADMIN_SA='{"type":"service_account",...}'
+
+# Run all flows
+npm run e2e:android
+
+# Run a single flow
+FLOWS=signup-email-password npm run e2e:android
+```
+
+The orchestrator at `scripts/maestro/run.ts` generates a unique
+`maestro+<runId>-<flow>@kiroku.test` per flow, pre-seeds users for flows
+that need them (login, forgot-password), runs the flow, and tears the
+user down in a `finally` so failed flows don't leak.
+
+## Adding new flows
+
+1. Create `.maestro/flows/<your-flow>.yaml`.
+2. Reuse testIDs from `CONST.TEST_IDS` rather than asserting on visible
+   text — flows must survive copy and translation changes.
+3. If your flow needs additional testIDs, add them to `CONST.TEST_IDS`
+   and the relevant screen in the same PR.
+4. If your flow needs a pre-seeded user, add the flow basename to the
+   `PRE_SEEDED` set in `scripts/maestro/run.ts`.
+5. Tag the flow (`tags: [smoke, signup, ...]`) so we can filter as the
+   suite grows.
+
+## Known limitations (tracked separately)
+
+- **iOS coverage**: deferred to a follow-up PR (macOS runners + Xcode
+  toolchain doubles CI cost; Android catches most regressions first).
+- **Email verification flow**: needs the Admin SDK to generate the
+  verification link without a real inbox. Deferred to PR 2.
+- **Google and Apple Sign-In**: render system-modal native UI that
+  Maestro cannot reliably drive. Plan: a "maestro" build flavor that
+  swaps the real providers for mocks so the post-OAuth code path stays
+  covered.
+- **Locale variants**: flows assume English defaults. Submit buttons
+  match by visible text because the shared `FormWrapper` doesn't yet
+  thread a `submitButtonTestID`. Once it does, these matchers become
+  locale-agnostic.
+
+## CI
+
+- Workflow: `.github/workflows/e2eAndroid.yml`
+- Required secrets:
+  - `STAGING_ENV_FILE` — full `.env.staging` contents (multi-line)
+  - `FIREBASE_DEV_ADMIN_SA` — dev Firebase service-account JSON, single
+    line. Generate at Firebase Console → Project settings → Service
+    accounts → Generate new private key.
+- Adding the workflow as a required status check on `master` is done
+  via branch protection, separately from this PR.
+- Failure artifacts (screenshots, video, command logs) are uploaded to
+  the workflow run with a 7-day retention.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "bump": "./scripts/bumpVersion.sh",
     "build": "tsc",
     "generate-icons": "node scripts/generate-icons.mjs",
-    "sync-brand-colors": "node scripts/sync-brand-colors.mjs"
+    "sync-brand-colors": "node scripts/sync-brand-colors.mjs",
+    "e2e:setup": "curl -Ls 'https://get.maestro.mobile.dev' | bash",
+    "e2e:android": "ts-node scripts/maestro/run.ts"
   },
   "dependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",

--- a/scripts/maestro/run.ts
+++ b/scripts/maestro/run.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env npx ts-node
+/**
+ * Maestro orchestrator: handles disposable test-user lifecycle around
+ * `maestro test` so the YAML flows stay declarative.
+ *
+ * For each flow:
+ *   1. Generates a unique email (maestro+<runId>-<flow>@kiroku.test).
+ *   2. (login/reset flows) Pre-seeds the user in dev Firebase, marks
+ *      email verified, completes onboarding shape in the DB.
+ *   3. Runs `maestro test <flow>` with EMAIL/PASSWORD injected via --env.
+ *   4. Tears down the Firebase user, regardless of flow outcome.
+ *
+ * Env:
+ *   FIREBASE_DEV_ADMIN_SA   service-account JSON (single line); required
+ *   MAESTRO_RUN_ID          optional run identifier (defaults to PID)
+ *   FLOWS                   optional comma-separated flow basenames to run
+ *                           (default: all flows under .maestro/flows/)
+ */
+import {spawnSync} from 'child_process';
+import {readdirSync} from 'fs';
+import path from 'path';
+import admin from 'firebase-admin';
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const FLOWS_DIR = path.join(ROOT, '.maestro', 'flows');
+const RUN_ID = process.env.MAESTRO_RUN_ID ?? String(process.pid);
+const PASSWORD = 'MaestroTest123!';
+
+type FlowName =
+  | 'signup-email-password'
+  | 'login-existing-user'
+  | 'forgot-password-flow';
+
+const PRE_SEEDED: ReadonlySet<FlowName> = new Set([
+  'login-existing-user',
+  'forgot-password-flow',
+]);
+
+function emailFor(flow: FlowName): string {
+  return `maestro+${RUN_ID}-${flow}@kiroku.test`;
+}
+
+function initFirebase(): void {
+  const raw = process.env.FIREBASE_DEV_ADMIN_SA;
+  if (!raw) {
+    throw new Error(
+      'FIREBASE_DEV_ADMIN_SA is required (dev Firebase service-account JSON)',
+    );
+  }
+  const serviceAccount = JSON.parse(raw) as admin.ServiceAccount;
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  });
+}
+
+async function seedUser(email: string): Promise<void> {
+  const user = await admin.auth().createUser({
+    email,
+    password: PASSWORD,
+    emailVerified: true,
+  });
+  // Mark onboarding complete so the login flow lands on Home, not the
+  // onboarding modal. Adjust if/when onboarding shape changes.
+  await admin.database().ref(`users/${user.uid}/private/onboarding`).set({
+    isComplete: true,
+    acceptedTermsVersion: 1,
+  });
+}
+
+async function deleteUser(email: string): Promise<void> {
+  try {
+    const user = await admin.auth().getUserByEmail(email);
+    await admin.database().ref(`users/${user.uid}`).remove();
+    await admin.auth().deleteUser(user.uid);
+  } catch (err) {
+    if ((err as {code?: string}).code !== 'auth/user-not-found') {
+      throw err;
+    }
+  }
+}
+
+function runFlow(flow: FlowName, email: string): number {
+  const result = spawnSync(
+    'maestro',
+    [
+      'test',
+      path.join(FLOWS_DIR, `${flow}.yaml`),
+      '--env',
+      `EMAIL=${email}`,
+      '--env',
+      `PASSWORD=${PASSWORD}`,
+    ],
+    {stdio: 'inherit', cwd: ROOT},
+  );
+  return result.status ?? 1;
+}
+
+function flowsToRun(): FlowName[] {
+  const explicit = process.env.FLOWS?.split(',').map(s => s.trim()) ?? [];
+  if (explicit.length > 0) {
+    return explicit as FlowName[];
+  }
+  return readdirSync(FLOWS_DIR)
+    .filter(f => f.endsWith('.yaml'))
+    .map(f => f.replace(/\.yaml$/, '') as FlowName);
+}
+
+async function main(): Promise<void> {
+  initFirebase();
+  let failed = 0;
+  // Flows run sequentially: each owns a unique disposable user, but we
+  // share one emulator and one Firebase project, so parallelism would
+  // race on screen state and quota.
+  for (const flow of flowsToRun()) {
+    const email = emailFor(flow);
+    process.stderr.write(`\n=== ${flow} (${email}) ===\n`);
+    try {
+      if (PRE_SEEDED.has(flow)) {
+        // eslint-disable-next-line no-await-in-loop
+        await seedUser(email);
+      }
+      const code = runFlow(flow, email);
+      if (code !== 0) {
+        failed += 1;
+      }
+    } finally {
+      // eslint-disable-next-line no-await-in-loop
+      await deleteUser(email);
+    }
+  }
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -952,6 +952,23 @@ const CONST = {
     // Number of concurrent taps to open then the Test modal menu
     NUMBER_OF_TAPS: 4,
   },
+  // Stable identifiers for end-to-end tests (Maestro). Reference these from
+  // both the screens and the .maestro/ flows so element targeting survives
+  // copy and translation changes. See contributingGuides/E2E_TESTING.md.
+  TEST_IDS: {
+    AUTH: {
+      EMAIL_INPUT: 'auth-email-input',
+      PASSWORD_INPUT: 'auth-password-input',
+      FORGOT_PASSWORD_LINK: 'auth-forgot-password-link',
+      TOGGLE_MODE: 'auth-toggle-mode',
+    },
+    FORGOT_PASSWORD: {
+      EMAIL_INPUT: 'forgot-password-email-input',
+    },
+    ONBOARDING: {
+      DISPLAY_NAME_INPUT: 'onboarding-display-name-input',
+    },
+  },
   TIMING: {
     HOMEPAGE_INITIAL_RENDER: 'homepage_initial_render',
     SEARCH_RENDER: 'search_render',

--- a/src/screens/Onboarding/DisplayNameScreen.tsx
+++ b/src/screens/Onboarding/DisplayNameScreen.tsx
@@ -113,6 +113,7 @@ function DisplayNameScreen({}: DisplayNameScreenProps) {
               InputComponent={TextInput}
               inputID={INPUT_IDS.USERNAME}
               name="username"
+              testID={CONST.TEST_IDS.ONBOARDING.DISPLAY_NAME_INPUT}
               label={translate('common.username')}
               aria-label={translate('common.username')}
               role={CONST.ROLE.PRESENTATION}

--- a/src/screens/SignUp/AuthScreen.tsx
+++ b/src/screens/SignUp/AuthScreen.tsx
@@ -192,6 +192,7 @@ function AuthScreen({route}: AuthScreenProps) {
               InputComponent={TextInput}
               inputID={INPUT_IDS.EMAIL}
               name="email"
+              testID={CONST.TEST_IDS.AUTH.EMAIL_INPUT}
               textContentType="emailAddress"
               keyboardType="email-address"
               label={translate('login.email')}
@@ -203,6 +204,7 @@ function AuthScreen({route}: AuthScreenProps) {
               InputComponent={TextInput}
               inputID={INPUT_IDS.PASSWORD}
               name="password"
+              testID={CONST.TEST_IDS.AUTH.PASSWORD_INPUT}
               label={translate('common.password')}
               aria-label={translate('common.password')}
               defaultValue=""
@@ -217,6 +219,7 @@ function AuthScreen({route}: AuthScreenProps) {
             {!isSignUp && (
               <PressableWithFeedback
                 style={[styles.link, styles.mt4]}
+                testID={CONST.TEST_IDS.AUTH.FORGOT_PASSWORD_LINK}
                 onPress={() => Navigation.navigate(ROUTES.FORGOT_PASSWORD)}
                 role={CONST.ROLE.LINK}
                 accessibilityLabel={translate('password.forgot')}>
@@ -227,7 +230,7 @@ function AuthScreen({route}: AuthScreenProps) {
               <DotIndicatorMessage
                 style={[styles.mv2]}
                 type="error"
-                // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 messages={{0: serverErrorMessage || ''}}
               />
             )}
@@ -236,6 +239,7 @@ function AuthScreen({route}: AuthScreenProps) {
             <Text style={styles.mr1}>{toggleHelperText}</Text>
             <PressableWithFeedback
               style={[styles.link]}
+              testID={CONST.TEST_IDS.AUTH.TOGGLE_MODE}
               onPress={onToggleMode}
               role={CONST.ROLE.BUTTON}
               accessibilityLabel={toggleActionText}>

--- a/src/screens/SignUp/ForgotPasswordScreen.tsx
+++ b/src/screens/SignUp/ForgotPasswordScreen.tsx
@@ -15,6 +15,7 @@ import INPUT_IDS from '@src/types/form/ForgotPasswordForm';
 import FormProvider from '@components/Form/FormProvider';
 import Text from '@components/Text';
 import type {Errors} from '@src/types/onyx/OnyxCommon';
+import CONST from '@src/CONST';
 import InputWrapper from '@components/Form/InputWrapper';
 import variables from '@src/styles/variables';
 import TextInput from '@components/TextInput';
@@ -107,6 +108,7 @@ function ForgotPasswordScreen() {
               InputComponent={TextInput}
               inputID={INPUT_IDS.EMAIL}
               name="email"
+              testID={CONST.TEST_IDS.FORGOT_PASSWORD.EMAIL_INPUT}
               shouldShowClearButton
               shouldSaveDraft
               maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
@@ -120,7 +122,7 @@ function ForgotPasswordScreen() {
               <DotIndicatorMessage
                 style={[styles.mv2]}
                 type="error"
-                // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 messages={{0: serverErrorMessage || ''}}
               />
             )}
@@ -128,7 +130,7 @@ function ForgotPasswordScreen() {
               <DotIndicatorMessage
                 style={[styles.mv2]}
                 type="success"
-                // eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 messages={{0: successMessage || ''}}
               />
             )}


### PR DESCRIPTION
## Summary

Stand up Maestro end-to-end coverage for the sign-up surface so the flow doesn't silently break between releases. This is v1 — **Android only, every PR, dev Firebase reused**. iOS, email-verification, and OAuth providers are scoped out and tracked in [contributingGuides/E2E_TESTING.md](contributingGuides/E2E_TESTING.md).

## What's in here

- **3 Maestro flows** under [.maestro/flows/](.maestro/flows/):
  - `signup-email-password` — fresh sign-up → Terms → Display Name → Home
  - `login-existing-user` — pre-seeded user → Home
  - `forgot-password-flow` — request reset email (UI path; no inbox assertion yet)
- **Orchestrator** at [scripts/maestro/run.ts](scripts/maestro/run.ts) — generates unique `maestro+<runId>-<flow>@kiroku.test` users, pre-seeds via Firebase Admin SDK where needed, tears down in a `finally`.
- **testID instrumentation** on the elements the flows touch — `AuthScreen`, `ForgotPasswordScreen`, `DisplayNameScreen`. New constants in `CONST.TEST_IDS`.
- **New CI workflow** at [.github/workflows/e2eAndroid.yml](.github/workflows/e2eAndroid.yml) — every PR, ~15 min. Builds the `stagingDebug` APK, boots an Android emulator via `reactivecircus/android-emulator-runner`, runs all flows. Uploads screenshots/video on failure.
- **Docs**: [.maestro/README.md](.maestro/README.md) and [contributingGuides/E2E_TESTING.md](contributingGuides/E2E_TESTING.md).
- **npm scripts**: `e2e:setup` (installs Maestro CLI), `e2e:android` (runs orchestrator).

## Decisions locked in (per scoping convo)

| Decision | Choice | Tradeoff noted |
| --- | --- | --- |
| Platform | Android only | iOS deferred to PR 2 |
| Trigger | Every PR | +~15 min per PR; cancel-in-progress configured |
| Email verification | Deferred | PR 2 adds Admin-SDK inbox-free link verification |
| Firebase project | Reuse dev | `maestro+*` users appear alongside real dev data |

## Required new secrets

Before this workflow can pass on a PR:

- `FIREBASE_DEV_ADMIN_SA` — dev Firebase service-account JSON, single line. Generate at Firebase Console → Project settings → Service accounts → Generate new private key.
- `STAGING_ENV_FILE` — full `.env.staging` contents (multi-line). Likely already mirrored from local `.env.staging`.

## Known limitations / iteration points

- Submit buttons are currently matched by visible English text (e.g., `tapOn: "Create account"`) because `FormWrapper` doesn't yet thread a `submitButtonTestID`. Locale-agnostic matchers want a small `FormWrapper`/`FormAlertWithSubmitButton`/`Button` change — left out of v1 to keep the diff scoped.
- `TermsScreen` continue button matches on text `"Accept"` for the same reason (no testID hook into `TermsScreenContent`).
- `assertVisible: "Today"` is a placeholder for "we landed on the authenticated home surface" — replace with a proper Home `testID` once we pick one.
- The orchestrator marks users `emailVerified: true` and writes `users/<uid>/private/onboarding = {isComplete: true, acceptedTermsVersion: 1}`. Adjust if onboarding shape evolves.

## Test plan

- [ ] Add `FIREBASE_DEV_ADMIN_SA` and `STAGING_ENV_FILE` repo secrets.
- [ ] Confirm `stagingDebug` APK builds in CI (the workflow is the first time we'd assemble this variant in GitHub Actions).
- [ ] Watch the first run of `E2E Android (Maestro)` on this PR; expect failures on real text matchers or testID gaps and iterate.
- [ ] Once green, mark the workflow required via branch protection (separate change).
- [ ] Verify `maestro+*` users land in the dev Firebase Auth list and disappear after each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)