### PR TITLE
feat(calendar): redesign sessions calendar day cell to Variant D

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -833,7 +833,7 @@
 "src/storage/storageUpload.ts"	"@typescript-eslint/switch-exhaustiveness-check"	1
 "src/styles/utils/generators/ModalStyleUtils.ts"	"@typescript-eslint/switch-exhaustiveness-check"	1
 "src/styles/utils/generators/ReportActionContextMenuStyleUtils.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"src/styles/utils/index.ts"	"@typescript-eslint/switch-exhaustiveness-check"	5
+"src/styles/utils/index.ts"	"@typescript-eslint/switch-exhaustiveness-check"	4
 "src/types/modules/jest.d.ts"	"@typescript-eslint/ban-types"	1
 "src/types/modules/jest.d.ts"	"@typescript-eslint/no-empty-object-type"	1
 "src/types/modules/react-native.d.ts"	"@typescript-eslint/no-empty-object-type"	9

--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -2,7 +2,6 @@ import {View} from 'react-native';
 import Text from '@components/Text';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import useStyleUtils from '@hooks/useStyleUtils';
-import useThemeStyles from '@hooks/useThemeStyles';
 import type {DayComponentProps} from '@components/SessionsCalendar/types';
 
 function DayComponent({
@@ -13,7 +12,6 @@ function DayComponent({
   theme, // eslint-disable-line @typescript-eslint/no-unused-vars
   onPress,
 }: DayComponentProps) {
-  const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
   const isDisabled = state === 'disabled';
   const isToday = state === 'today';
@@ -25,28 +23,26 @@ function DayComponent({
   return (
     <PressableWithoutFeedback
       accessibilityLabel=""
-      style={[
-        styles.alignItemsCenter,
-        styles.justifyContentCenter,
-        // styles.mnw100, // Uncomment to offset the text labels to the left
-      ]}
       onPress={() => onPress && date && onPress(date)}>
-      <Text
-        style={StyleUtils.getSessionsCalendarDayLabelStyle(
+      <View
+        style={StyleUtils.getSessionsCalendarDayCellStyle(
+          marking,
           isDisabled,
           isToday,
         )}>
-        {date?.day}
-      </Text>
-      <View
-        style={StyleUtils.getSessionsCalendarDayMarkingContainerStyle(
-          marking,
-          isDisabled,
-        )}>
         <Text
-          style={StyleUtils.getSessionsCalendarDayMarkingTextStyle(marking)}>
-          {unitsText}
+          style={StyleUtils.getSessionsCalendarDayLabelStyle(
+            marking,
+            isDisabled,
+          )}>
+          {date?.day}
         </Text>
+        {unitsText !== '' && (
+          <Text
+            style={StyleUtils.getSessionsCalendarDayUnitsTextStyle(marking)}>
+            {unitsText}
+          </Text>
+        )}
       </View>
     </PressableWithoutFeedback>
   );

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -155,29 +155,26 @@ function ColorPaletteScreen() {
               return (
                 <View
                   key={cell.day}
-                  style={[
-                    styles.alignItemsCenter,
-                    styles.justifyContentCenter,
-                  ]}>
+                  style={StyleUtils.getSessionsCalendarDayCellStyle(
+                    marking,
+                    false,
+                    false,
+                  )}>
                   <Text
                     style={StyleUtils.getSessionsCalendarDayLabelStyle(
-                      false,
+                      marking,
                       false,
                     )}>
                     {cell.day}
                   </Text>
-                  <View
-                    style={StyleUtils.getSessionsCalendarDayMarkingContainerStyle(
-                      marking,
-                      false,
-                    )}>
+                  {unitsText !== '' && (
                     <Text
-                      style={StyleUtils.getSessionsCalendarDayMarkingTextStyle(
+                      style={StyleUtils.getSessionsCalendarDayUnitsTextStyle(
                         marking,
                       )}>
                       {unitsText}
                     </Text>
-                  </View>
+                  )}
                 </View>
               );
             })}

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1323,23 +1323,24 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
   /**
    * Returns the outer cell style for a sessions-calendar day (Variant D).
    *
-   * The whole cell carries the heatmap tint; the day-number sits absolute in
-   * the top-left and the units number is centered as the visual hero. Today is
-   * marked with a 2px inset ring; off-month / disabled cells dim to ~35%.
+   * The whole cell carries the heatmap tint when a marking is present; days
+   * without a marking (future / outside the loaded data range) render as a
+   * transparent shell so they read as "no data" rather than "rest day".
+   * Today gets a 2px inset ring; off-month cells dim to ~35%.
    */
   getSessionsCalendarDayCellStyle: (
     marking: MarkingProps | undefined,
     isDisabled: boolean,
     isToday: boolean,
   ): ViewStyle => {
-    const backgroundColor = marking?.color ?? CONST.CALENDAR_COLORS.DARK.GREEN;
+    const markingColor = marking?.color;
     return {
-      width: variables.componentSizeNormalSmall,
-      height: variables.componentSizeNormalSmall,
+      width: variables.sessionsCalendarDaySize,
+      height: variables.sessionsCalendarDaySize,
       borderRadius: variables.componentBorderRadiusNormal,
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor,
+      backgroundColor: markingColor ?? 'transparent',
       opacity: isDisabled ? 0.35 : 1,
       borderWidth: isToday ? 2 : 0,
       borderColor: isToday ? theme.text : 'transparent',
@@ -1350,15 +1351,20 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
    * Returns the corner day-number label style (Variant D).
    *
    * Always positioned absolute top-left, including on alcohol-free days — the
-   * empty center is what signals AF, not a re-centered day number.
+   * empty center is what signals AF, not a re-centered day number. When the
+   * cell has no marking (future / out-of-range), the label uses the muted
+   * theme text color rather than light/dark inversion.
    */
   getSessionsCalendarDayLabelStyle: (
     marking: MarkingProps | undefined,
     isDisabled: boolean,
   ): TextStyle => {
-    const isLightColor = !!marking?.color && isLightHex(marking.color);
+    const markingColor = marking?.color;
+    const isLightColor = !!markingColor && isLightHex(markingColor);
     let textColor: Color;
-    if (isDisabled) {
+    if (!markingColor) {
+      textColor = theme.textSupporting;
+    } else if (isDisabled) {
       textColor = theme.textMutedReversed;
     } else if (isLightColor) {
       textColor = theme.textDark;

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1321,60 +1321,71 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
   },
 
   /**
-   * Returns the style for the sessions calendar month day label, e.g. 1, 2, 3, etc.
+   * Returns the outer cell style for a sessions-calendar day (Variant D).
+   *
+   * The whole cell carries the heatmap tint; the day-number sits absolute in
+   * the top-left and the units number is centered as the visual hero. Today is
+   * marked with a 2px inset ring; off-month / disabled cells dim to ~35%.
    */
-  getSessionsCalendarDayLabelStyle: (
+  getSessionsCalendarDayCellStyle: (
+    marking: MarkingProps | undefined,
     isDisabled: boolean,
     isToday: boolean,
-  ): TextStyle => {
-    let textColor: Color;
-    switch (true) {
-      case isDisabled:
-        textColor = theme.textMutedReversed;
-        break;
-      case isToday:
-        textColor = theme.link;
-        break;
-      default:
-        textColor = theme.textSupporting;
-    }
+  ): ViewStyle => {
+    const backgroundColor = marking?.color ?? CONST.CALENDAR_COLORS.DARK.GREEN;
     return {
-      ...styles.textMicro,
-      ...styles.alignSelfStart,
-      color: textColor,
+      width: variables.componentSizeNormalSmall,
+      height: variables.componentSizeNormalSmall,
+      borderRadius: variables.componentBorderRadiusNormal,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor,
+      opacity: isDisabled ? 0.35 : 1,
+      borderWidth: isToday ? 2 : 0,
+      borderColor: isToday ? theme.text : 'transparent',
     };
   },
 
   /**
-   * Returns the style for the sessions calendar day marking container
+   * Returns the corner day-number label style (Variant D).
+   *
+   * Always positioned absolute top-left, including on alcohol-free days — the
+   * empty center is what signals AF, not a re-centered day number.
    */
-  getSessionsCalendarDayMarkingContainerStyle: (
+  getSessionsCalendarDayLabelStyle: (
     marking: MarkingProps | undefined,
     isDisabled: boolean,
-  ): ViewStyle => {
-    const baseStyles = {
-      ...styles.alignSelfCenter,
-      ...styles.justifyContentCenter,
-      ...styles.componentSizeNormalSmall,
-    };
+  ): TextStyle => {
+    const isLightColor = !!marking?.color && isLightHex(marking.color);
+    let textColor: Color;
+    if (isDisabled) {
+      textColor = theme.textMutedReversed;
+    } else if (isLightColor) {
+      textColor = theme.textDark;
+    } else {
+      textColor = theme.textLight;
+    }
     return {
-      ...baseStyles,
-      ...(isDisabled ? styles.noBorder : styles.border),
-      ...(!isDisabled && {
-        backgroundColor: marking?.color ?? CONST.CALENDAR_COLORS.DARK.GREEN,
-      }),
+      position: 'absolute',
+      top: 3,
+      left: 5,
+      fontSize: variables.fontSizeExtraSmall,
+      fontWeight: '600',
+      lineHeight: 10,
+      color: textColor,
     };
   },
 
-  /** Returns styles for the session calendar day marking (units) */
-  getSessionsCalendarDayMarkingTextStyle: (
+  /** Returns the centered hero units-number style (Variant D). */
+  getSessionsCalendarDayUnitsTextStyle: (
     marking: MarkingProps | undefined,
   ): TextStyle => {
     const isLightColor = !!marking?.color && isLightHex(marking.color);
     const textColor = isLightColor ? theme.textDark : theme.textLight;
     return {
-      ...styles.textNormal,
-      ...styles.textAlignCenter,
+      fontSize: variables.fontSizeNormal,
+      fontWeight: '700',
+      textAlign: 'center',
       color: textColor,
     };
   },

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -22,6 +22,7 @@ export default {
   contentHeaderDesktopHeight: getValueUsingPixelRatio(80, 100),
   componentSizeSmall: getValueUsingPixelRatio(28, 32),
   componentSizeNormalSmall: 36,
+  sessionsCalendarDaySize: 44,
   componentSizeNormal: 40,
   componentSizeMedium: 48,
   inputComponentSizeNormal: 40,


### PR DESCRIPTION
## Summary

- Restyles the HomeScreen sessions-calendar day cell to match the locked **Variant D** spec from [`docs/statistics-calendar-variants.html`](docs/statistics-calendar-variants.html): day-number tucked to the top-left, units number centered as the visual hero, AF days show only the corner day-number on neutral tint, today gets a 2px inset ring, off-month cells dim to ~35%.
- Cell becomes a rounded square (8px radius) and the whole cell carries the heatmap tint instead of an inner pill. Reuses the existing `Preferences.units_to_colors` palette via `marking.color` — no data-shape changes.
- Reuses the same `getSessionsCalendarDay*` style utils, so the palette-picker preview on the Color Palette screen picks up the new look automatically.

This is preparatory work toward the Statistics feature (epic PetrCala/Kiroku#498). The same visual language will be reused by the new `CalendarHeatmap` component being scaffolded on `feature/statistics`; this PR lands the language on `master` independently so the existing sessions calendar already speaks it.

## Test plan

- [ ] Run `npm run ios`, navigate to HomeScreen, confirm:
  - [ ] Drink days show day-number in the corner + units number centered, with palette tint
  - [ ] AF days show only the corner day-number on the neutral palette tint (no center number)
  - [ ] Today is ringed with a 2px inset border
  - [ ] Off-month cells dim to ~35% opacity, no units text
  - [ ] Decimal units render as `2.5`, whole units as `2`
- [ ] Toggle theme between light and dark; confirm both render correctly
- [ ] Open Settings → Preferences → Color Palette and confirm the week preview still renders correctly under each palette
- [ ] Attach before/after screenshots in both themes

## Screenshots

_Verification screenshots to be attached by reviewer per offline verification request._

🤖 Generated with [Claude Code](https://claude.com/claude-code)