### PR TITLE
feat(preferences): add session color palette presets

### DIFF
--- a/__tests__/unit/libs/DataHandling.test.ts
+++ b/__tests__/unit/libs/DataHandling.test.ts
@@ -739,43 +739,43 @@ describe('unitsToColors', () => {
 
   it('should return green for 0 units', () => {
     expect(convertUnitsToColors(0, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.green,
+      PALETTES.classic.green,
     );
   });
 
   it('should return yellow for units up to yellow limit', () => {
     expect(convertUnitsToColors(1, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.yellow,
+      PALETTES.classic.yellow,
     );
     expect(convertUnitsToColors(2, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.yellow,
+      PALETTES.classic.yellow,
     );
   });
 
   it('should return orange for units between yellow and orange limits', () => {
     expect(convertUnitsToColors(3, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.orange,
+      PALETTES.classic.orange,
     );
     expect(convertUnitsToColors(4, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.orange,
+      PALETTES.classic.orange,
     );
   });
 
   it('should return red for units above the orange limit', () => {
     expect(convertUnitsToColors(5, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.red,
+      PALETTES.classic.red,
     );
     expect(convertUnitsToColors(6, mockUnitsToColors)).toBe(
-      PALETTES.CLASSIC.red,
+      PALETTES.classic.red,
     );
   });
 
   it('should honor a custom palette when provided', () => {
-    expect(convertUnitsToColors(0, mockUnitsToColors, PALETTES.OCEAN)).toBe(
-      PALETTES.OCEAN.green,
+    expect(convertUnitsToColors(0, mockUnitsToColors, PALETTES.ocean)).toBe(
+      PALETTES.ocean.green,
     );
-    expect(convertUnitsToColors(5, mockUnitsToColors, PALETTES.OCEAN)).toBe(
-      PALETTES.OCEAN.red,
+    expect(convertUnitsToColors(5, mockUnitsToColors, PALETTES.ocean)).toBe(
+      PALETTES.ocean.red,
     );
   });
 });

--- a/__tests__/unit/libs/DataHandling.test.ts
+++ b/__tests__/unit/libs/DataHandling.test.ts
@@ -32,6 +32,7 @@ import type {
   UnitsToColors,
 } from '@src/types/onyx';
 import CONST from '@src/CONST';
+import {PALETTES} from '@libs/SessionColorPalettes';
 import {randDrinkingSession} from '../../utils/collections/drinkingSessions';
 
 describe('formatDate function', () => {
@@ -737,21 +738,44 @@ describe('unitsToColors', () => {
   };
 
   it('should return green for 0 units', () => {
-    expect(convertUnitsToColors(0, mockUnitsToColors)).toBe('green');
+    expect(convertUnitsToColors(0, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.green,
+    );
   });
 
   it('should return yellow for units up to yellow limit', () => {
-    expect(convertUnitsToColors(1, mockUnitsToColors)).toBe('yellow');
-    expect(convertUnitsToColors(2, mockUnitsToColors)).toBe('yellow');
+    expect(convertUnitsToColors(1, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.yellow,
+    );
+    expect(convertUnitsToColors(2, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.yellow,
+    );
   });
 
   it('should return orange for units between yellow and orange limits', () => {
-    expect(convertUnitsToColors(3, mockUnitsToColors)).toBe('orange');
-    expect(convertUnitsToColors(4, mockUnitsToColors)).toBe('orange');
+    expect(convertUnitsToColors(3, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.orange,
+    );
+    expect(convertUnitsToColors(4, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.orange,
+    );
   });
 
   it('should return red for units above the orange limit', () => {
-    expect(convertUnitsToColors(5, mockUnitsToColors)).toBe('red');
-    expect(convertUnitsToColors(6, mockUnitsToColors)).toBe('red');
+    expect(convertUnitsToColors(5, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.red,
+    );
+    expect(convertUnitsToColors(6, mockUnitsToColors)).toBe(
+      PALETTES.CLASSIC.red,
+    );
+  });
+
+  it('should honor a custom palette when provided', () => {
+    expect(convertUnitsToColors(0, mockUnitsToColors, PALETTES.OCEAN)).toBe(
+      PALETTES.OCEAN.green,
+    );
+    expect(convertUnitsToColors(5, mockUnitsToColors, PALETTES.OCEAN)).toBe(
+      PALETTES.OCEAN.red,
+    );
   });
 });

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -669,7 +669,6 @@
 "src/components/DatePicker/CalendarPicker/index.tsx"	"rulesdir/no-use-state-initializer-functions"	4
 "src/components/DatePicker/index.tsx"	"react-hooks/set-state-in-effect"	1
 "src/components/DisplayNames/DisplayNamesWithTooltip.tsx"	"react-hooks/refs"	6
-"src/components/DrinkingSessionWindow/index.tsx"	"arrow-body-style"	1
 "src/components/DrinkingSessionWindow/index.tsx"	"react-hooks/set-state-in-render"	2
 "src/components/FlatList/index.tsx"	"react-hooks/refs"	1
 "src/components/FloatingActionButton.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
@@ -748,7 +747,6 @@
 "src/libs/ApiUtils.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/Console/index.ts"	"@typescript-eslint/no-base-to-string"	2
 "src/libs/Console/index.ts"	"rulesdir/no-onyx-connect"	1
-"src/libs/DataHandling.ts"	"arrow-body-style"	2
 "src/libs/DateUtils.ts"	"@typescript-eslint/switch-exhaustiveness-check"	1
 "src/libs/DateUtils.ts"	"arrow-body-style"	1
 "src/libs/DateUtils.ts"	"rulesdir/no-onyx-connect"	2
@@ -814,10 +812,8 @@
 "src/screens/DrinkingSession/EditSessionScreen.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "src/screens/DrinkingSession/LiveSessionScreen.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "src/screens/DrinkingSession/SessionDateScreen.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"arrow-body-style"	3
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"react-hooks/set-state-in-effect"	1
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
-"src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	2
 "src/screens/HomeScreen.tsx"	"react-hooks/set-state-in-effect"	3
 "src/screens/HomeScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
 "src/screens/Profile/FriendsFriendsScreen.tsx"	"react-hooks/set-state-in-effect"	2
@@ -832,7 +828,6 @@
 "src/screens/Settings/AppShareScreen.tsx"	"react-hooks/refs"	1
 "src/screens/Settings/AppShareScreen.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
 "src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx"	"arrow-body-style"	1
-"src/screens/Settings/Preferences/PreferencesScreen.tsx"	"arrow-body-style"	3
 "src/screens/Settings/Preferences/UnitsToColorsScreen.tsx"	"arrow-body-style"	1
 "src/screens/Settings/SettingsScreen.tsx"	"arrow-body-style"	3
 "src/screens/SignUp/SignUpScreenLayout/index.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -706,8 +706,7 @@
 "src/components/SelectionList/BaseSelectionList.tsx"	"react-hooks/immutability"	1
 "src/components/SelectionList/BaseSelectionList.tsx"	"react-hooks/set-state-in-effect"	2
 "src/components/SelectionList/types.ts"	"@typescript-eslint/no-duplicate-type-constituents"	1
-"src/components/SessionsCalendar/index.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"src/components/SessionsCalendar/index.tsx"	"react-hooks/set-state-in-effect"	2
+"src/components/SessionsCalendar/index.tsx"	"react-hooks/set-state-in-effect"	1
 "src/components/Skeletons/ItemListSkeletonView.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	2
 "src/components/StartSessionButtonAndPopover.tsx"	"react-hooks/set-state-in-effect"	1
 "src/components/StartSessionButtonAndPopover.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -113,6 +113,7 @@ const ROUTES = {
   SETTINGS_FIRST_DAY_OF_WEEK: 'settings/preferences/first-day-of-week',
   SETTINGS_UNITS_TO_COLORS: 'settings/preferences/units-to-colors',
   SETTINGS_DRINKS_TO_UNITS: 'settings/preferences/drinks-to-units',
+  SETTINGS_COLOR_PALETTE: 'settings/preferences/color-palette',
 
   SETTINGS_TERMS_OF_SERVICE: 'settings/terms-of-service',
   SETTINGS_PRIVACY_POLICY: 'settings/privacy-policy',

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -73,6 +73,7 @@ const SCREENS = {
       FIRST_DAY_OF_WEEK: 'Settings_Preferences_FirstDayOfWeek',
       UNITS_TO_COLORS: 'Settings_Preferences_UnitsToColors',
       DRINKS_TO_UNITS: 'Settings_Preferences_DrinksToUnits',
+      COLOR_PALETTE: 'Settings_Preferences_ColorPalette',
     },
 
     ADMIN: {

--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {View} from 'react-native';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {convertUnitsToColors} from '@libs/DataHandling';
+import {resolvePalette} from '@libs/SessionColorPalettes';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -64,9 +65,10 @@ function DrinkingSessionOverview({
   let sessionColor = convertUnitsToColors(
     totalUnits,
     preferences?.units_to_colors,
+    preferences?.session_color_palette,
   );
   if (session.blackout === true) {
-    sessionColor = 'black';
+    sessionColor = resolvePalette(preferences?.session_color_palette).black;
   }
 
   return (

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -19,6 +19,7 @@ import ConfirmModal from '@components/ConfirmModal';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import * as App from '@userActions/App';
 import {convertUnitsToColors} from '@libs/DataHandling';
+import {resolvePalette} from '@libs/SessionColorPalettes';
 import ScrollView from '@components/ScrollView';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import SuccessIndicator from '@components/SuccessIndicator';
@@ -47,7 +48,9 @@ function DrinkingSessionWindow({
   const sessionRef = useRef<DrinkingSession | undefined>(session);
   // Session details
   const [totalUnits, setTotalUnits] = useState<number>(0);
-  const [sessionColor, setSessionColor] = useState<string>('green');
+  const [sessionColor, setSessionColor] = useState<string>(
+    () => resolvePalette(preferences?.session_color_palette).green,
+  );
   // const [dbSyncSuccessful, setDbSyncSuccessful] = useState(false);
   const [discardModalVisible, setDiscardModalVisible] =
     useState<boolean>(false);

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -25,7 +25,6 @@ import SuccessIndicator from '@components/SuccessIndicator';
 import Log from '@libs/Log';
 import DateUtils from '@libs/DateUtils';
 import {isEqual} from 'lodash';
-import type {CalendarColors} from '@components/SessionsCalendar/types';
 import type {User} from 'firebase/auth';
 import {useFocusEffect} from '@react-navigation/native';
 import ERRORS from '@src/ERRORS';
@@ -59,9 +58,7 @@ function DrinkingSessionWindow({
     ? translate('common.discard')
     : translate('common.delete');
 
-  const hasSessionChanged = () => {
-    return !isEqual(sessionRef.current, session);
-  };
+  const hasSessionChanged = () => !isEqual(sessionRef.current, session);
 
   const isSaveDisabled = totalUnits <= 0;
 
@@ -165,6 +162,7 @@ function DrinkingSessionWindow({
     const newSessionColor = convertUnitsToColors(
       totalUnits,
       preferences.units_to_colors,
+      preferences.session_color_palette,
     );
     setTotalUnits(newTotalUnits);
     setSessionColor(newSessionColor);
@@ -220,7 +218,7 @@ function DrinkingSessionWindow({
           ]}>
           <Text
             style={[
-              styles.sessionUnitCountText(sessionColor as CalendarColors),
+              styles.sessionUnitCountText(sessionColor),
               styles.shadowStrong,
             ]}>
             {totalUnits}

--- a/src/components/SessionsCalendar/DayComponent/types.ts
+++ b/src/components/SessionsCalendar/DayComponent/types.ts
@@ -1,16 +1,8 @@
 import type {DayState, DateData, Theme} from 'react-native-calendars/src/types';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
-import type DeepValueOf from '@src/types/utils/DeepValueOf';
-import type CONST from '@src/CONST';
 
-/** A list of calendar colors that are light and should display a dark text on them */
-type LightCalendarColors = DeepValueOf<typeof CONST.CALENDAR_COLORS.LIGHT>;
-
-/** A list of calendar colors that are dark and should display a light text on them */
-type DarkCalendarColors = DeepValueOf<typeof CONST.CALENDAR_COLORS.DARK>;
-
-/** A list of all calendar colors */
-type CalendarColors = LightCalendarColors | DarkCalendarColors;
+/** A CSS color string (hex like '#FFA500' or a CSS named color) used for a calendar day marking */
+type CalendarColors = string;
 
 /** Props for a react native calendar day component */
 type DayComponentProps = {
@@ -22,9 +14,4 @@ type DayComponentProps = {
   onPress?: (day: DateData) => void;
 };
 
-export type {
-  DayComponentProps,
-  CalendarColors,
-  LightCalendarColors,
-  DarkCalendarColors,
-};
+export type {DayComponentProps, CalendarColors};

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -1,7 +1,6 @@
-import React, {memo, useCallback, useEffect, useState} from 'react';
+import React, {memo, useCallback, useEffect} from 'react';
 import {Calendar} from 'react-native-calendars';
 import type {DateData} from 'react-native-calendars';
-import type {MarkingTypes} from 'react-native-calendars/src/types';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import {format} from 'date-fns';
@@ -68,13 +67,11 @@ function SessionsCalendarView({
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
   const [preferredLocale] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
-  const [locale, setLocale] = useState<string>(CONST.LOCALES.DEFAULT);
+  const locale = preferredLocale ?? CONST.LOCALES.DEFAULT;
 
   useEffect(() => {
-    const newLocale = preferredLocale ?? CONST.LOCALES.DEFAULT;
-    setCalendarLocale(newLocale);
-    setLocale(newLocale);
-  }, [preferredLocale]);
+    setCalendarLocale(locale);
+  }, [locale]);
 
   const dayComponent = useCallback(
     ({date, state, marking, theme}: DayComponentProps) => (
@@ -100,7 +97,7 @@ function SessionsCalendarView({
       onPressArrowLeft={onLeftArrowPress}
       onPressArrowRight={onRightArrowPress}
       markedDates={markedDates}
-      markingType={'period' as MarkingTypes}
+      markingType="period"
       firstDay={CONST.WEEK_STARTS_ON}
       enableSwipeMonths={false}
       hideArrows={hideArrows}

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -1,0 +1,119 @@
+import React, {memo, useCallback, useEffect, useState} from 'react';
+import {Calendar} from 'react-native-calendars';
+import type {DateData} from 'react-native-calendars';
+import type {MarkingTypes} from 'react-native-calendars/src/types';
+import type {MarkedDates} from 'react-native-calendars/src/types';
+import {useOnyx} from 'react-native-onyx';
+import {format} from 'date-fns';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useStyleUtils from '@hooks/useStyleUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+import CONST from '@src/CONST';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+import DayComponent from './DayComponent';
+import type {DayComponentProps} from './types';
+import CalendarArrow from './CalendarArrow';
+import type {Direction} from './CalendarArrow';
+import setCalendarLocale from './setCalendarLocale';
+
+type SessionsCalendarViewProps = {
+  /** Marked dates payload to forward to react-native-calendars */
+  markedDates: MarkedDates;
+
+  /** Per-day total unit counts (used by the day cell to render the number) */
+  unitsMap: Map<DateString, number>;
+
+  /** The visible month */
+  visibleDate: DateData;
+
+  /** Earliest selectable date (defaults to CONST.DATE.MIN_DATE) */
+  minDate?: string;
+
+  /** Latest selectable date (defaults to today) */
+  maxDate?: string;
+
+  /** Tapped-day handler; omit to make the calendar non-interactive */
+  onDayPress?: (day: DateData) => void;
+
+  /** Month-arrow handlers; omit (with hideArrows) to make the calendar static */
+  onLeftArrowPress?: (subtractMonth: () => void) => void;
+  onRightArrowPress?: (addMonth: () => void) => void;
+
+  /** Hide month-nav arrows entirely (e.g. for an inline preview) */
+  hideArrows?: boolean;
+};
+
+/**
+ * Presentational calendar — pure props in, pixels out.
+ *
+ * No data fetching, no Firebase, no Onyx writes. The only side effect is
+ * setting the react-native-calendars locale when the user's preferred locale
+ * changes (a global library setting, not per-instance).
+ *
+ * The stateful orchestrator that pairs this with `useLazyMarkedDates` lives in
+ * `SessionsCalendar/index.tsx`. Reuse this view directly when you need to
+ * render a calendar from hand-crafted data (e.g. the palette-picker preview).
+ */
+function SessionsCalendarView({
+  markedDates,
+  unitsMap,
+  visibleDate,
+  minDate,
+  maxDate,
+  onDayPress,
+  onLeftArrowPress,
+  onRightArrowPress,
+  hideArrows,
+}: SessionsCalendarViewProps) {
+  const styles = useThemeStyles();
+  const StyleUtils = useStyleUtils();
+  const [preferredLocale] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
+  const [locale, setLocale] = useState<string>(CONST.LOCALES.DEFAULT);
+
+  useEffect(() => {
+    const newLocale = preferredLocale ?? CONST.LOCALES.DEFAULT;
+    setCalendarLocale(newLocale);
+    setLocale(newLocale);
+  }, [preferredLocale]);
+
+  const dayComponent = useCallback(
+    ({date, state, marking, theme}: DayComponentProps) => (
+      <DayComponent
+        date={date}
+        state={state}
+        units={date ? unitsMap.get(date.dateString as DateString) : 0}
+        marking={marking}
+        theme={theme}
+        onPress={onDayPress}
+      />
+    ),
+    [unitsMap, onDayPress],
+  );
+
+  return (
+    <Calendar
+      current={visibleDate.dateString}
+      dayComponent={dayComponent}
+      minDate={minDate ?? CONST.DATE.MIN_DATE}
+      maxDate={maxDate ?? format(new Date(), CONST.DATE.CALENDAR_FORMAT)}
+      monthFormat={CONST.DATE.MONTH_YEAR_ABBR_FORMAT}
+      onPressArrowLeft={onLeftArrowPress}
+      onPressArrowRight={onRightArrowPress}
+      markedDates={markedDates}
+      markingType={'period' as MarkingTypes}
+      firstDay={CONST.WEEK_STARTS_ON}
+      enableSwipeMonths={false}
+      hideArrows={hideArrows}
+      disableAllTouchEventsForDisabledDays
+      renderArrow={(direction: Direction) => CalendarArrow(direction)}
+      style={styles.sessionsCalendarContainer}
+      theme={StyleUtils.getSessionsCalendarStyle()}
+      // @ts-expect-error locale prop exists at runtime but is not declared in types
+      locale={locale}
+    />
+  );
+}
+
+SessionsCalendarView.displayName = 'SessionsCalendarView';
+export default memo(SessionsCalendarView);
+export type {SessionsCalendarViewProps};

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -40,6 +40,12 @@ type SessionsCalendarViewProps = {
 
   /** Hide month-nav arrows entirely (e.g. for an inline preview) */
   hideArrows?: boolean;
+
+  /** Hide the month-year text header (e.g. for an inline preview) */
+  hideMonthHeader?: boolean;
+
+  /** Hide the day-name row (M T W T F S S) */
+  hideDayNames?: boolean;
 };
 
 /**
@@ -63,6 +69,8 @@ function SessionsCalendarView({
   onLeftArrowPress,
   onRightArrowPress,
   hideArrows,
+  hideMonthHeader,
+  hideDayNames,
 }: SessionsCalendarViewProps) {
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
@@ -101,6 +109,8 @@ function SessionsCalendarView({
       firstDay={CONST.WEEK_STARTS_ON}
       enableSwipeMonths={false}
       hideArrows={hideArrows}
+      hideDayNames={hideDayNames}
+      renderHeader={hideMonthHeader ? () => null : undefined}
       disableAllTouchEventsForDisabledDays
       renderArrow={(direction: Direction) => CalendarArrow(direction)}
       style={styles.sessionsCalendarContainer}

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -1,28 +1,18 @@
 import React, {memo, useCallback, useEffect, useState} from 'react';
-import {useOnyx} from 'react-native-onyx';
-import type {MarkingTypes} from 'react-native-calendars/src/types';
 import type {DateData} from 'react-native-calendars';
-import {Calendar} from 'react-native-calendars';
+import {differenceInMonths, format} from 'date-fns';
 import {getPreviousMonth, getNextMonth} from '@libs/DataHandling';
 import type {DrinkingSessionList} from '@src/types/onyx';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
-import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
-import {differenceInMonths, format} from 'date-fns';
 import {useFirebase} from '@context/global/FirebaseContext';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
-import useStyleUtils from '@hooks/useStyleUtils';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
-import ONYXKEYS from '@src/ONYXKEYS';
-import DayComponent from './DayComponent';
-import type {Direction} from './CalendarArrow';
+import SessionsCalendarView from './SessionsCalendarView';
 import type SessionsCalendarProps from './types';
-import type {DayComponentProps} from './types';
-import CalendarArrow from './CalendarArrow';
-import setCalendarLocale from './setCalendarLocale';
 
 function SessionsCalendar({
   userID,
@@ -31,15 +21,11 @@ function SessionsCalendar({
   drinkingSessionData,
   preferences,
 }: SessionsCalendarProps) {
-  const styles = useThemeStyles();
-  const StyleUtils = useStyleUtils();
   const {auth} = useFirebase();
   const user = auth.currentUser;
-  const [preferredLocale] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
   const {markedDates, unitsMap, loadedFrom, loadMoreMonths, isLoading} =
     useLazyMarkedDates(userID, drinkingSessionData ?? {}, preferences);
   const [minDate, setMinDate] = useState<string>(CONST.DATE.MIN_DATE);
-  const [locale, setLocale] = useState<string>(CONST.LOCALES.DEFAULT);
 
   const calculateMinDate = (
     data: DrinkingSessionList | null | undefined,
@@ -64,87 +50,47 @@ function SessionsCalendar({
     const previousMonth = getPreviousMonth(visibleDate);
     onDateChange(previousMonth);
 
-    subtractMonth(); // Use the callback to move to the previous month
+    subtractMonth();
   };
 
   const handleRightArrowPress = (addMonth: () => void) => {
     const nextMonth = getNextMonth(visibleDate);
     onDateChange(nextMonth);
-    addMonth(); // Use the callback to move to the next month
+    addMonth();
   };
 
-  const dayComponent = useCallback(
-    ({date, state, marking, theme}: DayComponentProps) => {
-      const onDayPress = (dateData: DateData) => {
-        if (userID !== user?.uid) {
-          return;
-        }
-        Navigation.navigate(
-          ROUTES.DAY_OVERVIEW.getRoute(dateData.dateString as DateString),
-        );
-        // TODO display other user's sessions too in a clever manner
-      };
-
-      return (
-        <DayComponent
-          date={date}
-          state={state}
-          units={date ? unitsMap.get(date.dateString as DateString) : 0}
-          marking={marking}
-          theme={theme}
-          onPress={onDayPress}
-        />
+  const onDayPress = useCallback(
+    (dateData: DateData) => {
+      if (userID !== user?.uid) {
+        return;
+      }
+      Navigation.navigate(
+        ROUTES.DAY_OVERVIEW.getRoute(dateData.dateString as DateString),
       );
+      // TODO display other user's sessions too in a clever manner
     },
-    [unitsMap, user?.uid, userID],
+    [userID, user?.uid],
   );
 
   useEffect(() => {
     setMinDate(calculateMinDate(drinkingSessionData));
   }, [drinkingSessionData]);
 
-  useEffect(() => {
-    const newLocale = preferredLocale ?? CONST.LOCALES.DEFAULT;
-    setCalendarLocale(newLocale);
-    setLocale(newLocale);
-  }, [preferredLocale]);
-
   if (isLoading) {
     return <FlexibleLoadingIndicator />;
   }
 
   return (
-    <Calendar
-      current={visibleDate.dateString}
-      dayComponent={dayComponent}
-      minDate={minDate}
-      maxDate={format(new Date(), CONST.DATE.CALENDAR_FORMAT)}
-      monthFormat={CONST.DATE.MONTH_YEAR_ABBR_FORMAT} // e.g. "Mar 2024"
-      onPressArrowLeft={handleLeftArrowPress}
-      onPressArrowRight={handleRightArrowPress}
+    <SessionsCalendarView
       markedDates={markedDates}
-      markingType={'period' as MarkingTypes}
-      firstDay={CONST.WEEK_STARTS_ON} // e.g. Monday = 1
-      enableSwipeMonths={false}
-      disableAllTouchEventsForDisabledDays
-      renderArrow={(direction: Direction) => CalendarArrow(direction)}
-      style={styles.sessionsCalendarContainer}
-      theme={StyleUtils.getSessionsCalendarStyle()}
-      // @ts-expect-error locale prop exists at runtime but is not declared in types
-      locale={locale}
+      unitsMap={unitsMap}
+      visibleDate={visibleDate}
+      minDate={minDate}
+      onDayPress={onDayPress}
+      onLeftArrowPress={handleLeftArrowPress}
+      onRightArrowPress={handleRightArrowPress}
     />
   );
-  // {TODO implement this}
-  //   {
-  //     /* <Calendar
-  //         initialDate=""
-  //         context={{ date : '' }} // Disable marking of today
-  //         markingType="custom"
-  //         markedDates={reservedDates}
-  //         renderHeader={date => <Text>{moment(new Date(date)).format('YYYY MMMM')}</Text>}
-  //         enableSwipeMonths
-  // /> */
-  //   }
 }
 
 SessionsCalendar.displayName = 'SessionsCalendar';

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -180,11 +180,12 @@ function useLazyMarkedDates(
   }, [isFocused, user?.uid, userID]);
 
   useEffect(() => {
-    // Calculate only upon refocus
-    if (!isFocused) {
-      return;
-    }
-
+    // Rebuild markedDates whenever the underlying inputs change. Previously this
+    // bailed out when the screen wasn't focused as a perceived optimization, but
+    // that left the home calendar stale after a palette/threshold change made
+    // from an overlay screen — and depending on navigation behavior the effect
+    // didn't always re-fire on refocus. The useEffect dep array already keeps
+    // this cheap (it only runs when inputs actually change).
     setIsLoading(true);
     loadedFrom.current = null;
 
@@ -200,7 +201,7 @@ function useLazyMarkedDates(
 
     // TODOcheck the validity of loadMoreMonths and monthsLoaded for re-renders
     // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-  }, [sessions, preferences, userID, user?.uid, isFocused, monthsLoaded]);
+  }, [sessions, preferences, userID, user?.uid, monthsLoaded]);
 
   return {
     markedDates,

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -17,6 +17,7 @@ import {
   subMonths,
 } from 'date-fns';
 import {sessionsToDayMarking} from '@libs/DataHandling';
+import {resolvePalette} from '@libs/SessionColorPalettes';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
@@ -61,7 +62,9 @@ function useLazyMarkedDates(
     return subDays(startOfMonth(dateInCorrectMonth), 1);
   };
 
-  // Internal function to load sessions for a specific day into provided maps
+  // Internal function to load sessions for a specific day into provided maps.
+  // Days without sessions still get a marking so the palette-green background
+  // updates when the user switches palette (or when viewing a friend's calendar).
   const loadSessionsForDayInternal = (
     dayKey: DateString,
     markedDatesMapToUpdate: Map<DateString, MarkingProps>,
@@ -70,6 +73,8 @@ function useLazyMarkedDates(
     const relevantSessions = sessionIndex.current.get(dayKey) ?? [];
     const newMarking = sessionsToDayMarking(relevantSessions, preferences);
     if (!newMarking) {
+      const palette = resolvePalette(preferences.session_color_palette);
+      markedDatesMapToUpdate.set(dayKey, {color: palette.green});
       return;
     }
     markedDatesMapToUpdate.set(dayKey, newMarking.marking);

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -6,9 +6,7 @@ import type {
   Preferences,
 } from '@src/types/onyx';
 import CONST from '@src/CONST';
-import _ from 'lodash';
 import {
-  differenceInMonths,
   eachDayOfInterval,
   format,
   isWithinInterval,
@@ -28,10 +26,24 @@ import type {UserID, DateString} from '@src/types/onyx/OnyxCommon';
 import {useIsFocused} from '@react-navigation/native';
 
 /**
- * Custom hook to manage and memoize drinking session data with lazy loading
- * @param sessions Record of sessions keyed by session ID, can be null or undefined
- * @param preferences User's preferences
- * @returns Marked dates and units for the calendar
+ * Custom hook to derive a calendar's markedDates and per-day unit counts from a
+ * session list and the user's preferences.
+ *
+ * `markedDates` is computed synchronously via `useMemo` — when any input
+ * changes (sessions, preferences, the loaded month range), the next render
+ * already carries the new payload. The earlier state-based pipeline left the
+ * home calendar stale after a palette change because the state update path
+ * had several failure modes (focus gating, batched setState during overlay
+ * navigation, react-native-calendars memoization races). Synchronous
+ * derivation is the same pattern the palette-picker preview uses, which is
+ * why that path was reliable.
+ *
+ * `loadMoreMonths(N)` extends the visible range by N months by bumping
+ * `loadedMonths` state, which triggers the memo to recompute.
+ *
+ * @param userID  ID of the user whose sessions/preferences these are
+ * @param sessions Session list to render
+ * @param preferences Preferences driving thresholds and palette
  */
 function useLazyMarkedDates(
   userID: UserID,
@@ -41,174 +53,101 @@ function useLazyMarkedDates(
   const {auth} = useFirebase();
   const user = auth?.currentUser;
   const isFocused = useIsFocused();
-  const [markedDatesMap, setMarkedDatesMap] = useState<
-    Map<DateString, MarkingProps>
-  >(new Map());
-  const [unitsMap, setUnitsMap] = useState<Map<DateString, number>>(new Map());
-  const sessionIndex = useRef<Map<DateString, DrinkingSessionArray>>(new Map()); // synchronous
   const [monthsLoaded] = useOnyx(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED);
-  const loadedFrom = useRef<Date | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const defaultTimezone = CONST.DEFAULT_TIME_ZONE.selected;
 
-  /** Check up to which data the data has already loaded and return the date to load from. This date will capture one more month than the last loaded month. Always load one more day than the first day of the month in order to handle timezone modifications.
-   */
-  const getDateToLoadFrom = (monthsToLoad = 1): Date => {
+  // For a different user (e.g. friend profile) start fresh; otherwise resume from the saved scroll depth.
+  const initialMonths = user?.uid !== userID ? 0 : monthsLoaded ?? 0;
+  const [loadedMonths, setLoadedMonths] = useState<number>(initialMonths);
+
+  // Resync `loadedMonths` if the source user changes or Onyx delivers a different saved scroll depth.
+  useEffect(() => {
+    setLoadedMonths(user?.uid !== userID ? 0 : monthsLoaded ?? 0);
+  }, [userID, user?.uid, monthsLoaded]);
+
+  // Synchronously derive markedDates + unitsMap from the inputs.
+  // No effect, no setState — the next render has the new payload.
+  const {markedDatesMap, unitsMap, loadedFromDate} = useMemo(() => {
     const today = new Date();
-    const alreadyLoaded = loadedFrom.current;
-    const monthsDifference = differenceInMonths(today, alreadyLoaded ?? today);
-    const monthsToSubtract = monthsDifference + monthsToLoad;
-    const dateInCorrectMonth = subMonths(today, monthsToSubtract);
-    return subDays(startOfMonth(dateInCorrectMonth), 1);
-  };
+    const start = subDays(startOfMonth(subMonths(today, loadedMonths)), 1);
+    const end = today;
 
-  // Internal function to load sessions for a specific day into provided maps.
-  // Days without sessions still get a marking so the palette-green background
-  // updates when the user switches palette (or when viewing a friend's calendar).
-  const loadSessionsForDayInternal = (
-    dayKey: DateString,
-    markedDatesMapToUpdate: Map<DateString, MarkingProps>,
-    unitsMapToUpdate: Map<DateString, number>,
-  ) => {
-    const relevantSessions = sessionIndex.current.get(dayKey) ?? [];
-    const newMarking = sessionsToDayMarking(relevantSessions, preferences);
-    if (!newMarking) {
-      const palette = resolvePalette(preferences.session_color_palette);
-      markedDatesMapToUpdate.set(dayKey, {color: palette.green});
-      return;
-    }
-    markedDatesMapToUpdate.set(dayKey, newMarking.marking);
-    unitsMapToUpdate.set(dayKey, newMarking.units);
-  };
+    const sessionIndex = new Map<DateString, DrinkingSessionArray>();
+    Object.values(sessions)
+      .filter(session => isWithinInterval(session.start_time, {start, end}))
+      .forEach(session => {
+        const sessionDate = toZonedTime(
+          session.start_time,
+          session.timezone ?? defaultTimezone,
+        );
+        const dayKey = format(
+          sessionDate,
+          CONST.DATE.FNS_FORMAT_STRING,
+        ) as DateString;
+        const existing = sessionIndex.get(dayKey);
+        if (existing) {
+          existing.push(session);
+        } else {
+          sessionIndex.set(dayKey, [session]);
+        }
+      });
 
-  // Internal function to load sessions for a specific month into provided maps
-  const loadSessionsForMonthsInternal = (
-    newMonthsToLoad: number,
-    markedDatesMapToUpdate: Map<DateString, MarkingProps>,
-    unitsMapToUpdate: Map<DateString, number>,
-  ) => {
-    const index = sessionIndex.current;
-    const start = getDateToLoadFrom(newMonthsToLoad);
-    const end = loadedFrom.current ?? new Date();
+    const newMarkedDatesMap = new Map<DateString, MarkingProps>();
+    const newUnitsMap = new Map<DateString, number>();
+    const palette = resolvePalette(preferences.session_color_palette);
 
-    const relevantSessions = Object.values(sessions).filter(session =>
-      isWithinInterval(session.start_time, {start, end}),
-    );
-
-    // Build the sessionIndex for relevant sessions - do not use the in-built forEach method, as it introduces an erro into the assignment
-    // eslint-disable-next-line you-dont-need-lodash-underscore/for-each
-    _.forEach(relevantSessions, session => {
-      const sessionDate = toZonedTime(
-        session.start_time,
-        session.timezone ?? defaultTimezone,
-      );
-      const dayKey = format(
-        sessionDate,
-        CONST.DATE.FNS_FORMAT_STRING,
-      ) as DateString;
-
-      if (!index.has(dayKey)) {
-        index.set(dayKey, []);
+    eachDayOfInterval({start, end}).forEach(day => {
+      const dayKey = format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString;
+      const dailySessions = sessionIndex.get(dayKey) ?? [];
+      const newMarking = sessionsToDayMarking(dailySessions, preferences);
+      if (!newMarking) {
+        newMarkedDatesMap.set(dayKey, {color: palette.green});
+        return;
       }
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      index.get(dayKey)!.push(session);
+      newMarkedDatesMap.set(dayKey, newMarking.marking);
+      newUnitsMap.set(dayKey, newMarking.units);
     });
 
-    const datesToLoad = eachDayOfInterval({start, end});
-    const dayStrings = datesToLoad.map(
-      date => format(date, CONST.DATE.FNS_FORMAT_STRING) as DateString,
-    );
+    return {
+      markedDatesMap: newMarkedDatesMap,
+      unitsMap: newUnitsMap,
+      loadedFromDate: start,
+    };
+  }, [sessions, preferences, loadedMonths, defaultTimezone]);
 
-    // Mark the dates and units for each day - do not use the in-built forEach method, as it introduces an erro into the assignment
-    // eslint-disable-next-line you-dont-need-lodash-underscore/for-each
-    _.forEach(dayStrings, dayKey => {
-      loadSessionsForDayInternal(
-        dayKey,
-        markedDatesMapToUpdate,
-        unitsMapToUpdate,
-      );
-    });
-
-    loadedFrom.current = start;
-  };
-
-  /** Create a new map either using an existing object, or an empty object if the reset argument is set to true. Return the relevant map. */
-  function createNewMap<K, V>(
-    reset: boolean,
-    existingMap: Map<K, V>,
-  ): Map<K, V> {
-    return reset ? new Map<K, V>() : new Map(existingMap);
-  }
-
-  // Here, set the 'reset' argument to true if empty maps are needed
-  const loadMoreMonths = (newMonthsToLoad = 1, reset = false) => {
-    const newMarkedDatesMap = createNewMap<DateString, MarkingProps>(
-      reset,
-      markedDatesMap,
-    );
-    const newUnitsMap = createNewMap<DateString, number>(reset, unitsMap);
-
-    loadSessionsForMonthsInternal(
-      newMonthsToLoad,
-      newMarkedDatesMap,
-      newUnitsMap,
-    );
-
-    setMarkedDatesMap(newMarkedDatesMap);
-    setUnitsMap(newUnitsMap);
-  };
-
-  // Memoize the markedDates to avoid unnecessary re-renders
   const markedDates: MarkedDates = useMemo(
     () => Object.fromEntries(markedDatesMap),
     [markedDatesMap],
   );
 
+  // Mirror `loadedFromDate` into a ref for the orchestrator's arrow handler,
+  // which needs a stable reference (preserves the existing public interface).
+  // Only read in event handlers, so an effect-driven update is safe.
+  const loadedFrom = useRef<Date | null>(null);
   useEffect(() => {
-    // For the current user, save the number of months loaded when focus is lost
+    loadedFrom.current = loadedFromDate;
+  }, [loadedFromDate]);
+
+  const loadMoreMonths = (newMonthsToLoad = 1) => {
+    setLoadedMonths(prev => prev + newMonthsToLoad);
+  };
+
+  // On blur, persist the user's scroll depth so the next mount can resume.
+  useEffect(() => {
     if (isFocused) {
       return;
     }
     if (user?.uid === userID) {
-      const newMonthsLoaded = differenceInMonths(
-        new Date(),
-        loadedFrom.current ?? new Date(),
-      );
-      Calendar.setSessionsCalendarMonthsLoaded(newMonthsLoaded);
+      Calendar.setSessionsCalendarMonthsLoaded(loadedMonths);
     }
-  }, [isFocused, user?.uid, userID]);
-
-  useEffect(() => {
-    // Rebuild markedDates whenever the underlying inputs change. Previously this
-    // bailed out when the screen wasn't focused as a perceived optimization, but
-    // that left the home calendar stale after a palette/threshold change made
-    // from an overlay screen — and depending on navigation behavior the effect
-    // didn't always re-fire on refocus. The useEffect dep array already keeps
-    // this cheap (it only runs when inputs actually change).
-    setIsLoading(true);
-    loadedFrom.current = null;
-
-    // Resetting the session index causes recalculation of of dependent hooks when necssary, so it is not needed to reset them here
-    sessionIndex.current = new Map<DateString, DrinkingSessionArray>();
-
-    // If the current user has already loaded data, reload the same amount of months
-    // If this is the first time loading, or the user is different load the current month only
-    const newMonthsToLoad = user?.uid !== userID ? 0 : monthsLoaded ?? 0;
-
-    loadMoreMonths(newMonthsToLoad, true);
-    setIsLoading(false);
-
-    // TODOcheck the validity of loadMoreMonths and monthsLoaded for re-renders
-    // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-  }, [sessions, preferences, userID, user?.uid, monthsLoaded]);
+  }, [isFocused, user?.uid, userID, loadedMonths]);
 
   return {
     markedDates,
     unitsMap,
     loadedFrom,
     loadMoreMonths,
-    isLoading,
+    isLoading: false,
   };
 }
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -519,6 +519,15 @@ export default {
       brand: 'Značka',
       pink: 'Růžová',
     },
+    descriptions: {
+      classic: 'Jasné barvy semaforu',
+      sunset: 'Teplé zemité tóny',
+      ocean: 'Klidné modré a tyrkysové',
+      mono: 'Pouze odstíny šedé',
+      colorblindSafe: 'Rozlišitelné pro barvoslepé',
+      brand: 'Značkové barvy Kiroku',
+      pink: 'Růžová až po červenou',
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinky na jednotky',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -492,6 +492,7 @@ export default {
         'Nastavte přepočet drinků na jednotky a kdy se mění barva relace',
       drinksToUnits: 'Drinky na jednotky',
       unitsToColors: 'Jednotky na barvy',
+      colorPalette: 'Barevná paleta',
     },
     save: 'Uložit předvolby',
     saving: 'Ukládání vašich předvoleb...',
@@ -504,6 +505,18 @@ export default {
     title: 'Jednotky na barvy',
     description:
       'Nastavte hraniční body, při kterých se mění barvy relace; tyto body představují maximální hodnotu, do které zůstane relace v dané barvě',
+  },
+  colorPaletteScreen: {
+    title: 'Barvy relací',
+    description:
+      'Vyberte si barevnou paletu pro ukazatele relací v kalendáři i na obrazovkách relací.',
+    palettes: {
+      classic: 'Klasická',
+      sunset: 'Západ slunce',
+      ocean: 'Oceán',
+      mono: 'Monochromatická',
+      colorblindSafe: 'Pro barvoslepé',
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinky na jednotky',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -516,6 +516,8 @@ export default {
       ocean: 'Oceán',
       mono: 'Monochromatická',
       colorblindSafe: 'Pro barvoslepé',
+      brand: 'Značka',
+      pink: 'Růžová',
     },
   },
   drinksToUnitsScreen: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -518,6 +518,8 @@ export default {
       ocean: 'Ocean',
       mono: 'Monochrome',
       colorblindSafe: 'Colorblind-safe',
+      brand: 'Brand',
+      pink: 'Pink',
     },
   },
   drinksToUnitsScreen: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -493,6 +493,7 @@ export default {
         "Set how many units each drink is worth and when the session's color changes",
       drinksToUnits: 'Drinks to units',
       unitsToColors: 'Units to colors',
+      colorPalette: 'Color palette',
     },
     save: 'Save preferences',
     saving: 'Saving your preferences...',
@@ -506,6 +507,18 @@ export default {
     title: 'Units to Colors',
     description:
       'Set cutoff points where session colors change; each is the maximum value up to which the session retains that color',
+  },
+  colorPaletteScreen: {
+    title: 'Session colors',
+    description:
+      'Choose a color palette for your session indicators across the calendar and session screens.',
+    palettes: {
+      classic: 'Classic',
+      sunset: 'Sunset',
+      ocean: 'Ocean',
+      mono: 'Monochrome',
+      colorblindSafe: 'Colorblind-safe',
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinks to Units',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -521,6 +521,15 @@ export default {
       brand: 'Brand',
       pink: 'Pink',
     },
+    descriptions: {
+      classic: 'Bright traffic-light hues',
+      sunset: 'Warm earth tones',
+      ocean: 'Calm blues and teals',
+      mono: 'Shades of grey only',
+      colorblindSafe: 'Distinguishable for colorblind users',
+      brand: "Kiroku's brand colors",
+      pink: 'Soft pinks to red',
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinks to Units',

--- a/src/libs/DataHandling.ts
+++ b/src/libs/DataHandling.ts
@@ -9,6 +9,7 @@ import type {
   DrinkingSessionArray,
   DrinkingSessionList,
   Preferences,
+  SessionColorPalette,
   UnitsToColors,
   DrinksToUnits,
   DrinksList,
@@ -21,6 +22,7 @@ import _ from 'lodash';
 import type {TranslationPaths} from '@src/languages/types';
 import * as DSUtils from './DrinkingSessionUtils';
 import {getRandomInt} from './Choice';
+import {isLightHex, resolvePalette} from './SessionColorPalettes';
 
 function formatDate(date: Date): DateString {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
@@ -232,23 +234,27 @@ function sessionsToDayMarking(
   if (isEmptyObject(sessions)) {
     return null;
   }
-  const totalUnits = sessions.reduce((sum, session) => {
-    return (
+  const totalUnits = sessions.reduce(
+    (sum, session) =>
       sum +
-      DSUtils.calculateTotalUnits(session.drinks, preferences.drinks_to_units)
-    );
-  }, 0);
+      DSUtils.calculateTotalUnits(session.drinks, preferences.drinks_to_units),
+    0,
+  );
 
   const hasBlackout = sessions.some(obj => obj.blackout === true);
+  const palette = resolvePalette(preferences.session_color_palette);
   const color: CalendarColors = hasBlackout
-    ? CONST.CALENDAR_COLORS.DARK.BLACK
-    : convertUnitsToColors(totalUnits, preferences.units_to_colors);
+    ? palette.black
+    : convertUnitsToColors(
+        totalUnits,
+        preferences.units_to_colors,
+        preferences.session_color_palette,
+      );
 
-  // Determine text color based on background color
-  const shouldUseContrast = color in Object.values(CONST.CALENDAR_COLORS.DARK);
-  const textColor = shouldUseContrast
-    ? CONST.CALENDAR_COLORS.TEXT.WHITE
-    : CONST.CALENDAR_COLORS.TEXT.BLACK;
+  // Determine text color based on background color luminance
+  const textColor = isLightHex(color)
+    ? CONST.CALENDAR_COLORS.TEXT.BLACK
+    : CONST.CALENDAR_COLORS.TEXT.WHITE;
 
   const markingObject: SessionsCalendarDayMarking = {
     units: totalUnits,
@@ -269,15 +275,15 @@ function sumAllDrinks(drinks: DrinksList | undefined): number {
   if (isEmptyObject(drinks)) {
     return 0;
   }
-  return Object.values(drinks).reduce((total, drinkTypes) => {
-    return (
+  return Object.values(drinks).reduce(
+    (total, drinkTypes) =>
       total +
       Object.values(drinkTypes).reduce(
         (subTotal, drinkCount) => subTotal + (drinkCount ?? 0),
         0,
-      )
-    );
-  }, 0);
+      ),
+    0,
+  );
 }
 
 /** Sum up drinks of a specific type of alcohol across multiple sessions
@@ -481,21 +487,22 @@ function getZeroDrinksList(): DrinksList {
 function convertUnitsToColors(
   units: number,
   unitsToColors: UnitsToColors | undefined,
+  palette?: SessionColorPalette,
 ): CalendarColors {
+  const p = resolvePalette(palette);
   if (!unitsToColors) {
-    return CONST.CALENDAR_COLORS.DARK.GREEN;
+    return p.green;
   }
-  let sessionColor: CalendarColors;
   if (units === 0) {
-    sessionColor = CONST.CALENDAR_COLORS.DARK.GREEN;
-  } else if (units <= unitsToColors.yellow) {
-    sessionColor = CONST.CALENDAR_COLORS.LIGHT.YELLOW;
-  } else if (units <= unitsToColors.orange) {
-    sessionColor = CONST.CALENDAR_COLORS.LIGHT.ORANGE;
-  } else {
-    sessionColor = CONST.CALENDAR_COLORS.DARK.RED;
+    return p.green;
   }
-  return sessionColor;
+  if (units <= unitsToColors.yellow) {
+    return p.yellow;
+  }
+  if (units <= unitsToColors.orange) {
+    return p.orange;
+  }
+  return p.red;
 }
 
 /** Insert the key of a drink and find its matching verbose name.

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -137,6 +137,9 @@ const SettingsModalStackNavigator =
     [SCREENS.SETTINGS.PREFERENCES.DRINKS_TO_UNITS]: () =>
       require<ReactComponentModule>('@screens/Settings/Preferences/DrinksToUnitsScreen')
         .default,
+    [SCREENS.SETTINGS.PREFERENCES.COLOR_PALETTE]: () =>
+      require<ReactComponentModule>('@screens/Settings/Preferences/ColorPaletteScreen')
+        .default,
     [SCREENS.SETTINGS.ADMIN.ROOT]: () =>
       require<ReactComponentModule>('@screens/Settings/Admin/AdminScreen')
         .default,

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -1,4 +1,3 @@
- 
 import type {LinkingOptions} from '@react-navigation/native';
 import type {RootStackParamList} from '@navigation/types';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -129,6 +128,10 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
             },
             [SCREENS.SETTINGS.PREFERENCES.DRINKS_TO_UNITS]: {
               path: ROUTES.SETTINGS_DRINKS_TO_UNITS,
+              exact: true,
+            },
+            [SCREENS.SETTINGS.PREFERENCES.COLOR_PALETTE]: {
+              path: ROUTES.SETTINGS_COLOR_PALETTE,
               exact: true,
             },
             [SCREENS.SETTINGS.ACCOUNT.USER_NAME]: {

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -1,4 +1,3 @@
- 
 import type {
   CommonActions,
   NavigationContainerRefWithCurrent,
@@ -120,6 +119,7 @@ type SettingsNavigatorParamList = {
   [SCREENS.SETTINGS.PREFERENCES.FIRST_DAY_OF_WEEK]: undefined;
   [SCREENS.SETTINGS.PREFERENCES.UNITS_TO_COLORS]: undefined;
   [SCREENS.SETTINGS.PREFERENCES.DRINKS_TO_UNITS]: undefined;
+  [SCREENS.SETTINGS.PREFERENCES.COLOR_PALETTE]: undefined;
   [SCREENS.SETTINGS.ADMIN.ROOT]: undefined;
   [SCREENS.SETTINGS.ADMIN.FEEDBACK]: undefined;
   [SCREENS.SETTINGS.ADMIN.BUGS]: undefined;

--- a/src/libs/SessionColorPalettes.ts
+++ b/src/libs/SessionColorPalettes.ts
@@ -1,55 +1,13 @@
 import type {SessionColorPalette} from '@src/types/onyx';
-import {sessionPaletteColors as c} from '@styles/theme/colors';
+import {sessionPaletteColors} from '@styles/theme/colors';
 
-type PaletteId = 'CLASSIC' | 'SUNSET' | 'OCEAN' | 'MONO' | 'COLORBLIND_SAFE';
+type PaletteId = keyof typeof sessionPaletteColors;
 
-const PALETTE_IDS: readonly PaletteId[] = [
-  'CLASSIC',
-  'SUNSET',
-  'OCEAN',
-  'MONO',
-  'COLORBLIND_SAFE',
-] as const;
+const PALETTES: Record<PaletteId, SessionColorPalette> = sessionPaletteColors;
 
-const PALETTES: Record<PaletteId, SessionColorPalette> = {
-  CLASSIC: {
-    green: c.classicGreen,
-    yellow: c.classicYellow,
-    orange: c.classicOrange,
-    red: c.classicRed,
-    black: c.classicBlack,
-  },
-  SUNSET: {
-    green: c.sunsetGreen,
-    yellow: c.sunsetYellow,
-    orange: c.sunsetOrange,
-    red: c.sunsetRed,
-    black: c.sunsetBlack,
-  },
-  OCEAN: {
-    green: c.oceanGreen,
-    yellow: c.oceanYellow,
-    orange: c.oceanOrange,
-    red: c.oceanRed,
-    black: c.oceanBlack,
-  },
-  MONO: {
-    green: c.monoGreen,
-    yellow: c.monoYellow,
-    orange: c.monoOrange,
-    red: c.monoRed,
-    black: c.monoBlack,
-  },
-  COLORBLIND_SAFE: {
-    green: c.colorblindSafeGreen,
-    yellow: c.colorblindSafeYellow,
-    orange: c.colorblindSafeOrange,
-    red: c.colorblindSafeRed,
-    black: c.colorblindSafeBlack,
-  },
-};
+const PALETTE_IDS = Object.keys(PALETTES) as PaletteId[];
 
-const DEFAULT_PALETTE_ID: PaletteId = 'CLASSIC';
+const DEFAULT_PALETTE_ID: PaletteId = 'classic';
 
 function getPaletteIdFromColors(
   palette: SessionColorPalette | undefined,

--- a/src/libs/SessionColorPalettes.ts
+++ b/src/libs/SessionColorPalettes.ts
@@ -1,4 +1,5 @@
 import type {SessionColorPalette} from '@src/types/onyx';
+import {sessionPaletteColors as c} from '@styles/theme/colors';
 
 type PaletteId = 'CLASSIC' | 'SUNSET' | 'OCEAN' | 'MONO' | 'COLORBLIND_SAFE';
 
@@ -11,41 +12,40 @@ const PALETTE_IDS: readonly PaletteId[] = [
 ] as const;
 
 const PALETTES: Record<PaletteId, SessionColorPalette> = {
-  // Hex equivalents of CSS named colors so existing users see no visual change
   CLASSIC: {
-    green: '#008000',
-    yellow: '#FFFF00',
-    orange: '#FFA500',
-    red: '#FF0000',
-    black: '#000000',
+    green: c.classicGreen,
+    yellow: c.classicYellow,
+    orange: c.classicOrange,
+    red: c.classicRed,
+    black: c.classicBlack,
   },
   SUNSET: {
-    green: '#5C8A3A',
-    yellow: '#F2C14E',
-    orange: '#F08A4B',
-    red: '#C8412B',
-    black: '#1A0F0A',
+    green: c.sunsetGreen,
+    yellow: c.sunsetYellow,
+    orange: c.sunsetOrange,
+    red: c.sunsetRed,
+    black: c.sunsetBlack,
   },
   OCEAN: {
-    green: '#3B9C8B',
-    yellow: '#6FB8D6',
-    orange: '#3F7EA5',
-    red: '#1F3A6E',
-    black: '#0A1530',
+    green: c.oceanGreen,
+    yellow: c.oceanYellow,
+    orange: c.oceanOrange,
+    red: c.oceanRed,
+    black: c.oceanBlack,
   },
   MONO: {
-    green: '#D0D0D0',
-    yellow: '#9A9A9A',
-    orange: '#6A6A6A',
-    red: '#3A3A3A',
-    black: '#000000',
+    green: c.monoGreen,
+    yellow: c.monoYellow,
+    orange: c.monoOrange,
+    red: c.monoRed,
+    black: c.monoBlack,
   },
   COLORBLIND_SAFE: {
-    green: '#117733',
-    yellow: '#DDCC77',
-    orange: '#E69F00',
-    red: '#CC3311',
-    black: '#000000',
+    green: c.colorblindSafeGreen,
+    yellow: c.colorblindSafeYellow,
+    orange: c.colorblindSafeOrange,
+    red: c.colorblindSafeRed,
+    black: c.colorblindSafeBlack,
   },
 };
 

--- a/src/libs/SessionColorPalettes.ts
+++ b/src/libs/SessionColorPalettes.ts
@@ -1,0 +1,110 @@
+import type {SessionColorPalette} from '@src/types/onyx';
+
+type PaletteId = 'CLASSIC' | 'SUNSET' | 'OCEAN' | 'MONO' | 'COLORBLIND_SAFE';
+
+const PALETTE_IDS: readonly PaletteId[] = [
+  'CLASSIC',
+  'SUNSET',
+  'OCEAN',
+  'MONO',
+  'COLORBLIND_SAFE',
+] as const;
+
+const PALETTES: Record<PaletteId, SessionColorPalette> = {
+  // Hex equivalents of CSS named colors so existing users see no visual change
+  CLASSIC: {
+    green: '#008000',
+    yellow: '#FFFF00',
+    orange: '#FFA500',
+    red: '#FF0000',
+    black: '#000000',
+  },
+  SUNSET: {
+    green: '#5C8A3A',
+    yellow: '#F2C14E',
+    orange: '#F08A4B',
+    red: '#C8412B',
+    black: '#1A0F0A',
+  },
+  OCEAN: {
+    green: '#3B9C8B',
+    yellow: '#6FB8D6',
+    orange: '#3F7EA5',
+    red: '#1F3A6E',
+    black: '#0A1530',
+  },
+  MONO: {
+    green: '#D0D0D0',
+    yellow: '#9A9A9A',
+    orange: '#6A6A6A',
+    red: '#3A3A3A',
+    black: '#000000',
+  },
+  COLORBLIND_SAFE: {
+    green: '#117733',
+    yellow: '#DDCC77',
+    orange: '#E69F00',
+    red: '#CC3311',
+    black: '#000000',
+  },
+};
+
+const DEFAULT_PALETTE_ID: PaletteId = 'CLASSIC';
+
+function getPaletteIdFromColors(
+  palette: SessionColorPalette | undefined,
+): PaletteId | null {
+  if (!palette) {
+    return null;
+  }
+  for (const id of PALETTE_IDS) {
+    const preset = PALETTES[id];
+    if (
+      preset.green === palette.green &&
+      preset.yellow === palette.yellow &&
+      preset.orange === palette.orange &&
+      preset.red === palette.red &&
+      preset.black === palette.black
+    ) {
+      return id;
+    }
+  }
+  return null;
+}
+
+function resolvePalette(
+  palette: SessionColorPalette | undefined,
+): SessionColorPalette {
+  return palette ?? PALETTES[DEFAULT_PALETTE_ID];
+}
+
+function isLightHex(color: string): boolean {
+  let hex = color.trim();
+  if (!hex.startsWith('#')) {
+    return false;
+  }
+  if (hex.length === 4) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  if (hex.length !== 7) {
+    return false;
+  }
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return false;
+  }
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.6;
+}
+
+export type {PaletteId};
+export {
+  PALETTE_IDS,
+  PALETTES,
+  DEFAULT_PALETTE_ID,
+  getPaletteIdFromColors,
+  resolvePalette,
+  isLightHex,
+};

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -76,7 +76,7 @@ const getDefaultPreferences = (): Preferences => ({
     wine: 1,
   },
   theme: CONST.THEME.SYSTEM,
-  session_color_palette: PALETTES.CLASSIC,
+  session_color_palette: PALETTES.classic,
 });
 
 const getDefaultUserData = (profileData: Profile): UserData => {

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -46,6 +46,7 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
 import {getReasonForLeavingID} from '@libs/ReasonForLeaving';
+import {PALETTES} from '@libs/SessionColorPalettes';
 import Log from '@libs/Log';
 import ERRORS from '@src/ERRORS';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
@@ -75,6 +76,7 @@ const getDefaultPreferences = (): Preferences => ({
     wine: 1,
   },
   theme: CONST.THEME.SYSTEM,
+  session_color_palette: PALETTES.CLASSIC,
 });
 
 const getDefaultUserData = (profileData: Profile): UserData => {

--- a/src/screens/DrinkingSession/SessionSummaryScreen.tsx
+++ b/src/screens/DrinkingSession/SessionSummaryScreen.tsx
@@ -5,6 +5,7 @@ import {
   sumDrinksOfSingleType,
   convertUnitsToColors,
 } from '@libs/DataHandling';
+import {resolvePalette} from '@libs/SessionColorPalettes';
 import useLocalize from '@hooks/useLocalize';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {DrinkingSession} from '@src/types/onyx';
@@ -103,11 +104,15 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
   };
 
   const sessionColor = session.blackout
-    ? 'black'
-    : convertUnitsToColors(totalUnits, preferences?.units_to_colors);
+    ? resolvePalette(preferences?.session_color_palette).black
+    : convertUnitsToColors(
+        totalUnits,
+        preferences?.units_to_colors,
+        preferences?.session_color_palette,
+      );
 
-  const generalMenuItemsData: Menu = useMemo(() => {
-    return {
+  const generalMenuItemsData: Menu = useMemo(
+    () => ({
       sectionTranslationKey: 'sessionSummaryScreen.generalSection.title',
       items: [
         {
@@ -152,19 +157,21 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
           shouldHide: !session.note,
         },
       ],
-    };
-  }, [
-    translate,
-    session,
-    lastDrinkAdded,
-    sessionColor,
-    sessionDay,
-    sessionEndTime,
-    sessionStartTime,
-    totalUnits,
-    wasLiveSession,
-    styles,
-  ]);
+    }),
+    [
+      translate,
+      session.blackout,
+      session.note,
+      lastDrinkAdded,
+      sessionColor,
+      sessionDay,
+      sessionEndTime,
+      sessionStartTime,
+      totalUnits,
+      wasLiveSession,
+      styles,
+    ],
+  );
 
   const drinkMenuItemsData: Menu = useMemo(() => {
     const drinkSums = {
@@ -198,8 +205,8 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
     };
   }, [session.drinks]);
 
-  const otherMenuItemsData: Menu = useMemo(() => {
-    return {
+  const otherMenuItemsData: Menu = useMemo(
+    () => ({
       sectionTranslationKey: 'sessionSummaryScreen.otherSection.title',
       items: [
         {
@@ -215,53 +222,52 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
           ),
         },
       ],
-    };
-  }, [session, translate, wasLiveSession]);
+    }),
+    [session.timezone, translate, wasLiveSession],
+  );
 
   const getSessionSummarySection = useCallback(
-    (menuItemsData: Menu) => {
-      return (
-        <Section
-          title={translate(menuItemsData.sectionTranslationKey)}
-          titleStyles={styles.sectionTitleSimple}
-          containerStyles={styles.pb0}
-          childrenStyles={styles.pt3}>
-          <View>
-            {menuItemsData.items.map(
-              (detail, index) =>
-                !detail?.shouldHide && (
-                  <MenuItem
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`${detail.titleKey}_${index}`}
-                    title={detail.titleKey && translate(detail.titleKey)}
-                    titleStyle={styles.plainSectionTitle}
-                    description={detail.description}
-                    descriptionTextStyle={[
-                      styles.textNormalThemeText,
-                      styles.mw75,
-                      styles.textAlignRight,
-                    ]}
-                    numberOfLinesDescription={5}
-                    wrapperStyle={styles.sectionMenuItemTopDescription}
-                    style={[
-                      styles.pt0,
-                      index !== menuItemsData.items.length - 1 && styles.pb0,
-                      // Enable the following to add borders in between items
-                      // styles.borderBottomRounded,
-                      // {borderBottomLeftRadius: 35, borderBottomRightRadius: 35},
-                    ]}
-                    disabled
-                    shouldGreyOutWhenDisabled={false}
-                    shouldUseRowFlexDirection
-                    shouldShowRightComponent={!!detail.rightComponent}
-                    rightComponent={detail.rightComponent}
-                  />
-                ),
-            )}
-          </View>
-        </Section>
-      );
-    },
+    (menuItemsData: Menu) => (
+      <Section
+        title={translate(menuItemsData.sectionTranslationKey)}
+        titleStyles={styles.sectionTitleSimple}
+        containerStyles={styles.pb0}
+        childrenStyles={styles.pt3}>
+        <View>
+          {menuItemsData.items.map(
+            (detail, index) =>
+              !detail?.shouldHide && (
+                <MenuItem
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${detail.titleKey}_${index}`}
+                  title={detail.titleKey && translate(detail.titleKey)}
+                  titleStyle={styles.plainSectionTitle}
+                  description={detail.description}
+                  descriptionTextStyle={[
+                    styles.textNormalThemeText,
+                    styles.mw75,
+                    styles.textAlignRight,
+                  ]}
+                  numberOfLinesDescription={5}
+                  wrapperStyle={styles.sectionMenuItemTopDescription}
+                  style={[
+                    styles.pt0,
+                    index !== menuItemsData.items.length - 1 && styles.pb0,
+                    // Enable the following to add borders in between items
+                    // styles.borderBottomRounded,
+                    // {borderBottomLeftRadius: 35, borderBottomRightRadius: 35},
+                  ]}
+                  disabled
+                  shouldGreyOutWhenDisabled={false}
+                  shouldUseRowFlexDirection
+                  shouldShowRightComponent={!!detail.rightComponent}
+                  rightComponent={detail.rightComponent}
+                />
+              ),
+          )}
+        </View>
+      </Section>
+    ),
     [
       styles.pb0,
       styles.plainSectionTitle,

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -193,12 +193,7 @@ function ColorPaletteScreen() {
                     },
                   ]}>
                   <View style={[styles.flexColumn, styles.flex1]}>
-                    <Text
-                      style={[
-                        styles.textNormal,
-                        styles.textStrong,
-                        isActive ? {color: accent} : null,
-                      ]}>
+                    <Text style={[styles.textNormal, styles.textStrong]}>
                       {paletteName}
                     </Text>
                     <Text style={[styles.textMicroSupporting, styles.mt1]}>

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -25,17 +25,6 @@ import {
 } from '@libs/SessionColorPalettes';
 import useTheme from '@hooks/useTheme';
 
-const PALETTE_NAME_KEYS: Record<
-  PaletteId,
-  'classic' | 'sunset' | 'ocean' | 'mono' | 'colorblindSafe'
-> = {
-  CLASSIC: 'classic',
-  SUNSET: 'sunset',
-  OCEAN: 'ocean',
-  MONO: 'mono',
-  COLORBLIND_SAFE: 'colorblindSafe',
-};
-
 const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'green',
   'yellow',
@@ -103,7 +92,7 @@ function ColorPaletteScreen() {
               const palette = PALETTES[id];
               const isActive = id === activePaletteId;
               const paletteName = translate(
-                `colorPaletteScreen.palettes.${PALETTE_NAME_KEYS[id]}`,
+                `colorPaletteScreen.palettes.${id}` as const,
               );
               return (
                 <PressableWithFeedback

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -23,7 +23,12 @@ import {
   DEFAULT_PALETTE_ID,
   getPaletteIdFromColors,
 } from '@libs/SessionColorPalettes';
-import useTheme from '@hooks/useTheme';
+import {sessionPaletteColors} from '@styles/theme/colors';
+
+// Brand orange (tangerine400) — fixed across themes so the selection accent stays on-brand.
+const ACCENT = sessionPaletteColors.brand.orange;
+// ~8% opacity orange wash for the selected-row background.
+const ACCENT_TINT = `${ACCENT}1F`;
 
 const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'green',
@@ -35,7 +40,6 @@ const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
 
 function ColorPaletteScreen() {
   const styles = useThemeStyles();
-  const theme = useTheme();
   const {translate} = useLocalize();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
@@ -94,32 +98,49 @@ function ColorPaletteScreen() {
               const paletteName = translate(
                 `colorPaletteScreen.palettes.${id}` as const,
               );
+              const paletteDescription = translate(
+                `colorPaletteScreen.descriptions.${id}` as const,
+              );
               return (
                 <PressableWithFeedback
                   key={id}
                   accessibilityLabel={paletteName}
+                  accessibilityState={{selected: isActive}}
                   onPress={() => onSelectPalette(id)}
                   style={[
                     styles.flexRow,
                     styles.alignItemsCenter,
                     styles.justifyContentBetween,
                     styles.p4,
-                    styles.border,
                     styles.mb2,
+                    {
+                      borderRadius: 12,
+                      borderLeftWidth: 4,
+                      borderLeftColor: isActive ? ACCENT : 'transparent',
+                      backgroundColor: isActive ? ACCENT_TINT : 'transparent',
+                    },
                   ]}>
                   <View style={[styles.flexColumn, styles.flex1]}>
-                    <Text style={[styles.textNormal, styles.textStrong]}>
+                    <Text
+                      style={[
+                        styles.textNormal,
+                        styles.textStrong,
+                        isActive ? {color: ACCENT} : null,
+                      ]}>
                       {paletteName}
+                    </Text>
+                    <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                      {paletteDescription}
                     </Text>
                     <View style={[styles.flexRow, styles.mt2]}>
                       {PREVIEW_KEYS.map(key => (
                         <View
                           key={key}
                           style={{
-                            width: 16,
-                            height: 16,
-                            borderRadius: 4,
-                            marginRight: 4,
+                            width: 40,
+                            height: 22,
+                            borderRadius: 6,
+                            marginRight: 8,
                             backgroundColor: palette[key],
                           }}
                         />
@@ -129,7 +150,7 @@ function ColorPaletteScreen() {
                   {isActive && (
                     <Icon
                       src={KirokuIcons.Checkmark}
-                      fill={theme.iconSuccessFill}
+                      fill={ACCENT}
                       width={20}
                       height={20}
                     />

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -26,14 +26,10 @@ import {
   DEFAULT_PALETTE_ID,
   getPaletteIdFromColors,
 } from '@libs/SessionColorPalettes';
-import {sessionPaletteColors} from '@styles/theme/colors';
 import SessionsCalendarView from '@components/SessionsCalendar/SessionsCalendarView';
+import useTheme from '@hooks/useTheme';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
-
-// Brand orange (tangerine400) — fixed across themes so the selection accent stays on-brand.
-const ACCENT = sessionPaletteColors.brand.orange;
-const ACCENT_TINT = `${ACCENT}1F`;
 
 const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'green',
@@ -92,6 +88,7 @@ function buildPreviewMarkedData(
 
 function ColorPaletteScreen() {
   const styles = useThemeStyles();
+  const theme = useTheme();
   const {translate} = useLocalize();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
@@ -99,6 +96,12 @@ function ColorPaletteScreen() {
   const [pendingPaletteId, setPendingPaletteId] = useState<PaletteId | null>(
     null,
   );
+  const [saving, setSaving] = useState(false);
+
+  // Selection accent uses the app brand color (yellowStrong) so the picker stays
+  // visually integrated with the rest of the app.
+  const accent = theme.appColor;
+  const accentTint = `${accent}1F`;
 
   const activePaletteId =
     getPaletteIdFromColors(preferences?.session_color_palette) ??
@@ -113,22 +116,20 @@ function ColorPaletteScreen() {
   );
 
   const onSelectPalette = (id: PaletteId) => {
-    if (id === displayPaletteId) {
+    if (saving || id === displayPaletteId) {
       return;
     }
     setPendingPaletteId(id);
-    (async () => {
-      try {
-        await Preferences.updatePreferences(db, user, {
-          session_color_palette: PALETTES[id],
-        });
-        Navigation.goBack();
-      } catch (error) {
+    setSaving(true);
+    Preferences.updatePreferences(db, user, {
+      session_color_palette: PALETTES[id],
+    })
+      .catch(error => {
         setPendingPaletteId(null);
         const errorMessage = error instanceof Error ? error.message : '';
         Alert.alert(translate('preferencesScreen.error.save'), errorMessage);
-      }
-    })();
+      })
+      .finally(() => setSaving(false));
   };
 
   return (
@@ -151,7 +152,7 @@ function ColorPaletteScreen() {
             style={[
               styles.mb4,
               styles.overflowHidden,
-              {borderRadius: 12, borderWidth: 1, borderColor: ACCENT_TINT},
+              {borderRadius: 12, borderWidth: 1, borderColor: accentTint},
             ]}>
             <SessionsCalendarView
               markedDates={previewData.markedDates}
@@ -185,8 +186,8 @@ function ColorPaletteScreen() {
                     {
                       borderRadius: 12,
                       borderLeftWidth: 4,
-                      borderLeftColor: isActive ? ACCENT : 'transparent',
-                      backgroundColor: isActive ? ACCENT_TINT : 'transparent',
+                      borderLeftColor: isActive ? accent : 'transparent',
+                      backgroundColor: isActive ? accentTint : 'transparent',
                     },
                   ]}>
                   <View style={[styles.flexColumn, styles.flex1]}>
@@ -194,7 +195,7 @@ function ColorPaletteScreen() {
                       style={[
                         styles.textNormal,
                         styles.textStrong,
-                        isActive ? {color: ACCENT} : null,
+                        isActive ? {color: accent} : null,
                       ]}>
                       {paletteName}
                     </Text>
@@ -219,7 +220,7 @@ function ColorPaletteScreen() {
                   {isActive && (
                     <Icon
                       src={KirokuIcons.Checkmark}
-                      fill={ACCENT}
+                      fill={accent}
                       width={20}
                       height={20}
                     />

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -159,6 +159,8 @@ function ColorPaletteScreen() {
               unitsMap={previewData.unitsMap}
               visibleDate={visibleDate}
               hideArrows
+              hideMonthHeader
+              hideDayNames
             />
           </View>
           <View>

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -1,0 +1,159 @@
+import React, {useState} from 'react';
+import {Alert, View} from 'react-native';
+import {useFirebase} from '@context/global/FirebaseContext';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import Navigation from '@libs/Navigation/Navigation';
+import ScreenWrapper from '@components/ScreenWrapper';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import ScrollView from '@components/ScrollView';
+import Section from '@components/Section';
+import Text from '@components/Text';
+import {PressableWithFeedback} from '@components/Pressable';
+import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import * as Preferences from '@userActions/Preferences';
+import type {SessionColorPalette} from '@src/types/onyx';
+import type {PaletteId} from '@libs/SessionColorPalettes';
+import {
+  PALETTE_IDS,
+  PALETTES,
+  DEFAULT_PALETTE_ID,
+  getPaletteIdFromColors,
+} from '@libs/SessionColorPalettes';
+import useTheme from '@hooks/useTheme';
+
+const PALETTE_NAME_KEYS: Record<
+  PaletteId,
+  'classic' | 'sunset' | 'ocean' | 'mono' | 'colorblindSafe'
+> = {
+  CLASSIC: 'classic',
+  SUNSET: 'sunset',
+  OCEAN: 'ocean',
+  MONO: 'mono',
+  COLORBLIND_SAFE: 'colorblindSafe',
+};
+
+const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
+  'green',
+  'yellow',
+  'orange',
+  'red',
+  'black',
+];
+
+function ColorPaletteScreen() {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const {auth, db} = useFirebase();
+  const user = auth.currentUser;
+  const {preferences} = useDatabaseData();
+  const [saving, setSaving] = useState(false);
+
+  const activePaletteId =
+    getPaletteIdFromColors(preferences?.session_color_palette) ??
+    DEFAULT_PALETTE_ID;
+
+  const onSelectPalette = (id: PaletteId) => {
+    (async () => {
+      try {
+        setSaving(true);
+        await Preferences.updatePreferences(db, user, {
+          session_color_palette: PALETTES[id],
+        });
+        Navigation.goBack();
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('preferencesScreen.error.save'), errorMessage);
+      } finally {
+        setSaving(false);
+      }
+    })();
+  };
+
+  if (saving) {
+    return (
+      <FullScreenLoadingIndicator
+        loadingText={translate('preferencesScreen.saving')}
+      />
+    );
+  }
+
+  return (
+    <ScreenWrapper testID={ColorPaletteScreen.displayName}>
+      <HeaderWithBackButton
+        title={translate('colorPaletteScreen.title')}
+        shouldShowBackButton
+        onBackButtonPress={() => Navigation.goBack()}
+        onCloseButtonPress={() => Navigation.dismissModal()}
+      />
+      <ScrollView style={[styles.flexGrow1, styles.mnw100]}>
+        <Section
+          title={translate('colorPaletteScreen.title')}
+          titleStyles={styles.generalSectionTitle}
+          subtitle={translate('colorPaletteScreen.description')}
+          subtitleMuted
+          isCentralPane
+          childrenStyles={styles.pt3}>
+          <View>
+            {PALETTE_IDS.map(id => {
+              const palette = PALETTES[id];
+              const isActive = id === activePaletteId;
+              const paletteName = translate(
+                `colorPaletteScreen.palettes.${PALETTE_NAME_KEYS[id]}`,
+              );
+              return (
+                <PressableWithFeedback
+                  key={id}
+                  accessibilityLabel={paletteName}
+                  onPress={() => onSelectPalette(id)}
+                  style={[
+                    styles.flexRow,
+                    styles.alignItemsCenter,
+                    styles.justifyContentBetween,
+                    styles.p4,
+                    styles.border,
+                    styles.mb2,
+                  ]}>
+                  <View style={[styles.flexColumn, styles.flex1]}>
+                    <Text style={[styles.textNormal, styles.textStrong]}>
+                      {paletteName}
+                    </Text>
+                    <View style={[styles.flexRow, styles.mt2]}>
+                      {PREVIEW_KEYS.map(key => (
+                        <View
+                          key={key}
+                          style={{
+                            width: 16,
+                            height: 16,
+                            borderRadius: 4,
+                            marginRight: 4,
+                            backgroundColor: palette[key],
+                          }}
+                        />
+                      ))}
+                    </View>
+                  </View>
+                  {isActive && (
+                    <Icon
+                      src={KirokuIcons.Checkmark}
+                      fill={theme.iconSuccessFill}
+                      width={20}
+                      height={20}
+                    />
+                  )}
+                </PressableWithFeedback>
+              );
+            })}
+          </View>
+        </Section>
+      </ScrollView>
+    </ScreenWrapper>
+  );
+}
+
+ColorPaletteScreen.displayName = 'ColorPaletteScreen';
+export default ColorPaletteScreen;

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -1,5 +1,8 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {Alert, View} from 'react-native';
+import type {DateData} from 'react-native-calendars';
+import type {MarkedDates} from 'react-native-calendars/src/types';
+import {eachDayOfInterval, endOfMonth, format, startOfMonth} from 'date-fns';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import Navigation from '@libs/Navigation/Navigation';
@@ -7,7 +10,6 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import Text from '@components/Text';
@@ -15,6 +17,7 @@ import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import * as Preferences from '@userActions/Preferences';
+import {dateToDateData} from '@libs/DataHandling';
 import type {SessionColorPalette} from '@src/types/onyx';
 import type {PaletteId} from '@libs/SessionColorPalettes';
 import {
@@ -24,10 +27,12 @@ import {
   getPaletteIdFromColors,
 } from '@libs/SessionColorPalettes';
 import {sessionPaletteColors} from '@styles/theme/colors';
+import SessionsCalendarView from '@components/SessionsCalendar/SessionsCalendarView';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+import CONST from '@src/CONST';
 
 // Brand orange (tangerine400) — fixed across themes so the selection accent stays on-brand.
 const ACCENT = sessionPaletteColors.brand.orange;
-// ~8% opacity orange wash for the selected-row background.
 const ACCENT_TINT = `${ACCENT}1F`;
 
 const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
@@ -38,42 +43,93 @@ const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'black',
 ];
 
+/**
+ * Build a fixed demo dataset showcasing all five severity colors across the
+ * visible month. Mirrors the shape produced by `useLazyMarkedDates` so the
+ * presentational `SessionsCalendarView` renders identically.
+ */
+function buildPreviewMarkedData(
+  palette: SessionColorPalette,
+  visibleDate: DateData,
+): {markedDates: MarkedDates; unitsMap: Map<DateString, number>} {
+  const monthStart = startOfMonth(new Date(visibleDate.timestamp));
+  const monthEnd = endOfMonth(new Date(visibleDate.timestamp));
+  const allDays = eachDayOfInterval({start: monthStart, end: monthEnd});
+
+  const overlay = new Map<
+    number,
+    {slot: keyof SessionColorPalette; units: number}
+  >([
+    [3, {slot: 'yellow', units: 2}],
+    [5, {slot: 'yellow', units: 3}],
+    [7, {slot: 'orange', units: 7}],
+    [10, {slot: 'red', units: 12}],
+    [12, {slot: 'yellow', units: 1}],
+    [14, {slot: 'orange', units: 8}],
+    [17, {slot: 'red', units: 14}],
+    [20, {slot: 'orange', units: 6}],
+    [23, {slot: 'yellow', units: 3}],
+    [25, {slot: 'black', units: 20}],
+    [27, {slot: 'orange', units: 9}],
+  ]);
+
+  const markedDates: MarkedDates = {};
+  const unitsMap = new Map<DateString, number>();
+
+  allDays.forEach(day => {
+    const dayKey = format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString;
+    const o = overlay.get(day.getDate());
+    if (o) {
+      markedDates[dayKey] = {color: palette[o.slot]};
+      unitsMap.set(dayKey, o.units);
+    } else {
+      markedDates[dayKey] = {color: palette.green};
+    }
+  });
+
+  return {markedDates, unitsMap};
+}
+
 function ColorPaletteScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
   const {preferences} = useDatabaseData();
-  const [saving, setSaving] = useState(false);
+  const [pendingPaletteId, setPendingPaletteId] = useState<PaletteId | null>(
+    null,
+  );
 
   const activePaletteId =
     getPaletteIdFromColors(preferences?.session_color_palette) ??
     DEFAULT_PALETTE_ID;
+  // Optimistic preview: while a save is in flight, render the just-tapped palette.
+  const displayPaletteId = pendingPaletteId ?? activePaletteId;
+
+  const visibleDate = useMemo(() => dateToDateData(new Date()), []);
+  const previewData = useMemo(
+    () => buildPreviewMarkedData(PALETTES[displayPaletteId], visibleDate),
+    [displayPaletteId, visibleDate],
+  );
 
   const onSelectPalette = (id: PaletteId) => {
+    if (id === displayPaletteId) {
+      return;
+    }
+    setPendingPaletteId(id);
     (async () => {
       try {
-        setSaving(true);
         await Preferences.updatePreferences(db, user, {
           session_color_palette: PALETTES[id],
         });
         Navigation.goBack();
       } catch (error) {
+        setPendingPaletteId(null);
         const errorMessage = error instanceof Error ? error.message : '';
         Alert.alert(translate('preferencesScreen.error.save'), errorMessage);
-      } finally {
-        setSaving(false);
       }
     })();
   };
-
-  if (saving) {
-    return (
-      <FullScreenLoadingIndicator
-        loadingText={translate('preferencesScreen.saving')}
-      />
-    );
-  }
 
   return (
     <ScreenWrapper testID={ColorPaletteScreen.displayName}>
@@ -91,10 +147,23 @@ function ColorPaletteScreen() {
           subtitleMuted
           isCentralPane
           childrenStyles={styles.pt3}>
+          <View
+            style={[
+              styles.mb4,
+              styles.overflowHidden,
+              {borderRadius: 12, borderWidth: 1, borderColor: ACCENT_TINT},
+            ]}>
+            <SessionsCalendarView
+              markedDates={previewData.markedDates}
+              unitsMap={previewData.unitsMap}
+              visibleDate={visibleDate}
+              hideArrows
+            />
+          </View>
           <View>
             {PALETTE_IDS.map(id => {
               const palette = PALETTES[id];
-              const isActive = id === activePaletteId;
+              const isActive = id === displayPaletteId;
               const paletteName = translate(
                 `colorPaletteScreen.palettes.${id}` as const,
               );

--- a/src/screens/Settings/Preferences/PreferencesScreen.tsx
+++ b/src/screens/Settings/Preferences/PreferencesScreen.tsx
@@ -20,6 +20,11 @@ import LocaleUtils from '@libs/LocaleUtils';
 import Section from '@components/Section';
 import MenuItem from '@components/MenuItem';
 import CONST from '@src/CONST';
+import type {PaletteId} from '@libs/SessionColorPalettes';
+import {
+  DEFAULT_PALETTE_ID,
+  getPaletteIdFromColors,
+} from '@libs/SessionColorPalettes';
 
 type MenuData = {
   title?: string;
@@ -53,8 +58,8 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
   //   setCurrentPreferences(prev => ({...prev, first_day_of_week: newValue}));
   // };
 
-  const generalMenuItemsData: Menu = useMemo(() => {
-    return {
+  const generalMenuItemsData: Menu = useMemo(
+    () => ({
       sectionTranslationKey: 'preferencesScreen.generalSection.title',
       items: [
         // {
@@ -75,10 +80,25 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
           pageRoute: ROUTES.SETTINGS_THEME,
         },
       ],
-    };
-  }, [translate, preferences?.theme, preferredLocale]); // Check whether preferred locale does not cause infinite re-render
+    }),
+    [translate, preferences?.theme, preferredLocale],
+  ); // Check whether preferred locale does not cause infinite re-render
+
+  const activePaletteId: PaletteId =
+    getPaletteIdFromColors(preferences?.session_color_palette) ??
+    DEFAULT_PALETTE_ID;
 
   const drinksAndUnitsMenuItemsData: Menu = useMemo(() => {
+    const paletteNameKeys: Record<
+      PaletteId,
+      'classic' | 'sunset' | 'ocean' | 'mono' | 'colorblindSafe'
+    > = {
+      CLASSIC: 'classic',
+      SUNSET: 'sunset',
+      OCEAN: 'ocean',
+      MONO: 'mono',
+      COLORBLIND_SAFE: 'colorblindSafe',
+    };
     return {
       sectionTranslationKey: 'preferencesScreen.drinksAndUnitsSection.title',
       subtitle: translate(
@@ -97,9 +117,18 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
           ),
           pageRoute: ROUTES.SETTINGS_UNITS_TO_COLORS,
         },
+        {
+          title: translate(
+            'preferencesScreen.drinksAndUnitsSection.colorPalette',
+          ),
+          description: translate(
+            `colorPaletteScreen.palettes.${paletteNameKeys[activePaletteId]}`,
+          ),
+          pageRoute: ROUTES.SETTINGS_COLOR_PALETTE,
+        },
       ],
     };
-  }, [translate]);
+  }, [translate, activePaletteId]);
 
   /**
    * Retuns JSX.Element with menu items
@@ -107,41 +136,39 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
    * @returns the menu items for passed data
    */
   const getMenuItemsSection = useCallback(
-    (menuItemsData: Menu) => {
-      return (
-        <Section
-          title={translate(menuItemsData.sectionTranslationKey)}
-          titleStyles={styles.generalSectionTitle}
-          subtitle={menuItemsData.subtitle}
-          subtitleMuted
-          isCentralPane
-          childrenStyles={styles.pt3}>
-          <>
-            {menuItemsData.items.map((detail, index) => (
-              <MenuItem
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${detail.title}_${index}`}
-                title={detail.title}
-                titleStyle={styles.plainSectionTitle}
-                description={detail.description}
-                wrapperStyle={styles.sectionMenuItemTopDescription}
-                disabled={detail.disabled}
-                shouldGreyOutWhenDisabled={false}
-                shouldUseRowFlexDirection
-                shouldShowRightIcon={!detail.rightComponent}
-                shouldShowRightComponent={!!detail.rightComponent}
-                rightComponent={detail.rightComponent}
-                onPress={singleExecution(() => {
-                  waitForNavigate(() => {
-                    Navigation.navigate(detail.pageRoute);
-                  })();
-                })}
-              />
-            ))}
-          </>
-        </Section>
-      );
-    },
+    (menuItemsData: Menu) => (
+      <Section
+        title={translate(menuItemsData.sectionTranslationKey)}
+        titleStyles={styles.generalSectionTitle}
+        subtitle={menuItemsData.subtitle}
+        subtitleMuted
+        isCentralPane
+        childrenStyles={styles.pt3}>
+        <>
+          {menuItemsData.items.map((detail, index) => (
+            <MenuItem
+              // eslint-disable-next-line react/no-array-index-key
+              key={`${detail.title}_${index}`}
+              title={detail.title}
+              titleStyle={styles.plainSectionTitle}
+              description={detail.description}
+              wrapperStyle={styles.sectionMenuItemTopDescription}
+              disabled={detail.disabled}
+              shouldGreyOutWhenDisabled={false}
+              shouldUseRowFlexDirection
+              shouldShowRightIcon={!detail.rightComponent}
+              shouldShowRightComponent={!!detail.rightComponent}
+              rightComponent={detail.rightComponent}
+              onPress={singleExecution(() => {
+                waitForNavigate(() => {
+                  Navigation.navigate(detail.pageRoute);
+                })();
+              })}
+            />
+          ))}
+        </>
+      </Section>
+    ),
     [
       singleExecution,
       styles.generalSectionTitle,

--- a/src/screens/Settings/Preferences/PreferencesScreen.tsx
+++ b/src/screens/Settings/Preferences/PreferencesScreen.tsx
@@ -88,18 +88,8 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
     getPaletteIdFromColors(preferences?.session_color_palette) ??
     DEFAULT_PALETTE_ID;
 
-  const drinksAndUnitsMenuItemsData: Menu = useMemo(() => {
-    const paletteNameKeys: Record<
-      PaletteId,
-      'classic' | 'sunset' | 'ocean' | 'mono' | 'colorblindSafe'
-    > = {
-      CLASSIC: 'classic',
-      SUNSET: 'sunset',
-      OCEAN: 'ocean',
-      MONO: 'mono',
-      COLORBLIND_SAFE: 'colorblindSafe',
-    };
-    return {
+  const drinksAndUnitsMenuItemsData: Menu = useMemo(
+    () => ({
       sectionTranslationKey: 'preferencesScreen.drinksAndUnitsSection.title',
       subtitle: translate(
         'preferencesScreen.drinksAndUnitsSection.description',
@@ -122,13 +112,14 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
             'preferencesScreen.drinksAndUnitsSection.colorPalette',
           ),
           description: translate(
-            `colorPaletteScreen.palettes.${paletteNameKeys[activePaletteId]}`,
+            `colorPaletteScreen.palettes.${activePaletteId}` as const,
           ),
           pageRoute: ROUTES.SETTINGS_COLOR_PALETTE,
         },
       ],
-    };
-  }, [translate, activePaletteId]);
+    }),
+    [translate, activePaletteId],
+  );
 
   /**
    * Retuns JSX.Element with menu items

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -102,41 +102,64 @@ const colors: Record<string, Color> = {
 };
 
 /**
- * Hex tokens for session severity palettes (green → yellow → orange → red → black).
- * Consumed by `src/libs/SessionColorPalettes.ts` — keep hex values here, not in logic code.
+ * Session severity palettes (green → yellow → orange → red → black).
+ * Consumed by `src/libs/SessionColorPalettes.ts`. The keys here are the palette ids —
+ * adding a new palette = one new entry. PaletteId, PALETTE_IDS, and PALETTES all derive from this.
+ *
+ * "Classic" uses hex equivalents of the CSS named colors so existing users see no visual change.
+ * "Brand" and "pink" pull from the shared color tokens above to stay consistent with app theming.
  */
 const sessionPaletteColors = {
-  // Hex equivalents of CSS named colors so existing users see no visual change
-  classicGreen: '#008000',
-  classicYellow: '#FFFF00',
-  classicOrange: '#FFA500',
-  classicRed: '#FF0000',
-  classicBlack: '#000000',
-
-  sunsetGreen: '#5C8A3A',
-  sunsetYellow: '#F2C14E',
-  sunsetOrange: '#F08A4B',
-  sunsetRed: '#C8412B',
-  sunsetBlack: '#1A0F0A',
-
-  oceanGreen: '#3B9C8B',
-  oceanYellow: '#6FB8D6',
-  oceanOrange: '#3F7EA5',
-  oceanRed: '#1F3A6E',
-  oceanBlack: '#0A1530',
-
-  monoGreen: '#D0D0D0',
-  monoYellow: '#9A9A9A',
-  monoOrange: '#6A6A6A',
-  monoRed: '#3A3A3A',
-  monoBlack: '#000000',
-
-  colorblindSafeGreen: '#117733',
-  colorblindSafeYellow: '#DDCC77',
-  colorblindSafeOrange: '#E69F00',
-  colorblindSafeRed: '#CC3311',
-  colorblindSafeBlack: '#000000',
-} as const;
+  classic: {
+    green: '#008000',
+    yellow: '#FFFF00',
+    orange: '#FFA500',
+    red: '#FF0000',
+    black: '#000000',
+  },
+  sunset: {
+    green: '#5C8A3A',
+    yellow: '#F2C14E',
+    orange: '#F08A4B',
+    red: '#C8412B',
+    black: '#1A0F0A',
+  },
+  ocean: {
+    green: '#3B9C8B',
+    yellow: '#6FB8D6',
+    orange: '#3F7EA5',
+    red: '#1F3A6E',
+    black: '#0A1530',
+  },
+  mono: {
+    green: '#D0D0D0',
+    yellow: '#9A9A9A',
+    orange: '#6A6A6A',
+    red: '#3A3A3A',
+    black: '#000000',
+  },
+  colorblindSafe: {
+    green: '#117733',
+    yellow: '#DDCC77',
+    orange: '#E69F00',
+    red: '#CC3311',
+    black: '#000000',
+  },
+  brand: {
+    green: colors.tangerine100,
+    yellow: colors.tangerine300,
+    orange: colors.tangerine400,
+    red: colors.tangerine600,
+    black: '#000000',
+  },
+  pink: {
+    green: colors.pink100,
+    yellow: colors.pink300,
+    orange: colors.pink500,
+    red: colors.red,
+    black: '#000000',
+  },
+};
 
 export {sessionPaletteColors};
 export default colors;

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -146,10 +146,12 @@ const sessionPaletteColors = {
     black: '#000000',
   },
   brand: {
-    green: colors.tangerine100,
-    yellow: colors.tangerine300,
-    orange: colors.tangerine400,
-    red: colors.tangerine600,
+    // Anchored on yellowStrong (the actual app brand color used by theme.appColor)
+    // so the Brand palette feels native against the rest of the UI.
+    green: colors.yellow200,
+    yellow: colors.yellowStrong,
+    orange: colors.yellow600,
+    red: colors.yellow700,
     black: '#000000',
   },
   pink: {

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -101,4 +101,42 @@ const colors: Record<string, Color> = {
   orange900: '#E65100',
 };
 
+/**
+ * Hex tokens for session severity palettes (green → yellow → orange → red → black).
+ * Consumed by `src/libs/SessionColorPalettes.ts` — keep hex values here, not in logic code.
+ */
+const sessionPaletteColors = {
+  // Hex equivalents of CSS named colors so existing users see no visual change
+  classicGreen: '#008000',
+  classicYellow: '#FFFF00',
+  classicOrange: '#FFA500',
+  classicRed: '#FF0000',
+  classicBlack: '#000000',
+
+  sunsetGreen: '#5C8A3A',
+  sunsetYellow: '#F2C14E',
+  sunsetOrange: '#F08A4B',
+  sunsetRed: '#C8412B',
+  sunsetBlack: '#1A0F0A',
+
+  oceanGreen: '#3B9C8B',
+  oceanYellow: '#6FB8D6',
+  oceanOrange: '#3F7EA5',
+  oceanRed: '#1F3A6E',
+  oceanBlack: '#0A1530',
+
+  monoGreen: '#D0D0D0',
+  monoYellow: '#9A9A9A',
+  monoOrange: '#6A6A6A',
+  monoRed: '#3A3A3A',
+  monoBlack: '#000000',
+
+  colorblindSafeGreen: '#117733',
+  colorblindSafeYellow: '#DDCC77',
+  colorblindSafeOrange: '#E69F00',
+  colorblindSafeRed: '#CC3311',
+  colorblindSafeBlack: '#000000',
+} as const;
+
+export {sessionPaletteColors};
 export default colors;

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -20,7 +20,7 @@ import CONST from '@src/CONST';
 import type {StyledSafeAreaInsets} from '@hooks/useStyledSafeAreaInsets';
 import type {Theme as RNCalendarsTheme} from 'react-native-calendars/src/types';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
-import type {LightCalendarColors} from '@components/SessionsCalendar/DayComponent/types';
+import {isLightHex} from '@libs/SessionColorPalettes';
 import {defaultStyles} from '..';
 import type {ThemeStyles} from '..';
 import containerComposeStyles from './containerComposeStyles';
@@ -1370,11 +1370,7 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
   getSessionsCalendarDayMarkingTextStyle: (
     marking: MarkingProps | undefined,
   ): TextStyle => {
-    const isLightColor =
-      marking?.color &&
-      Object.values(CONST.CALENDAR_COLORS.LIGHT).includes(
-        marking.color as LightCalendarColors,
-      );
+    const isLightColor = !!marking?.color && isLightHex(marking.color);
     const textColor = isLightColor ? theme.textDark : theme.textLight;
     return {
       ...styles.textNormal,

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -19,6 +19,24 @@ type UnitsToColors = {
 /** A model mapping drinks to unit values */
 type DrinksToUnits = Record<DrinkKey, number>;
 
+/** A model mapping session band names to hex colors */
+type SessionColorPalette = {
+  /** Hex color for zero-unit (green) band */
+  green: string;
+
+  /** Hex color for low-unit (yellow) band */
+  yellow: string;
+
+  /** Hex color for mid-unit (orange) band */
+  orange: string;
+
+  /** Hex color for high-unit (red) band */
+  red: string;
+
+  /** Hex color for blackout sessions */
+  black: string;
+};
+
 /** User's preferences */
 type Preferences = {
   /** User's preferred first day of week */
@@ -35,10 +53,19 @@ type Preferences = {
 
   /** User's preferred theme */
   theme?: Theme;
+
+  /** User's selected session color palette */
+  session_color_palette?: SessionColorPalette;
 };
 
 /** A collection of preferences of multiple users */
 type PreferencesList = Record<UserID, Preferences>;
 
 export default Preferences;
-export type {UnitsToColors, DrinksToUnits, PreferencesList, Theme};
+export type {
+  UnitsToColors,
+  DrinksToUnits,
+  PreferencesList,
+  Theme,
+  SessionColorPalette,
+};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -41,6 +41,7 @@ import type {
   UnitsToColors,
   DrinksToUnits,
   Theme,
+  SessionColorPalette,
 } from './Preferences';
 import type Request from './Request';
 import type ReasonForLeaving from './ReasonForLeaving';
@@ -126,6 +127,7 @@ export type {
   Request,
   Response,
   Session,
+  SessionColorPalette,
   SessionPlaceholder,
   SessionPlaceholderList,
   StartSession,


### PR DESCRIPTION
## Summary

- Adds a new **Session colors** screen under *Preferences → Drinks and Units* that lets users choose from five preset palettes (Classic, Sunset, Ocean, Monochrome, Colorblind-safe).
- The selected palette is stored as `session_color_palette` on the user's preferences and is consumed everywhere session colors are rendered (calendar day cells, live session window, day overview cards, session summary).
- Classic uses the exact CSS-named-color hex equivalents (`green`, `yellow`, `orange`, `red`, `black`) so existing users see zero visual change unless they opt in.

## What changed

- New preference field `session_color_palette` (optional; defaults to Classic when absent — no migration needed).
- New screen `ColorPaletteScreen.tsx` with one card per preset showing a 5-dot preview strip and a check icon on the active palette. Tap to save + close.
- `convertUnitsToColors(units, unitsToColors, palette?)` now takes the palette as a third arg and returns a hex string. `CalendarColors` is now `string` (was a union of CSS-named-color literals).
- Text-contrast logic in `getSessionsCalendarDayMarkingTextStyle` (and the equivalent fallback in `DataHandling.ts`) now uses a luminance check (`isLightHex`) so any hex palette gets sensible contrast.
- New presets module: `src/libs/SessionColorPalettes.ts`.
- Translations added for `en` and `cs_cz`.

## Test plan

- [ ] Open Preferences → Drinks and Units → Color palette
- [ ] Tap each preset (Classic, Sunset, Ocean, Monochrome, Colorblind-safe), verify the screen dismisses and the chosen palette name is shown back on the Preferences row
- [ ] Verify calendar day cells render with the new palette
- [ ] Open a live drinking session and confirm the unit-count text and tab indicator pick up the new palette
- [ ] Verify text contrast remains readable on all 5 palettes (especially MONO yellow/orange and COLORBLIND_SAFE yellow)
- [ ] Confirm Classic preserves the prior visual look (compare to a session viewed before the upgrade)
- [ ] Test graceful fallback: with a fresh account (no `session_color_palette` on Firebase) the app should render as Classic without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)