### PR TITLE
fix(account): hide email and password fields for non-email providers

### DIFF
--- a/src/screens/Settings/Account/AccountScreen.tsx
+++ b/src/screens/Settings/Account/AccountScreen.tsx
@@ -19,6 +19,7 @@ import ScrollView from '@components/ScrollView';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
+import CONST from '@src/CONST';
 
 type AccountScreenProps = StackScreenProps<
   SettingsNavigatorParamList,
@@ -36,6 +37,10 @@ function AccountScreen({route}: AccountScreenProps) {
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const {userData} = useDatabaseData();
   const profileData = userData?.profile;
+
+  const hasEmailProvider = (user?.providerData ?? []).some(
+    p => p.providerId === CONST.AUTH_PROVIDER.PASSWORD,
+  );
 
   // providerData is not a React-tracked value; this snapshot is acceptable for
   // the menu summary because mutations land on the dedicated Connected Accounts
@@ -67,16 +72,20 @@ function AccountScreen({route}: AccountScreenProps) {
       title: profileData?.display_name ?? '',
       pageRoute: ROUTES.SETTINGS_DISPLAY_NAME,
     },
-    {
-      description: translate('common.email'),
-      title: user?.email ?? '',
-      pageRoute: ROUTES.SETTINGS_EMAIL,
-    },
-    {
-      description: translate('common.password'),
-      title: '••••••••',
-      pageRoute: ROUTES.SETTINGS_PASSWORD,
-    },
+    ...(hasEmailProvider
+      ? [
+          {
+            description: translate('common.email'),
+            title: user?.email ?? '',
+            pageRoute: ROUTES.SETTINGS_EMAIL,
+          },
+          {
+            description: translate('common.password'),
+            title: '••••••••',
+            pageRoute: ROUTES.SETTINGS_PASSWORD,
+          },
+        ]
+      : []),
     {
       description: translate('connectedAccounts.title'),
       title: linkedProviderLabels,


### PR DESCRIPTION
## Summary

- Users who registered via Google or Apple only have no email/password credentials to manage
- The Email and Password rows in Account Settings were showing for these users, which is misleading and could cause confusion (e.g., a Google-only user seeing a password row they can't actually use)
- This PR conditionally renders those two rows only when the user has the `password` provider linked (`CONST.AUTH_PROVIDER.PASSWORD`)

## Changes

**`src/screens/Settings/Account/AccountScreen.tsx`**
- Import `CONST` to access `AUTH_PROVIDER.PASSWORD`
- Add `hasEmailProvider` boolean derived from `user?.providerData`
- Spread the email and password `generalOptions` entries only when `hasEmailProvider` is `true`

## Test plan

- [ ] Sign in with email/password → Email and Password rows appear in Account Settings
- [ ] Sign in with Google only → Email and Password rows are hidden; Name, Nickname, Connected Accounts, Timezone remain
- [ ] Sign in with Apple only → same as above
- [ ] Link email/password via Connected Accounts → navigate back to Account Settings and confirm the rows now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)