### PR TITLE
docs: fix worfklows -> workflows typo in CONTRIBUTING

### DIFF
--- a/contributingGuides/CONTRIBUTING.md
+++ b/contributingGuides/CONTRIBUTING.md
@@ -43,7 +43,7 @@ program = gpg
    1. Tests - All tests must pass before a merge of a pull request
    1. Lint - All code must pass lint checks before a merge of a pull request
 
-6. Make sure you do not use GitHub keywords in your comments (such as `fixes`), as these can mess with worfklows and other automatic checks. To avoid this, follow the pull request template when modifying your comments.
+6. Make sure you do not use GitHub keywords in your comments (such as `fixes`), as these can mess with workflows and other automatic checks. To avoid this, follow the pull request template when modifying your comments.
 7. Upon submission, include an explicit manual tests you performed that validates your changes work on all platforms.
 8. You're now ready to submit your pull request for final evaluation. Following your submission, the assigned reviewer will examine your PR. Depending on their assessment, your request may be accepted and merged, rejected, or you might be asked to make changes to your code.
 


### PR DESCRIPTION
## Summary
- Fix a small typo in `contributingGuides/CONTRIBUTING.md` (worfklows -> workflows).

## Notes
- Test PR opened by Claude to validate end-to-end CI roundtrip behavior (branch creation, commit, push, PR open, status checks).
- Pure docs change. No functional impact.

## Test plan
- [x] Prettier ran on changed file
- [ ] CI completes on this PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)