### PR TITLE
feat(calendar): inline spinner while fetching older months

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -1,14 +1,17 @@
 import React, {memo, useCallback, useEffect} from 'react';
+import {ActivityIndicator, View} from 'react-native';
 import {Calendar} from 'react-native-calendars';
 import type {DateData} from 'react-native-calendars';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import {format} from 'date-fns';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useStyleUtils from '@hooks/useStyleUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
+import Text from '@components/Text';
 import DayComponent from './DayComponent';
 import type {DayComponentProps} from './types';
 import CalendarArrow from './CalendarArrow';
@@ -46,6 +49,10 @@ type SessionsCalendarViewProps = {
 
   /** Hide the day-name row (M T W T F S S) */
   hideDayNames?: boolean;
+
+  /** Show an inline spinner next to the month header while older months are
+   *  being fetched after a back-nav past the loaded window edge. */
+  isFetchingOlderMonths?: boolean;
 };
 
 /**
@@ -71,9 +78,11 @@ function SessionsCalendarView({
   hideArrows,
   hideMonthHeader,
   hideDayNames,
+  isFetchingOlderMonths,
 }: SessionsCalendarViewProps) {
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
+  const theme = useTheme();
   const [preferredLocale] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
   const locale = preferredLocale ?? CONST.LOCALES.DEFAULT;
 
@@ -82,17 +91,57 @@ function SessionsCalendarView({
   }, [locale]);
 
   const dayComponent = useCallback(
-    ({date, state, marking, theme}: DayComponentProps) => (
+    ({date, state, marking, theme: dayTheme}: DayComponentProps) => (
       <DayComponent
         date={date}
         state={state}
         units={date ? unitsMap.get(date.dateString as DateString) : 0}
         marking={marking}
-        theme={theme}
+        theme={dayTheme}
         onPress={onDayPress}
       />
     ),
     [unitsMap, onDayPress],
+  );
+
+  // Custom header: matches the default month-text styling but reserves space
+  // for an inline spinner shown only while an older-months fetch is in flight.
+  // Keeping the header always-customized (not just when fetching) avoids a
+  // layout jump between native-header and custom-header rendering.
+  // The lib passes an `XDate` (no published d.ts; treated as `any` here). All we
+  // need is its epoch — extract via `getTime()` and rebuild a native `Date`.
+  const renderHeader = useCallback(
+    (date?: {getTime(): number}) => {
+      if (hideMonthHeader || !date) {
+        return null;
+      }
+      const formatted = format(
+        new Date(date.getTime()),
+        CONST.DATE.MONTH_YEAR_ABBR_FORMAT,
+      );
+      return (
+        <View style={styles.sessionsCalendarHeader}>
+          <Text style={styles.sessionsCalendarHeaderMonthText}>
+            {formatted}
+          </Text>
+          {isFetchingOlderMonths && (
+            <ActivityIndicator
+              size="small"
+              color={theme.spinner}
+              style={styles.sessionsCalendarHeaderSpinner}
+            />
+          )}
+        </View>
+      );
+    },
+    [
+      hideMonthHeader,
+      isFetchingOlderMonths,
+      styles.sessionsCalendarHeader,
+      styles.sessionsCalendarHeaderMonthText,
+      styles.sessionsCalendarHeaderSpinner,
+      theme.spinner,
+    ],
   );
 
   return (
@@ -110,7 +159,7 @@ function SessionsCalendarView({
       enableSwipeMonths={false}
       hideArrows={hideArrows}
       hideDayNames={hideDayNames}
-      renderHeader={hideMonthHeader ? () => null : undefined}
+      renderHeader={renderHeader}
       disableAllTouchEventsForDisabledDays
       renderArrow={(direction: Direction) => CalendarArrow(direction)}
       style={styles.sessionsCalendarContainer}

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -20,6 +20,7 @@ function SessionsCalendar({
   onDateChange,
   drinkingSessionData,
   preferences,
+  isFetchingOlderMonths,
 }: SessionsCalendarProps) {
   const {auth} = useFirebase();
   const user = auth.currentUser;
@@ -89,6 +90,7 @@ function SessionsCalendar({
       onDayPress={onDayPress}
       onLeftArrowPress={handleLeftArrowPress}
       onRightArrowPress={handleRightArrowPress}
+      isFetchingOlderMonths={isFetchingOlderMonths}
     />
   );
 }

--- a/src/components/SessionsCalendar/types.ts
+++ b/src/components/SessionsCalendar/types.ts
@@ -19,6 +19,10 @@ type SessionsCalendarProps = {
 
   /** User's preferences */
   preferences: Preferences;
