### PR TITLE
fix(profile): always render sessions calendar so older months stay reachable

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -12,7 +12,6 @@ import type {
   ForceUpdateTextParams,
   ForgotPasswordSuccessParams,
   FriendRequestsCountParams,
-  NoDrinkingSessionsParams,
   OnboardingStepCounterParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
@@ -781,8 +780,6 @@ export default {
   profileScreen: {
     title: 'Profil',
     titleNotSelf: 'Přehled uživatele',
-    noDrinkingSessions: ({isSelf}: NoDrinkingSessionsParams) =>
-      `${isSelf ? 'Zatím jste' : 'Tento uživatel zatím'} nepřidal(a) žádné alkoholové relace.`,
     seeAllFriends: 'Zobrazit všechny přátele',
     drinkingSessions: ({sessionsCount}: DrinkingSessionsParams) =>
       `${Str.pluralize('Alkoholová Relace', 'Alkoholových Relací', sessionsCount)}`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -13,7 +13,6 @@ import type {
   ForceUpdateTextParams,
   ForgotPasswordSuccessParams,
   FriendRequestsCountParams,
-  NoDrinkingSessionsParams,
   OnboardingStepCounterParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
@@ -791,8 +790,6 @@ export default {
   profileScreen: {
     title: 'Profile',
     titleNotSelf: 'Friend Overview',
-    noDrinkingSessions: ({isSelf}: NoDrinkingSessionsParams) =>
-      `${isSelf ? 'You have not' : 'This user has not'} added any drinking sessions yet.`,
     seeAllFriends: 'See all friends',
     drinkingSessions: ({sessionsCount}: DrinkingSessionsParams) =>
       `Drinking ${Str.pluralize('Session', 'Sessions', sessionsCount)}`,

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -29,10 +29,6 @@ type FriendRequestsCountParams = {
   requestsCount: number;
 };
 
-type NoDrinkingSessionsParams = {
-  isSelf: boolean;
-};
-
 type OnboardingStepCounterParams = {
   currentStep: number;
   totalSteps: number;
@@ -70,7 +66,6 @@ export type {
   ForceUpdateTextParams,
   ForgotPasswordSuccessParams,
   FriendRequestsCountParams,
-  NoDrinkingSessionsParams,
   OnboardingStepCounterParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -210,27 +210,16 @@ function ProfileScreen({route}: ProfileScreenProps) {
             onPress={onSeeAllFriendsButtonPress}
           />
         </View>
-        {drinkingSessionData ? (
-          <View style={[]}>
-            <StatOverview statsData={statsData} />
-            <SessionsCalendar
-              userID={userID}
-              visibleDate={visibleDateData}
-              onDateChange={(date: DateData) => setVisibleDateData(date)}
-              drinkingSessionData={drinkingSessionData}
-              preferences={preferences}
-            />
-          </View>
-        ) : (
-          <View style={[styles.borderTop, styles.borderRadiusXLarge]}>
-            <Text
-              style={[styles.textNormal, styles.textAlignCenter, styles.mt4]}>
-              {translate('profileScreen.noDrinkingSessions', {
-                isSelf: user?.uid === userID,
-              })}
-            </Text>
-          </View>
-        )}
+        <View style={[]}>
+          <StatOverview statsData={statsData} />
+          <SessionsCalendar
+            userID={userID}
+            visibleDate={visibleDateData}
+            onDateChange={(date: DateData) => setVisibleDateData(date)}
+            drinkingSessionData={drinkingSessionData}
+            preferences={preferences}
+          />
+        </View>
         <View style={[styles.flexRow, styles.justifyContentEnd]}>
           {user?.uid !== userID && (
             <Button


### PR DESCRIPTION
### Details

The profile screen hid the sessions calendar entirely when the initial 3-month windowed fetch returned no sessions, showing a "no drinking sessions yet" message instead. That removed the only UI affordance (the left-arrow month nav) to widen the fetch window backwards — so any older sessions the user actually had became unreachable.

This PR removes the conditional and always renders `SessionsCalendar`. The downstream `useLazyMarkedDates` hook already handles a missing session list via `drinkingSessionData ?? {}` (see [src/components/SessionsCalendar/index.tsx:27](https://github.com/PetrCala/Kiroku/blob/master/src/components/SessionsCalendar/index.tsx#L27)), so an empty calendar renders cleanly and the user can press the left arrow to load older months.

The friend's last-session timestamp in the friend list serves as the proxy that tells the user how far back to scroll.

Also removes the now-unused `profileScreen.noDrinkingSessions` translation strings (en + cs_cz) and the `NoDrinkingSessionsParams` type.

### Tests

1. Open a profile (your own or a friend's) for a user who has **no sessions** in the last 3 months but does have sessions further back.
2. Verify the sessions calendar renders (empty, current month) instead of the "no drinking sessions yet" text.
3. Press the left-arrow several times to scroll back month-by-month.
4. Verify that as you scroll past the initial window, older sessions appear as marked days.
5. Open a profile for a user with recent sessions and verify the calendar behavior is unchanged.
6. Open your own profile when you have no sessions at all and verify the calendar still renders (empty) and is navigable.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open a profile that was previously cached with no recent sessions.
3. Verify the calendar still renders (will be empty if no cached data); no crash on missing `drinkingSessionData`.

### QA Steps

1. On staging, create or use an account with no sessions in the last 3 months but with older history.
2. Open the profile screen for that account.
3. Verify the calendar renders for the current month (empty) instead of a "no sessions" message.
4. Navigate back via the left arrow and verify older sessions load.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)