### PR TITLE
refactor(onyx): drop deprecated withOnyx HOC shim

### DIFF
--- a/src/components/FormAlertWrapper.tsx
+++ b/src/components/FormAlertWrapper.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type Network from '@src/types/onyx/Network';
 import FormHelpMessage from './FormHelpMessage';
-import {withNetwork} from './OnyxProvider';
 import RenderHTML from './RenderHTML';
 import Text from './Text';
 
@@ -29,9 +28,6 @@ type FormAlertWrapperProps = {
   /** Error message to display above button */
   message?: string;
 
-  /** Props to detect online status */
-  network: Network;
-
   /** Callback fired when the "fix the errors" link is pressed */
   onFixTheErrorsLinkPressed?: () => void;
 };
@@ -47,11 +43,11 @@ function FormAlertWrapper({
   isAlertVisible = false,
   isMessageHtml = false,
   message = '',
-  network,
   onFixTheErrorsLinkPressed = () => {}, // eslint-disable-line @typescript-eslint/no-unused-vars
 }: FormAlertWrapperProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  const {isOffline} = useNetwork();
 
   let content;
   if (!message?.length) {
@@ -77,12 +73,11 @@ function FormAlertWrapper({
           {content}
         </FormHelpMessage>
       )}
-      {children(!!network?.isOffline)}
+      {children(isOffline)}
     </View>
   );
 }
 
 FormAlertWrapper.displayName = 'FormAlertWrapper';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-export default withNetwork()(FormAlertWrapper);
+export default FormAlertWrapper;

--- a/src/components/OnyxProvider.tsx
+++ b/src/components/OnyxProvider.tsx
@@ -5,10 +5,8 @@ import createOnyxContext from './createOnyxContext';
 
 // Set up any providers for individual keys. This should only be used in cases where many components will subscribe to
 // the same key (e.g. FlatList renderItem components)
-const [withNetwork, NetworkProvider, NetworkContext] = createOnyxContext(
-  ONYXKEYS.NETWORK,
-);
-const [withUserData, UserDataProvider, , useUserData] = createOnyxContext(
+const [NetworkProvider, NetworkContext] = createOnyxContext(ONYXKEYS.NETWORK);
+const [UserDataProvider, , useUserData] = createOnyxContext(
   ONYXKEYS.USER_DATA_LIST,
 );
 // const [withCurrentDate, CurrentDateProvider] = createOnyxContext(
@@ -31,8 +29,9 @@ const [withUserData, UserDataProvider, , useUserData] = createOnyxContext(
 // );
 // const [withReportCommentDrafts, ReportCommentDraftsProvider] =
 //   createOnyxContext(ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT);
-const [withPreferredTheme, PreferredThemeProvider, PreferredThemeContext] =
-  createOnyxContext(ONYXKEYS.PREFERRED_THEME);
+const [PreferredThemeProvider, PreferredThemeContext] = createOnyxContext(
+  ONYXKEYS.PREFERRED_THEME,
+);
 // const [
 //   withFrequentlyUsedEmojis,
 //   FrequentlyUsedEmojisProvider,
@@ -44,7 +43,7 @@ const [withPreferredTheme, PreferredThemeProvider, PreferredThemeContext] =
 //   PreferredEmojiSkinToneProvider,
 //   PreferredEmojiSkinToneContext,
 // ] = createOnyxContext(ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE);
-const [, SessionProvider, , useSession] = createOnyxContext(ONYXKEYS.SESSION);
+const [SessionProvider, , useSession] = createOnyxContext(ONYXKEYS.SESSION);
 
 type OnyxProviderProps = {
   /** Rendered child component */
@@ -76,25 +75,4 @@ OnyxProvider.displayName = 'OnyxProvider';
 
 export default OnyxProvider;
 
-export {
-  withNetwork,
-  withUserData,
-  useUserData,
-  //   withReportActionsDrafts,
-  //   withCurrentDate,
-  //   withBlockedFromConcierge,
-  //   withBetas,
-  NetworkContext,
-  //   BetasContext,
-  //   withReportCommentDrafts,
-  withPreferredTheme,
-  PreferredThemeContext,
-  //   useBetas,
-  //   withFrequentlyUsedEmojis,
-  //   useFrequentlyUsedEmojis,
-  //   withPreferredEmojiSkinTone,
-  //   PreferredEmojiSkinToneContext,
-  //   useBlockedFromConcierge,
-  //   useReportActionsDrafts,
-  useSession,
-};
+export {useUserData, NetworkContext, PreferredThemeContext, useSession};

--- a/src/components/createOnyxContext.tsx
+++ b/src/components/createOnyxContext.tsx
@@ -7,8 +7,6 @@ import {UCFirst} from '@libs/StringUtilsKiroku';
 
 // createOnyxContext return type
 type CreateOnyxContext<TOnyxKey extends OnyxKey> = [
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  () => (Component: ComponentType<any>) => ComponentType<any>, // Deprecated withOnyx HOC (for backward compatibility)
   ComponentType<ChildrenProps>, // Provider
   React.Context<OnyxValue<TOnyxKey>>, // Context
   () => NonNullable<OnyxValue<TOnyxKey>>, // useOnyxContext hook
@@ -34,17 +32,6 @@ export default <TOnyxKey extends OnyxKey>(
 
   Provider.displayName = `${UCFirst(onyxKeyName)}Provider`;
 
-  // Deprecated HOC for backward compatibility - maintains old withOnyx two-step calling pattern
-  // Old pattern: withNetwork()(Component)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const withOnyxKey = () => (Component: ComponentType<any>) => {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `withOnyx HOC is deprecated. Use ${UCFirst(onyxKeyName)}Provider and useOnyxContext instead.`,
-    );
-    return Component;
-  };
-
   const useOnyxContext = () => {
     const value = useContext(Context);
     if (value === CONTEXT_UNSET) {
@@ -56,7 +43,6 @@ export default <TOnyxKey extends OnyxKey>(
   };
 
   return [
-    withOnyxKey,
     Provider,
     Context as unknown as React.Context<OnyxValue<TOnyxKey>>,
     useOnyxContext,


### PR DESCRIPTION
## Summary
- Migrate `FormAlertWrapper` — the last caller of `withNetwork()` — to read offline state via the existing `useNetwork` hook.
- Remove the no-op `withOnyxKey` shim from `createOnyxContext` (the one that emitted the `withOnyx HOC is deprecated. Use NetworkProvider and useOnyxContext instead.` console warning) and the matching `withNetwork` / `withUserData` / `withPreferredTheme` re-exports from `OnyxProvider`.
- Side effect: this restores offline detection in `FormAlertWrapper`. The shim had stopped injecting the `network` prop, so the render-prop `isOffline` argument was silently always `false` for the offline-disabled submit button in `FormAlertWithSubmitButton`.

## Test plan
- [ ] App boots cleanly and the deprecation warning no longer appears on the auth screen.
- [ ] Submit a form while offline (airplane mode) — the submit button on `FormAlertWithSubmitButton` should render in the disabled offline variant.
- [ ] CI: typecheck, lint, tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)