### PR TITLE
chore(i18n): localize remaining raw English UI strings

### DIFF
--- a/src/components/Buttons/SessionDrinksInputWindow.tsx
+++ b/src/components/Buttons/SessionDrinksInputWindow.tsx
@@ -4,6 +4,7 @@ import {sumDrinksOfSingleType} from '@libs/DataHandling';
 import * as DSUtils from '@src/libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import type {DrinkingSessionId, DrinkKey, DrinksList} from '@src/types/onyx';
+import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -27,6 +28,7 @@ function SessionDrinksInputWindow({
   sessionId,
 }: SessionDrinksInputWindowProps) {
   const styles = useThemeStyles();
+  const {translate} = useLocalize();
   const {preferences} = useDatabaseData();
   const [shouldHighlight, setShouldHighlight] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>(
@@ -157,7 +159,7 @@ function SessionDrinksInputWindow({
         onPress={handleContainerPress}
         style={styles.sessionDrinksInputContainer(shouldHighlight)}>
         <TextInput
-          accessibilityLabel="Text input field"
+          accessibilityLabel={translate('common.textInputField')}
           ref={inputRef}
           style={[
             styles.textLarge,

--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -363,9 +363,11 @@ function VerifyEmailModal() {
               style={[styles.mt2, styles.alignItemsCenter]}
               onPress={onDevSkipPress}
               role={CONST.ROLE.BUTTON}
-              accessibilityLabel="Skip verification (dev only)">
+              accessibilityLabel={translate(
+                'verifyEmailScreen.skipVerificationDevOnly',
+              )}>
               <Text style={[styles.link, styles.textSupporting]}>
-                Skip verification (dev only)
+                {translate('verifyEmailScreen.skipVerificationDevOnly')}
               </Text>
             </PressableWithFeedback>
           )}

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -39,6 +39,7 @@ export default {
     new: 'Nové',
     search: 'Hledat',
     searchWithThreeDots: 'Hledat...',
+    textInputField: 'Textové pole',
     next: 'Další',
     previous: 'Předchozí',
     goBack: 'Jít zpět',
@@ -731,6 +732,7 @@ export default {
     emailVerified: 'E-mail byl ověřen!',
     iHaveVerified: 'E-mail mám ověřený',
     useADifferentEmail: 'Špatný e-mail? Použijte jiný',
+    skipVerificationDevOnly: 'Přeskočit ověření (pouze pro vývoj)',
     changeEmail: {
       title: 'Použít jiný e-mail',
       prompt: 'Zadejte novou adresu a heslo — ověřovací odkaz vám pošleme tam.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -40,6 +40,7 @@ export default {
     new: 'New',
     search: 'Search',
     searchWithThreeDots: 'Search...',
+    textInputField: 'Text input field',
     next: 'Next',
     previous: 'Previous',
     goBack: 'Go back',
@@ -734,6 +735,7 @@ export default {
     emailVerified: 'Email verified!',
     iHaveVerified: 'I have verified my email',
     useADifferentEmail: 'Wrong email? Use a different one',
+    skipVerificationDevOnly: 'Skip verification (dev only)',
     changeEmail: {
       title: 'Use a different email',
       prompt:

--- a/src/libs/Navigation/AppNavigator/createCustomBottomTabNavigator/TopBar.tsx
+++ b/src/libs/Navigation/AppNavigator/createCustomBottomTabNavigator/TopBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {View} from 'react-native';
-import Text from '@components/Text';
 // import Search from '@components/Search';
 // import WorkspaceSwitcherButton from '@components/WorkspaceSwitcherButton';
 // import useActiveWorkspace from '@hooks/useActiveWorkspace';
@@ -28,7 +27,6 @@ function TopBar() {
       ]}
       // dataSet={{dragArea: true}}>
     >
-      <Text>Hello, world!</Text>
       {/* <WorkspaceSwitcherButton activeWorkspaceID={activeWorkspaceID} />
       <Search
         placeholder={translate('sidebarScreen.buttonSearch')}


### PR DESCRIPTION
## Summary
- Replaced `accessibilityLabel="Text input field"` in `SessionDrinksInputWindow` with `translate('common.textInputField')` (new common key).
- Replaced the dev-only `"Skip verification (dev only)"` label/text in `VerifyEmailModal` with `translate('verifyEmailScreen.skipVerificationDevOnly')` (new key under `verifyEmailScreen`).
- Removed the `<Text>Hello, world!</Text>` placeholder in the stubbed custom `TopBar` (the rest of that file is commented-out scaffold, so the placeholder is just deleted along with its now-unused `Text` import).
- Added matching Czech translations for both new keys.

These were the only user-visible raw English strings left in `src/` after a sweep of JSX text, `title`/`label`/`placeholder`/`accessibilityLabel` props, and `Alert.alert` calls. Logging-only strings (`Log.alert`, `throw new Error`, dev diagnostic `Alert.alert` in `HttpUtils`) and React `displayName` strings were intentionally left alone.

## Test plan
- [ ] Open the live drinking session screen → drink count input still works and reads "Text input field" to a screen reader (and "Textové pole" in Czech).
- [ ] In a dev/staging/adhoc build, sign up with an unverified email → the "Skip verification (dev only)" link still appears under the verify-email modal, localized.
- [ ] `npm run typecheck-tsgo` passes (verified locally).
- [ ] Lint passes on the changed files (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)