### PR TITLE
fix(skeleton): align HomeScreen skeleton with actual layout

### DIFF
--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -61,33 +61,54 @@ function StatOverviewSkeleton() {
             styles.alignItemsCenter,
             styles.justifyContentCenter,
           ]}>
-          <Block width={56} height={28} style={styles.mb2} />
-          <Block width={96} height={12} />
+          {/* Matches fontSizeXXXXLarge (36px) bold value text */}
+          <Block width={72} height={44} style={styles.mb2} />
+          {/* Matches fontSizeNormal (15px) label, 2 lines, max-width 150 */}
+          <Block width={130} height={36} />
         </View>
       ))}
     </View>
   );
 }
 
-const CALENDAR_WEEKS = [0, 1, 2, 3, 4, 5] as const;
+const CALENDAR_WEEKS = [0, 1, 2, 3, 4] as const;
 const CALENDAR_DAYS = [0, 1, 2, 3, 4, 5, 6] as const;
 
-/** Placeholder for the sessions calendar (rough 6×7 day grid). */
+/** Placeholder for the sessions calendar matching react-native-calendars layout. */
 function SessionsCalendarSkeleton() {
   const styles = useThemeStyles();
   return (
     <View style={[styles.sessionsCalendarContainer, styles.p4]}>
+      {/* Month header: left arrow + month name + right arrow */}
+      <View
+        style={[
+          styles.flexRow,
+          styles.alignItemsCenter,
+          styles.justifyContentBetween,
+          styles.mb3,
+        ]}>
+        <Block width={24} height={24} radius={4} />
+        <Block width={100} height={18} />
+        <Block width={24} height={24} radius={4} />
+      </View>
+      {/* Day-name row (Mon Tue Wed …) */}
+      <View style={[styles.flexRow, styles.justifyContentBetween, styles.mb3]}>
+        {CALENDAR_DAYS.map(day => (
+          <Block key={`name-${day}`} width={20} height={12} />
+        ))}
+      </View>
+      {/* Week rows — each cell mirrors DayComponent: day number + marking box */}
       {CALENDAR_WEEKS.map(week => (
         <View
           key={`week-${week}`}
           style={[styles.flexRow, styles.justifyContentBetween, styles.mb3]}>
           {CALENDAR_DAYS.map(day => (
-            <Block
+            <View
               key={`day-${week}-${day}`}
-              width={32}
-              height={32}
-              radius={16}
-            />
+              style={[styles.flexColumn, styles.alignItemsCenter]}>
+              <Block width={16} height={12} style={styles.mb1} />
+              <Block width={28} height={28} radius={4} />
+            </View>
           ))}
         </View>
       ))}


### PR DESCRIPTION
## Summary

- **`StatOverviewSkeleton`**: corrected block dimensions to match the actual `StatItem` — content block now `72×44` (was `56×28`, matching `fontSizeXXXXLarge` 36px bold) and label block now `130×36` (was `96×12`, matching 2 lines of `fontSizeNormal` 15px at max-width 150)
- **`SessionsCalendarSkeleton`**: added the two rows that were entirely missing — a **month-header row** (left arrow + month name + right arrow) and a **day-name row** (7 abbreviated labels); reduced week rows from 6 → 5 (correct for the vast majority of months); replaced uniform 32×32 circles with stacked cells that mirror `DayComponent` (small day-number block on top + square marking block below)

## Test plan

- [ ] Trigger the loading state for the home screen (e.g. cold start / clear session cache) and verify the skeleton visually matches the shape of the fully-loaded screen
- [ ] Confirm `StatOverview` placeholder blocks are taller and wider than before
- [ ] Confirm the calendar skeleton now shows a header row, a day-names row, and 5 week rows with double-block cells
- [ ] No TypeScript or lint errors (`npm run typecheck-tsgo`, `npm run lint-changed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)