### PR TITLE
ci(android): cache Gradle and Boost downloads to fix flaky deploys

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -60,6 +60,20 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Set REACT_NATIVE_DOWNLOADS_DIR
+        run: echo "REACT_NATIVE_DOWNLOADS_DIR=$HOME/.rn-downloads" >> "$GITHUB_ENV"
+
+      - name: Cache Gradle and React Native downloads (Boost, etc.)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.rn-downloads
+          key: ${{ runner.os }}-android-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties', 'package-lock.json', 'patches/**') }}
+          restore-keys: |
+            ${{ runner.os }}-android-gradle-
+
       - name: Decrypt keystore
         run: cd android/app && gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output kiroku-play-key.keystore kiroku-play-key.keystore.gpg
         env:


### PR DESCRIPTION
## Summary

The Android deploy job has been intermittently failing on the `downloadBoost` Gradle task with `java.net.SocketTimeoutException: Read timed out` when fetching the Boost tarball from `archives.boost.io`. Since the CI runner has no Gradle cache, every build re-downloads Boost from scratch — any network blip kills the whole 40-minute deploy. All three fastlane retry attempts hit the same failure in [run 26227201233](https://github.com/PetrCala/Kiroku/actions/runs/26227201233/job/77177442502).

This is not a code regression; it's network flake against a host outside our control, made fatal by the lack of caching.

## Changes

- Persist `~/.gradle/caches`, `~/.gradle/wrapper`, and `~/.rn-downloads` across runs via `actions/cache@v4`, keyed on Android Gradle files, the wrapper props, `package-lock.json`, and patches.
- Export `REACT_NATIVE_DOWNLOADS_DIR=$HOME/.rn-downloads` so React Native's `downloadBoost` task (which uses `overwrite(false)` and `onlyIfModified(true)`) reuses the cached tarball and skips the network entirely on subsequent builds.

First build after this lands still hits `archives.boost.io`; every subsequent build with the same cache key skips the download. `restore-keys` falls back to the latest cache when the key misses, so dependency bumps still benefit from a partial restore.

## Notes for reviewer

- Scoped to `platformDeploy.yml` only (used by both staging and production deploys via `deploy.yml`). `testBuild.yml` could benefit from the same change as a follow-up — left out to keep this PR minimal.
- The `Set REACT_NATIVE_DOWNLOADS_DIR` step exports the resolved `$HOME/...` path to `GITHUB_ENV` rather than writing `~/...` directly into the env block, because Gradle's `System.getenv()` doesn't tilde-expand.

## Test plan

- [ ] Merge to `staging`, observe next deploy populates the cache (first run still downloads Boost).
- [ ] Confirm the following deploy reuses the cache (no `downloadBoost` network fetch in logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)