### PR TITLE
chore(firebase): migrate to RNFirebase modular API

### DIFF
--- a/src/components/ErrorBoundary/index.native.tsx
+++ b/src/components/ErrorBoundary/index.native.tsx
@@ -1,4 +1,8 @@
-import crashlytics from '@react-native-firebase/crashlytics';
+import {
+  getCrashlytics,
+  log,
+  recordError,
+} from '@react-native-firebase/crashlytics';
 import React from 'react';
 import Log from '@libs/Log';
 import BaseErrorBoundary from './BaseErrorBoundary';
@@ -13,8 +17,9 @@ const logError: LogError = (errorMessage, error, errorInfo) => {
     errorString.includes('native module') ||
     errorString.includes('rct');
 
-  crashlytics().recordError(error);
-  crashlytics().log(`${errorMessage} | errorInfo: ${errorInfo}`);
+  const crashlytics = getCrashlytics();
+  recordError(crashlytics, error);
+  log(crashlytics, `${errorMessage} | errorInfo: ${errorInfo}`);
 
   if (isFirebaseError) {
     // Firebase/native module initialization error detected

--- a/src/libs/Firebase/FirebasePerformance.native.ts
+++ b/src/libs/Firebase/FirebasePerformance.native.ts
@@ -1,19 +1,27 @@
-import perf from '@react-native-firebase/perf';
+import {getPerformance, trace} from '@react-native-firebase/perf';
 import type {FirebasePerformanceTypes} from '@react-native-firebase/perf';
 
 const activeTraces = new Map<string, FirebasePerformanceTypes.Trace>();
 
 async function startTrace(traceName: string): Promise<void> {
-  const trace = await perf().startTrace(traceName);
-  activeTraces.set(traceName, trace);
+  // The modular `trace()` export aliases its return type to
+  // `FirebasePerformanceTypes.Module.Trace`, which TS resolves to `unknown`
+  // (Module is a class, not a namespace, in the upstream types). Cast to the
+  // actual Trace class type to restore method visibility.
+  const traceInstance = trace(
+    getPerformance(),
+    traceName,
+  ) as FirebasePerformanceTypes.Trace;
+  await traceInstance.start();
+  activeTraces.set(traceName, traceInstance);
 }
 
 async function stopTrace(traceName: string): Promise<void> {
-  const trace = activeTraces.get(traceName);
-  if (!trace) {
+  const traceInstance = activeTraces.get(traceName);
+  if (!traceInstance) {
     return;
   }
-  await trace.stop();
+  await traceInstance.stop();
   activeTraces.delete(traceName);
 }
 

--- a/src/libs/setCrashlyticsUserId/index.native.ts
+++ b/src/libs/setCrashlyticsUserId/index.native.ts
@@ -1,7 +1,7 @@
-import crashlytics from '@react-native-firebase/crashlytics';
+import {getCrashlytics, setUserId} from '@react-native-firebase/crashlytics';
 
 const setCrashlyticsUserId = (accountID: string | number) => {
-  crashlytics().setUserId(String(accountID));
+  setUserId(getCrashlytics(), String(accountID));
 };
 
 export default setCrashlyticsUserId;

--- a/src/setup/platformSetup/index.native.ts
+++ b/src/setup/platformSetup/index.native.ts
@@ -1,8 +1,13 @@
-import crashlytics from '@react-native-firebase/crashlytics';
-import perf from '@react-native-firebase/perf';
+import {
+  getCrashlytics,
+  log,
+  recordError,
+  setCrashlyticsCollectionEnabled,
+} from '@react-native-firebase/crashlytics';
+import {getPerformance} from '@react-native-firebase/perf';
 import CONFIG from '@src/CONFIG';
 
-/* eslint-disable rulesdir/prefer-early-return */
+ 
 
 // Forwards uncaught JS errors to Crashlytics' log buffer before the default
 // handler runs. Worklet/Reanimated errors surface here as fatal JSErrors that
@@ -26,17 +31,19 @@ function installCrashlyticsJSErrorBridge() {
   const previousHandler = errorUtils.getGlobalHandler();
   errorUtils.setGlobalHandler((error, isFatal) => {
     try {
+      const crashlytics = getCrashlytics();
       const name = error?.name ?? 'Error';
       const message = error?.message ?? String(error);
-      crashlytics().log(
+      log(
+        crashlytics,
         `[JS ${isFatal ? 'FATAL' : 'soft'}] ${name}: ${message}`,
       );
       const stack = error?.stack;
       if (stack) {
-        crashlytics().log(stack.split('\n').slice(0, 30).join('\n'));
+        log(crashlytics, stack.split('\n').slice(0, 30).join('\n'));
       }
       if (error instanceof Error) {
-        crashlytics().recordError(error);
+        recordError(crashlytics, error);
       }
     } catch {
       // Never let the bridge itself throw — fall through to the default handler.
@@ -47,8 +54,8 @@ function installCrashlyticsJSErrorBridge() {
 
 export default function () {
   if (!CONFIG.SEND_CRASH_REPORTS) {
-    crashlytics().setCrashlyticsCollectionEnabled(false);
-    perf().setPerformanceCollectionEnabled(false);
+    setCrashlyticsCollectionEnabled(getCrashlytics(), false);
+    getPerformance().dataCollectionEnabled = false;
     return;
   }
   installCrashlyticsJSErrorBridge();


### PR DESCRIPTION
## Summary
- Silences the v22 deprecation warnings from `@react-native-firebase/perf` and `@react-native-firebase/crashlytics` that fire on every cold start, and gets the codebase ready for the next major release where the namespaced API is removed.
- Five call sites migrated from the default-export namespaced API (`perf()`, `crashlytics()`) to the new functional modular API (`getPerformance()` + `trace()`, `getCrashlytics()` + `setUserId` / `log` / `recordError` / `setCrashlyticsCollectionEnabled`).
- Behavior is unchanged — same Firebase services, same data, just the new call shape per https://rnfirebase.io/migrating-to-v22.

### Files touched
- [src/libs/Firebase/FirebasePerformance.native.ts](src/libs/Firebase/FirebasePerformance.native.ts) — `perf().startTrace(name)` → `trace(getPerformance(), name)` + `.start()`
- [src/libs/setCrashlyticsUserId/index.native.ts](src/libs/setCrashlyticsUserId/index.native.ts) — `crashlytics().setUserId(...)` → `setUserId(getCrashlytics(), ...)`
- [src/setup/platformSetup/index.native.ts](src/setup/platformSetup/index.native.ts) — `crashlytics().log/recordError/setCrashlyticsCollectionEnabled`, `perf().setPerformanceCollectionEnabled` → modular equivalents (perf opt-out uses `getPerformance().dataCollectionEnabled = false`, the recommended replacement)
- [src/components/ErrorBoundary/index.native.tsx](src/components/ErrorBoundary/index.native.tsx) — `crashlytics().recordError/log` → modular equivalents

## Notes
- The modular `trace()` export has a type-alias quirk in the upstream `@react-native-firebase/perf` types (`FirebasePerformanceTypes.Module.Trace` doesn't resolve, because `Module` is a class not a namespace). Added a single cast with an explanatory comment to restore method visibility — runtime is unaffected.
- These are all `.native.ts` / `.native.tsx` files; web fallbacks were already no-ops and don't need changes.

## Test plan
- [ ] **iOS cold start** — open the app, watch Metro / Xcode console: confirm none of these warnings appear anymore: `perf().startTrace`, `setCrashlyticsUserId`, `setUserId`.
- [ ] **Android cold start** — same check via `adb logcat | grep -i firebase` or Flipper / RN dev menu console.
- [ ] **Performance trace ends up in Firebase** — sign in to trigger the `AuthScreens` mount path (this is the `Timing.start` call site at `AuthScreens.tsx:185`); after a few minutes confirm a trace shows up in the Firebase Performance console for this build.
- [ ] **Crashlytics user id wired** — sign in, then in Firebase Crashlytics confirm a session shows the expected user id (Firebase auth uid) attached — proves `setUserId` flows through.
- [ ] **Force a non-fatal error** — use the dev menu's "Force JS error" or throw inside a screen wrapped in `ErrorBoundary`, confirm a non-fatal report lands in Crashlytics with the `errorMessage | errorInfo` log line attached.
- [ ] **Opt-out path** — temporarily flip `CONFIG.SEND_CRASH_REPORTS` to `false`, restart, confirm no crash reports and no perf traces are sent (and importantly, no crash on the `dataCollectionEnabled = false` assignment).
- [ ] **JS global error bridge** — trigger a synthetic uncaught error (e.g. via dev menu); confirm the `[JS soft] ...: ...` line appears in the next Crashlytics report's "Logs" tab.
- [ ] **Sign-out / sign-in cycle** — verifies `setUserId` is re-invoked from `Kiroku.tsx:261` without throwing.
- [ ] **CI** — `typecheck`, `lint`, `test` workflows green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)