### PR TITLE
ci(platformDeploy): bump xcodebuild settings timeout for iOS Fastlane

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -221,6 +221,12 @@ jobs:
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           VERSION: ${{ env.IOS_VERSION }}
           TESTFLIGHT_CHANGELOG: ${{ env.TESTFLIGHT_CHANGELOG }}
+          # `xcodebuild -showBuildSettings` on this workspace can take much
+          # longer than fastlane's 3s default × 4 retries (~45s total),
+          # especially on a fresh-SDK install pass. Bump both knobs so the
+          # build_app step doesn't time out before xcodebuild has answered.
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
 
       # Preserve the dSYM as a workflow artifact so we can symbolicate native
       # crash reports later without trips to App Store Connect. Fastlane's


### PR DESCRIPTION
## Summary

Staging deploys (the `deploy.yml` → `platformDeploy.yml` pipeline that runs on push to `staging`) are failing in the iOS **Run Fastlane** step. Most recent example: run [26295906533](https://github.com/PetrCala/Kiroku/actions/runs/26295906533) for `chore: release 0.3.12-18` — `Build and deploy iOS` → `Run Fastlane` exits 1 with no IPA / dSYM produced.

This is the same failure mode that hit the PR test-build path and was patched in `testBuild.yml` by fc350da (`ci(testBuild): bump xcodebuild settings timeout for iOS Fastlane step`). Fastlane's default `xcodebuild -showBuildSettings` budget is 3s × 4 retries (~45s total), and this workspace — especially right after the platform-SDK install pass — regularly exceeds that, so `build_app` aborts before xcodebuild ever answers.

The fix mirrors `testBuild.yml`: set `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=120` and `FASTLANE_XCODEBUILD_SETTINGS_RETRIES=5` on the iOS Fastlane step in `platformDeploy.yml`, so the staging/production deploy pipeline matches the already-fixed test-build pipeline.

## Test plan

- [ ] CI lint / typecheck pass on this PR
- [ ] After merge, next push to `staging` (e.g. cherry-pick or release bump) completes the `Build and deploy iOS` → `Run Fastlane` step without exiting 1
- [ ] iOS dSYM artifact is uploaded (the `Stash iOS dSYM as workflow artifact` step no longer warns "No files were found")

https://claude.ai/code/session_01WjnSBWRz855gp5G4ZiyeeU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjnSBWRz855gp5G4ZiyeeU)_