+
+  /** Show an inline spinner next to the month header while older months are
+   *  being fetched after a back-nav past the loaded window edge. */
+  isFetchingOlderMonths?: boolean;
 };
 
 type SessionsCalendarDayMarking = {

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -21,6 +21,9 @@ type DatabaseDataContextType = {
   preferences?: Preferences;
   unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
+  /** True while a wider-window resubscribe for `drinkingSessionData` is in
+   *  flight (calendar scrolled past the loaded edge). */
+  isFetchingOlderMonths: boolean;
 };
 
 const DatabaseDataContext = createContext<DatabaseDataContextType | undefined>(
@@ -54,7 +57,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
     'userData',
   ];
 
-  const {data} = useListenToData(dataTypes, userID);
+  const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
 
   const value = useMemo(
     () => ({
@@ -63,8 +66,9 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
       preferences: data.preferences,
       unconfirmedDays: data.unconfirmedDays,
       userData: data.userData,
+      isFetchingOlderMonths,
     }),
-    [data],
+    [data, isFetchingOlderMonths],
   );
 
   // Sync theme preference from Firebase to Onyx when preferences are loaded

--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -17,6 +17,9 @@ type UseDrinkingSessionsFetchReturn = {
    *  without flipping this back to true. Consumers should NOT show a full
    *  loading state on widens. */
   isLoading: boolean;
+  /** True while a wider-window re-fetch is in flight (user scrolled the
+   *  calendar past the loaded edge). Cleared when the new `get()` resolves. */
+  isFetchingOlderMonths: boolean;
 };
 
 /**
@@ -42,6 +45,9 @@ function useDrinkingSessionsFetch(
 
   const [data, setData] = useState<DrinkingSessionList | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isFetchingOlderMonths, setIsFetchingOlderMonths] =
+    useState<boolean>(false);
+  const prevSessionsMonthsBackRef = useRef<number | null>(null);
 
   // Latest-wins request token. Bumped before each fetch; on resolve we ignore
   // the response unless its token still matches `currentTokenRef.current`.
@@ -74,6 +80,12 @@ function useDrinkingSessionsFetch(
     }
 
     const token = ++currentTokenRef.current;
+    const prev = prevSessionsMonthsBackRef.current;
+    const isWiden = prev !== null && sessionsMonthsBack > prev;
+    prevSessionsMonthsBackRef.current = sessionsMonthsBack;
+    if (isWiden) {
+      setIsFetchingOlderMonths(true);
+    }
     const startAtMillis = subMonths(new Date(), sessionsMonthsBack).getTime();
     const sessionsQuery = query(
       ref(db, path),
@@ -95,6 +107,7 @@ function useDrinkingSessionsFetch(
         hasResolvedInitialRef.current = true;
         setIsLoading(false);
       }
+      setIsFetchingOlderMonths(false);
     };
 
     get(sessionsQuery)
@@ -108,7 +121,7 @@ function useDrinkingSessionsFetch(
       .catch(() => finalize(undefined));
   }, [db, userID, sessionsMonthsBack, monthsLoadedMeta.status]);
 
-  return {data, isLoading};
+  return {data, isLoading, isFetchingOlderMonths};
 }
 
 export default useDrinkingSessionsFetch;

--- a/src/hooks/useListenToData/index.ts
+++ b/src/hooks/useListenToData/index.ts
@@ -16,7 +16,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {DrinkingSessionList} from '@src/types/onyx';
 import {subMonths} from 'date-fns';
 import {orderByChild, query, ref, startAt} from 'firebase/database';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import Onyx, {useOnyx} from 'react-native-onyx';
 
 /* eslint-disable react-compiler/react-compiler */
@@ -24,6 +24,11 @@ import Onyx, {useOnyx} from 'react-native-onyx';
 // Define a type for the hook's return value
 type UseListenToDataReturn = {
   data: FetchData;
+  /** True while a wider-window resubscribe for `drinkingSessionData` is in
+   *  flight (user scrolled the calendar past the loaded edge). Cleared on the
+   *  first listener callback after the widen. Stays false during the initial
+   *  subscription and during incremental live updates within the same window. */
+  isFetchingOlderMonths: boolean;
 };
 
 const DRINKING_SESSIONS_KEY: FetchDataKey = 'drinkingSessionData';
@@ -93,6 +98,16 @@ const useListenToData = (
     },
   );
 
