### PR TITLE
perf(home): replace full-screen loader with skeleton states

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -813,7 +813,6 @@
 "src/screens/DrinkingSession/SessionDateScreen.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"react-hooks/set-state-in-effect"	1
 "src/screens/DrinkingSession/SessionSummaryScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
-"src/screens/HomeScreen.tsx"	"react-hooks/set-state-in-effect"	1
 "src/screens/HomeScreen.tsx"	"rulesdir/no-use-state-initializer-functions"	2
 "src/screens/Profile/FriendsFriendsScreen.tsx"	"react-hooks/set-state-in-effect"	2
 "src/screens/Profile/ProfileScreen.tsx"	"arrow-body-style"	2

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import SessionsCalendar from '@components/SessionsCalendar';
 import type {DateData} from 'react-native-calendars';
@@ -43,6 +43,11 @@ import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
 import Button from '@components/Button';
+import {
+  HomeHeaderSkeleton,
+  SessionsCalendarSkeleton,
+  StatOverviewSkeleton,
+} from './HomeScreenSkeleton';
 
 type HomeScreenProps = StackScreenProps<
   BottomTabNavigatorParamList,
@@ -62,7 +67,7 @@ function HomeScreen({route}: HomeScreenProps) {
   const [visibleDate, setVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),
   );
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const hasMarkedReadyRef = useRef(false);
 
   // Derive stats synchronously from the visible month + drink unit mapping.
   // Narrowed to `drinksToUnits` so unrelated preference updates (e.g. picking
@@ -126,12 +131,21 @@ function HomeScreen({route}: HomeScreenProps) {
     }, [db, user, userData, preferences, drinkingSessionData]),
   );
 
