### PR TITLE
docs(statistics): add interactive preview + calendar variants

### DIFF
--- a/docs/statistics-calendar-variants.html
+++ b/docs/statistics-calendar-variants.html
@@ -1,0 +1,492 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kiroku · Sessions calendar — variants</title>
+<style>
+  :root {
+    --heat-0: transparent;
+    --heat-1: #FFF1A8;
+    --heat-2: #FFD86B;
+    --heat-3: #FFB627;
+    --heat-4: #FF8C00;
+    --heat-5: #E36800;
+    --brand-yellow: #FED607;
+    --brand-yellow-strong: #FFC403;
+
+    --page-bg: #F4F5F7;
+    --page-fg: #1A1D21;
+    --panel-bg: #FFFFFF;
+    --panel-border: #E5E7EB;
+    --muted: #6B7280;
+  }
+  body.theme-dark {
+    --page-bg: #0B0D11;
+    --page-fg: #F4F5F7;
+    --panel-bg: #181B22;
+    --panel-border: #232730;
+    --muted: #8B95A1;
+  }
+  body.theme-dark .frame {
+    --app-bg: #0F1115;
+    --card-bg: #181B22;
+    --card-border: #232730;
+    --text: #F4F5F7;
+    --text-supporting: #B9BFC8;
+    --text-muted: #7E8694;
+    --neutral-cell: #1F232C;
+  }
+  body:not(.theme-dark) .frame {
+    --app-bg: #FFFFFF;
+    --card-bg: #FFFFFF;
+    --card-border: #ECEEF1;
+    --text: #1A1D21;
+    --text-supporting: #495060;
+    --text-muted: #8B95A1;
+    --neutral-cell: #F4F5F7;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 0; background: var(--page-bg); color: var(--page-fg); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif; }
+
+  .toolbar {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; gap: 12px; align-items: center; padding: 12px 20px;
+    background: var(--panel-bg); border-bottom: 1px solid var(--panel-border);
+    flex-wrap: wrap;
+  }
+  .toolbar h1 { margin: 0; font-size: 15px; font-weight: 600; }
+  .toolbar .spacer { flex: 1; }
+  .toolbar .group { display: inline-flex; border: 1px solid var(--panel-border); border-radius: 8px; overflow: hidden; background: var(--panel-bg); }
+  .toolbar .group button { border: 0; padding: 6px 12px; background: transparent; cursor: pointer; font-size: 13px; border-right: 1px solid var(--panel-border); color: var(--page-fg); }
+  .toolbar .group button:last-child { border-right: 0; }
+  .toolbar .group button.active { background: var(--brand-yellow); font-weight: 600; color: #1A1D21; }
+
+  .stage { padding: 24px; max-width: 1400px; margin: 0 auto; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 28px;
+  }
+  @media (max-width: 920px) { .grid { grid-template-columns: 1fr; } }
+
+  .variant {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 20px;
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .variant .vhead { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+  .variant .vhead h2 { margin: 0; font-size: 16px; font-weight: 700; }
+  .variant .vhead .badge {
+    font-size: 10px; font-weight: 700; padding: 3px 8px; border-radius: 10px;
+    background: rgba(139, 92, 246, 0.15); color: #6D28D9;
+  }
+  .variant .pros-cons {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+    font-size: 12px; line-height: 1.5;
+  }
+  .variant .pros-cons h4 { font-size: 11px; font-weight: 700; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .variant .pros { color: #1F7A4D; }
+  .variant .cons { color: #B26A00; }
+  .variant .pros ul, .variant .cons ul { margin: 0; padding-left: 14px; color: var(--page-fg); }
+
+  /* ---- mini-frame containing the calendar so it looks in-context ---- */
+  .frame {
+    background: var(--app-bg); color: var(--text);
+    border-radius: 16px;
+    border: 1px solid var(--card-border);
+    padding: 14px;
+  }
+  .frame .heatmap-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+  .frame .heatmap-header h3 { font-size: 14px; margin: 0; font-weight: 600; }
+  .frame .heatmap-header .nav button {
+    width: 26px; height: 26px; border-radius: 7px;
+    background: transparent; border: 1px solid var(--card-border);
+    color: var(--text-supporting); cursor: pointer; margin-left: 4px;
+  }
+
+  .heatmap { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+  .heatmap .dow {
+    font-size: 10px; color: var(--text-muted); text-align: center; padding: 2px 0;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .heatmap .cell {
+    aspect-ratio: 1 / 1;
+    border-radius: 8px;
+    background: var(--neutral-cell);
+    position: relative;
+    overflow: hidden;
+  }
+  .heatmap .cell.muted { opacity: 0.35; }
+  .heatmap .cell.today { box-shadow: 0 0 0 2px var(--text) inset; }
+
+  /* level paints — used by variants A, B, D */
+  .heatmap .cell.level-1 { background: var(--heat-1); }
+  .heatmap .cell.level-2 { background: var(--heat-2); }
+  .heatmap .cell.level-3 { background: var(--heat-3); }
+  .heatmap .cell.level-4 { background: var(--heat-4); }
+  .heatmap .cell.level-5 { background: var(--heat-5); }
+
+  /* =====================================================================
+     VARIANT A — Stacked: day number on top, units small below
+     Color = background intensity. Single visual layer. Quietest.
+     ===================================================================== */
+  .va .cell {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 0;
+  }
+  .va .cell .daynum {
+    font-size: 11px; font-weight: 600; color: var(--text-supporting); line-height: 1;
+  }
+  .va .cell.level-3 .daynum,
+  .va .cell.level-4 .daynum,
+  .va .cell.level-5 .daynum { color: rgba(0,0,0,0.72); }
+  .va .cell .units {
+    font-size: 13px; font-weight: 700; color: var(--text); line-height: 1.1; margin-top: 1px;
+  }
+  .va .cell.level-3 .units,
+  .va .cell.level-4 .units,
+  .va .cell.level-5 .units { color: rgba(0,0,0,0.85); }
+
+  /* =====================================================================
+     VARIANT B — Corner chip: day number centered, tiny units pill top-right
+     Tint is soft (only 35% intensity). Day is hero, units is a footnote.
+     ===================================================================== */
+  .vb .cell {
+    background: var(--neutral-cell);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vb .cell.level-1 { background: color-mix(in srgb, var(--heat-1) 50%, var(--neutral-cell)); }
+  .vb .cell.level-2 { background: color-mix(in srgb, var(--heat-2) 50%, var(--neutral-cell)); }
+  .vb .cell.level-3 { background: color-mix(in srgb, var(--heat-3) 50%, var(--neutral-cell)); }
+  .vb .cell.level-4 { background: color-mix(in srgb, var(--heat-4) 55%, var(--neutral-cell)); }
+  .vb .cell.level-5 { background: color-mix(in srgb, var(--heat-5) 55%, var(--neutral-cell)); }
+  .vb .cell .daynum {
+    font-size: 14px; font-weight: 600; color: var(--text);
+  }
+  .vb .cell .chip {
+    position: absolute; top: 3px; right: 3px;
+    background: rgba(0,0,0,0.55); color: #fff;
+    font-size: 9px; font-weight: 700;
+    padding: 1px 4px; border-radius: 6px; line-height: 1.2;
+  }
+  body.theme-dark .vb .cell .chip { background: rgba(255,255,255,0.78); color: #1A1D21; }
+
+  /* =====================================================================
+     VARIANT C — Two-zone: day on neutral top, units on colored bottom
+     Strong separation. Always readable. Mirrors the current chip pattern
+     but spread across the whole cell so color intensity still encodes load.
+     ===================================================================== */
+  .vc .cell {
+    background: var(--neutral-cell);
+    display: flex; flex-direction: column;
+  }
+  .vc .cell .top {
+    flex: 1; display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 600; color: var(--text-supporting);
+  }
+  .vc .cell .bot {
+    height: 14px;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--neutral-cell);
+    font-size: 10px; font-weight: 700; color: rgba(0,0,0,0.7);
+  }
+  .vc .cell.level-1 .bot { background: var(--heat-1); }
+  .vc .cell.level-2 .bot { background: var(--heat-2); }
+  .vc .cell.level-3 .bot { background: var(--heat-3); }
+  .vc .cell.level-4 .bot { background: var(--heat-4); color: rgba(0,0,0,0.85); }
+  .vc .cell.level-5 .bot { background: var(--heat-5); color: rgba(255,255,255,0.95); }
+  /* level-0 = AF day → bottom strip invisible, cell looks pure neutral */
+  .vc .cell.level-0 .bot { background: transparent; }
+
+  /* =====================================================================
+     VARIANT D — Units-as-hero: when units > 0, the units number IS the
+     cell (big, centered). Day number tucks to the corner. AF days show
+     only the day number, no number/zero noise. Most distinct rhythm.
+     ===================================================================== */
+  .vd .cell {
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vd .cell .daynum {
+    position: absolute; top: 3px; left: 5px;
+    font-size: 9px; font-weight: 600; color: var(--text-muted); line-height: 1;
+  }
+  .vd .cell.level-3 .daynum,
+  .vd .cell.level-4 .daynum,
+  .vd .cell.level-5 .daynum { color: rgba(0,0,0,0.55); }
+  .vd .cell .units {
+    font-size: 15px; font-weight: 700; color: var(--text);
+  }
+  .vd .cell.level-3 .units,
+  .vd .cell.level-4 .units,
+  .vd .cell.level-5 .units { color: rgba(0,0,0,0.85); }
+  /* AF days: day number stays in the corner; cell center is empty.
+     Color intensity tells the story; units only render when > 0. */
+
+  /* legend */
+  .legend {
+    display: flex; gap: 6px; align-items: center;
+    font-size: 10px; color: var(--text-muted);
+    margin-top: 10px; justify-content: flex-end;
+  }
+  .legend .swatch { width: 12px; height: 12px; border-radius: 3px; }
+
+  /* picker bar */
+  .pick-bar {
+    margin-top: 28px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 18px 20px;
+    display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+  }
+  .pick-bar h3 { margin: 0; font-size: 14px; font-weight: 700; }
+  .pick-bar p { margin: 0; font-size: 13px; color: var(--muted); }
+</style>
+</head>
+<body class="theme-light">
+  <div class="toolbar">
+    <h1>Sessions calendar — variants</h1>
+    <span class="spacer"></span>
+    <div class="group" data-toggle="theme">
+      <button data-theme="light" class="active">Light</button>
+      <button data-theme="dark">Dark</button>
+    </div>
+  </div>
+
+  <div class="stage">
+    <div class="grid">
+
+      <!-- ============================ VARIANT A ============================ -->
+      <div class="variant">
+        <div class="vhead">
+          <h2>A · Stacked</h2>
+          <span class="badge">day on top, units below</span>
+        </div>
+        <div class="frame">
+          <div class="heatmap-header">
+            <h3>May 2026</h3>
+            <div class="nav"><button>‹</button><button>›</button></div>
+          </div>
+          <div class="heatmap va" data-grid></div>
+          <div class="legend">
+            <span>Less</span>
+            <span class="swatch" style="background: var(--neutral-cell)"></span>
+            <span class="swatch" style="background: var(--heat-1)"></span>
+            <span class="swatch" style="background: var(--heat-2)"></span>
+            <span class="swatch" style="background: var(--heat-3)"></span>
+            <span class="swatch" style="background: var(--heat-4)"></span>
+            <span class="swatch" style="background: var(--heat-5)"></span>
+            <span>More</span>
+          </div>
+        </div>
+        <div class="pros-cons">
+          <div class="pros"><h4>Strengths</h4><ul><li>Closest to existing mental model (day + units)</li><li>Both data points always visible</li><li>Simplest a11y story</li></ul></div>
+          <div class="cons"><h4>Costs</h4><ul><li>Two text rows per cell can read busy at month-scale</li><li>Contrast on level-3/4/5 needs careful tuning</li></ul></div>
+        </div>
+      </div>
+
+      <!-- ============================ VARIANT B ============================ -->
+      <div class="variant">
+        <div class="vhead">
+          <h2>B · Corner chip</h2>
+          <span class="badge">day hero, units footnote</span>
+        </div>
+        <div class="frame">
+          <div class="heatmap-header">
+            <h3>May 2026</h3>
+            <div class="nav"><button>‹</button><button>›</button></div>
+          </div>
+          <div class="heatmap vb" data-grid></div>
+          <div class="legend">
+            <span>Less</span>
+            <span class="swatch" style="background: var(--neutral-cell)"></span>
+            <span class="swatch" style="background: color-mix(in srgb, var(--heat-1) 50%, var(--neutral-cell))"></span>
+            <span class="swatch" style="background: color-mix(in srgb, var(--heat-2) 50%, var(--neutral-cell))"></span>
+            <span class="swatch" style="background: color-mix(in srgb, var(--heat-3) 50%, var(--neutral-cell))"></span>
+            <span class="swatch" style="background: color-mix(in srgb, var(--heat-4) 55%, var(--neutral-cell))"></span>
+            <span class="swatch" style="background: color-mix(in srgb, var(--heat-5) 55%, var(--neutral-cell))"></span>
+            <span>More</span>
+          </div>
+        </div>
+        <div class="pros-cons">
+          <div class="pros"><h4>Strengths</h4><ul><li>Calmest at a glance — date dominates, color is mood</li><li>Tint stays subtle so cell never looks "loud"</li><li>Best for users who navigate by date first</li></ul></div>
+          <div class="cons"><h4>Costs</h4><ul><li>Units chip is small (9px) — readability on small screens?</li><li>Less direct mapping from existing colored-circle UI</li></ul></div>
+        </div>
+      </div>
+
+      <!-- ============================ VARIANT C ============================ -->
+      <div class="variant">
+        <div class="vhead">
+          <h2>C · Two-zone</h2>
+          <span class="badge">neutral top, colored bottom strip</span>
+        </div>
+        <div class="frame">
+          <div class="heatmap-header">
+            <h3>May 2026</h3>
+            <div class="nav"><button>‹</button><button>›</button></div>
+          </div>
+          <div class="heatmap vc" data-grid></div>
+          <div class="legend">
+            <span>Less</span>
+            <span class="swatch" style="background: var(--neutral-cell)"></span>
+            <span class="swatch" style="background: var(--heat-1)"></span>
+            <span class="swatch" style="background: var(--heat-2)"></span>
+            <span class="swatch" style="background: var(--heat-3)"></span>
+            <span class="swatch" style="background: var(--heat-4)"></span>
+            <span class="swatch" style="background: var(--heat-5)"></span>
+            <span>More</span>
+          </div>
+        </div>
+        <div class="pros-cons">
+          <div class="pros"><h4>Strengths</h4><ul><li>Day number always on neutral — perfectly readable</li><li>AF days look visibly "clean" (no colored strip)</li><li>Closest to the current colored-pill metaphor, just spread out</li></ul></div>
+          <div class="cons"><h4>Costs</h4><ul><li>Two-zone construction = slightly more Skia path math</li><li>Color band is shorter → intensity feels less dominant</li></ul></div>
+        </div>
+      </div>
+
+      <!-- ============================ VARIANT D ============================ -->
+      <div class="variant">
+        <div class="vhead">
+          <h2>D · Units-as-hero <span style="font-size: 11px; color: #1F7A4D; font-weight: 700;">✓ CHOSEN</span></h2>
+          <span class="badge">units centered; day number always in corner</span>
+        </div>
+        <div class="frame">
+          <div class="heatmap-header">
+            <h3>May 2026</h3>
+            <div class="nav"><button>‹</button><button>›</button></div>
+          </div>
+          <div class="heatmap vd" data-grid></div>
+          <div class="legend">
+            <span>Less</span>
+            <span class="swatch" style="background: var(--neutral-cell)"></span>
+            <span class="swatch" style="background: var(--heat-1)"></span>
+            <span class="swatch" style="background: var(--heat-2)"></span>
+            <span class="swatch" style="background: var(--heat-3)"></span>
+            <span class="swatch" style="background: var(--heat-4)"></span>
+            <span class="swatch" style="background: var(--heat-5)"></span>
+            <span>More</span>
+          </div>
+        </div>
+        <div class="pros-cons">
+          <div class="pros"><h4>Strengths</h4><ul><li>Strong rhythm — eye is drawn to drink days, AF days fade back</li><li>Reinforces the "AF days are the win" framing from doc §3</li><li>Single dominant element per cell — never busy</li></ul></div>
+          <div class="cons"><h4>Costs</h4><ul><li>Day-number lookup is harder (corner, small)</li><li>Two layouts per cell type = more cases in the Skia code</li></ul></div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="pick-bar">
+      <h3>Pick a direction →</h3>
+      <p>Once you point at A / B / C / D (or a Frankenstein of two), I'll spawn a separate session with the chosen variant locked in and a self-contained brief to migrate <code>src/components/SessionsCalendar/DayComponent</code>.</p>
+    </div>
+  </div>
+
+<script>
+  // Theme toggle
+  document.querySelectorAll('.toolbar .group').forEach(group => {
+    group.addEventListener('click', e => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      group.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      if (group.dataset.toggle === 'theme') {
+        document.body.classList.toggle('theme-dark', btn.dataset.theme === 'dark');
+      }
+    });
+  });
+
+  // Shared mock data — same shape for all 4 variants so they're directly comparable
+  // -1 = off-month padding, 0 = AF day, 1..5 = units bucket
+  const heatLevels = [
+    -1,-1,-1,-1,  0, 2, 1,    // W1: leading padding + Fri/Sat/Sun (May 1-3)
+     0, 0, 1, 0,  2, 3, 4,    // W2 (May 4-10)
+     0, 1, 0, 0,  0, 2, 3,    // W3 (May 11-17)
+     0, 0, 2, 0,  1, 2, 0,    // W4 (May 18-24)
+     0, 1, 0, 0,  0,-1,-1,    // W5 (May 25-31)
+  ];
+  // Approximate units value to render in each cell (level 0 = no units)
+  const unitsValues = [
+    null,null,null,null,  0, 2,   1.5,
+       0,   0, 1,   0,   2.5, 4,   6,
+       0, 1.5, 0,   0,    0, 2,   4.5,
+       0,   0, 3,   0,    1, 2,   0,
+       0,   1, 0,   0,    0,null,null,
+  ];
+  const dayNums = [27,28,29,30, 1,2,3, 4,5,6,7,8,9,10, 11,12,13,14,15,16,17, 18,19,20,21,22,23,24, 25,26,27,28,29,30,31];
+  const dowLabels = ['M','T','W','T','F','S','S'];
+  const todayIdx = 25; // May 22
+
+  function fmtUnits(u) {
+    if (u === null || u === undefined) return '';
+    return Number.isInteger(u) ? String(u) : u.toFixed(1);
+  }
+
+  function build(grid, variant) {
+    dowLabels.forEach(d => {
+      const el = document.createElement('div');
+      el.className = 'dow'; el.textContent = d;
+      grid.appendChild(el);
+    });
+    for (let i = 0; i < heatLevels.length; i++) {
+      const lvl = heatLevels[i];
+      const cell = document.createElement('div');
+      const muted = (lvl === -1);
+      cell.className = 'cell ' + (muted ? 'muted level-0' : 'level-' + lvl);
+      if (i === todayIdx) cell.classList.add('today');
+      const day = dayNums[i];
+      const units = unitsValues[i];
+
+      if (variant === 'A') {
+        if (day !== undefined) {
+          const dn = document.createElement('span'); dn.className = 'daynum'; dn.textContent = day;
+          cell.appendChild(dn);
+        }
+        if (!muted && units !== null && units > 0) {
+          const u = document.createElement('span'); u.className = 'units'; u.textContent = fmtUnits(units);
+          cell.appendChild(u);
+        }
+      } else if (variant === 'B') {
+        if (day !== undefined) {
+          const dn = document.createElement('span'); dn.className = 'daynum'; dn.textContent = day;
+          cell.appendChild(dn);
+        }
+        if (!muted && units !== null && units > 0) {
+          const u = document.createElement('span'); u.className = 'chip'; u.textContent = fmtUnits(units);
+          cell.appendChild(u);
+        }
+      } else if (variant === 'C') {
+        const top = document.createElement('div'); top.className = 'top';
+        top.textContent = (day !== undefined) ? day : '';
+        const bot = document.createElement('div'); bot.className = 'bot';
+        bot.textContent = (!muted && units !== null && units > 0) ? fmtUnits(units) : '';
+        cell.appendChild(top); cell.appendChild(bot);
+      } else if (variant === 'D') {
+        if (!muted && units !== null && units > 0) {
+          if (day !== undefined) {
+            const dn = document.createElement('span'); dn.className = 'daynum'; dn.textContent = day;
+            cell.appendChild(dn);
+          }
+          const u = document.createElement('span'); u.className = 'units'; u.textContent = fmtUnits(units);
+          cell.appendChild(u);
+        } else {
+          // AF day or muted — show only day number, centered
+          if (day !== undefined) {
+            const dn = document.createElement('span'); dn.className = 'daynum'; dn.textContent = day;
+            cell.appendChild(dn);
+          }
+        }
+      }
+      grid.appendChild(cell);
+    }
+  }
+
+  document.querySelectorAll('.heatmap.va').forEach(g => build(g, 'A'));
+  document.querySelectorAll('.heatmap.vb').forEach(g => build(g, 'B'));
+  document.querySelectorAll('.heatmap.vc').forEach(g => build(g, 'C'));
+  document.querySelectorAll('.heatmap.vd').forEach(g => build(g, 'D'));
+</script>
+</body>
+</html>

--- a/docs/statistics-preview.html
+++ b/docs/statistics-preview.html
@@ -1,0 +1,649 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kiroku · Statistics v1 — Preview</title>
+<style>
+  /* ============================================================
+     Kiroku Statistics v1 — interactive preview
+     Companion to contributingGuides/STATISTICS.md and epic #498.
+     Single-file, no build. Open in any browser.
+     ============================================================ */
+
+  :root {
+    /* Kiroku brand palette — derived from src/styles/theme/themes/{light,dark}.ts */
+    --brand-yellow: #FED607;
+    --brand-yellow-strong: #FFC403;
+    --brand-orange-200: #FF9F1C;
+    --brand-orange-500: #E36800;
+    --brand-orange-800: #8C3D00;
+
+    /* Units-to-colors heatmap ramp (yellow → orange, NO red, per §3) */
+    --heat-0: transparent;
+    --heat-1: #FFF1A8;
+    --heat-2: #FFD86B;
+    --heat-3: #FFB627;
+    --heat-4: #FF8C00;
+    --heat-5: #E36800;
+
+    /* Page chrome */
+    --page-bg: #F4F5F7;
+    --page-fg: #1A1D21;
+    --panel-bg: #FFFFFF;
+    --panel-border: #E5E7EB;
+    --muted: #6B7280;
+  }
+
+  body.theme-dark .frame {
+    --app-bg: #0F1115;
+    --card-bg: #181B22;
+    --card-border: #232730;
+    --text: #F4F5F7;
+    --text-supporting: #B9BFC8;
+    --text-muted: #7E8694;
+    --divider: #232730;
+    --skeleton: #232730;
+    --skeleton-shimmer: #2D323D;
+    --tone-supportive: #2A2310;
+    --tone-celebratory: #2A1F0D;
+    --header-bg: #0F1115;
+  }
+  body:not(.theme-dark) .frame {
+    --app-bg: #FFFFFF;
+    --card-bg: #FFFFFF;
+    --card-border: #ECEEF1;
+    --text: #1A1D21;
+    --text-supporting: #495060;
+    --text-muted: #8B95A1;
+    --divider: #ECEEF1;
+    --skeleton: #ECEEF1;
+    --skeleton-shimmer: #F4F5F7;
+    --tone-supportive: #FFF8E1;
+    --tone-celebratory: #FFF4DA;
+    --header-bg: #FFFFFF;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--page-bg);
+    color: var(--page-fg);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ---------- top toolbar ---------- */
+  .toolbar {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; gap: 12px; align-items: center;
+    padding: 12px 20px;
+    background: var(--panel-bg);
+    border-bottom: 1px solid var(--panel-border);
+    flex-wrap: wrap;
+  }
+  .toolbar h1 {
+    margin: 0; font-size: 15px; font-weight: 600;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .toolbar h1 .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--brand-yellow-strong); }
+  .toolbar .meta { font-size: 12px; color: var(--muted); }
+  .toolbar .spacer { flex: 1; }
+  .toolbar .group {
+    display: inline-flex; border: 1px solid var(--panel-border); border-radius: 8px; overflow: hidden; background: white;
+  }
+  .toolbar .group button {
+    border: 0; padding: 6px 12px; background: transparent; cursor: pointer; font-size: 13px;
+    border-right: 1px solid var(--panel-border);
+  }
+  .toolbar .group button:last-child { border-right: 0; }
+  .toolbar .group button.active { background: var(--brand-yellow); font-weight: 600; }
+  .toolbar a.linkbtn {
+    font-size: 12px; color: #2563EB; text-decoration: none; padding: 6px 10px;
+    border: 1px solid var(--panel-border); border-radius: 8px; background: white;
+  }
+  .toolbar a.linkbtn:hover { background: #F4F5F7; }
+
+  /* ---------- main layout ---------- */
+  .stage {
+    display: grid;
+    grid-template-columns: minmax(420px, 1fr) 380px;
+    gap: 24px;
+    padding: 24px;
+    align-items: start;
+    max-width: 1280px; margin: 0 auto;
+  }
+  @media (max-width: 960px) {
+    .stage { grid-template-columns: 1fr; }
+  }
+
+  /* ---------- device frame ---------- */
+  .device {
+    width: 390px; margin: 0 auto;
+    background: #0F1115; border-radius: 44px; padding: 14px;
+    box-shadow: 0 30px 60px rgba(0,0,0,0.18), 0 8px 20px rgba(0,0,0,0.08);
+    position: relative;
+  }
+  .device .notch {
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    width: 120px; height: 28px; background: #0F1115; border-radius: 0 0 18px 18px; z-index: 3;
+  }
+  .frame {
+    background: var(--app-bg); color: var(--text);
+    border-radius: 32px; overflow: hidden;
+    height: 740px; display: flex; flex-direction: column;
+    position: relative;
+  }
+  .frame .statusbar {
+    height: 44px; flex: 0 0 auto;
+    display: flex; justify-content: space-between; align-items: flex-end;
+    padding: 0 28px 6px; font-size: 12px; font-weight: 600; color: var(--text);
+    background: var(--header-bg);
+  }
+  .frame .header {
+    padding: 8px 16px 14px; background: var(--header-bg);
+    display: flex; align-items: center; gap: 8px;
+    border-bottom: 1px solid var(--divider);
+  }
+  .frame .header .back { width: 28px; height: 28px; display: grid; place-items: center; color: var(--text-supporting); }
+  .frame .header h2 { margin: 0; font-size: 17px; font-weight: 600; }
+  .frame .scroll {
+    flex: 1; overflow-y: auto;
+    padding: 16px 14px 28px;
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .frame .scroll::-webkit-scrollbar { width: 4px; }
+  .frame .scroll::-webkit-scrollbar-thumb { background: var(--card-border); border-radius: 2px; }
+
+  /* ---------- cards ---------- */
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 14px;
+    position: relative;
+  }
+  .card .title { font-size: 13px; color: var(--text-supporting); margin: 0 0 2px; font-weight: 500; }
+  .card .subtitle { font-size: 12px; color: var(--text-muted); margin: 0; }
+
+  /* ---------- KPI 3-up grid ---------- */
+  .kpi-group { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .kpi {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 12px 12px 10px;
+    display: flex; flex-direction: column; gap: 4px;
+    min-height: 96px;
+    position: relative;
+  }
+  .kpi.tone-supportive { background: var(--tone-supportive); }
+  .kpi.tone-celebratory { background: var(--tone-celebratory); border-color: var(--brand-yellow-strong); }
+  .kpi.span-2 { grid-column: 1 / -1; }
+  .kpi .label { font-size: 11px; color: var(--text-supporting); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; }
+  .kpi .value-row { display: flex; align-items: baseline; gap: 6px; }
+  .kpi .value { font-size: 28px; font-weight: 700; color: var(--text); line-height: 1.1; }
+  .kpi .unit { font-size: 12px; color: var(--text-supporting); }
+  .kpi .delta {
+    display: inline-flex; align-items: center; gap: 3px;
+    font-size: 11px; font-weight: 600; color: var(--text-supporting);
+  }
+  .kpi .delta.up   { color: #B26A00; }
+  .kpi .delta.down { color: #1F7A4D; }   /* down = good in this app (less drinking) */
+  .kpi .delta.flat { color: var(--text-muted); }
+  .kpi .sparkline { margin-top: 6px; height: 26px; }
+
+  /* ---------- calendar heatmap ---------- */
+  .heatmap {
+    display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px;
+  }
+  .heatmap .dow {
+    font-size: 10px; color: var(--text-muted); text-align: center; padding: 2px 0;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .heatmap .cell {
+    aspect-ratio: 1 / 1; border-radius: 6px;
+    background: var(--card-border);
+    position: relative;
+  }
+  .heatmap .cell.muted { opacity: 0.3; }
+  .heatmap .cell .daynum {
+    position: absolute; top: 2px; left: 4px;
+    font-size: 9px; color: rgba(0,0,0,0.45); font-weight: 600;
+  }
+  body.theme-dark .heatmap .cell .daynum { color: rgba(255,255,255,0.6); }
+  .heatmap .cell.level-0 { background: var(--card-border); }
+  .heatmap .cell.level-1 { background: var(--heat-1); }
+  .heatmap .cell.level-2 { background: var(--heat-2); }
+  .heatmap .cell.level-3 { background: var(--heat-3); }
+  .heatmap .cell.level-4 { background: var(--heat-4); }
+  .heatmap .cell.level-5 { background: var(--heat-5); }
+  .heatmap .cell.today { box-shadow: 0 0 0 2px var(--text) inset; }
+
+  .heatmap-header {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 8px;
+  }
+  .heatmap-header .nav { display: flex; gap: 4px; }
+  .heatmap-header .nav button {
+    width: 28px; height: 28px; border-radius: 8px; background: transparent;
+    border: 1px solid var(--card-border); cursor: pointer; color: var(--text-supporting);
+  }
+  .heatmap-header h3 { font-size: 14px; font-weight: 600; margin: 0; color: var(--text); }
+  .heatmap-legend {
+    display: flex; gap: 6px; align-items: center;
+    font-size: 10px; color: var(--text-muted);
+    margin-top: 10px; justify-content: flex-end;
+  }
+  .heatmap-legend .swatch { width: 12px; height: 12px; border-radius: 3px; }
+
+  /* ---------- weekly bars ---------- */
+  .weekly {
+    height: 160px; position: relative;
+    margin-top: 8px;
+  }
+  .weekly .band {
+    position: absolute; left: 0; right: 0;
+    background: var(--text);
+    opacity: 0.06;
+    pointer-events: none;
+  }
+  .weekly .band-label {
+    position: absolute; right: 0;
+    font-size: 9px; color: var(--text-muted);
+    background: var(--card-bg); padding: 0 4px;
+  }
+  .weekly .bars {
+    position: absolute; inset: 0;
+    display: grid; grid-template-columns: repeat(8, 1fr); gap: 8px;
+    align-items: end;
+  }
+  .weekly .bar-col { display: flex; flex-direction: column; align-items: center; height: 100%; gap: 6px; }
+  .weekly .bar-col .bar {
+    width: 80%;
+    background: linear-gradient(180deg, var(--brand-yellow-strong) 0%, var(--brand-orange-200) 100%);
+    border-radius: 6px 6px 2px 2px;
+    transition: opacity 0.15s;
+  }
+  .weekly .bar-col .bar.current { background: linear-gradient(180deg, var(--brand-orange-200) 0%, var(--brand-orange-500) 100%); }
+  .weekly .bar-col .wklabel { font-size: 9px; color: var(--text-muted); }
+
+  /* ---------- footer copy ---------- */
+  .footer-note {
+    text-align: center; font-size: 12px; color: var(--text-muted);
+    padding: 4px 16px 8px; font-style: italic;
+  }
+
+  /* ---------- empty / loading states ---------- */
+  .empty-illustration {
+    width: 64px; height: 64px; border-radius: 50%;
+    background: var(--brand-yellow); margin: 24px auto 12px;
+    display: grid; place-items: center; font-size: 32px;
+  }
+  .empty-title { text-align: center; font-size: 17px; font-weight: 600; margin: 0 16px 6px; color: var(--text); }
+  .empty-body { text-align: center; font-size: 13px; color: var(--text-supporting); margin: 0 24px 24px; line-height: 1.5; }
+  .empty-cta {
+    display: block; margin: 0 auto; padding: 12px 24px;
+    background: var(--brand-yellow); color: #1A1D21;
+    border: 0; border-radius: 12px; font-weight: 600; font-size: 14px; cursor: pointer;
+  }
+  .skeleton {
+    background: linear-gradient(90deg, var(--skeleton) 0%, var(--skeleton-shimmer) 50%, var(--skeleton) 100%);
+    background-size: 200% 100%;
+    animation: shimmer 1.4s linear infinite;
+    border-radius: 8px;
+  }
+  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  .skel-line { height: 12px; margin-bottom: 8px; }
+  .skel-block { height: 120px; }
+
+  /* ---------- issue-map overlay ---------- */
+  body.show-issuemap [data-issue]::after {
+    content: '#' attr(data-issue);
+    position: absolute;
+    top: -8px; right: -8px;
+    background: #8B5CF6; color: white;
+    font-size: 10px; font-weight: 700;
+    padding: 2px 6px; border-radius: 10px;
+    box-shadow: 0 2px 6px rgba(139, 92, 246, 0.4);
+    z-index: 5;
+  }
+  body.show-issuemap [data-issue] { outline: 1px dashed rgba(139, 92, 246, 0.5); outline-offset: 2px; }
+
+  /* ---------- right-side steering panel ---------- */
+  .panel {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 18px;
+    position: sticky; top: 80px;
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .panel h2 { font-size: 14px; font-weight: 700; margin: 0; }
+  .panel section { display: flex; flex-direction: column; gap: 6px; }
+  .panel section h3 { font-size: 12px; font-weight: 600; margin: 0; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  .panel ol, .panel ul { margin: 0; padding-left: 18px; font-size: 13px; line-height: 1.5; }
+  .panel .qa { font-size: 12px; color: #6B7280; }
+  .panel textarea {
+    width: 100%; min-height: 100px;
+    font-family: inherit; font-size: 13px;
+    border: 1px solid var(--panel-border); border-radius: 8px;
+    padding: 8px; resize: vertical;
+  }
+  .panel .pill {
+    display: inline-block; background: rgba(139, 92, 246, 0.12); color: #6D28D9;
+    font-size: 10px; padding: 2px 6px; border-radius: 10px; font-weight: 600;
+    margin-left: 4px;
+  }
+
+  /* ---------- state-specific visibility ---------- */
+  .frame[data-state="populated"] .state-empty,
+  .frame[data-state="populated"] .state-loading { display: none; }
+  .frame[data-state="empty"] .state-populated,
+  .frame[data-state="empty"] .state-loading { display: none; }
+  .frame[data-state="loading"] .state-populated,
+  .frame[data-state="loading"] .state-empty { display: none; }
+</style>
+</head>
+<body class="theme-light">
+  <div class="toolbar">
+    <h1><span class="dot"></span> Kiroku · Statistics v1 preview</h1>
+    <span class="meta">epic #498 · design doc §7</span>
+    <span class="spacer"></span>
+
+    <div class="group" data-toggle="state">
+      <button data-state="populated" class="active">Populated</button>
+      <button data-state="empty">Empty</button>
+      <button data-state="loading">Loading</button>
+    </div>
+
+    <div class="group" data-toggle="theme">
+      <button data-theme="light" class="active">Light</button>
+      <button data-theme="dark">Dark</button>
+    </div>
+
+    <div class="group" data-toggle="issuemap">
+      <button data-issuemap="off" class="active">Map: off</button>
+      <button data-issuemap="on">Map: on</button>
+    </div>
+
+    <a class="linkbtn" href="https://github.com/PetrCala/Kiroku/blob/feature/statistics/contributingGuides/STATISTICS.md" target="_blank">Design doc ↗</a>
+  </div>
+
+  <div class="stage">
+    <!-- ============ DEVICE FRAME ============ -->
+    <div class="device">
+      <div class="notch"></div>
+      <div class="frame" data-state="populated">
+        <div class="statusbar"><span>9:41</span><span>● ● ●</span></div>
+        <div class="header" data-issue="509">
+          <div class="back">‹</div>
+          <h2>Statistics</h2>
+        </div>
+
+        <!-- ============ POPULATED STATE ============ -->
+        <div class="scroll state-populated">
+
+          <!-- KPI 3-up (actually 2×2 on this width) -->
+          <div class="kpi-group" data-issue="506">
+            <div class="kpi tone-celebratory" data-issue="501">
+              <span class="label">Alcohol-free days</span>
+              <div class="value-row">
+                <span class="value">14</span>
+                <span class="unit">/ 22 this month</span>
+              </div>
+              <span class="delta down">▲ 3 vs last month</span>
+              <svg class="sparkline" viewBox="0 0 100 26" preserveAspectRatio="none">
+                <polyline points="0,18 14,16 28,14 42,15 56,12 70,10 84,7 100,5" fill="none" stroke="var(--brand-orange-500)" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </div>
+
+            <div class="kpi" data-issue="501">
+              <span class="label">Sessions this week</span>
+              <div class="value-row">
+                <span class="value">2</span>
+              </div>
+              <span class="delta down">▼ 1 vs last week</span>
+              <svg class="sparkline" viewBox="0 0 100 26" preserveAspectRatio="none">
+                <polyline points="0,8 14,10 28,6 42,12 56,8 70,14 84,16 100,18" fill="none" stroke="var(--brand-yellow-strong)" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </div>
+
+            <div class="kpi" data-issue="501">
+              <span class="label">Avg units / session</span>
+              <div class="value-row">
+                <span class="value">2.3</span>
+                <span class="unit">rolling 30d</span>
+              </div>
+              <span class="delta flat">— steady</span>
+              <svg class="sparkline" viewBox="0 0 100 26" preserveAspectRatio="none">
+                <polyline points="0,14 14,12 28,15 42,13 56,14 70,12 84,15 100,13" fill="none" stroke="var(--brand-yellow-strong)" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </div>
+
+            <div class="kpi tone-supportive" data-issue="501">
+              <span class="label">Units this week</span>
+              <div class="value-row">
+                <span class="value">4.6</span>
+              </div>
+              <span class="delta down">▼ 2.1 vs last week</span>
+              <svg class="sparkline" viewBox="0 0 100 26" preserveAspectRatio="none">
+                <polyline points="0,8 14,10 28,8 42,12 56,10 70,14 84,16 100,18" fill="none" stroke="var(--brand-orange-200)" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </div>
+          </div>
+
+          <!-- Calendar heatmap -->
+          <div class="card" data-issue="508">
+            <div class="heatmap-header">
+              <h3>May 2026</h3>
+              <div class="nav">
+                <button>‹</button>
+                <button>›</button>
+              </div>
+            </div>
+            <div class="heatmap" id="heatmap-grid">
+              <!-- populated by JS -->
+            </div>
+            <div class="heatmap-legend">
+              <span>Less</span>
+              <span class="swatch" style="background: var(--card-border);"></span>
+              <span class="swatch" style="background: var(--heat-1);"></span>
+              <span class="swatch" style="background: var(--heat-2);"></span>
+              <span class="swatch" style="background: var(--heat-3);"></span>
+              <span class="swatch" style="background: var(--heat-4);"></span>
+              <span class="swatch" style="background: var(--heat-5);"></span>
+              <span>More</span>
+            </div>
+          </div>
+
+          <!-- Weekly bars -->
+          <div class="card" data-issue="507">
+            <p class="title">Weekly trend</p>
+            <p class="subtitle">Last 8 weeks · band shows your typical range</p>
+            <div class="weekly" id="weekly-bars">
+              <!-- populated by JS -->
+            </div>
+          </div>
+
+          <div class="footer-note">You're inside your usual range this week. Nice and steady. 🌱</div>
+        </div>
+
+        <!-- ============ EMPTY STATE ============ -->
+        <div class="scroll state-empty">
+          <div class="empty-illustration">📊</div>
+          <h3 class="empty-title">Your statistics live here</h3>
+          <p class="empty-body">Once you've logged a few sessions, this screen will show your alcohol-free days, weekly trends, and a calendar overview — all framed around what you're doing well.</p>
+          <button class="empty-cta">Log a session</button>
+        </div>
+
+        <!-- ============ LOADING STATE ============ -->
+        <div class="scroll state-loading">
+          <div class="kpi-group">
+            <div class="kpi"><div class="skeleton skel-line" style="width: 60%;"></div><div class="skeleton" style="height: 28px; width: 40%; margin-top: 4px;"></div><div class="skeleton skel-line" style="width: 80%; margin-top: 10px;"></div></div>
+            <div class="kpi"><div class="skeleton skel-line" style="width: 60%;"></div><div class="skeleton" style="height: 28px; width: 40%; margin-top: 4px;"></div><div class="skeleton skel-line" style="width: 80%; margin-top: 10px;"></div></div>
+            <div class="kpi"><div class="skeleton skel-line" style="width: 60%;"></div><div class="skeleton" style="height: 28px; width: 40%; margin-top: 4px;"></div><div class="skeleton skel-line" style="width: 80%; margin-top: 10px;"></div></div>
+            <div class="kpi"><div class="skeleton skel-line" style="width: 60%;"></div><div class="skeleton" style="height: 28px; width: 40%; margin-top: 4px;"></div><div class="skeleton skel-line" style="width: 80%; margin-top: 10px;"></div></div>
+          </div>
+          <div class="card"><div class="skeleton skel-line" style="width: 40%;"></div><div class="skeleton skel-block" style="margin-top: 10px;"></div></div>
+          <div class="card"><div class="skeleton skel-line" style="width: 40%;"></div><div class="skeleton skel-block" style="margin-top: 10px;"></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============ STEERING PANEL ============ -->
+    <div class="panel">
+      <h2>Steering notes</h2>
+
+      <section>
+        <h3>What this preview is</h3>
+        <p style="font-size: 13px; margin: 0; color: var(--page-fg);">
+          The v1 Statistics screen as described in <a href="https://github.com/PetrCala/Kiroku/blob/feature/statistics/contributingGuides/STATISTICS.md#7-concrete-v1-surface" target="_blank">design doc §7</a>,
+          composed of the 4 KPIs, calendar heatmap, and 8-week bars with band-of-normal overlay.
+          Toggle <b>Map: on</b> to see which GitHub issue implements each element.
+        </p>
+      </section>
+
+      <section>
+        <h3>Issue map</h3>
+        <ul>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/498" target="_blank">#498</a> — epic</li>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/501" target="_blank">#501</a> — KPI selectors</li>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/506" target="_blank">#506</a> — KpiCard + group shell</li>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/507" target="_blank">#507</a> — WeeklyBars chart</li>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/508" target="_blank">#508</a> — CalendarHeatmap (Skia)</li>
+          <li><a href="https://github.com/PetrCala/Kiroku/issues/509" target="_blank">#509</a> — screen + nav entry + states</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Open product questions <span class="pill">decide</span></h3>
+        <ol>
+          <li><b>3-up KPI grid:</b> Doc says 3-up, but with 4 KPIs we render 2×2 on a 390px screen. Drop one? Or stack 1+3?</li>
+          <li><b>"Delta down = good":</b> drinking less is good but visually <i>down</i> often reads as bad. Preview reverses color (down=green, up=amber). Keep, or use ↓ + green pill consistently?</li>
+          <li><b>Hero KPI:</b> Should "alcohol-free days" be visually elevated (full-width, celebratory tone) since it's the most affirmative metric? Preview tones it celebratory but keeps grid size.</li>
+          <li><b>Footer copy:</b> tone-adaptive ("you're inside your usual range", "nice and steady", "your alcohol-free days are climbing") vs. static reassurance.</li>
+          <li><b>Nav entry:</b> bottom tab vs. Profile entry — doc §11 Q1 still open.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h3>Your steering notes</h3>
+        <textarea placeholder="Type your reactions here. I'll fold them into a follow-up — feedback to existing issues, new issues, or design-doc edits."></textarea>
+        <p class="qa">These notes are local-only — save the file or copy them out.</p>
+      </section>
+
+      <section>
+        <h3>Suggested next moves</h3>
+        <ol>
+          <li>React to the layout above; tell me what to change.</li>
+          <li>I iterate the preview (it's one file).</li>
+          <li>Once stable, commit it as <code>docs/statistics-preview.html</code> and link it from each Phase B/C issue so the orchestrator's agents see it.</li>
+          <li>I file follow-up issues for the decisions above and edit the design doc where needed.</li>
+        </ol>
+      </section>
+    </div>
+  </div>
+
+<script>
+  // ----- toolbar wiring -----
+  document.querySelectorAll('.toolbar .group').forEach(group => {
+    group.addEventListener('click', e => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      group.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const kind = group.dataset.toggle;
+      if (kind === 'state') {
+        document.querySelector('.frame').dataset.state = btn.dataset.state;
+      } else if (kind === 'theme') {
+        document.body.classList.toggle('theme-dark', btn.dataset.theme === 'dark');
+      } else if (kind === 'issuemap') {
+        document.body.classList.toggle('show-issuemap', btn.dataset.issuemap === 'on');
+      }
+    });
+  });
+
+  // ----- realistic mock data: 31 days of session activity for May 2026 -----
+  // Levels 0..5 where 0 = alcohol-free, 5 = heaviest day in the window.
+  // Weighted so ~45% of days are alcohol-free (matches "14 of 22 this month" hero KPI).
+  const heatLevels = [
+    /* W1 (Apr 27 - May 3, May only from May 1) */ -1, -1, -1, -1,  0, 2, 1,
+    /* W2 (May 4 - May 10)                     */  0,  0,  1,  0,  2, 3, 4,
+    /* W3 (May 11 - May 17)                    */  0,  1,  0,  0,  0, 2, 3,
+    /* W4 (May 18 - May 24)                    */  0,  0,  2,  0,  1, 2, 0,
+    /* W5 (May 25 - May 31)                    */  0,  1,  0,  0,  0,-1,-1,
+  ];
+  const dowLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const grid = document.getElementById('heatmap-grid');
+  dowLabels.forEach(d => {
+    const el = document.createElement('div');
+    el.className = 'dow'; el.textContent = d;
+    grid.appendChild(el);
+  });
+  // Day numbers: Apr 27..30 are muted, May 1..31, then padding muted
+  const dayNums = [27,28,29,30, 1,2,3, 4,5,6,7,8,9,10, 11,12,13,14,15,16,17, 18,19,20,21,22,23,24, 25,26,27,28,29,30,31];
+  // First 4 cells and any -1 cells render as muted/off-month
+  for (let i = 0; i < heatLevels.length; i++) {
+    const cell = document.createElement('div');
+    const lvl = heatLevels[i];
+    if (lvl === -1) {
+      cell.className = 'cell muted level-0';
+    } else {
+      cell.className = `cell level-${lvl}`;
+    }
+    const d = dayNums[i];
+    if (d !== undefined) {
+      const tag = document.createElement('span');
+      tag.className = 'daynum'; tag.textContent = d;
+      cell.appendChild(tag);
+    }
+    // Mark May 22 as "today"
+    if (i === 25) cell.classList.add('today');
+    grid.appendChild(cell);
+  }
+
+  // ----- weekly bars (8 weeks, units per week) -----
+  // Each value in 0..1 of chart height. Band is p25..p75 of these.
+  const weeks = [
+    {label: 'W14', val: 0.55},
+    {label: 'W15', val: 0.72},
+    {label: 'W16', val: 0.48},
+    {label: 'W17', val: 0.83},
+    {label: 'W18', val: 0.62},
+    {label: 'W19', val: 0.95},
+    {label: 'W20', val: 0.51},
+    {label: 'W21', val: 0.32}, // current week — lowest, supportive cue
+  ];
+  // p25, p75 of these vals (rough)
+  const sorted = [...weeks.map(w => w.val)].sort((a,b)=>a-b);
+  const p25 = sorted[1], p75 = sorted[5];
+  const chart = document.getElementById('weekly-bars');
+  const band = document.createElement('div');
+  band.className = 'band';
+  band.style.bottom = (p25 * 130) + 'px';
+  band.style.height = ((p75 - p25) * 130) + 'px';
+  chart.appendChild(band);
+  const bandLabel = document.createElement('div');
+  bandLabel.className = 'band-label';
+  bandLabel.textContent = 'your typical range';
+  bandLabel.style.bottom = (p75 * 130 + 2) + 'px';
+  chart.appendChild(bandLabel);
+  const barsWrap = document.createElement('div');
+  barsWrap.className = 'bars';
+  weeks.forEach((w, i) => {
+    const col = document.createElement('div');
+    col.className = 'bar-col';
+    const bar = document.createElement('div');
+    bar.className = 'bar' + (i === weeks.length - 1 ? ' current' : '');
+    bar.style.height = (w.val * 130) + 'px';
+    const lbl = document.createElement('span');
+    lbl.className = 'wklabel'; lbl.textContent = w.label;
+    col.appendChild(bar);
+    col.appendChild(lbl);
+    barsWrap.appendChild(col);
+  });
+  chart.appendChild(barsWrap);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Two self-contained HTML artifacts that give the Statistics epic (#498) visual ground truth — open either file directly in a browser, no build needed.

- **`docs/statistics-preview.html`** — the full v1 Statistics screen from [design doc §7](https://github.com/PetrCala/Kiroku/blob/feature/statistics/contributingGuides/STATISTICS.md#7-concrete-v1-surface): 4 KPI cards, calendar heatmap, 8-week bars with the Whoop-style band-of-normal overlay. Includes:
  - Populated / Empty / Loading state toggle
  - Light / Dark theme toggle
  - **Issue-map overlay** — toggle "Map: on" to see purple `#NNN` badges tying each block to its implementing issue (#501, #506, #507, #508, #509)
  - Steering panel on the right surfacing 5 open product questions that the design doc leaves under-specified
- **`docs/statistics-calendar-variants.html`** — 4 explored day-cell designs (Stacked / Corner chip / Two-zone / Units-as-hero) with pros and costs for each. **Variant D (Units-as-hero) is locked as the chosen direction**: day number always in the corner, units number centered when > 0, color intensity from `Preferences.units_to_colors`. This will be the spec for the upcoming `SessionsCalendar/DayComponent` redesign.

## Why this lives in the repo

The orchestrator's agents working through #499–#509 should reference these as a north star. Without a committed artifact, the visual intent lives only in chat history and drifts as tasks land.

## Test plan

- [ ] Open `docs/statistics-preview.html` in a browser — confirm all 3 states render, theme toggle works, issue-map overlay annotates the right blocks
- [ ] Open `docs/statistics-calendar-variants.html` — confirm all 4 variants render with mock data, theme toggle works, Variant D is marked ✓ CHOSEN
- [ ] No code changes — no need for typecheck / lint / build

## Notes

- No new dependencies, no source code changes, no Onyx changes
- The actual implementation of the locked calendar variant is being kicked off as a separate session, scoped to `src/components/SessionsCalendar/DayComponent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)