### PR TITLE
feat(preferences): toggle to use own palette for everyone

### DIFF
--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -15,7 +15,7 @@ import {
   subMonths,
 } from 'date-fns';
 import {sessionsToDayMarking} from '@libs/DataHandling';
-import {resolvePalette} from '@libs/SessionColorPalettes';
+import useResolvedPalette from '@hooks/useResolvedPalette';
 import lodashDebounce from 'lodash/debounce';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {MarkedDates} from 'react-native-calendars/src/types';
@@ -103,19 +103,36 @@ function useLazyMarkedDates(
     return {sessionIndex: index, dayKeys: days, loadedFromDate: start};
   }, [sessions, loadedMonths, defaultTimezone]);
 
+  // Resolve which palette to render with. When the viewer has enabled
+  // `use_own_palette_for_others`, this swaps the viewed user's palette for the
+  // viewer's own; otherwise it returns the viewed user's palette.
+  const palette = useResolvedPalette(preferences);
+
+  // Substitute the resolved palette into the preferences object so downstream
+  // pure functions (sessionsToDayMarking → convertUnitsToColors) use it without
+  // needing to know about the toggle. Unit thresholds and drink mappings stay
+  // the viewed user's — only the palette is swapped.
+  const effectivePreferences = useMemo(
+    () => ({...preferences, session_color_palette: palette}),
+    [preferences, palette],
+  );
+
   // Second pass — build markedDates + unitsMap from the pre-built index.
   // This is the only memo that needs `preferences`; on a palette change it
   // walks the day list (~30 entries) instead of re-filtering N sessions.
