### PR TITLE
fix(boot): cap auth-data wait so splash can't hang

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -719,6 +719,15 @@ const CONST = {
     HIDDEN: `hidden`,
   },
 
+  // Cap how long the boot splash waits for the authed user's RTDB data
+  // (userData + preferences) to hydrate. Past this point, splash hides
+  // and HomeScreen falls back to its skeleton state. Without the cap an
+  // incomplete RTDB document, slow network, or offline cold start would
+  // keep the splash up until the 15 s force-hide safety net in
+  // SplashScreenHider, which is poor UX. 3 s is comfortably longer than
+  // a warm listener (typically <500 ms) and shorter than the safety net.
+  BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS: 3 * 1000,
+
   KEYBOARD_TYPE: {
     VISIBLE_PASSWORD: 'visible-password',
     ASCII_CAPABLE: 'ascii-capable',

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -157,6 +157,17 @@ function AuthScreensContent() {
     }
     setIsAuthDataReady(true);
   }, [userData, preferences, setIsAuthDataReady]);
+  // Safety: if the listener doesn't deliver both fields within the
+  // timeout (offline cold start, slow network, or missing fields in the
+  // user's RTDB document), flip the gate anyway. HomeScreen renders
+  // skeletons until real data arrives, so this falls back to a brief
+  // skeleton flash instead of leaving the user staring at the splash.
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setIsAuthDataReady(true);
+    }, CONST.BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS);
+    return () => clearTimeout(timeoutId);
+  }, [setIsAuthDataReady]);
   // Reset on sign-out (AuthScreens unmounts) so a subsequent sign-in
   // re-gates the splash on fresh data.
   useEffect(() => () => setIsAuthDataReady(false), [setIsAuthDataReady]);


### PR DESCRIPTION
## Summary

- Cap the boot splash's auth-data wait at 3 s so it can't hang when the user's RTDB document is incomplete, the network is slow, or the device is offline at launch.
- Falls back to `HomeScreen`'s existing skeleton state until live data arrives, instead of leaving the splash up for 15 s and then snapping away via the `SplashScreenHider` safety net.

## Why

Commit [`4381afc6`](https://github.com/PetrCala/Kiroku/commit/4381afc6) added `isAuthDataReady` so the splash held until both `userData` and `preferences` arrived from the live listener — avoiding a brief skeleton flash on cold-start of authed sessions. Three real-world cases break that gate:

- Offline cold start: the RTDB listener can't fire, so `userData`/`preferences` stay `undefined`.
- Missing fields in a user's RTDB document (legacy accounts, partial migrations).
- Slow networks: the listener takes seconds to resolve.

In each case the predicate at `Kiroku.tsx:131-139` never becomes true and the user stares at the splash until the 15 s `SplashScreenHider` fallback fires.

This is not iOS-vs-Android: the gate lives entirely in JS and has no `Platform.OS` branching. The earlier iOS bootsplash refactors did not change the predicate.

## What changed

- `src/CONST.ts` — add `BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS = 3000`.
- `src/libs/Navigation/AppNavigator/AuthScreens.tsx` — add a `setTimeout` that flips `isAuthDataReady` to `true` after the cap, sibling to the existing listener-driven effect. Cleaned up on unmount so a sign-out before the timeout doesn't fire after a re-mount.

## Test plan

- [ ] Cold start an authed account online → splash hides as before (no regression in the happy path; listener fires well under 3 s).
- [ ] Cold start an authed account with airplane mode on → splash hides after ~3 s instead of ~15 s; HomeScreen shows skeletons; reconnect → real content paints.
- [ ] Sign-out then sign-in → splash gating resets and the timer doesn't carry across sessions.
- [ ] Cold start unauthenticated (fresh install) → unchanged; splash hides as soon as nav/theme are ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
