### PR TITLE
perf(profile): per-user session fetch window with collection key

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -338,6 +338,12 @@ const CONST = {
   // and extends the window when the user scrolls back past the loaded edge.
   SESSIONS_INITIAL_FETCH_MONTHS: 3,
 
+  // Debounce window (ms) for persisting the calendar's scroll depth. Coalesces
+  // rapid left-arrow scrolls into a single Firebase listener resubscribe /
+  // friend-profile refetch at the end of the run. Long enough to absorb a
+  // burst, short enough to feel responsive.
+  SESSIONS_CALENDAR_PERSIST_DEBOUNCE_MS: 150,
+
   FIREBASE_STORAGE_URL: 'https://firebasestorage.googleapis.com',
   FRIEND_REQUEST_STATUS: {
     SELF: 'self',

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -170,6 +170,12 @@ const ONYXKEYS = {
     DRINKING_SESSION: 'drinkingSession_',
     FEEDBACK: 'feedback_',
     BUG: 'bug_',
+    /**
+     * Per-user count of months the sessions calendar has been scrolled back.
+     * Drives the Firebase `start_time` window for both the auth-user live
+     * listener and the friend-profile one-shot fetcher.
+     */
+    SESSIONS_CALENDAR_MONTHS_BY_USER_ID: 'sessionsCalendarMonthsByUserID_',
     //     POLICY: 'policy_',
     //     POLICY_TAGS: 'policyTags_',
     //     POLICY_RECENTLY_USED_TAGS: 'nvp_recentlyUsedTags_',
@@ -253,6 +259,7 @@ type OnyxCollectionValuesMapping = {
   [ONYXKEYS.COLLECTION.DRINKING_SESSION]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.COLLECTION.FEEDBACK]: OnyxTypes.Feedback;
   [ONYXKEYS.COLLECTION.BUG]: OnyxTypes.Bug;
+  [ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID]: number;
   //   [ONYXKEYS.COLLECTION.POLICY]: OnyxTypes.Policy;
   //   [ONYXKEYS.COLLECTION.POLICY_DRAFTS]: OnyxTypes.Policy;
   //     .POLICY_RECENTLY_USED_CATEGORIES]: OnyxTypes.RecentlyUsedCategories;

--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -1,0 +1,114 @@
+import {useFirebase} from '@context/global/FirebaseContext';
+import {fetchDataKeyToDbPath} from '@hooks/useFetchData/utils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {DrinkingSessionList} from '@src/types/onyx';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+import {subMonths} from 'date-fns';
+import {get, orderByChild, query, ref, startAt} from 'firebase/database';
+import {useEffect, useRef, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
+
+type UseDrinkingSessionsFetchReturn = {
+  /** Last-good snapshot of the windowed session list. Stays populated across
+   *  widen re-fetches so the calendar doesn't blank out during the round trip. */
+  data: DrinkingSessionList | undefined;
+  /** True only on the initial fetch — later widens swap `data` on resolve
+   *  without flipping this back to true. Consumers should NOT show a full
+   *  loading state on widens. */
+  isLoading: boolean;
+};
+
+/**
+ * One-shot Firebase `get()` for a target user's drinking sessions, windowed
+ * server-side by `start_time` to the most recent
+ * `CONST.SESSIONS_INITIAL_FETCH_MONTHS` months (or wider if the user has
+ * scrolled the calendar back, persisted per-UID in
+ * `${COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`).
+ *
+ * Used by the friend-profile screen so opening a profile with thousands of
+ * sessions doesn't download the entire collection. When the calendar widens
+ * (via [[useLazyMarkedDates.loadMoreMonths]]) the Onyx entry bumps and this
+ * hook fires a new `get()` with an earlier `startAt`. Stale in-flight
+ * responses are dropped via a request token.
+ */
+function useDrinkingSessionsFetch(
+  userID: UserID,
+): UseDrinkingSessionsFetchReturn {
+  const {db} = useFirebase();
+  const [monthsLoaded, monthsLoadedMeta] = useOnyx(
+    `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
+  );
+
+  const [data, setData] = useState<DrinkingSessionList | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // Latest-wins request token. Bumped before each fetch; on resolve we ignore
+  // the response unless its token still matches `currentTokenRef.current`.
+  // Prevents stale wider/narrower responses from clobbering a newer fetch.
+  const currentTokenRef = useRef(0);
+  const hasResolvedInitialRef = useRef(false);
+
+  const sessionsMonthsBack = Math.max(
+    CONST.SESSIONS_INITIAL_FETCH_MONTHS,
+    monthsLoaded ?? 0,
+  );
+
+  useEffect(() => {
+    // Skip until prerequisites are in place. `isLoading` stays `true` —
+    // ProfileScreen mounts after auth so `db` and `userID` are always set in
+    // practice, and Onyx hydration is fast.
+    if (
+      !db ||
+      !userID ||
+      // Wait for Onyx to hydrate so we don't fetch the default 3 months and
+      // then immediately re-fetch when the saved wider depth arrives.
+      monthsLoadedMeta.status !== 'loaded'
+    ) {
+      return;
+    }
+
+    const path = fetchDataKeyToDbPath('drinkingSessionData', userID);
+    if (!path) {
+      return;
+    }
+
+    const token = ++currentTokenRef.current;
+    const startAtMillis = subMonths(new Date(), sessionsMonthsBack).getTime();
+    const sessionsQuery = query(
+      ref(db, path),
+      orderByChild('start_time'),
+      startAt(startAtMillis),
+    );
+
+    const finalize = (next: DrinkingSessionList | undefined) => {
+      if (token !== currentTokenRef.current) {
+        return;
+      }
+      if (next !== undefined) {
+        setData(next);
+      } else if (!hasResolvedInitialRef.current) {
+        // First resolve with no sessions — clear any stale state.
+        setData(undefined);
+      }
+      if (!hasResolvedInitialRef.current) {
+        hasResolvedInitialRef.current = true;
+        setIsLoading(false);
+      }
+    };
+
+    get(sessionsQuery)
+      .then(snapshot => {
+        finalize(
+          snapshot.exists()
+            ? (snapshot.val() as DrinkingSessionList)
+            : undefined,
+        );
+      })
+      .catch(() => finalize(undefined));
+  }, [db, userID, sessionsMonthsBack, monthsLoadedMeta.status]);
+
+  return {data, isLoading};
+}
+
+export default useDrinkingSessionsFetch;

--- a/src/hooks/useFetchData/index.ts
+++ b/src/hooks/useFetchData/index.ts
@@ -1,9 +1,6 @@
 import {useEffect, useState} from 'react';
-import {subMonths} from 'date-fns';
-import {get, orderByChild, query, ref, startAt} from 'firebase/database';
 import {readDataOnce} from '@database/baseFunctions'; // Ensure this import is added
 import {useFirebase} from '@context/global/FirebaseContext';
-import CONST from '@src/CONST';
 import type RefetchDatabaseData from '@src/types/utils/RefetchDatabaseData';
 import type {FetchData, FetchDataKey, FetchDataKeys} from './types';
 import {fetchDataKeyToDbPath} from './utils';
@@ -64,27 +61,17 @@ const useFetchData = (
 
     const fetchData = async () => {
       setIsLoading(true);
+      // NOTE: `drinkingSessionData` is intentionally NOT handled here — that
+      // key has been pulled out into the dedicated `useDrinkingSessionsFetch`
+      // hook, which owns the windowed `start_time` query and the per-UID
+      // re-fetch loop. Consumers (e.g. ProfileScreen) call both hooks side
+      // by side.
       const promises = keysToFetch.map(async dataType => {
         const path = fetchDataKeyToDbPath(dataType, userID);
         if (!path) {
           return {};
         }
-        let fetchedData: unknown = null;
-        if (dataType === 'drinkingSessionData') {
-          const startAtMillis = subMonths(
-            new Date(),
-            CONST.SESSIONS_INITIAL_FETCH_MONTHS,
-          ).getTime();
-          const sessionsQuery = query(
-            ref(db, path),
-            orderByChild('start_time'),
-            startAt(startAtMillis),
-          );
-          const snapshot = await get(sessionsQuery);
-          fetchedData = snapshot.exists() ? snapshot.val() : null;
-        } else {
-          fetchedData = await readDataOnce(db, path);
-        }
+        const fetchedData = await readDataOnce(db, path);
         return {[dataType]: fetchedData};
       });
 

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -16,14 +16,13 @@ import {
 } from 'date-fns';
 import {sessionsToDayMarking} from '@libs/DataHandling';
 import {resolvePalette} from '@libs/SessionColorPalettes';
+import lodashDebounce from 'lodash/debounce';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as Calendar from '@userActions/Calendar';
-import {useFirebase} from '@context/global/FirebaseContext';
 import type {UserID, DateString} from '@src/types/onyx/OnyxCommon';
-import {useIsFocused} from '@react-navigation/native';
 
 /**
  * Custom hook to derive a calendar's markedDates and per-day unit counts from a
@@ -50,20 +49,24 @@ function useLazyMarkedDates(
   sessions: DrinkingSessionList,
   preferences: Preferences,
 ) {
-  const {auth} = useFirebase();
-  const user = auth?.currentUser;
-  const isFocused = useIsFocused();
-  const [monthsLoaded] = useOnyx(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED);
+  const [monthsLoaded, monthsLoadedMeta] = useOnyx(
+    `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
+  );
   const defaultTimezone = CONST.DEFAULT_TIME_ZONE.selected;
 
-  // For a different user (e.g. friend profile) start fresh; otherwise resume from the saved scroll depth.
-  const initialMonths = user?.uid !== userID ? 0 : monthsLoaded ?? 0;
-  const [loadedMonths, setLoadedMonths] = useState<number>(initialMonths);
+  // Resume the user's saved scroll depth (or 0 if this is the first visit).
+  // Same logic for auth user and friends — state is per-UID now.
+  const [loadedMonths, setLoadedMonths] = useState<number>(monthsLoaded ?? 0);
 
-  // Resync `loadedMonths` if the source user changes or Onyx delivers a different saved scroll depth.
+  // Resync `loadedMonths` when the source UID changes or when Onyx finishes
+  // hydrating with a different saved depth. Gated on `metadata.status` so we
+  // don't reset to 0 during the brief window where Onyx hasn't hydrated yet.
   useEffect(() => {
-    setLoadedMonths(user?.uid !== userID ? 0 : monthsLoaded ?? 0);
-  }, [userID, user?.uid, monthsLoaded]);
+    if (monthsLoadedMeta.status !== 'loaded') {
+      return;
+    }
+    setLoadedMonths(monthsLoaded ?? 0);
+  }, [userID, monthsLoaded, monthsLoadedMeta.status]);
 
   // First pass — rebuild the session-by-day index only when sessions or the
   // visible range change. Preferences are *not* a dependency here: a palette
@@ -135,30 +138,29 @@ function useLazyMarkedDates(
     loadedFrom.current = loadedFromDate;
   }, [loadedFromDate]);
 
+  // Debounce the Onyx write so a rapid left-arrow scroll fires only one
+  // listener-resubscribe / one friend-fetcher refetch at the end of the run.
+  // The local visible window still updates synchronously below via setState,
+  // so the calendar itself stays responsive.
+  const persistMonthsLoaded = useMemo(
+    () =>
+      lodashDebounce((uid: UserID, next: number) => {
+        Calendar.setSessionsCalendarMonthsLoadedForUser(uid, next);
+      }, CONST.SESSIONS_CALENDAR_PERSIST_DEBOUNCE_MS),
+    [],
+  );
+
+  // Cancel any pending debounced write on unmount so we don't leak a stale
+  // timer (or write a depth that belongs to a previously-viewed user).
+  useEffect(() => () => persistMonthsLoaded.cancel(), [persistMonthsLoaded]);
+
   const loadMoreMonths = (newMonthsToLoad = 1) => {
     setLoadedMonths(prev => {
       const next = prev + newMonthsToLoad;
-      // Eagerly persist for the auth user so the Firebase session listener can
-      // widen its `start_time` window in lockstep with the calendar. The
-      // friend-profile path (`user?.uid !== userID`) uses a one-shot fetch
-      // and therefore doesn't extend — its calendar simply shows empty days
-      // past the initial fetch window.
-      if (user?.uid === userID) {
-        Calendar.setSessionsCalendarMonthsLoaded(next);
-      }
+      persistMonthsLoaded(userID, next);
       return next;
     });
   };
-
-  // On blur, persist the user's scroll depth so the next mount can resume.
-  useEffect(() => {
-    if (isFocused) {
-      return;
-    }
-    if (user?.uid === userID) {
-      Calendar.setSessionsCalendarMonthsLoaded(loadedMonths);
-    }
-  }, [isFocused, user?.uid, userID, loadedMonths]);
 
   return {
     markedDates,

--- a/src/hooks/useListenToData/index.ts
+++ b/src/hooks/useListenToData/index.ts
@@ -52,7 +52,11 @@ const useListenToData = (
   const {db} = useFirebase();
   const {translate} = useLocalize();
   const [data, setData] = useState<Partial<Record<FetchDataKey, unknown>>>({});
-  const [monthsLoaded] = useOnyx(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED);
+  const [monthsLoaded, monthsLoadedMeta] = useOnyx(
+    // `userID` may be empty during the auth-resolving window; the suffix is
+    // tolerated by Onyx and the effect below gates on its loaded status.
+    `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID ?? ''}`,
+  );
 
   // Months of session history to subscribe to. Keeps the fetch window at least
   // as wide as the user's saved calendar scroll depth so cold-start coverage
@@ -98,6 +102,11 @@ const useListenToData = (
     if (!db || !dataTypes.includes(DRINKING_SESSIONS_KEY)) {
       return;
     }
+    // Wait for Onyx to hydrate so we don't subscribe with the default 3-month
+    // window and then immediately resubscribe with the saved wider value.
+    if (monthsLoadedMeta.status !== 'loaded') {
+      return;
+    }
     const path = fetchDataKeyToDbPath(DRINKING_SESSIONS_KEY, userID);
     if (!path) {
       return;
@@ -119,7 +128,7 @@ const useListenToData = (
 
     return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [db, userID, sessionsMonthsBack]);
+  }, [db, userID, sessionsMonthsBack, monthsLoadedMeta.status]);
 
   return {
     data: data as FetchData,

--- a/src/libs/actions/Calendar.ts
+++ b/src/libs/actions/Calendar.ts
@@ -1,11 +1,23 @@
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
 import Onyx from 'react-native-onyx';
 
-function setSessionsCalendarMonthsLoaded(monthsLoaded: number): void {
-  Onyx.merge(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED, monthsLoaded);
+/**
+ * Persist how many months back the sessions calendar has been scrolled for a
+ * given user. The value is read by the Firebase session listener (auth user)
+ * and the friend-profile fetcher to size their `start_time` window.
+ */
+function setSessionsCalendarMonthsLoadedForUser(
+  userID: UserID,
+  monthsLoaded: number,
+): void {
+  Onyx.merge(
+    `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
+    monthsLoaded,
+  );
 }
 
 export {
   // eslint-disable-next-line import/prefer-default-export
-  setSessionsCalendarMonthsLoaded,
+  setSessionsCalendarMonthsLoadedForUser,
 };

--- a/src/libs/migrateOnyx.ts
+++ b/src/libs/migrateOnyx.ts
@@ -1,10 +1,5 @@
 import Log from './Log';
-// import CheckForPreviousReportActionID from './migrations/CheckForPreviousReportActionID';
-// import KeyReportActionsDraftByReportActionID from './migrations/KeyReportActionsDraftByReportActionID';
-// import NVPMigration from './migrations/NVPMigration';
-// import RemoveEmptyReportActionsDrafts from './migrations/RemoveEmptyReportActionsDrafts';
-// import RenameReceiptFilename from './migrations/RenameReceiptFilename';
-// import TransactionBackupsToCollection from './migrations/TransactionBackupsToCollection';
+import DropLegacySessionsCalendarMonthsLoaded from './migrations/DropLegacySessionsCalendarMonthsLoaded';
 
 export default function () {
   const startTime = Date.now();
@@ -12,26 +7,15 @@ export default function () {
 
   return new Promise<void>(resolve => {
     // Add all migrations to an array so they are executed in order
-    // const migrationPromises = [
-    //   CheckForPreviousReportActionID,
-    //   RenameReceiptFilename,
-    //   KeyReportActionsDraftByReportActionID,
-    //   TransactionBackupsToCollection,
-    //   RemoveEmptyReportActionsDrafts,
-    //   NVPMigration,
-    // ];
+    const migrationPromises = [DropLegacySessionsCalendarMonthsLoaded];
 
     // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the
     // previous promise to finish before moving onto the next one.
-    /* eslint-disable arrow-body-style */
-    // migrationPromises
-    //   .reduce<Promise<void | void[]>>((previousPromise, migrationPromise) => {
-    //     return previousPromise.then(() => {
-    //       return migrationPromise();
-    //     });
-    //   }, Promise.resolve())
-    // TODO add migrations if necessary
-    Promise.resolve()
+    migrationPromises
+      // eslint-disable-next-line arrow-body-style
+      .reduce<Promise<void | void[]>>((previousPromise, migrationPromise) => {
+        return previousPromise.then(() => migrationPromise());
+      }, Promise.resolve())
 
       // Once all migrations are done, resolve the main promise
       .then(() => {

--- a/src/libs/migrations/DropLegacySessionsCalendarMonthsLoaded.ts
+++ b/src/libs/migrations/DropLegacySessionsCalendarMonthsLoaded.ts
@@ -1,0 +1,25 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import Log from '@libs/Log';
+
+/**
+ * The home-calendar scroll depth used to live under a single Onyx key
+ * (`SESSIONS_CALENDAR_MONTHS_LOADED: number`). It has moved to a per-user
+ * collection (`COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID`) so both the
+ * auth-user listener and the friend-profile fetcher can read their own UID's
+ * depth.
+ *
+ * This migration runs before auth resolves (the `migrateOnyx` framework is a
+ * pre-auth boot step), so we can't copy the legacy value into
+ * `${prefix}${authUid}` — we don't know the auth UID yet. We just drop the
+ * key. Cost: users who had scrolled the home calendar back several months
+ * will see the default 3-month window on first launch after upgrade and
+ * re-scroll once. Acceptable tradeoff for an 8-byte preference.
+ */
+export default function DropLegacySessionsCalendarMonthsLoaded(): Promise<void> {
+  Log.info(
+    '[Migrate Onyx] DropLegacySessionsCalendarMonthsLoaded: clearing legacy key',
+  );
+  // eslint-disable-next-line rulesdir/prefer-actions-set-data
+  return Onyx.set(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED, null);
+}

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -25,6 +25,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import DBPATHS from '@src/DBPATHS';
 import ROUTES from '@src/ROUTES';
 import useFetchData from '@hooks/useFetchData';
+import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import ScreenWrapper from '@components/ScreenWrapper';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -47,15 +48,20 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const {auth, db} = useFirebase();
   const {userID} = route.params;
   const user = auth.currentUser;
-  const relevantDataKeys: FetchDataKeys = [
-    'userData',
-    'drinkingSessionData',
-    'preferences',
-  ];
+  // `drinkingSessionData` is fetched separately via `useDrinkingSessionsFetch`
+  // — that hook windows the Firebase query by `start_time` and re-fetches when
+  // the calendar widens. `useFetchData` stays for the non-windowed keys.
+  const relevantDataKeys: FetchDataKeys = ['userData', 'preferences'];
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
-  const {data: fetchedData, isLoading} = useFetchData(userID, relevantDataKeys);
+  const {data: fetchedData, isLoading: isFetchLoading} = useFetchData(
+    userID,
+    relevantDataKeys,
+  );
+  const {data: drinkingSessionData, isLoading: isSessionsLoading} =
+    useDrinkingSessionsFetch(userID);
+  const isLoading = isFetchLoading || isSessionsLoading;
   const [selfFriends, setSelfFriends] = useState<UserList | null | undefined>();
   const [friendCount, setFriendCount] = useState(0);
   const [commonFriendCount, setCommonFriendCount] = useState(0);
@@ -67,7 +73,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const [manageFriendModalVisible, setManageFriendModalVisible] =
     useState(false);
   const userData = fetchedData?.userData;
-  const drinkingSessionData = fetchedData?.drinkingSessionData;
   const preferences = fetchedData?.preferences;
   const profileData = userData?.profile;
   const friends = userData?.friends;


### PR DESCRIPTION
## Summary

Stacked on #469. Extends the recent-window fetch design to **friend profiles** (which still fetched all sessions past 3 months under #469's friend path).

- Replaces single `SESSIONS_CALENDAR_MONTHS_LOADED: number` Onyx key with an Onyx **collection** `COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID` (one number per UID) — mirrors the Expensify pattern used by `COLLECTION.SELECTED_TAB` etc.
- `useLazyMarkedDates` writes per-UID unconditionally (drops the previous own-vs-friend branching). Writes are debounced 150ms so a rapid left-arrow scroll only fires one listener resubscribe / friend refetch at the end.
- New `useDrinkingSessionsFetch` hook handles friend-profile sessions with its own `get()`-and-window loop, latest-wins request token, and stale-data preservation so the calendar never blanks during a widen. `useFetchData` (self-flagged "to be deleted") is left clean of session logic.
- All three Onyx-driven effects (`useLazyMarkedDates`, `useListenToData`, `useDrinkingSessionsFetch`) gate on `metadata.status === 'loaded'` to avoid the double-fetch race during Onyx hydration.
- Adds a migration via the existing (until-now-unused) `migrateOnyx` framework that drops the legacy single key. Runs pre-auth so it can't copy to the new collection — users who had scrolled deep re-scroll once on first launch after upgrade. Acceptable for an 8-byte preference.

Refs [#460](https://github.com/PetrCala/Kiroku/issues/460).

## Test plan

- [ ] `npm run typecheck` (CI gate) passes
- [ ] `npm run lint` (CI gate) passes
- [ ] **Own user regression** — cold launch, scroll back several months, force-quit + relaunch: scroll depth restored, fetch window matches.
- [ ] **Friend profile** — open a friend with months of data: recent 3 months render; scroll back past month 3 — previous data stays rendered briefly, then older sessions fill in (no blank flash).
- [ ] **Rapid scrolling** — hammer the left arrow: only the final widened state triggers a fetch (debounce + token).
- [ ] **Cross-friend isolation** — open friend A, scroll back; open friend B; reopen friend A: A's depth resumes; B unaffected.
- [ ] **Migration** — seed legacy `SESSIONS_CALENDAR_MONTHS_LOADED` to `5` in a debug build, launch: legacy key cleared, no auto-seed of new collection (entry created lazily on first scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)