### PR TITLE
fix(splash): stop false 'still visible' alert from stale closure

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -179,32 +179,38 @@ function Kiroku() {
   }, []);
 
   useEffect(() => {
-    setTimeout(() => {
-      const appState = AppState.currentState;
-      Log.info('[BootSplash] splash screen status', false, {
-        appState,
-        splashScreenState,
-      });
-
-      if (splashScreenState === CONST.BOOT_SPLASH_STATE.VISIBLE) {
-        const propsToLog = {
-          updateRequired,
-          updateAvailable,
-          // isSidebarLoaded,
-          // focusModeNotification,
-          isAuthenticated,
-          isThemeReady,
-          preferredTheme,
-          lastVisitedPath,
-        };
-        Log.alert(
-          '[BootSplash] splash screen is still visible',
-          {propsToLog},
-          false,
-        );
-      }
+    if (splashScreenState !== CONST.BOOT_SPLASH_STATE.VISIBLE) {
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      Log.alert(
+        '[BootSplash] splash screen is still visible',
+        {
+          propsToLog: {
+            appState: AppState.currentState,
+            updateRequired,
+            updateAvailable,
+            isAuthenticated,
+            isThemeReady,
+            preferredTheme,
+            lastVisitedPath,
+          },
+        },
+        false,
+      );
     }, 30 * 1000);
+    return () => clearTimeout(timer);
+  }, [
+    splashScreenState,
+    updateRequired,
+    updateAvailable,
+    isAuthenticated,
+    isThemeReady,
+    preferredTheme,
+    lastVisitedPath,
+  ]);
 
+  useEffect(() => {
     // This timer is set in the native layer when launching the app and we stop it here so we can measure how long
     // it took for the main app itself to load.
     // StartupTimer.stop();


### PR DESCRIPTION
## Summary
- The 30s splash diagnostic in [src/Kiroku.tsx](src/Kiroku.tsx) captured `splashScreenState` in its initial closure (deps array was `[]`), so it always logged the stale `'visible'` value 30s after startup, even after the splash hid normally.
- The captured `if (splashScreenState === VISIBLE)` branch then fired a misleading `[alrt] [BootSplash] splash screen is still visible` log on every clean boot. `propsToLog` was equally stale (e.g. `isAuthenticated: false` even for signed-in users).
- Moved the timer into its own effect gated on `splashScreenState`, with a cleanup that `clearTimeout`s the pending fire when the splash transitions to `HIDDEN`. All logged values are now in the deps array, so anything that does fire reflects current state.
- Dropped the redundant `[BootSplash] splash screen status` info log — the stuck-splash alert is the only event worth recording.

The actual splash hide path was never broken; only the telemetry was lying.

## Test plan
- [ ] Cold start the app authenticated — confirm no `[alrt] [BootSplash] splash screen is still visible` after 30s
- [ ] Cold start unauthenticated — same
- [ ] Artificially pin `shouldHideSplash` to false (e.g. force `isThemeReady` false) and confirm the alert *does* fire after 30s with accurate current-state `propsToLog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)