### PR TITLE
fix(social): make friends tab swipe snappier and less bouncy

### DIFF
--- a/src/screens/Social/SwipeablePager.tsx
+++ b/src/screens/Social/SwipeablePager.tsx
@@ -20,7 +20,7 @@ type SwipeablePagerProps<R extends Route> = {
   renderScene: (props: {route: R}) => React.ReactNode;
 };
 
-const SPRING_CONFIG = {damping: 22, stiffness: 220};
+const SPRING_CONFIG = {dampingRatio: 1, duration: 280};
 const RUBBERBAND_RESISTANCE = 0.4;
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- The custom `SwipeablePager` driving the Social (friends) screen's two tabs was using an underdamped spring (`{damping: 22, stiffness: 220}`, damping ratio ≈ 0.74), causing visible overshoot and oscillation when snapping between the friend list and friend requests tabs.
- Swapped it for a critically damped, time-based spring (`{dampingRatio: 1, duration: 280}`) so the transition settles immediately with no bounce — closer to the feel of React Navigation's normal stack screen transition.

## Test plan
- [ ] Open the Social/friends screen and swipe between Friend List and Friend Requests — confirm the snap settles cleanly with no visible bounce.
- [ ] Tap to switch tabs (no gesture) — confirm the animated index change still feels snappy (~280 ms) without overshoot.
- [ ] Rubber-band the edges (swipe right past tab 0, swipe left past the last tab) — confirm the elastic resistance + release still settles smoothly.
- [ ] On the first tab, swipe right past start — confirm the navigation back cascade still fires and the pager springs back to zero without bounce.

https://claude.ai/code/session_01DgdcCqfe6oSrvTkbnqX5bi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgdcCqfe6oSrvTkbnqX5bi)_