### PR TITLE
perf(home): split markedDates memo, narrow stats deps, stabilize onDateChange

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -813,7 +813,7 @@
 "src/screens/DrinkingSession/SessionDateScreen.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"react-hooks/set-state-in-effect"	1
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
-"src/screens/HomeScreen.tsx"	"react-hooks/set-state-in-effect"	3
+"src/screens/HomeScreen.tsx"	"react-hooks/set-state-in-effect"	1
 "src/screens/HomeScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
 "src/screens/Profile/FriendsFriendsScreen.tsx"	"react-hooks/set-state-in-effect"	2
 "src/screens/Profile/ProfileScreen.tsx"	"arrow-body-style"	2

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -65,14 +65,15 @@ function useLazyMarkedDates(
     setLoadedMonths(user?.uid !== userID ? 0 : monthsLoaded ?? 0);
   }, [userID, user?.uid, monthsLoaded]);
 
-  // Synchronously derive markedDates + unitsMap from the inputs.
-  // No effect, no setState — the next render has the new payload.
-  const {markedDatesMap, unitsMap, loadedFromDate} = useMemo(() => {
+  // First pass — rebuild the session-by-day index only when sessions or the
+  // visible range change. Preferences are *not* a dependency here: a palette
+  // or threshold change must not trigger the O(N) session filter+index pass.
+  const {sessionIndex, dayKeys, loadedFromDate} = useMemo(() => {
     const today = new Date();
     const start = subDays(startOfMonth(subMonths(today, loadedMonths)), 1);
     const end = today;
 
-    const sessionIndex = new Map<DateString, DrinkingSessionArray>();
+    const index = new Map<DateString, DrinkingSessionArray>();
     Object.values(sessions)
       .filter(session => isWithinInterval(session.start_time, {start, end}))
       .forEach(session => {
@@ -84,20 +85,30 @@ function useLazyMarkedDates(
           sessionDate,
           CONST.DATE.FNS_FORMAT_STRING,
         ) as DateString;
-        const existing = sessionIndex.get(dayKey);
+        const existing = index.get(dayKey);
         if (existing) {
           existing.push(session);
         } else {
-          sessionIndex.set(dayKey, [session]);
+          index.set(dayKey, [session]);
         }
       });
 
+    const days = eachDayOfInterval({start, end}).map(
+      day => format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString,
+    );
+
+    return {sessionIndex: index, dayKeys: days, loadedFromDate: start};
+  }, [sessions, loadedMonths, defaultTimezone]);
+
+  // Second pass — build markedDates + unitsMap from the pre-built index.
+  // This is the only memo that needs `preferences`; on a palette change it
+  // walks the day list (~30 entries) instead of re-filtering N sessions.
+  const {markedDatesMap, unitsMap} = useMemo(() => {
     const newMarkedDatesMap = new Map<DateString, MarkingProps>();
     const newUnitsMap = new Map<DateString, number>();
     const palette = resolvePalette(preferences.session_color_palette);
 
-    eachDayOfInterval({start, end}).forEach(day => {
-      const dayKey = format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString;
+    dayKeys.forEach(dayKey => {
       const dailySessions = sessionIndex.get(dayKey) ?? [];
       const newMarking = sessionsToDayMarking(dailySessions, preferences);
       if (!newMarking) {
@@ -108,12 +119,8 @@ function useLazyMarkedDates(
       newUnitsMap.set(dayKey, newMarking.units);
     });
 
-    return {
-      markedDatesMap: newMarkedDatesMap,
-      unitsMap: newUnitsMap,
-      loadedFromDate: start,
-    };
-  }, [sessions, preferences, loadedMonths, defaultTimezone]);
+    return {markedDatesMap: newMarkedDatesMap, unitsMap: newUnitsMap};
+  }, [sessionIndex, dayKeys, preferences]);
 
   const markedDates: MarkedDates = useMemo(
     () => Object.fromEntries(markedDatesMap),

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 import SessionsCalendar from '@components/SessionsCalendar';
 import type {DateData} from 'react-native-calendars';
@@ -62,9 +62,33 @@ function HomeScreen({route}: HomeScreenProps) {
   const [visibleDate, setVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),
   );
-  const [drinkingSessionsCount, setDrinkingSessionsCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [unitsConsumed, setUnitsConsumed] = useState<number>(0);
+
+  // Derive stats synchronously from the visible month + drink unit mapping.
+  // Narrowed to `drinksToUnits` so unrelated preference updates (e.g. picking
+  // a color palette) don't recompute the stats.
+  const drinksToUnits = preferences?.drinks_to_units;
+  const {drinkingSessionsCount, unitsConsumed} = useMemo(() => {
+    if (!drinksToUnits || !drinkingSessionData) {
+      return {drinkingSessionsCount: 0, unitsConsumed: 0};
+    }
+    const drinkingSessionArray: DrinkingSessionArray =
+      Object.values(drinkingSessionData);
+    const monthUnits = calculateThisMonthUnits(
+      visibleDate,
+      drinkingSessionArray,
+      drinksToUnits,
+    );
+    const monthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
+      timestampToDate(visibleDate.timestamp),
+      drinkingSessionArray,
+      false,
+    ).length;
+    return {
+      drinkingSessionsCount: monthSessionCount,
+      unitsConsumed: monthUnits,
+    };
+  }, [drinkingSessionData, visibleDate, drinksToUnits]);
 
   const statsData: StatData = [
     {
@@ -80,29 +104,6 @@ function HomeScreen({route}: HomeScreenProps) {
       content: String(roundToTwoDecimalPlaces(unitsConsumed)),
     },
   ];
-
-  // Monitor visible month and various statistics
-  useEffect(() => {
-    if (!preferences) {
-      return;
-    }
-    const drinkingSessionArray: DrinkingSessionArray = drinkingSessionData
-      ? Object.values(drinkingSessionData)
-      : [];
-    const thisMonthUnits = calculateThisMonthUnits(
-      visibleDate,
-      drinkingSessionArray,
-      preferences.drinks_to_units,
-    );
-    const thisMonthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
-      timestampToDate(visibleDate.timestamp),
-      drinkingSessionArray,
-      false,
-    ).length; // Replace this in the future
-
-    setDrinkingSessionsCount(thisMonthSessionCount);
-    setUnitsConsumed(thisMonthUnits);
-  }, [drinkingSessionData, visibleDate, preferences]);
 
   useEffect(() => {
     // Update the ongoing session local data
@@ -185,7 +186,7 @@ function HomeScreen({route}: HomeScreenProps) {
             <SessionsCalendar
               userID={user.uid}
               visibleDate={visibleDate}
-              onDateChange={(date: DateData) => setVisibleDate(date)}
+              onDateChange={setVisibleDate}
               drinkingSessionData={drinkingSessionData}
               preferences={preferences}
             />


### PR DESCRIPTION
## Summary

Three independent home-screen perf wins identified during the [#460](https://github.com/PetrCala/Kiroku/issues/460) discussion. Each is small and surgical; net diff is **+50 / −42** across 3 files.

## What changed

### #1 — \`useLazyMarkedDates\` split into two memos

[src/hooks/useLazyMarkedDates.ts](src/hooks/useLazyMarkedDates.ts) had one big \`useMemo\` keyed on \`[sessions, preferences, loadedMonths, defaultTimezone]\`. Every palette tap fired a new \`preferences\` reference (Firebase listener returns fresh objects), which re-ran the whole memo — including \`Object.values(sessions).filter(isWithinInterval(...))\` and per-session \`toZonedTime\` + \`format\` calls. O(N) work on every palette change.

Split into two passes:
- **Pass 1** (deps: \`sessions, loadedMonths, defaultTimezone\`) — rebuilds the per-day session index. Only runs when sessions change or the loaded range extends.
- **Pass 2** (deps: \`sessionIndex, dayKeys, preferences\`) — derives \`markedDatesMap\` + \`unitsMap\` from the prebuilt index by walking the precomputed \`dayKeys\` array (~30 entries).

Palette changes go from **O(N) sessions** to **O(days_in_range)** — for a heavy user with 1000 sessions, that's a >30× reduction in work per palette tap.

### #2 — HomeScreen stats useEffect → useMemo + narrowed deps

[src/screens/HomeScreen.tsx](src/screens/HomeScreen.tsx) used \`useEffect\` + two \`useState\`s to compute \`drinkingSessionsCount\` / \`unitsConsumed\`, depending on the whole \`preferences\` object. Palette changes pumped a fresh \`preferences\` ref through that effect, re-running \`getSingleMonthDrinkingSessions\` + \`calculateThisMonthUnits\` (both O(N)) for stats that don't depend on the palette.

Converted to a single \`useMemo\` keyed on \`[drinkingSessionData, visibleDate, drinksToUnits]\`. \`drinksToUnits\` is extracted as a local first so the React Compiler can preserve memoization (it can't see through optional chains in dep arrays).

Side benefits:
- Derives synchronously — no extra render cycle.
- Removes two \`setState\` calls from inside \`useEffect\` (eslint-seatbelt drops by 2).

### #5 — Stable \`onDateChange\` lets \`SessionsCalendar\`'s \`memo()\` work

\`<SessionsCalendar onDateChange={(date) => setVisibleDate(date)} ... />\` was a fresh arrow every HomeScreen render, defeating the \`memo()\` wrapper. \`setVisibleDate\` from \`useState\` is already a stable callable with the right signature. One-line change.

## Out of scope

- The home-calendar-stale-on-palette-change bug ([#460](https://github.com/PetrCala/Kiroku/issues/460)). This PR doesn't try to fix that; the bug is upstream of \`useLazyMarkedDates\` (somewhere in the listener → context chain).
- API-side fetch optimization — separate effort.
- Item #3 (combine count + units into a single sessions pass) and #4 (per-session \`calculateTotalUnits\` cache) from the analysis are deferred — they're useful but smaller than these three.

## Test plan

- [ ] Cold-load home screen with a large session history; confirm initial render time hasn't regressed.
- [ ] Open the color palette picker, tap several palettes; navigate back to home; confirm the calendar renders without jank.
- [ ] Scroll the calendar back a month, then forward; confirm month-nav still works (loadMoreMonths is unchanged in interface).
- [ ] \`npm run test\` — passes.
- [ ] \`npm run typecheck\` — passes.
- [ ] \`npm run lint\` — passes (eslint-seatbelt decremented appropriately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)