### PR TITLE
fix(ci): download iOS 26.1 platform SDK before Fastlane build

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -201,6 +201,9 @@ jobs:
       - name: Set iOS version in ENV
         run: echo "IOS_VERSION=$(echo '${{ inputs.APP_VERSION }}' | tr '-' '.')" >> "$GITHUB_ENV"
 
+      - name: Install iOS platform SDK
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Generate release notes
         if: ${{ inputs.SHOULD_DEPLOY_PRODUCTION }}
         continue-on-error: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,8 +102,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled rootProject.ext.multiDexEnabled
-        versionCode 1000031171
-        versionName "0.3.11-71"
+        versionCode 1000031200
+        versionName "0.3.12-0"
         // Supported language variants must be declared here to avoid from being removed during the compilation.
         // This also helps us to not include unnecessary language variants in the APK.
         resConfigs "en", "cs"

--- a/ios/kiroku/Info.plist
+++ b/ios/kiroku/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.11</string>
+	<string>0.3.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.3.11.71</string>
+	<string>0.3.12.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationLaunchProhibited</key>

--- a/ios/kirokuTests/Info.plist
+++ b/ios/kirokuTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.11</string>
+	<string>0.3.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.3.11.71</string>
+	<string>0.3.12.0</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiroku",
-  "version": "0.3.11-71",
+  "version": "0.3.12-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiroku",
-      "version": "0.3.11-71",
+      "version": "0.3.12-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiroku",
-  "version": "0.3.11-71",
+  "version": "0.3.12-0",
   "private": true,
   "type": "commonjs",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Xcode 26 no longer bundles the iOS SDK — it must be fetched as a separate platform package
- The `macos-26` runner has `Xcode_26.1.1.app` but without the iOS 26.1 platform, causing every staging/production iOS build to fail with: `iOS 26.1 is not installed. Please download and install the platform from Xcode > Settings > Components`
- Adds `xcodebuild -downloadPlatform iOS` step before the Fastlane build to install the missing platform SDK

**Failing run:** https://github.com/PetrCala/Kiroku/actions/runs/26251036105/job/77262000775

## Test plan

- [ ] Verify the iOS job in the next staging deploy passes the archive step
- [ ] Confirm dSYM artifact is uploaded successfully after the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)