### PR TITLE
style(dayOverview): smooth session rows with left-strip + tint

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -84,6 +84,7 @@ function DrinkingSessionOverview({
         styles.mh1,
         styles.mb2,
         {
+          minHeight: 84,
           borderRadius: 12,
           borderLeftWidth: 4,
           borderLeftColor: sessionColor,

--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -76,45 +76,47 @@ function DrinkingSessionOverview({
       accessibilityLabel={translate('dayOverviewScreen.sessionWindow', {
         sessionId,
       })}
-      style={[styles.flexRow, styles.border, styles.mh1, styles.mt1]}
+      style={[
+        styles.flexRow,
+        styles.alignItemsCenter,
+        styles.justifyContentBetween,
+        styles.p4,
+        styles.mh1,
+        styles.mb2,
+        {
+          borderRadius: 12,
+          borderLeftWidth: 4,
+          borderLeftColor: sessionColor,
+          backgroundColor: `${sessionColor}1F`,
+        },
+      ]}
       onPress={() => onSessionButtonPress()}>
-      <View
-        style={[styles.drinkingSessionOverviewTabIndicator(sessionColor)]}
-      />
-      <View
-        style={[
-          styles.drinkingSessionOverviewMainTab,
-          styles.borderLeft,
-          styles.pr2,
-          styles.pl1,
-        ]}>
-        <View style={[styles.flexGrow1, styles.flexColumn]}>
-          <Text style={[styles.textNormalThemeText, styles.p1]}>
-            {translate('common.units')}: {totalUnits}
+      <View style={[styles.flexColumn, styles.flex1]}>
+        <Text style={[styles.textNormal, styles.textStrong]}>
+          {translate('common.units')}: {totalUnits}
+        </Text>
+        {shouldDisplayTime && (
+          <Text style={[styles.textMicroSupporting, styles.mt1]}>
+            {translate('common.time')}: {timeString}
           </Text>
-          {shouldDisplayTime && (
-            <Text style={[styles.textNormalThemeText, styles.p1]}>
-              {translate('common.time')}: {nonMidnightString(timeString)}
-            </Text>
-          )}
-        </View>
-        {session?.ongoing ? (
-          <Button
-            danger
-            onPress={() => onSessionButtonPress()}
-            text={translate('dayOverviewScreen.ongoing')}
-          />
-        ) : (
-          isEditModeOn && (
-            <Button
-              large
-              style={styles.bgTransparent}
-              icon={KirokuIcons.Edit}
-              onPress={onNavigateToEditSession}
-            />
-          )
         )}
       </View>
+      {session?.ongoing ? (
+        <Button
+          danger
+          onPress={() => onSessionButtonPress()}
+          text={translate('dayOverviewScreen.ongoing')}
+        />
+      ) : (
+        isEditModeOn && (
+          <Button
+            large
+            style={styles.bgTransparent}
+            icon={KirokuIcons.Edit}
+            onPress={onNavigateToEditSession}
+          />
+        )
+      )}
     </PressableWithFeedback>
   );
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -867,25 +867,6 @@ const styles = (theme: ThemeColors) =>
       marginTop: 8,
     },
 
-    drinkingSessionOverviewTabIndicator: (sessionColor: CalendarColors) =>
-      ({
-        height: variables.sessionOverviewTabHeight,
-        width: 20,
-        backgroundColor: sessionColor,
-        borderTopLeftRadius: variables.componentBorderRadiusNormal,
-        borderBottomLeftRadius: variables.componentBorderRadiusNormal,
-      }) satisfies ViewStyle,
-
-    drinkingSessionOverviewMainTab: {
-      flexGrow: 1,
-      flexDirection: 'row',
-      alignItems: 'center',
-      borderTopRightRadius: variables.componentBorderRadiusNormal,
-      borderBottomRightRadius: variables.componentBorderRadiusNormal,
-      height: variables.sessionOverviewTabHeight,
-      backgroundColor: theme.cardBG,
-    },
-
     drinkTypesViewTab: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -217,7 +217,6 @@ export default {
 
   textInputAutoGrowMaxHeight: 115,
 
-  sessionOverviewTabHeight: 85,
   statItemTextMaxWidth: 150,
   sessionUnitCountFontSize: 90,
   sessionDrinksTabHeight: 50,


### PR DESCRIPTION
## Summary
- Restyle each session row on the Day Overview screen to match the selected-palette highlight on the Color Palette screen: 4px left border strip in the session color + 12% session-color tint background, instead of the old 20px solid color block paired with a separate card.
- Drop the now-unused `drinkingSessionOverviewTabIndicator`, `drinkingSessionOverviewMainTab`, and `sessionOverviewTabHeight` style/variable entries.
- Stop double-wrapping the time string with `nonMidnightString` (already normalized when `timeString` is computed).

## Test plan
- [ ] Open the Day Overview for a day with multiple sessions of different severities — rows should render as smooth rounded cards with a colored left strip and a soft tinted background matching the session color.
- [ ] Toggle edit mode — the edit button still appears and works on completed sessions.
- [ ] Confirm an ongoing session row shows the red "Ongoing" button correctly.
- [ ] Verify a blackout session renders with the palette's black color on both the strip and the tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)