### PR TITLE
fix(auth-screen): keep typed credentials after sign-up/login error

### DIFF
--- a/src/screens/SignUp/AuthScreen.tsx
+++ b/src/screens/SignUp/AuthScreen.tsx
@@ -160,91 +160,88 @@ function AuthScreen({route}: AuthScreenProps) {
         ),
       ]}
       testID={AuthScreen.displayName}>
-      {isLoading ? (
+      <SignUpScreenLayout
+        welcomeHeader=""
+        welcomeText=""
+        ref={currentScreenLayoutRef}
+        navigateFocus={navigateFocus}>
+        <View style={[styles.gap3, styles.mb4]}>
+          <AppleSignIn onError={setServerErrorMessage} />
+          <GoogleSignIn onError={setServerErrorMessage} />
+        </View>
+        <OAuthLinkModal />
+        <OrDelimiter containerStyle={styles.mb4} />
+        <FormProvider
+          formID={ONYXKEYS.FORMS.AUTH_FORM}
+          validate={validate}
+          onSubmit={onSubmit}
+          shouldValidateOnBlur={false}
+          shouldValidateOnChange
+          includeSafeAreaPaddingBottom={false}
+          submitButtonText={submitButtonText}
+          submitButtonStyles={styles.pb5}
+          submitFlexEnabled={false}
+          isSubmitButtonVisible={!isLoading}
+          shouldUseScrollView={false}>
+          <InputWrapper
+            InputComponent={TextInput}
+            inputID={INPUT_IDS.EMAIL}
+            name="email"
+            textContentType="emailAddress"
+            keyboardType="email-address"
+            label={translate('login.email')}
+            aria-label={translate('login.email')}
+            defaultValue=""
+            spellCheck={false}
+          />
+          <InputWrapper
+            InputComponent={TextInput}
+            inputID={INPUT_IDS.PASSWORD}
+            name="password"
+            label={translate('common.password')}
+            aria-label={translate('common.password')}
+            defaultValue=""
+            spellCheck={false}
+            secureTextEntry
+            autoComplete={
+              Browser.getBrowser() === CONST.BROWSER.SAFARI ? 'username' : 'off'
+            }
+          />
+          {!isSignUp && (
+            <PressableWithFeedback
+              style={[styles.link, styles.mt4]}
+              onPress={() => Navigation.navigate(ROUTES.FORGOT_PASSWORD)}
+              role={CONST.ROLE.LINK}
+              accessibilityLabel={translate('password.forgot')}>
+              <Text style={styles.link}>{translate('password.forgot')}</Text>
+            </PressableWithFeedback>
+          )}
+          {!!serverErrorMessage && (
+            <DotIndicatorMessage
+              style={[styles.mv2]}
+              type="error"
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              messages={{0: serverErrorMessage || ''}}
+            />
+          )}
+        </FormProvider>
+        <View style={styles.changeSignUpScreenLinkContainer}>
+          <Text style={styles.mr1}>{toggleHelperText}</Text>
+          <PressableWithFeedback
+            style={[styles.link]}
+            onPress={onToggleMode}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={toggleActionText}>
+            <Text style={[styles.link]}>{toggleActionText}</Text>
+          </PressableWithFeedback>
+        </View>
+      </SignUpScreenLayout>
+      {isLoading && (
         <FullScreenLoadingIndicator
           loadingText={translate(
             isSignUp ? 'signUpScreen.signingIn' : 'logInScreen.loggingIn',
           )}
         />
-      ) : (
-        <SignUpScreenLayout
-          welcomeHeader=""
-          welcomeText=""
-          ref={currentScreenLayoutRef}
-          navigateFocus={navigateFocus}>
-          <View style={[styles.gap3, styles.mb4]}>
-            <AppleSignIn onError={setServerErrorMessage} />
-            <GoogleSignIn onError={setServerErrorMessage} />
-          </View>
-          <OAuthLinkModal />
-          <OrDelimiter containerStyle={styles.mb4} />
-          <FormProvider
-            formID={ONYXKEYS.FORMS.AUTH_FORM}
-            validate={validate}
-            onSubmit={onSubmit}
-            shouldValidateOnBlur={false}
-            shouldValidateOnChange
-            includeSafeAreaPaddingBottom={false}
-            submitButtonText={submitButtonText}
-            submitButtonStyles={styles.pb5}
-            submitFlexEnabled={false}
-            isSubmitButtonVisible={!isLoading}
-            shouldUseScrollView={false}>
-            <InputWrapper
-              InputComponent={TextInput}
-              inputID={INPUT_IDS.EMAIL}
-              name="email"
-              textContentType="emailAddress"
-              keyboardType="email-address"
-              label={translate('login.email')}
-              aria-label={translate('login.email')}
-              defaultValue=""
-              spellCheck={false}
-            />
-            <InputWrapper
-              InputComponent={TextInput}
-              inputID={INPUT_IDS.PASSWORD}
-              name="password"
-              label={translate('common.password')}
-              aria-label={translate('common.password')}
-              defaultValue=""
-              spellCheck={false}
-              secureTextEntry
-              autoComplete={
-                Browser.getBrowser() === CONST.BROWSER.SAFARI
-                  ? 'username'
-                  : 'off'
-              }
-            />
-            {!isSignUp && (
-              <PressableWithFeedback
-                style={[styles.link, styles.mt4]}
-                onPress={() => Navigation.navigate(ROUTES.FORGOT_PASSWORD)}
-                role={CONST.ROLE.LINK}
-                accessibilityLabel={translate('password.forgot')}>
-                <Text style={styles.link}>{translate('password.forgot')}</Text>
-              </PressableWithFeedback>
-            )}
-            {!!serverErrorMessage && (
-              <DotIndicatorMessage
-                style={[styles.mv2]}
-                type="error"
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                messages={{0: serverErrorMessage || ''}}
-              />
-            )}
-          </FormProvider>
-          <View style={styles.changeSignUpScreenLinkContainer}>
-            <Text style={styles.mr1}>{toggleHelperText}</Text>
-            <PressableWithFeedback
-              style={[styles.link]}
-              onPress={onToggleMode}
-              role={CONST.ROLE.BUTTON}
-              accessibilityLabel={toggleActionText}>
-              <Text style={[styles.link]}>{toggleActionText}</Text>
-            </PressableWithFeedback>
-          </View>
-        </SignUpScreenLayout>
       )}
     </ScreenWrapper>
   );


### PR DESCRIPTION
### Details

On the auth screen (sign-up + log-in toggle), tapping **Create Account** / **Log in** with credentials that fail validation server-side (e.g. email already in use, wrong password, weak password, etc.) was wiping the email and password fields. The user then had to retype everything from scratch.

**Root cause.** The screen rendered `isLoading ? <FullScreenLoadingIndicator /> : <SignUpScreenLayout>…<FormProvider /></SignUpScreenLayout>`. `FormProvider` keeps its input values in React local state, and the email/password `InputWrapper`s don't opt into `shouldSaveDraft`, so nothing is persisted in Onyx. When submit set `isLoading` to true, the entire form unmounted; on error `isLoading` flipped back to false and the form remounted with empty state.

**Fix.** Always render `SignUpScreenLayout` (and the `FormProvider` inside it). Render `FullScreenLoadingIndicator` as a conditional sibling overlay. It already uses `position: 'absolute'`, `zIndex: 10`, and a solid `componentBG` background, so it covers the form visually while loading without unmounting it. On submission error the form stays mounted and the user's input is preserved.

Successful submits still navigate away from the screen, and `clearSignInData()` continues to clear `AUTH_FORM` / `AUTH_FORM_DRAFT` on success — no behavior change there. The change is isolated to `src/screens/SignUp/AuthScreen.tsx`; `FormProvider`, `InputWrapper`, `FormActions`, and `Session` actions are untouched, so other forms (password change, profile forms, etc.) are unaffected.

### Tests

1. Open the app while logged out so the sign-up screen is shown.
2. In **sign-up** mode, enter an email that is already registered + any valid-looking password. Tap **Create Account**.
   - Expected: the full-screen spinner shows briefly, then the inline error message appears below the form, and **both the email and password fields still contain what you typed**.
3. Tap **Log in here** to switch to log-in mode. Enter a valid email and an intentionally wrong password. Tap **Log in**.
   - Expected: spinner shows briefly, error message appears, **email and password fields still populated**.
4. In sign-up mode, enter a weak password (e.g. `abc`) and any email. Tap **Create Account**.
   - Expected: client-side validation error renders under the password field; fields stay populated (no regression).
5. In sign-up mode, enter a fresh email + a strong password and tap **Create Account**.
   - Expected: spinner shows; on success, navigation proceeds normally; no flicker / no visible form re-render right before navigation.
6. Trigger any server error, then tap the **Log in here** / **Sign up here** toggle.
   - Expected: the server error message clears (pre-existing `onToggleMode` behavior); no regression.
7. Verify no errors appear in the JS console.

### Offline tests

1. Put the device in airplane mode on the auth screen.
2. Try to submit the form.
   - Expected: `onSubmit` early-returns due to the existing `!isOnline` guard; the offline-state behavior is unchanged.

### QA Steps

1. On staging, repeat **Tests** steps 2–5 above and confirm that typed credentials persist after every error case but get cleared (via post-success navigation) on a successful sign-up / log-in.
2. Verify no errors appear in the JS console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)