+  const paletteGreen = palette.green;
   const {markedDatesMap, unitsMap} = useMemo(() => {
     const newMarkedDatesMap = new Map<DateString, MarkingProps>();
     const newUnitsMap = new Map<DateString, number>();
-    const palette = resolvePalette(preferences.session_color_palette);
 
     dayKeys.forEach(dayKey => {
       const dailySessions = sessionIndex.get(dayKey) ?? [];
-      const newMarking = sessionsToDayMarking(dailySessions, preferences);
+      const newMarking = sessionsToDayMarking(
+        dailySessions,
+        effectivePreferences,
+      );
       if (!newMarking) {
-        newMarkedDatesMap.set(dayKey, {color: palette.green});
+        newMarkedDatesMap.set(dayKey, {color: paletteGreen});
         return;
       }
       newMarkedDatesMap.set(dayKey, newMarking.marking);
@@ -123,7 +140,7 @@ function useLazyMarkedDates(
     });
 
     return {markedDatesMap: newMarkedDatesMap, unitsMap: newUnitsMap};
-  }, [sessionIndex, dayKeys, preferences]);
+  }, [sessionIndex, dayKeys, effectivePreferences, paletteGreen]);
 
   const markedDates: MarkedDates = useMemo(
     () => Object.fromEntries(markedDatesMap),

--- a/src/hooks/useResolvedPalette.ts
+++ b/src/hooks/useResolvedPalette.ts
@@ -1,0 +1,27 @@
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import {resolvePalette} from '@libs/SessionColorPalettes';
+import type {Preferences, SessionColorPalette} from '@src/types/onyx';
+
+/**
+ * Resolves which session color palette to render with for a given user's data.
+ *
+ * Default: the viewed user's own palette is used (preserving the per-user
+ * palette preview). When the current viewer has enabled
+ * `use_own_palette_for_others`, their own palette overrides the viewed user's
+ * so that the app's color treatment stays consistent.
+ *
+ * Pass `undefined` when rendering data that has no clear owner — the resolver
+ * falls back to the default palette via `resolvePalette`.
+ */
+function useResolvedPalette(
+  viewedUserPreferences: Preferences | undefined,
+): SessionColorPalette {
+  const {preferences: ownPreferences} = useDatabaseData();
+  const useOwn = ownPreferences?.use_own_palette_for_others === true;
+  const source = useOwn
+    ? ownPreferences?.session_color_palette
+    : viewedUserPreferences?.session_color_palette;
+  return resolvePalette(source);
+}
+
+export default useResolvedPalette;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -528,6 +528,11 @@ export default {
       brand: 'Značkové barvy Kiroku',
       pink: 'Růžová až po červenou',
     },
+    useOwnPaletteForOthers: {
+      label: 'Používat moji paletu pro všechny',
+      description:
+        'Relace přátel se zobrazí ve vybrané paletě místo v jejich vlastní.',
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinky na jednotky',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -530,6 +530,11 @@ export default {
       brand: "Kiroku's brand colors",
       pink: 'Soft pinks to red',
     },
+    useOwnPaletteForOthers: {
+      label: 'Use my palette for everyone',
+      description:
+        "Friends' sessions will appear in your selected palette instead of theirs.",
+    },
   },
   drinksToUnitsScreen: {
     title: 'Drinks to Units',

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -77,6 +77,7 @@ const getDefaultPreferences = (): Preferences => ({
   },
   theme: CONST.THEME.SYSTEM,
   session_color_palette: PALETTES.classic,
+  use_own_palette_for_others: false,
 });
 
 const getDefaultUserData = (profileData: Profile): UserData => {

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -12,6 +12,7 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
+import Switch from '@components/Switch';
 import Text from '@components/Text';
 import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
@@ -97,6 +98,10 @@ function ColorPaletteScreen() {
     null,
   );
   const [saving, setSaving] = useState(false);
+  const [pendingUseOwnForOthers, setPendingUseOwnForOthers] = useState<
+    boolean | null
+  >(null);
+  const [savingUseOwnForOthers, setSavingUseOwnForOthers] = useState(false);
 
   // Selection accent uses the app brand color (yellowStrong) so the picker stays
   // visually integrated with the rest of the app.
@@ -132,6 +137,28 @@ function ColorPaletteScreen() {
       .finally(() => setSaving(false));
   };
 
+  const persistedUseOwnForOthers =
+    preferences?.use_own_palette_for_others === true;
+  const displayUseOwnForOthers =
+    pendingUseOwnForOthers ?? persistedUseOwnForOthers;
+
+  const onToggleUseOwnForOthers = (next: boolean) => {
+    if (savingUseOwnForOthers || next === displayUseOwnForOthers) {
+      return;
+    }
+    setPendingUseOwnForOthers(next);
+    setSavingUseOwnForOthers(true);
+    Preferences.updatePreferences(db, user, {
+      use_own_palette_for_others: next,
+    })
+      .catch(error => {
+        setPendingUseOwnForOthers(null);
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('preferencesScreen.error.save'), errorMessage);
+      })
+      .finally(() => setSavingUseOwnForOthers(false));
+  };
+
   return (
     <ScreenWrapper testID={ColorPaletteScreen.displayName}>
       <HeaderWithBackButton
@@ -161,6 +188,31 @@ function ColorPaletteScreen() {
               hideArrows
               hideMonthHeader
               hideDayNames
+            />
+          </View>
+          <View
+            style={[
+              styles.flexRow,
+              styles.alignItemsCenter,
+              styles.justifyContentBetween,
+              styles.mb4,
+            ]}>
+            <View style={[styles.flexColumn, styles.flex1, styles.mr3]}>
+              <Text style={[styles.textNormal, styles.textStrong]}>
+                {translate('colorPaletteScreen.useOwnPaletteForOthers.label')}
+              </Text>
+              <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                {translate(
+                  'colorPaletteScreen.useOwnPaletteForOthers.description',
+                )}
+              </Text>
+            </View>
+            <Switch
+              accessibilityLabel={translate(
+                'colorPaletteScreen.useOwnPaletteForOthers.label',
+              )}
+              isOn={displayUseOwnForOthers}
+              onToggle={onToggleUseOwnForOthers}
             />
           </View>
           <View>

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -1,8 +1,5 @@
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import {Alert, View} from 'react-native';
-import type {DateData} from 'react-native-calendars';
-import type {MarkedDates} from 'react-native-calendars/src/types';
-import {eachDayOfInterval, endOfMonth, format, startOfMonth} from 'date-fns';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import Navigation from '@libs/Navigation/Navigation';
@@ -10,6 +7,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useStyleUtils from '@hooks/useStyleUtils';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import Switch from '@components/Switch';
@@ -18,7 +16,6 @@ import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import * as Preferences from '@userActions/Preferences';
-import {dateToDateData} from '@libs/DataHandling';
 import type {SessionColorPalette} from '@src/types/onyx';
 import type {PaletteId} from '@libs/SessionColorPalettes';
 import {
@@ -27,10 +24,7 @@ import {
   DEFAULT_PALETTE_ID,
   getPaletteIdFromColors,
 } from '@libs/SessionColorPalettes';
-import SessionsCalendarView from '@components/SessionsCalendar/SessionsCalendarView';
 import useTheme from '@hooks/useTheme';
-import type {DateString} from '@src/types/onyx/OnyxCommon';
-import CONST from '@src/CONST';
 
 const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'green',
@@ -40,55 +34,28 @@ const PREVIEW_KEYS: ReadonlyArray<keyof SessionColorPalette> = [
   'black',
 ];
 
-/**
- * Build a fixed demo dataset showcasing all five severity colors across the
- * visible month. Mirrors the shape produced by `useLazyMarkedDates` so the
- * presentational `SessionsCalendarView` renders identically.
- */
-function buildPreviewMarkedData(
-  palette: SessionColorPalette,
-  visibleDate: DateData,
-): {markedDates: MarkedDates; unitsMap: Map<DateString, number>} {
-  const monthStart = startOfMonth(new Date(visibleDate.timestamp));
-  const monthEnd = endOfMonth(new Date(visibleDate.timestamp));
-  const allDays = eachDayOfInterval({start: monthStart, end: monthEnd});
+type WeekCell = {
+  day: number;
+  slot: keyof SessionColorPalette;
+  units: number;
+};
 
-  const overlay = new Map<
-    number,
-    {slot: keyof SessionColorPalette; units: number}
-  >([
-    [3, {slot: 'yellow', units: 2}],
-    [5, {slot: 'yellow', units: 3}],
-    [7, {slot: 'orange', units: 7}],
-    [10, {slot: 'red', units: 12}],
-    [12, {slot: 'yellow', units: 1}],
-    [14, {slot: 'orange', units: 8}],
-    [17, {slot: 'red', units: 14}],
-    [20, {slot: 'orange', units: 6}],
-    [23, {slot: 'yellow', units: 3}],
-    [25, {slot: 'black', units: 20}],
-    [27, {slot: 'orange', units: 9}],
-  ]);
-
-  const markedDates: MarkedDates = {};
-  const unitsMap = new Map<DateString, number>();
-
-  allDays.forEach(day => {
-    const dayKey = format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString;
-    const o = overlay.get(day.getDate());
-    if (o) {
-      markedDates[dayKey] = {color: palette[o.slot]};
-      unitsMap.set(dayKey, o.units);
-    } else {
-      markedDates[dayKey] = {color: palette.green};
-    }
-  });
-
-  return {markedDates, unitsMap};
-}
+// A representative week — 3 rest days + 4 active days covering each severity
+// once. Keeps the preview honest about what a normal week looks like rather
+// than showing every cell maxed out.
+const WEEK_OVERLAY: readonly WeekCell[] = [
+  {day: 10, slot: 'green', units: 0},
+  {day: 11, slot: 'yellow', units: 3},
+  {day: 12, slot: 'green', units: 0},
+  {day: 13, slot: 'orange', units: 7},
+  {day: 14, slot: 'red', units: 12},
+  {day: 15, slot: 'black', units: 20},
+  {day: 16, slot: 'green', units: 0},
+];
 
 function ColorPaletteScreen() {
   const styles = useThemeStyles();
+  const StyleUtils = useStyleUtils();
   const theme = useTheme();
   const {translate} = useLocalize();
   const {auth, db} = useFirebase();
@@ -113,12 +80,7 @@ function ColorPaletteScreen() {
     DEFAULT_PALETTE_ID;
   // Optimistic preview: while a save is in flight, render the just-tapped palette.
   const displayPaletteId = pendingPaletteId ?? activePaletteId;
-
-  const visibleDate = useMemo(() => dateToDateData(new Date()), []);
-  const previewData = useMemo(
-    () => buildPreviewMarkedData(PALETTES[displayPaletteId], visibleDate),
-    [displayPaletteId, visibleDate],
-  );
+  const displayPalette = PALETTES[displayPaletteId];
 
   const onSelectPalette = (id: PaletteId) => {
     if (saving || id === displayPaletteId) {
@@ -167,29 +129,61 @@ function ColorPaletteScreen() {
         onBackButtonPress={() => Navigation.goBack()}
         onCloseButtonPress={() => Navigation.dismissModal()}
       />
-      <ScrollView style={[styles.flexGrow1, styles.mnw100]}>
+      <ScrollView
+        style={[styles.flexGrow1, styles.mnw100]}
+        stickyHeaderIndices={[1]}>
         <Section
           title={translate('colorPaletteScreen.title')}
           titleStyles={styles.generalSectionTitle}
           subtitle={translate('colorPaletteScreen.description')}
           subtitleMuted
-          isCentralPane
-          childrenStyles={styles.pt3}>
+          isCentralPane>
+          <View />
+        </Section>
+        <View style={[styles.ph5, styles.pv2, {backgroundColor: theme.appBG}]}>
           <View
             style={[
-              styles.mb4,
               styles.overflowHidden,
+              styles.p3,
+              styles.flexRow,
+              styles.justifyContentBetween,
               {borderRadius: 12, borderWidth: 1, borderColor: accentTint},
             ]}>
-            <SessionsCalendarView
-              markedDates={previewData.markedDates}
-              unitsMap={previewData.unitsMap}
-              visibleDate={visibleDate}
-              hideArrows
-              hideMonthHeader
-              hideDayNames
-            />
+            {WEEK_OVERLAY.map(cell => {
+              const marking = {color: displayPalette[cell.slot]};
+              const unitsText = cell.units > 0 ? String(cell.units) : '';
+              return (
+                <View
+                  key={cell.day}
+                  style={[
+                    styles.alignItemsCenter,
+                    styles.justifyContentCenter,
+                  ]}>
+                  <Text
+                    style={StyleUtils.getSessionsCalendarDayLabelStyle(
+                      false,
+                      false,
+                    )}>
+                    {cell.day}
+                  </Text>
+                  <View
+                    style={StyleUtils.getSessionsCalendarDayMarkingContainerStyle(
+                      marking,
+                      false,
+                    )}>
+                    <Text
+                      style={StyleUtils.getSessionsCalendarDayMarkingTextStyle(
+                        marking,
+                      )}>
+                      {unitsText}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
           </View>
+        </View>
+        <View style={[styles.ph5, styles.pt3]}>
           <View
             style={[
               styles.flexRow,
@@ -278,7 +272,7 @@ function ColorPaletteScreen() {
               );
             })}
           </View>
-        </Section>
+        </View>
       </ScrollView>
     </ScreenWrapper>
   );

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -56,6 +56,11 @@ type Preferences = {
 
   /** User's selected session color palette */
   session_color_palette?: SessionColorPalette;
+
+  /** When true, other users' sessions are rendered using the viewer's own
+   *  palette instead of each owner's palette. Undefined/false preserves the
+   *  original behavior (each user's own palette is shown). */
+  use_own_palette_for_others?: boolean;
 };
 
 /** A collection of preferences of multiple users */


### PR DESCRIPTION
## Summary

- Adds `use_own_palette_for_others` preference. When enabled, friends' drinking sessions render in the viewer's selected color palette instead of each owner's. Default (off) preserves current behavior.
- Toggle lives at the top of the Color Palette screen (Settings → Preferences → Session colors), where users are already choosing their palette.
- Resolution is centralized in a new `useResolvedPalette` hook. `useLazyMarkedDates` swaps the resolved palette into the preferences object handed to pure data functions, so individual render sites don't need to know about the toggle.
- Palette only — unit thresholds (`units_to_colors`) and drink mappings (`drinks_to_units`) still come from the viewed user, so session severity isn't misrepresented.

## Test plan

- [ ] Settings → Preferences → Session colors shows the new toggle row between the live preview and palette list, with subcopy explaining the behavior.
- [ ] With toggle OFF (default), open a friend's profile: their calendar still renders in their chosen palette.
- [ ] With toggle ON, friend's calendar renders in your selected palette; switching your palette updates their calendar live.
- [ ] Your own calendar (Home, Day Overview, Session Summary, Live/Edit Session) always renders in your palette regardless of toggle.
- [ ] Toggle save survives app restart (persisted via `Preferences.updatePreferences`).
- [ ] Toggle the switch off → on → off rapidly; UI stays in sync and no save races visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)