+  // Tracks whether a widen (sessionsMonthsBack increase) is currently waiting
+  // on its first listener callback. Held in a ref so the listener closure can
+  // read+clear it without re-subscribing.
+  const [isFetchingOlderMonths, setIsFetchingOlderMonths] = useState(false);
+  const prevSessionsMonthsBackRef = useRef<number | null>(null);
+  const pendingWidenRef = useRef(false);
+  // Tracks the userID the widen-state refs above belong to, so we can reset
+  // them when the active user changes (their saved depth is independent).
+  const widenTrackedUserIDRef = useRef<string | undefined>(userID);
+
   // Reset session data during render when the active user changes so the
   // previous user's data never bleeds across an account switch. Seeds with the
   // new user's cached snapshot if one exists. See
@@ -100,6 +115,10 @@ const useListenToData = (
   const [prevUserID, setPrevUserID] = useState(userID);
   if (prevUserID !== userID) {
     setPrevUserID(userID);
+    if (isFetchingOlderMonths) {
+      // The new user's first subscription is an initial fetch, not a widen.
+      setIsFetchingOlderMonths(false);
+    }
     if (dataTypes.includes(DRINKING_SESSIONS_KEY)) {
       const seed =
         cachedSessions === null ? EMPTY_SESSIONS : cachedSessions ?? undefined;
@@ -156,6 +175,21 @@ const useListenToData = (
       return;
     }
 
+    if (widenTrackedUserIDRef.current !== userID) {
+      // userID changed — the saved depth for the new user is independent of
+      // the previous user's. Drop prior widen-tracking before comparing.
+      widenTrackedUserIDRef.current = userID;
+      prevSessionsMonthsBackRef.current = null;
+      pendingWidenRef.current = false;
+    }
+    const prev = prevSessionsMonthsBackRef.current;
+    if (prev !== null && sessionsMonthsBack > prev) {
+      // Widen detected — mark in-flight until the new subscription fires.
+      pendingWidenRef.current = true;
+      setIsFetchingOlderMonths(true);
+    }
+    prevSessionsMonthsBackRef.current = sessionsMonthsBack;
+
     const startAtMillis = subMonths(new Date(), sessionsMonthsBack).getTime();
     const sessionsQuery = query(
       ref(db, path),
@@ -169,6 +203,10 @@ const useListenToData = (
         ...prevData,
         [DRINKING_SESSIONS_KEY]: sessions,
       }));
+      if (pendingWidenRef.current) {
+        pendingWidenRef.current = false;
+        setIsFetchingOlderMonths(false);
+      }
 
       if (userID) {
         // Persist authoritative live data so the next cold launch can render
@@ -188,6 +226,7 @@ const useListenToData = (
 
   return {
     data: data as FetchData,
+    isFetchingOlderMonths,
   };
 };
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -62,7 +62,8 @@ function HomeScreen({route}: HomeScreenProps) {
   const {isOnline} = useUserConnection();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
-  const {drinkingSessionData, preferences, userData} = useDatabaseData();
+  const {drinkingSessionData, preferences, userData, isFetchingOlderMonths} =
+    useDatabaseData();
   const [visibleDate, setVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),
   );
@@ -189,6 +190,7 @@ function HomeScreen({route}: HomeScreenProps) {
           onDateChange={setVisibleDate}
           drinkingSessionData={drinkingSessionData}
           preferences={preferences}
+          isFetchingOlderMonths={isFetchingOlderMonths}
         />
       </>
     );

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -59,8 +59,11 @@ function ProfileScreen({route}: ProfileScreenProps) {
     userID,
     relevantDataKeys,
   );
-  const {data: drinkingSessionData, isLoading: isSessionsLoading} =
-    useDrinkingSessionsFetch(userID);
+  const {
+    data: drinkingSessionData,
+    isLoading: isSessionsLoading,
+    isFetchingOlderMonths,
+  } = useDrinkingSessionsFetch(userID);
   const isLoading = isFetchLoading || isSessionsLoading;
   const [selfFriends, setSelfFriends] = useState<UserList | null | undefined>();
   const [friendCount, setFriendCount] = useState(0);
@@ -218,6 +221,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
             onDateChange={(date: DateData) => setVisibleDateData(date)}
             drinkingSessionData={drinkingSessionData}
             preferences={preferences}
+            isFetchingOlderMonths={isFetchingOlderMonths}
           />
         </View>
         <View style={[styles.flexRow, styles.justifyContentEnd]}>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1544,6 +1544,22 @@ const styles = (theme: ThemeColors) =>
       borderBottomWidth: 1,
     },
 
+    sessionsCalendarHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+
+    sessionsCalendarHeaderMonthText: {
+      ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
+      color: theme.text,
+      fontSize: variables.fontSizeLarge,
+    },
+
+    sessionsCalendarHeaderSpinner: {
+      marginLeft: 8,
+    },
+
     sessionColorMarker: (sessionColor: CalendarColors) =>
       ({
         height: variables.sessionColorMarkerSize,


### PR DESCRIPTION
## Summary
- Adds a small `ActivityIndicator` next to the calendar's month header that appears while older months are being fetched after a back-nav past the loaded window edge. The calendar stays visible the whole time — no full-screen overlay.
- Plumbs a real `isFetchingOlderMonths` flag through `useListenToData` (home / self profile via `DatabaseDataContext`) and `useDrinkingSessionsFetch` (friend profiles). The flag flips true when `sessionsMonthsBack` increases and clears when the resubscribed listener fires (or the new `get()` resolves), so it tracks the actual round trip rather than a fixed timer.
- Replaces the calendar's default header rendering with a custom `renderHeader` that lays out the formatted month text plus the spinner. Styling mirrors the lib's default month text (`EXP_NEUE_BOLD`, `fontSizeLarge`).

## Notes
- `useListenToData` resets its widen-tracking refs when `userID` changes so a user switch doesn't get misread as a back-nav widen.
- `ConfigContext` also consumes `useListenToData` but only destructures `{data}` — adding a return field doesn't break it.

## Test plan
- [ ] Open the home calendar. Tap the left arrow repeatedly past the loaded edge — a small spinner should appear next to the month header while the older sessions are loading, then disappear once the data lands.
- [ ] Same on a friend's profile (back-nav past the initial 3-month window).
- [ ] No spinner shown on the initial mount of the calendar.
- [ ] No spinner shown for incremental live updates within the current window (e.g., a new session is added).
- [ ] Switching between own profile and a friend's doesn't leave the spinner stuck on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)