### PR TITLE
feat(devmenu): Clear Onyx item + TestToolsModal placeholder

### DIFF
--- a/src/components/CustomDevMenu/index.native.tsx
+++ b/src/components/CustomDevMenu/index.native.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect} from 'react';
 import {DevSettings} from 'react-native';
+import Onyx from 'react-native-onyx';
 import toggleTestToolsModal from '@userActions/TestTool';
 import type CustomDevMenuElement from './types';
 
@@ -7,6 +8,14 @@ const CustomDevMenu: CustomDevMenuElement = Object.assign(
   () => {
     useEffect(() => {
       DevSettings.addMenuItem('Open Test Preferences', toggleTestToolsModal);
+      DevSettings.addMenuItem('Clear Onyx', () => {
+        // Reload only after the wipe lands, so the next mount hydrates from
+        // empty storage (matches a cold install from Onyx's perspective).
+        // Firebase Auth keeps its own session, so the user stays signed in
+        // — useful for testing one-time-hydration paths like the
+        // earliest_session_at backfill without re-doing the sign-in dance.
+        Onyx.clear().finally(() => DevSettings.reload());
+      });
     }, []);
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <></>;

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -25,14 +25,14 @@ import type {
   AuthScreensParamList,
   RootStackParamList,
 } from '@libs/Navigation/types';
-// import toggleTestToolsModal from '@userActions/TestTool';
+import toggleTestToolsModal from '@userActions/TestTool';
 import CONST from '@src/CONST';
 // import CustomDevMenu from './CustomDevMenu';
 import HeaderGap from './HeaderGap';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
 // import OfflineIndicator from './OfflineIndicator';
 import SafeAreaConsumer from './SafeAreaConsumer';
-// import TestToolsModal from './TestToolsModal';
+import TestToolsModal from './TestToolsModal';
 import withNavigationFallback from './withNavigationFallback';
 import CustomDevMenu from './CustomDevMenu';
 // import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -170,10 +170,6 @@ function ScreenWrapper(
 
   isKeyboardShownRef.current = keyboardState?.isKeyboardShown ?? false;
 
-  const toggleTestToolsModal = () => {
-    // toggleTestToolsModal();
-  };
-
   const panResponder = useRef(
     PanResponder.create({
       onStartShouldSetPanResponderCapture: (_e, gestureState) =>
@@ -300,7 +296,7 @@ function ScreenWrapper(
                   }
                   enabled={shouldEnablePickerAvoiding}> */}
                 <HeaderGap styles={headerGapStyles} />
-                {/* <TestToolsModal /> */}
+                {isDevelopment && <TestToolsModal />}
                 {isDevelopment && <CustomDevMenu />}
                 <ScreenWrapperStatusContext.Provider value={contextValue}>
                   {

--- a/src/components/TestToolsModal/index.tsx
+++ b/src/components/TestToolsModal/index.tsx
@@ -1,0 +1,69 @@
+import {useCallback} from 'react';
+import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import Button from '@components/Button';
+import Modal from '@components/Modal';
+import Text from '@components/Text';
+import useEnvironment from '@hooks/useEnvironment';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import toggleTestToolsModal from '@userActions/TestTool';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+/**
+ * Developer-only debug panel. Opened via the CustomDevMenu entry
+ * (⌘D → Open Test Preferences) or by the four-finger tap gesture wired up
+ * in ScreenWrapper. Today this is a placeholder — the action and Onyx flag
+ * are real but the panel just explains what it's for. Real toggles (feature
+ * flags, environment overrides, forced network states, etc.) can be added
+ * directly to the View below.
+ */
+function TestToolsModal() {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const {environment} = useEnvironment();
+  const [isVisible] = useOnyx(ONYXKEYS.IS_TEST_TOOLS_MODAL_OPEN);
+
+  const handleClose = useCallback(() => {
+    if (isVisible) {
+      toggleTestToolsModal();
+    }
+  }, [isVisible]);
+
+  return (
+    <Modal
+      isVisible={!!isVisible}
+      type={CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
+      onClose={handleClose}>
+      <View style={[styles.p5, styles.gap4]}>
+        <Text style={styles.textHeadlineH1}>
+          {translate('testTools.title')}
+        </Text>
+        <Text style={[styles.textNormal, styles.textSupporting]}>
+          {translate('testTools.intro')}
+        </Text>
+        <Text style={[styles.textNormal, styles.textSupporting]}>
+          {translate('testTools.placeholderNotice')}
+        </Text>
+        <View style={styles.gap2}>
+          <Text style={[styles.textNormal, styles.textSupporting]}>
+            {`${translate('testTools.environmentLabel')}: ${environment}`}
+          </Text>
+          <Text style={[styles.textNormal, styles.textSupporting]}>
+            {translate('testTools.howToOpen')}
+          </Text>
+        </View>
+        <Button
+          large
+          success
+          text={translate('common.close')}
+          onPress={handleClose}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+TestToolsModal.displayName = 'TestToolsModal';
+export default TestToolsModal;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -884,6 +884,15 @@ export default {
     heading: 'Probíhá údržba',
     text: 'V současné době probíhá údržba v následujícím časovém rozmezí:',
   },
+  testTools: {
+    title: 'Testovací nástroje',
+    intro: 'Vývojářský panel pro úpravy za běhu a ladění.',
+    placeholderNotice:
+      'Toto je zástupný panel. Skutečné přepínače — feature flagy, přepsání prostředí, vynucené stavy sítě — sem postupně přibudou.',
+    environmentLabel: 'Prostředí',
+    howToOpen:
+      'Otevřete přes ⌘D → Open Test Preferences nebo čtyřprstovým ťuknutím kdekoli v aplikaci.',
+  },
   userOffline: {
     heading: 'Jste offline',
     text: 'Aplikace Kiroku zatím nepodporuje offline režim. Děkujeme vám za trpělivost při vývoji této funkce.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -895,6 +895,15 @@ export default {
     heading: 'Under Maintenance',
     text: 'We are currently under maintenance for the following time frame:',
   },
+  testTools: {
+    title: 'Test Tools',
+    intro: 'Developer-only panel for runtime tweaks and debugging.',
+    placeholderNotice:
+      'This is a placeholder. Real toggles — feature flags, environment overrides, forced network states — will land here over time.',
+    environmentLabel: 'Environment',
+    howToOpen:
+      'Open via ⌘D → Open Test Preferences, or a four-finger tap anywhere in the app.',
+  },
   userOffline: {
     heading: 'You are offline',
     text: 'Unfortunately, Kiroku does not support offline mode yet. We appreciate your patience while we work on this feature.',


### PR DESCRIPTION
### Details

Two related dev-menu improvements:

**1. Clear Onyx menu item.** Adds a new entry next to **Open Test Preferences** in the React Native dev menu (⌘D on simulator). Calls `Onyx.clear()` then `DevSettings.reload()` once the wipe lands, so the next mount hydrates from empty Onyx storage — same shape as a cold install from Onyx's perspective. Firebase Auth keeps its own session storage, so the user stays signed in across the reload. Deliberate: makes it easy to exercise one-time-hydration paths (e.g. the `earliest_session_at` backfill from [PR #487](https://github.com/PetrCala/Kiroku/pull/487)) without re-doing the sign-in dance.

**2. TestToolsModal as an informational placeholder.** The flag (`IS_TEST_TOOLS_MODAL_OPEN`), the toggle action (`src/libs/actions/TestTool.ts`), the dev-menu entry, and a four-finger-tap PanResponder in `ScreenWrapper` were all ported from Expensify but the modal component itself was commented out — so tapping the dev-menu item flipped an Onyx flag that nothing read. This lights up the scaffolding with a small panel that:

- Explains the Test Tools surface in one paragraph.
- Notes this is a placeholder so future toggles (feature flags, env overrides, forced network states) have a clear home.
- Shows the current environment.
- Tells the user how to open it (⌘D or four-finger tap).

The modal is gated on `isDevelopment`, matching the existing `CustomDevMenu` pattern. The local no-op `toggleTestToolsModal` stub in `ScreenWrapper` is removed so the PanResponder finally invokes the real action. Strings localized into `en.ts` and `cs_cz.ts`.

**Scope:** dev-only. `CustomDevMenu` is gated on `isDevelopment`, the modal render is gated on `isDevelopment`, and `DevSettings.addMenuItem` is a no-op in release builds anyway.

### Tests

1. Run the app in the iOS simulator: `npm run ios`
2. **⌘D** → verify both **Open Test Preferences** and **Clear Onyx** appear in the RN dev menu.
3. Tap **Clear Onyx** — app reloads with empty Onyx state, user stays signed in via Firebase.
4. Tap **Open Test Preferences** (or four-finger-tap anywhere in the app) — verify the **Test Tools** modal appears centered, with intro text, environment label, and how-to-open hint.
5. Tap **Close** — modal dismisses.
6. Tap **Open Test Preferences** again — modal toggles back open (covers the throttle).
- [ ] Verify that no errors appear in the JS console
- [ ] Verify the Czech translation displays correctly when locale is set to `cs_cz`

### Offline tests

Both items are pure local state. Clearing Onyx while offline still wipes storage and reloads; the post-reload app sits at the loading state until Firebase reconnects (same as a cold install with no network). The Test Tools modal has no network dependencies.

### QA Steps

Not applicable — both behaviors are dev-only and don't ship to production builds.

### PR Author Checklist

- [x] Behaviors are gated to dev builds (`isDevelopment` guard in `ScreenWrapper` + `DevSettings.addMenuItem` no-op in release)
- [x] Prettier / ESLint / `typecheck-tsgo` all clean on touched files (no new warnings; pre-existing `react-hooks/refs` and unused-disable warnings in `ScreenWrapper` are not from this PR)
- [x] Strings localized in en + cs_cz
- [x] No new dependencies
- [x] Existing utilities reused: `Modal`, `Button`, `Text`, `useThemeStyles`, `useLocalize`, `useEnvironment`, `useOnyx` — no new abstractions

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)