+  // Fire the "home is ready" side effects exactly once, when all the initial
+  // data has arrived. The screen renders skeletons in the meantime, so these
+  // side effects no longer gate the visible UI.
   useEffect(() => {
-    if (!!loadingText || !preferences || !userData || !user) {
+    if (
+      hasMarkedReadyRef.current ||
+      !!loadingText ||
+      !preferences ||
+      !userData ||
+      !user
+    ) {
       return;
     }
+    hasMarkedReadyRef.current = true;
     Session.setHasCheckedAutoLogin(true);
-    setIsLoading(false);
     Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
   }, [loadingText, preferences, userData, user]);
 
@@ -143,9 +157,45 @@ function HomeScreen({route}: HomeScreenProps) {
     return <UserOffline />;
   }
 
-  if (isLoading || !preferences || !userData) {
+  // Active operations (e.g. saving a session) still take a full-screen overlay
+  // so they don't compete with the home UI for attention.
+  if (loadingText) {
     return <FullScreenLoadingIndicator loadingText={loadingText} />;
   }
+
+  // Render the shell + skeletons immediately. Real components swap in for
+  // their skeletons as each piece of data resolves from Firebase.
+  const isPreferencesReady = !!preferences;
+  const isUserDataReady = !!userData;
+  const isSessionsReady = drinkingSessionData !== undefined;
+  const hasSessions = isSessionsReady && !!drinkingSessionData;
+  const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
+
+  const renderMainContent = () => {
+    if (showSkeletonContent) {
+      return (
+        <>
+          <StatOverviewSkeleton />
+          <SessionsCalendarSkeleton />
+        </>
+      );
+    }
+    if (hasSessions) {
+      return (
+        <>
+          <StatOverview statsData={statsData} />
+          <SessionsCalendar
+            userID={user.uid}
+            visibleDate={visibleDate}
+            onDateChange={setVisibleDate}
+            drinkingSessionData={drinkingSessionData}
+            preferences={preferences}
+          />
+        </>
+      );
+    }
+    return <NoSessionsInfo />;
+  };
 
   return (
     <ScreenWrapper
@@ -153,25 +203,29 @@ function HomeScreen({route}: HomeScreenProps) {
       includePaddingTop={false}
       includeSafeAreaPaddingBottom={getPlatform() !== CONST.PLATFORM.IOS}>
       {/* // TODO rewrite this into the HeaderWithBackButton component */}
-      <View style={[styles.headerBar, styles.borderBottom]}>
-        <Button
-          style={[styles.flexRow, styles.bgTransparent]}
-          onPress={() =>
-            Navigation.navigate(ROUTES.PROFILE.getRoute(user.uid))
-          }>
-          <ProfileImage
-            storage={storage}
-            userID={user.uid}
-            downloadPath={userData.profile.photo_url}
-            style={styles.avatarMedium}
-            // refreshTrigger={refreshCounter}
-            refreshTrigger={0}
-          />
-          <Text style={[styles.headerText, styles.textLarge, styles.ml3]}>
-            {userData?.profile?.display_name ?? ''}
-          </Text>
-        </Button>
-      </View>
+      {isUserDataReady ? (
+        <View style={[styles.headerBar, styles.borderBottom]}>
+          <Button
+            style={[styles.flexRow, styles.bgTransparent]}
+            onPress={() =>
+              Navigation.navigate(ROUTES.PROFILE.getRoute(user.uid))
+            }>
+            <ProfileImage
+              storage={storage}
+              userID={user.uid}
+              downloadPath={userData.profile.photo_url}
+              style={styles.avatarMedium}
+              // refreshTrigger={refreshCounter}
+              refreshTrigger={0}
+            />
+            <Text style={[styles.headerText, styles.textLarge, styles.ml3]}>
+              {userData?.profile?.display_name ?? ''}
+            </Text>
+          </Button>
+        </View>
+      ) : (
+        <HomeHeaderSkeleton />
+      )}
       <ScrollView>
         {!!ongoingSessionData?.ongoing && (
           <MessageBanner
@@ -180,20 +234,7 @@ function HomeScreen({route}: HomeScreenProps) {
             onPress={() => DS.navigateToOngoingSessionScreen()}
           />
         )}
-        {drinkingSessionData ? (
-          <>
-            <StatOverview statsData={statsData} />
-            <SessionsCalendar
-              userID={user.uid}
-              visibleDate={visibleDate}
-              onDateChange={setVisibleDate}
-              drinkingSessionData={drinkingSessionData}
-              preferences={preferences}
-            />
-          </>
-        ) : (
-          <NoSessionsInfo />
-        )}
+        {renderMainContent()}
       </ScrollView>
       <BottomTabBar />
     </ScreenWrapper>

--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import {View} from 'react-native';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+
+type BlockProps = {
+  width: number;
+  height: number;
+  radius?: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+function Block({width, height, radius = 6, style}: BlockProps) {
+  const theme = useTheme();
+  return (
+    <View
+      style={[
+        {
+          width,
+          height,
+          borderRadius: radius,
+          backgroundColor: theme.highlightBG,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+/** Placeholder for the home-screen header (profile avatar + display name). */
+function HomeHeaderSkeleton() {
+  const styles = useThemeStyles();
+  const avatarSize = variables.avatarSizeMedium;
+  return (
+    <View
+      style={[
+        styles.headerBar,
+        styles.borderBottom,
+        styles.flexRow,
+        styles.alignItemsCenter,
+        styles.pl5,
+      ]}>
+      <Block width={avatarSize} height={avatarSize} radius={avatarSize / 2} />
+      <Block width={140} height={16} style={styles.ml3} />
+    </View>
+  );
+}
+
+/** Placeholder for the two stat cards (sessions + units this month). */
+function StatOverviewSkeleton() {
+  const styles = useThemeStyles();
+  return (
+    <View style={styles.statOverviewContainer}>
+      {['sessions', 'units'].map(slot => (
+        <View
+          key={slot}
+          style={[
+            styles.flexColumn,
+            styles.alignItemsCenter,
+            styles.justifyContentCenter,
+          ]}>
+          <Block width={56} height={28} style={styles.mb2} />
+          <Block width={96} height={12} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const CALENDAR_WEEKS = [0, 1, 2, 3, 4, 5] as const;
+const CALENDAR_DAYS = [0, 1, 2, 3, 4, 5, 6] as const;
+
+/** Placeholder for the sessions calendar (rough 6×7 day grid). */
+function SessionsCalendarSkeleton() {
+  const styles = useThemeStyles();
+  return (
+    <View style={[styles.sessionsCalendarContainer, styles.p4]}>
+      {CALENDAR_WEEKS.map(week => (
+        <View
+          key={`week-${week}`}
+          style={[styles.flexRow, styles.justifyContentBetween, styles.mb3]}>
+          {CALENDAR_DAYS.map(day => (
+            <Block
+              key={`day-${week}-${day}`}
+              width={32}
+              height={32}
+              radius={16}
+            />
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export {HomeHeaderSkeleton, StatOverviewSkeleton, SessionsCalendarSkeleton};


### PR DESCRIPTION
## Summary

The home screen previously blocked behind a centered \`<FullScreenLoadingIndicator>\` until `preferences`, `userData`, and `drinkingSessionData` all resolved from Firebase. For users with thousands of sessions, that's a multi-second blank-spinner stare on every cold load.

This PR renders the home **shell** immediately on cold load and swaps in real components per-section as their data arrives. Static gray placeholders mark out where the profile name, stat cards, and calendar grid will land. No animation — just a structural skeleton so the layout doesn't jump when content arrives.

## What changed

- New [src/screens/HomeScreenSkeleton.tsx](src/screens/HomeScreenSkeleton.tsx): three small subcomponents (\`HomeHeaderSkeleton\`, \`StatOverviewSkeleton\`, \`SessionsCalendarSkeleton\`) sized to match the real component footprint. Uses \`theme.highlightBG\` so it adapts to light/dark.
- [src/screens/HomeScreen.tsx](src/screens/HomeScreen.tsx) drops the \`isLoading || !preferences || !userData → FullScreenLoadingIndicator\` gate. The shell renders as soon as \`user\` is defined. Per-section: header uses skeleton until \`userData\` loads; stats + calendar use skeletons until both \`preferences\` and \`drinkingSessionData\` load.
- \`<FullScreenLoadingIndicator>\` is preserved for in-flight operations (\`loadingText\` — e.g. "Saving your preferences...") so save flows still get a focused overlay.
- The one-shot side effects (\`Session.setHasCheckedAutoLogin(true)\`, \`Timing.end(HOMEPAGE_INITIAL_RENDER)\`) previously rode on the \`isLoading\` useState; now gated by a \`useRef\` one-shot guard, semantically identical.

## Why no animation?

Pulse/shimmer animations are a nice polish but they're not the value — the value is "the user sees something the moment the splash dismisses". Static gray boxes are faster to ship, lower-risk, and convey "loading" clearly enough. Easy to add an opacity pulse later if desired.

## Test plan

- [ ] Cold-launch the app. The home shell appears immediately after splash; stats/calendar fill in once data resolves. No full-screen spinner unless an explicit save/load is in flight.
- [ ] Save a drinking session → confirm the full-screen "Saving..." overlay still appears (the \`loadingText\` path).
- [ ] Sign out → sign in → confirm the home loads correctly with skeletons → real content.
- [ ] Visual: light mode + dark mode. Skeletons should be visible but unobtrusive in both.
- [ ] No drinking sessions at all (new account) → confirm \`NoSessionsInfo\` shows once data resolves to empty, not skeletons forever.

## Related

- [#460](https://github.com/PetrCala/Kiroku/issues/460) — broader home perf discussion. This PR is "Option C" from that thread (perceived perf). Options A (server-side date filter) and B (Onyx cache for instant subsequent loads) are separately tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)