### PR TITLE
fix(apple-signin/verify-email): Android nonce + 'Use a different email' escape hatch

### DIFF
--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -20,6 +20,7 @@ type AppleSignInProps = {
 
 type AppleAndroidSignInResult = {
   idToken: string | undefined;
+  rawNonce: string | undefined;
   displayName: string | null;
 };
 
@@ -50,7 +51,11 @@ async function appleSignInRequestAndroid(): Promise<AppleAndroidSignInResult | n
   const displayName =
     [name?.firstName, name?.lastName].filter(Boolean).join(' ') || null;
 
-  return {idToken: response.id_token, displayName};
+  return {
+    idToken: response.id_token,
+    rawNonce: response.nonce ?? undefined,
+    displayName,
+  };
 }
 
 /**
@@ -73,10 +78,13 @@ function AppleSignIn({
         return;
       }
 
-      const {idToken, displayName} = result;
+      const {idToken, rawNonce, displayName} = result;
 
       const provider = new OAuthProvider('apple.com');
-      const credential = provider.credential({idToken: idToken ?? ''});
+      const credential = provider.credential({
+        idToken: idToken ?? '',
+        rawNonce,
+      });
 
       onPress();
       // Shown at the Kiroku-level overlay so it stays visible across the
@@ -92,6 +100,7 @@ function AppleSignIn({
           User.stashPendingOAuthCredential(firebaseError, {
             providerId: 'apple.com',
             idToken: idToken ?? '',
+            rawNonce,
             displayName,
           })
         ) {

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -8,6 +8,7 @@ import Log from '@libs/Log';
 import * as Session from '@libs/actions/Session';
 import {sleep} from '@libs/TimeUtils';
 import * as UserUtils from '@libs/UserUtils';
+import * as ValidationUtils from '@libs/ValidationUtils';
 import * as User from '@userActions/User';
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
@@ -20,8 +21,10 @@ import {PressableWithFeedback} from './Pressable';
 import SafeAreaConsumer from './SafeAreaConsumer';
 import SuccessAnimation from './SuccessAnimation';
 import Text from './Text';
+import TextInput from './TextInput';
 
 type ResendStatus = 'idle' | 'success' | 'error';
+type ModalView = 'verify' | 'changeEmail';
 
 /**
  * Mandatory email-verification modal. Shown immediately after signup (and on
@@ -43,6 +46,16 @@ function VerifyEmailModal() {
   const [isLoading, setIsLoading] = useState(false);
   const [resendStatus, setResendStatus] = useState<ResendStatus>('idle');
   const [errorText, setErrorText] = useState('');
+
+  // changeEmail sub-view state
+  const [view, setView] = useState<ModalView>('verify');
+  const [newEmailInput, setNewEmailInput] = useState('');
+  const [passwordInput, setPasswordInput] = useState('');
+  const [changeEmailError, setChangeEmailError] = useState('');
+  const [isChangeEmailLoading, setIsChangeEmailLoading] = useState(false);
+  // Set to the new address after a successful email change so the verify
+  // view body reflects the address we actually sent the link to.
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
 
   // On mount, reload the user to pick up any verification that happened
   // out-of-band (e.g. user clicked the link in another tab/app before
@@ -130,6 +143,48 @@ function VerifyEmailModal() {
     });
   };
 
+  const onChangeEmailSubmit = () => {
+    (async () => {
+      setChangeEmailError('');
+      const trimmedEmail = newEmailInput.trim();
+
+      const emailError = ValidationUtils.validateEmail(
+        trimmedEmail,
+        user?.email,
+      );
+      if (emailError) {
+        setChangeEmailError(translate(emailError));
+        return;
+      }
+      if (!passwordInput) {
+        setChangeEmailError(
+          translate('verifyEmailScreen.changeEmail.error.passwordRequired'),
+        );
+        return;
+      }
+
+      setIsChangeEmailLoading(true);
+      try {
+        await User.sendUpdateEmailLink(user, trimmedEmail, passwordInput);
+        setPendingEmail(trimmedEmail);
+        setResendStatus('idle');
+        setErrorText('');
+        setNewEmailInput('');
+        setPasswordInput('');
+        setView('verify');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '';
+        setChangeEmailError(
+          errorMessage || translate('verifyEmailScreen.error.generic'),
+        );
+      } finally {
+        setIsChangeEmailLoading(false);
+      }
+    })();
+  };
+
+  const displayEmail = pendingEmail ?? user?.email ?? '';
+
   return (
     <SafeAreaConsumer>
       {({safeAreaPaddingBottomStyle}) => (
@@ -155,82 +210,180 @@ function VerifyEmailModal() {
                 : styles.pb5,
             ]}>
             {!emailVerified ? (
-              <View>
-                <View
-                  style={[
-                    styles.flexGrow1,
-                    styles.justifyContentCenter,
-                    styles.alignItemsCenter,
-                  ]}>
-                  <Icon src={KirokuIcons.Mail} fill={theme.appColor} large />
-                  <Text
-                    textAlign="center"
-                    style={[styles.textHeadlineH2, styles.mt3]}>
-                    {translate('verifyEmailScreen.title')}
-                  </Text>
-                  <Text textAlign="center" style={styles.mt3}>
-                    {translate('verifyEmailScreen.body', {
-                      email: user?.email ?? '',
-                    })}
-                  </Text>
-                </View>
-                <View style={styles.pb1}>
-                  {resendStatus === 'success' && (
-                    <DotIndicatorMessage
-                      style={[styles.mv2]}
-                      type="success"
-                      messages={{
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
-                        0: translate('verifyEmailScreen.emailSent'),
-                      }}
-                    />
-                  )}
-                  {!!errorText && (
-                    <DotIndicatorMessage
-                      style={[styles.mv2]}
-                      type="error"
-                      // eslint-disable-next-line @typescript-eslint/naming-convention
-                      messages={{0: errorText}}
-                    />
-                  )}
-                  <Button
-                    success
-                    large
-                    isLoading={isLoading}
-                    style={styles.mt1}
-                    text={translate('verifyEmailScreen.iHaveVerified')}
-                    onPress={onVerifyButtonPress}
-                  />
-                  <Button
-                    large
-                    style={styles.mt1}
-                    text={translate('verifyEmailScreen.resendEmail')}
-                    onPress={onResendButtonPress}
-                  />
-                  <PressableWithFeedback
-                    style={[styles.mt4, styles.alignItemsCenter]}
-                    onPress={onSignOutPress}
-                    role={CONST.ROLE.BUTTON}
-                    accessibilityLabel={translate('settingsScreen.signOut')}>
-                    <Text style={styles.link}>
-                      {translate('settingsScreen.signOut')}
+              view === 'changeEmail' ? (
+                <View style={styles.flex1}>
+                  <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
+                    <Text
+                      textAlign="center"
+                      style={[styles.textHeadlineH2, styles.mb3]}>
+                      {translate('verifyEmailScreen.changeEmail.title')}
                     </Text>
-                  </PressableWithFeedback>
-                  {(CONFIG.IS_IN_DEVELOPMENT ||
-                    CONFIG.IS_IN_STAGING ||
-                    CONFIG.IS_IN_ADHOC) && (
+                    <Text textAlign="center" style={styles.mb4}>
+                      {translate('verifyEmailScreen.changeEmail.prompt')}
+                    </Text>
+                    <TextInput
+                      label={translate(
+                        'verifyEmailScreen.changeEmail.newEmailLabel',
+                      )}
+                      value={newEmailInput}
+                      onChangeText={text => {
+                        setNewEmailInput(text);
+                        setChangeEmailError('');
+                      }}
+                      inputMode={CONST.INPUT_MODE.EMAIL}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      spellCheck={false}
+                    />
+                    <TextInput
+                      label={translate(
+                        'verifyEmailScreen.changeEmail.passwordLabel',
+                      )}
+                      value={passwordInput}
+                      onChangeText={text => {
+                        setPasswordInput(text);
+                        setChangeEmailError('');
+                      }}
+                      secureTextEntry
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      containerStyles={[styles.mt3]}
+                    />
+                    {!!changeEmailError && (
+                      <DotIndicatorMessage
+                        style={[styles.mv2]}
+                        type="error"
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        messages={{0: changeEmailError}}
+                      />
+                    )}
+                  </View>
+                  <View style={styles.pb1}>
+                    <Button
+                      success
+                      large
+                      isLoading={isChangeEmailLoading}
+                      style={styles.mt1}
+                      text={translate('verifyEmailScreen.changeEmail.submit')}
+                      onPress={onChangeEmailSubmit}
+                    />
                     <PressableWithFeedback
-                      style={[styles.mt2, styles.alignItemsCenter]}
-                      onPress={onDevSkipPress}
+                      style={[styles.mt4, styles.alignItemsCenter]}
+                      onPress={() => {
+                        setChangeEmailError('');
+                        setView('verify');
+                      }}
                       role={CONST.ROLE.BUTTON}
-                      accessibilityLabel="Skip verification (dev only)">
-                      <Text style={[styles.link, styles.textSupporting]}>
-                        Skip verification (dev only)
+                      accessibilityLabel={translate(
+                        'verifyEmailScreen.changeEmail.back',
+                      )}>
+                      <Text style={styles.link}>
+                        {translate('verifyEmailScreen.changeEmail.back')}
                       </Text>
                     </PressableWithFeedback>
-                  )}
+                  </View>
                 </View>
-              </View>
+              ) : (
+                <View>
+                  <View
+                    style={[
+                      styles.flexGrow1,
+                      styles.justifyContentCenter,
+                      styles.alignItemsCenter,
+                    ]}>
+                    <Icon src={KirokuIcons.Mail} fill={theme.appColor} large />
+                    <Text
+                      textAlign="center"
+                      style={[styles.textHeadlineH2, styles.mt3]}>
+                      {translate('verifyEmailScreen.title')}
+                    </Text>
+                    <Text textAlign="center" style={styles.mt3}>
+                      {translate('verifyEmailScreen.body', {
+                        email: displayEmail,
+                      })}
+                    </Text>
+                  </View>
+                  <View style={styles.pb1}>
+                    {resendStatus === 'success' && (
+                      <DotIndicatorMessage
+                        style={[styles.mv2]}
+                        type="success"
+                        messages={{
+                          // eslint-disable-next-line @typescript-eslint/naming-convention
+                          0: translate('verifyEmailScreen.emailSent'),
+                        }}
+                      />
+                    )}
+                    {!!pendingEmail && resendStatus === 'idle' && (
+                      <DotIndicatorMessage
+                        style={[styles.mv2]}
+                        type="success"
+                        messages={{
+                          // eslint-disable-next-line @typescript-eslint/naming-convention
+                          0: translate('verifyEmailScreen.changeEmail.sent', {
+                            email: pendingEmail,
+                          }),
+                        }}
+                      />
+                    )}
+                    {!!errorText && (
+                      <DotIndicatorMessage
+                        style={[styles.mv2]}
+                        type="error"
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        messages={{0: errorText}}
+                      />
+                    )}
+                    <Button
+                      success
+                      large
+                      isLoading={isLoading}
+                      style={styles.mt1}
+                      text={translate('verifyEmailScreen.iHaveVerified')}
+                      onPress={onVerifyButtonPress}
+                    />
+                    <Button
+                      large
+                      style={styles.mt1}
+                      text={translate('verifyEmailScreen.resendEmail')}
+                      onPress={onResendButtonPress}
+                    />
+                    <PressableWithFeedback
+                      style={[styles.mt3, styles.alignItemsCenter]}
+                      onPress={() => setView('changeEmail')}
+                      role={CONST.ROLE.BUTTON}
+                      accessibilityLabel={translate(
+                        'verifyEmailScreen.useADifferentEmail',
+                      )}>
+                      <Text style={[styles.link, styles.textSupporting]}>
+                        {translate('verifyEmailScreen.useADifferentEmail')}
+                      </Text>
+                    </PressableWithFeedback>
+                    <PressableWithFeedback
+                      style={[styles.mt4, styles.alignItemsCenter]}
+                      onPress={onSignOutPress}
+                      role={CONST.ROLE.BUTTON}
+                      accessibilityLabel={translate('settingsScreen.signOut')}>
+                      <Text style={styles.link}>
+                        {translate('settingsScreen.signOut')}
+                      </Text>
+                    </PressableWithFeedback>
+                    {(CONFIG.IS_IN_DEVELOPMENT ||
+                      CONFIG.IS_IN_STAGING ||
+                      CONFIG.IS_IN_ADHOC) && (
+                      <PressableWithFeedback
+                        style={[styles.mt2, styles.alignItemsCenter]}
+                        onPress={onDevSkipPress}
+                        role={CONST.ROLE.BUTTON}
+                        accessibilityLabel="Skip verification (dev only)">
+                        <Text style={[styles.link, styles.textSupporting]}>
+                          Skip verification (dev only)
+                        </Text>
+                      </PressableWithFeedback>
+                    )}
+                  </View>
+                </View>
+              )
             ) : (
               <SuccessAnimation
                 iconSource={KirokuIcons.Checkmark}

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -185,6 +185,195 @@ function VerifyEmailModal() {
 
   const displayEmail = pendingEmail ?? user?.email ?? '';
 
+  const renderModalContent = () => {
+    if (emailVerified) {
+      return (
+        <SuccessAnimation
+          iconSource={KirokuIcons.Checkmark}
+          text={translate('verifyEmailScreen.emailVerified')}
+          visible
+          onAnimationEnd={onSuccessAnimationEnd}
+          style={styles.flexGrow1}
+        />
+      );
+    }
+    if (view === 'changeEmail') {
+      return (
+        <View style={styles.flex1}>
+          <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
+            <Text
+              textAlign="center"
+              style={[styles.textHeadlineH2, styles.mb3]}>
+              {translate('verifyEmailScreen.changeEmail.title')}
+            </Text>
+            <Text textAlign="center" style={styles.mb4}>
+              {translate('verifyEmailScreen.changeEmail.prompt')}
+            </Text>
+            <TextInput
+              label={translate('verifyEmailScreen.changeEmail.newEmailLabel')}
+              accessibilityLabel={translate(
+                'verifyEmailScreen.changeEmail.newEmailLabel',
+              )}
+              value={newEmailInput}
+              onChangeText={text => {
+                setNewEmailInput(text);
+                setChangeEmailError('');
+              }}
+              inputMode={CONST.INPUT_MODE.EMAIL}
+              autoCapitalize="none"
+              autoCorrect={false}
+              spellCheck={false}
+            />
+            <TextInput
+              label={translate('verifyEmailScreen.changeEmail.passwordLabel')}
+              accessibilityLabel={translate(
+                'verifyEmailScreen.changeEmail.passwordLabel',
+              )}
+              value={passwordInput}
+              onChangeText={text => {
+                setPasswordInput(text);
+                setChangeEmailError('');
+              }}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              containerStyles={[styles.mt3]}
+            />
+            {!!changeEmailError && (
+              <DotIndicatorMessage
+                style={[styles.mv2]}
+                type="error"
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                messages={{0: changeEmailError}}
+              />
+            )}
+          </View>
+          <View style={styles.pb1}>
+            <Button
+              success
+              large
+              isLoading={isChangeEmailLoading}
+              style={styles.mt1}
+              text={translate('verifyEmailScreen.changeEmail.submit')}
+              onPress={onChangeEmailSubmit}
+            />
+            <PressableWithFeedback
+              style={[styles.mt4, styles.alignItemsCenter]}
+              onPress={() => {
+                setChangeEmailError('');
+                setView('verify');
+              }}
+              role={CONST.ROLE.BUTTON}
+              accessibilityLabel={translate(
+                'verifyEmailScreen.changeEmail.back',
+              )}>
+              <Text style={styles.link}>
+                {translate('verifyEmailScreen.changeEmail.back')}
+              </Text>
+            </PressableWithFeedback>
+          </View>
+        </View>
+      );
+    }
+    return (
+      <View>
+        <View
+          style={[
+            styles.flexGrow1,
+            styles.justifyContentCenter,
+            styles.alignItemsCenter,
+          ]}>
+          <Icon src={KirokuIcons.Mail} fill={theme.appColor} large />
+          <Text textAlign="center" style={[styles.textHeadlineH2, styles.mt3]}>
+            {translate('verifyEmailScreen.title')}
+          </Text>
+          <Text textAlign="center" style={styles.mt3}>
+            {translate('verifyEmailScreen.body', {email: displayEmail})}
+          </Text>
+        </View>
+        <View style={styles.pb1}>
+          {resendStatus === 'success' && (
+            <DotIndicatorMessage
+              style={[styles.mv2]}
+              type="success"
+              messages={{
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                0: translate('verifyEmailScreen.emailSent'),
+              }}
+            />
+          )}
+          {!!pendingEmail && resendStatus === 'idle' && (
+            <DotIndicatorMessage
+              style={[styles.mv2]}
+              type="success"
+              messages={{
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                0: translate('verifyEmailScreen.changeEmail.sent', {
+                  email: pendingEmail,
+                }),
+              }}
+            />
+          )}
+          {!!errorText && (
+            <DotIndicatorMessage
+              style={[styles.mv2]}
+              type="error"
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              messages={{0: errorText}}
+            />
+          )}
+          <Button
+            success
+            large
+            isLoading={isLoading}
+            style={styles.mt1}
+            text={translate('verifyEmailScreen.iHaveVerified')}
+            onPress={onVerifyButtonPress}
+          />
+          <Button
+            large
+            style={styles.mt1}
+            text={translate('verifyEmailScreen.resendEmail')}
+            onPress={onResendButtonPress}
+          />
+          <PressableWithFeedback
+            style={[styles.mt3, styles.alignItemsCenter]}
+            onPress={() => setView('changeEmail')}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={translate(
+              'verifyEmailScreen.useADifferentEmail',
+            )}>
+            <Text style={[styles.link, styles.textSupporting]}>
+              {translate('verifyEmailScreen.useADifferentEmail')}
+            </Text>
+          </PressableWithFeedback>
+          <PressableWithFeedback
+            style={[styles.mt4, styles.alignItemsCenter]}
+            onPress={onSignOutPress}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={translate('settingsScreen.signOut')}>
+            <Text style={styles.link}>
+              {translate('settingsScreen.signOut')}
+            </Text>
+          </PressableWithFeedback>
+          {(CONFIG.IS_IN_DEVELOPMENT ||
+            CONFIG.IS_IN_STAGING ||
+            CONFIG.IS_IN_ADHOC) && (
+            <PressableWithFeedback
+              style={[styles.mt2, styles.alignItemsCenter]}
+              onPress={onDevSkipPress}
+              role={CONST.ROLE.BUTTON}
+              accessibilityLabel="Skip verification (dev only)">
+              <Text style={[styles.link, styles.textSupporting]}>
+                Skip verification (dev only)
+              </Text>
+            </PressableWithFeedback>
+          )}
+        </View>
+      </View>
+    );
+  };
+
   return (
     <SafeAreaConsumer>
       {({safeAreaPaddingBottomStyle}) => (
@@ -209,190 +398,7 @@ function VerifyEmailModal() {
                 ? safeAreaPaddingBottomStyle
                 : styles.pb5,
             ]}>
-            {!emailVerified ? (
-              view === 'changeEmail' ? (
-                <View style={styles.flex1}>
-                  <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
-                    <Text
-                      textAlign="center"
-                      style={[styles.textHeadlineH2, styles.mb3]}>
-                      {translate('verifyEmailScreen.changeEmail.title')}
-                    </Text>
-                    <Text textAlign="center" style={styles.mb4}>
-                      {translate('verifyEmailScreen.changeEmail.prompt')}
-                    </Text>
-                    <TextInput
-                      label={translate(
-                        'verifyEmailScreen.changeEmail.newEmailLabel',
-                      )}
-                      value={newEmailInput}
-                      onChangeText={text => {
-                        setNewEmailInput(text);
-                        setChangeEmailError('');
-                      }}
-                      inputMode={CONST.INPUT_MODE.EMAIL}
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      spellCheck={false}
-                    />
-                    <TextInput
-                      label={translate(
-                        'verifyEmailScreen.changeEmail.passwordLabel',
-                      )}
-                      value={passwordInput}
-                      onChangeText={text => {
-                        setPasswordInput(text);
-                        setChangeEmailError('');
-                      }}
-                      secureTextEntry
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      containerStyles={[styles.mt3]}
-                    />
-                    {!!changeEmailError && (
-                      <DotIndicatorMessage
-                        style={[styles.mv2]}
-                        type="error"
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
-                        messages={{0: changeEmailError}}
-                      />
-                    )}
-                  </View>
-                  <View style={styles.pb1}>
-                    <Button
-                      success
-                      large
-                      isLoading={isChangeEmailLoading}
-                      style={styles.mt1}
-                      text={translate('verifyEmailScreen.changeEmail.submit')}
-                      onPress={onChangeEmailSubmit}
-                    />
-                    <PressableWithFeedback
-                      style={[styles.mt4, styles.alignItemsCenter]}
-                      onPress={() => {
-                        setChangeEmailError('');
-                        setView('verify');
-                      }}
-                      role={CONST.ROLE.BUTTON}
-                      accessibilityLabel={translate(
-                        'verifyEmailScreen.changeEmail.back',
-                      )}>
-                      <Text style={styles.link}>
-                        {translate('verifyEmailScreen.changeEmail.back')}
-                      </Text>
-                    </PressableWithFeedback>
-                  </View>
-                </View>
-              ) : (
-                <View>
-                  <View
-                    style={[
-                      styles.flexGrow1,
-                      styles.justifyContentCenter,
-                      styles.alignItemsCenter,
-                    ]}>
-                    <Icon src={KirokuIcons.Mail} fill={theme.appColor} large />
-                    <Text
-                      textAlign="center"
-                      style={[styles.textHeadlineH2, styles.mt3]}>
-                      {translate('verifyEmailScreen.title')}
-                    </Text>
-                    <Text textAlign="center" style={styles.mt3}>
-                      {translate('verifyEmailScreen.body', {
-                        email: displayEmail,
-                      })}
-                    </Text>
-                  </View>
-                  <View style={styles.pb1}>
-                    {resendStatus === 'success' && (
-                      <DotIndicatorMessage
-                        style={[styles.mv2]}
-                        type="success"
-                        messages={{
-                          // eslint-disable-next-line @typescript-eslint/naming-convention
-                          0: translate('verifyEmailScreen.emailSent'),
-                        }}
-                      />
-                    )}
-                    {!!pendingEmail && resendStatus === 'idle' && (
-                      <DotIndicatorMessage
-                        style={[styles.mv2]}
-                        type="success"
-                        messages={{
-                          // eslint-disable-next-line @typescript-eslint/naming-convention
-                          0: translate('verifyEmailScreen.changeEmail.sent', {
-                            email: pendingEmail,
-                          }),
-                        }}
-                      />
-                    )}
-                    {!!errorText && (
-                      <DotIndicatorMessage
-                        style={[styles.mv2]}
-                        type="error"
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
-                        messages={{0: errorText}}
-                      />
-                    )}
-                    <Button
-                      success
-                      large
-                      isLoading={isLoading}
-                      style={styles.mt1}
-                      text={translate('verifyEmailScreen.iHaveVerified')}
-                      onPress={onVerifyButtonPress}
-                    />
-                    <Button
-                      large
-                      style={styles.mt1}
-                      text={translate('verifyEmailScreen.resendEmail')}
-                      onPress={onResendButtonPress}
-                    />
-                    <PressableWithFeedback
-                      style={[styles.mt3, styles.alignItemsCenter]}
-                      onPress={() => setView('changeEmail')}
-                      role={CONST.ROLE.BUTTON}
-                      accessibilityLabel={translate(
-                        'verifyEmailScreen.useADifferentEmail',
-                      )}>
-                      <Text style={[styles.link, styles.textSupporting]}>
-                        {translate('verifyEmailScreen.useADifferentEmail')}
-                      </Text>
-                    </PressableWithFeedback>
-                    <PressableWithFeedback
-                      style={[styles.mt4, styles.alignItemsCenter]}
-                      onPress={onSignOutPress}
-                      role={CONST.ROLE.BUTTON}
-                      accessibilityLabel={translate('settingsScreen.signOut')}>
-                      <Text style={styles.link}>
-                        {translate('settingsScreen.signOut')}
-                      </Text>
-                    </PressableWithFeedback>
-                    {(CONFIG.IS_IN_DEVELOPMENT ||
-                      CONFIG.IS_IN_STAGING ||
-                      CONFIG.IS_IN_ADHOC) && (
-                      <PressableWithFeedback
-                        style={[styles.mt2, styles.alignItemsCenter]}
-                        onPress={onDevSkipPress}
-                        role={CONST.ROLE.BUTTON}
-                        accessibilityLabel="Skip verification (dev only)">
-                        <Text style={[styles.link, styles.textSupporting]}>
-                          Skip verification (dev only)
-                        </Text>
-                      </PressableWithFeedback>
-                    )}
-                  </View>
-                </View>
-              )
-            ) : (
-              <SuccessAnimation
-                iconSource={KirokuIcons.Checkmark}
-                text={translate('verifyEmailScreen.emailVerified')}
-                visible
-                onAnimationEnd={onSuccessAnimationEnd}
-                style={styles.flexGrow1}
-              />
-            )}
+            {renderModalContent()}
           </View>
         </Modal>
       )}

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -702,6 +702,20 @@ export default {
     emailSent: 'Ověřovací e-mail byl odeslán.',
     emailVerified: 'E-mail byl ověřen!',
     iHaveVerified: 'E-mail mám ověřený',
+    useADifferentEmail: 'Špatný e-mail? Použijte jiný',
+    changeEmail: {
+      title: 'Použít jiný e-mail',
+      prompt: 'Zadejte novou adresu a heslo — ověřovací odkaz vám pošleme tam.',
+      newEmailLabel: 'Nová e-mailová adresa',
+      passwordLabel: 'Vaše heslo',
+      submit: 'Odeslat ověřovací odkaz',
+      sent: ({email}: VerifyEmailScreenEmailParmas) =>
+        `Ověřovací odkaz byl odeslán na ${email}. Otevřete jej a pak klepněte na 'E-mail mám ověřený'.`,
+      back: 'Zpět',
+      error: {
+        passwordRequired: 'Zadejte prosím heslo.',
+      },
+    },
     error: {
       generic: 'Chyba při ověřování vašeho e-mailu',
       sending: 'Chyba při odesílání ověřovacího e-mailu',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -705,6 +705,21 @@ export default {
     emailSent: 'Verification email sent.',
     emailVerified: 'Email verified!',
     iHaveVerified: 'I have verified my email',
+    useADifferentEmail: 'Wrong email? Use a different one',
+    changeEmail: {
+      title: 'Use a different email',
+      prompt:
+        "Enter a new address and your password — we'll send the verification link there instead.",
+      newEmailLabel: 'New email address',
+      passwordLabel: 'Your password',
+      submit: 'Send verification link',
+      sent: ({email}: VerifyEmailScreenEmailParmas) =>
+        `Verification link sent to ${email}. Open it, then tap 'I have verified my email'.`,
+      back: 'Back',
+      error: {
+        passwordRequired: 'Please enter your password.',
+      },
+    },
     error: {
       generic: 'Error verifying your email',
       sending: 'Error sending verification email',

--- a/src/libs/OAuthCredential/index.android.ts
+++ b/src/libs/OAuthCredential/index.android.ts
@@ -45,7 +45,10 @@ async function getAppleCredential(): Promise<AuthCredential | null> {
       return null;
     }
     const provider = new OAuthProvider('apple.com');
-    return provider.credential({idToken: response.id_token});
+    return provider.credential({
+      idToken: response.id_token,
+      rawNonce: response.nonce ?? undefined,
+    });
   } catch (error: unknown) {
     const e = error as {message?: string};
     if (e.message === appleAuthAndroid.Error.SIGNIN_CANCELLED) {


### PR DESCRIPTION
## Summary

Two auth fixes on the same branch, both surfaced in the open-beta audit.

---

### 1 — Android Apple Sign-In nonce (`auth/missing-or-invalid-nonce`)

`appleAuthAndroid` auto-generates a nonce (`nonceEnabled: true` by default) and embeds its SHA-256 hash in the Apple ID token. Firebase validates nonce integrity by computing `SHA256(rawNonce)` and comparing it to the JWT claim — so the raw nonce **must** be forwarded via `OAuthProvider.credential({idToken, rawNonce})`.

Both Android call sites were omitting it, causing `auth/missing-or-invalid-nonce` on every Android Apple Sign-In attempt. Same class of bug fixed for iOS in PR #437; Android was not covered.

**Changed files:**
- `AppleSignIn/index.android.tsx` — adds `rawNonce` to the result type, surfaces `response.nonce`, threads it into `provider.credential()` and `stashPendingOAuthCredential()` (so the collision-resolution modal also reconstructs the credential correctly)
- `OAuthCredential/index.android.ts` — same `rawNonce` addition for the Connected Accounts re-auth / proactive link path

---

### 2 — `VerifyEmailModal`: "Wrong email? Use a different one"

Users whose email was silently dropped (Czech ISPs with Firebase's default sender domain) had no recovery path other than signing out and re-registering. This adds an inline `changeEmail` sub-view reachable via a tertiary link below "Resend email".

**Flow:**
1. User taps "Wrong email? Use a different one"
2. New-email + password form appears within the same modal (no navigation, since the rest of the app is gated)
3. On submit, calls `User.sendUpdateEmailLink` — reauthenticates, then fires `verifyBeforeUpdateEmail` to the new address
4. On success, flips back to verify view with the new address in the body and a green confirmation banner
5. User verifies the new address and taps "I have verified my email"

Validation mirrors `EmailScreen`: format check, same-as-current check (`ValidationUtils.validateEmail`), password required guard. Translations added for both `en` and `cs_cz`.

---

## Test plan

**Android Apple Sign-In:**
- [ ] Tap Sign in with Apple → completes without `auth/missing-or-invalid-nonce`
- [ ] Tap Sign in with Apple with an email that already has an email/password account → collision modal appears → link succeeds
- [ ] Connected Accounts → Link Apple → completes without error

**"Use a different email":**
- [ ] Sign up with a bad/inaccessible email → `VerifyEmailModal` appears
- [ ] Tap "Wrong email? Use a different one" → form appears
- [ ] Submit with blank email → validation error
- [ ] Submit with same email → "same email" validation error
- [ ] Submit with invalid format → validation error
- [ ] Submit with no password → password required error
- [ ] Submit with wrong password → Firebase error surfaced inline
- [ ] Submit with valid new email + correct password → verify view comes back, new address shown in body, green banner
- [ ] Tap "I have verified my email" after verifying new address → modal dismisses

## Related

- PR #437 — iOS Apple Sign-In nonce fix (same bug, different platform)
- Issue #443 — email deliverability audit (this partially mitigates the Czech ISP problem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)