### PR TITLE
refactor(styles): extract getColorAccentRowStyle helper

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -13,6 +13,7 @@ import {nonMidnightString} from '@libs/StringUtilsKiroku';
 import Button from '@components/Button';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useStyleUtils from '@hooks/useStyleUtils';
 import Text from '@components/Text';
 import DateUtils from '@libs/DateUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -27,6 +28,7 @@ function DrinkingSessionOverview({
   const {preferences} = useDatabaseData();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
+  const StyleUtils = useStyleUtils();
   // Convert the timestamp to a Date object
   const timeString = nonMidnightString(
     DateUtils.getLocalizedTime(session.start_time, session.timezone),
@@ -83,13 +85,8 @@ function DrinkingSessionOverview({
         styles.p4,
         styles.mh1,
         styles.mb2,
-        {
-          minHeight: 84,
-          borderRadius: 12,
-          borderLeftWidth: 4,
-          borderLeftColor: sessionColor,
-          backgroundColor: `${sessionColor}1F`,
-        },
+        StyleUtils.getColorAccentRowStyle(sessionColor),
+        {minHeight: 84},
       ]}
       onPress={() => onSessionButtonPress()}>
       <View style={[styles.flexColumn, styles.flex1]}>

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -228,12 +228,7 @@ function ColorPaletteScreen() {
                     styles.justifyContentBetween,
                     styles.p4,
                     styles.mb2,
-                    {
-                      borderRadius: 12,
-                      borderLeftWidth: 4,
-                      borderLeftColor: isActive ? accent : 'transparent',
-                      backgroundColor: isActive ? accentTint : 'transparent',
-                    },
+                    StyleUtils.getColorAccentRowStyle(isActive ? accent : null),
                   ]}>
                   <View style={[styles.flexColumn, styles.flex1]}>
                     <Text style={[styles.textNormal, styles.textStrong]}>

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1629,6 +1629,22 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
   }),
 
   /**
+   * Card row with a colored 4px left strip and a matching ~12% tinted
+   * background. Pass `null` for an inactive/unhighlighted state — strip and
+   * background both become transparent so the row keeps its layout but reads
+   * as inert. Used for selection highlights (e.g. palette picker) and
+   * categorical color-coding (e.g. day overview session rows).
+   *
+   * The caller composes layout (flex, padding, margin) around this.
+   */
+  getColorAccentRowStyle: (color: string | null): ViewStyle => ({
+    borderRadius: 12,
+    borderLeftWidth: 4,
+    borderLeftColor: color ?? 'transparent',
+    backgroundColor: color ? `${color}1F` : 'transparent',
+  }),
+
+  /**
    * When adding a new prefix character, adjust this method to add expected character width.
    * This is because character width isn't known before it's rendered to the screen, and once it's rendered,
    * it's too late to calculate it's width because the change in padding would cause a visible jump.


### PR DESCRIPTION
## Summary
- Extract the shared "row with a colored 4px left strip + ~12% tinted background" visual into a single `StyleUtils.getColorAccentRowStyle(color | null)` helper.
- Convert the two existing call sites — [ColorPaletteScreen](src/screens/Settings/Preferences/ColorPaletteScreen.tsx) (selection highlight, pass `null` when inactive) and [DrinkingSessionOverview](src/components/DrinkingSessionOverview/index.tsx) (categorical color coding per session) — to use it.
- Layout primitives (`flexRow`, `p4`, `mb2`, `minHeight`, etc.) stay at the call site; the helper only owns the colored visual identity.

## Why
The two components landed the same shape independently — palette picker first, then day overview rows in [#521](https://github.com/PetrCala/Kiroku/pull/521). Pulling it into `StyleUtils` gives future adopters one canonical hook and makes any tweak (radius, strip width, tint opacity) a one-line change.

## Test plan
- [ ] Color palette screen — selected palette still shows the appColor left strip + tint, unselected rows still render flat.
- [ ] Day Overview — each session row still renders with its severity color on the left strip + matching tint; row height stays consistent in and out of edit mode.
- [ ] No visual change expected on either screen — this is a pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)