### PR TITLE
fix(social): preserve scroll position when paginating friend list

### DIFF
--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -209,10 +209,18 @@ function UserListComponent({
     );
   }, [fullUserArray, isFetchingStatuses, userStatusList]);
 
+  // Gate on `profileList` being populated rather than the transient
+  // `loadingDisplayData` flag. Once we have profiles cached, pagination's
+  // background re-fetch (which briefly flips loadingDisplayData back to true)
+  // must not unmount the FlatList — doing so resets scroll position and made
+  // the list jump to the top whenever onEndReached fired.
+  const hasLoadedProfiles = !isEmptyObject(profileList);
   const isListReady =
-    hasComputedOrderedList && allStatusesLoaded && !loadingDisplayData;
+    hasComputedOrderedList &&
+    allStatusesLoaded &&
+    (hasLoadedProfiles || !loadingDisplayData);
 
-  if (!isListReady || isLoading) {
+  if (isLoading || !isListReady) {
     return (
       <View
         style={[


### PR DESCRIPTION
## Summary

- Friend list infinite scroll snapped back to the top whenever `onEndReached` fired at the bottom of the loaded slice.
- Root cause: `UserListComponent` gated the FlatList behind `!loadingDisplayData`. When pagination appended new user IDs, `useProfileList` flipped `loadingDisplayData` back to `true` while it fetched the new profiles. That swapped the FlatList for the full-screen loading indicator mid-scroll, unmounting the list and resetting scroll offset to 0. When the fetch resolved, the FlatList remounted at the top.
- Fix: keep the FlatList mounted as long as `profileList` has at least one cached profile. The existing footer spinner already advertises pagination; we don't need to unmount the whole list to surface it. Initial-load gating is unchanged (still waits for the first fetch since `profileList` starts empty).

## Test plan

- [ ] Open the Friends screen with enough friends to require multiple pages (>20).
- [ ] Scroll to the bottom of the loaded slice — verify the list does **not** jump to the top while the next page loads.
- [ ] Verify the footer spinner still appears during the fetch and the next batch appends in place.
- [ ] On first open with cold cache, verify the full-screen loader still shows until the first batch of profiles arrives (no flash of empty list).
- [ ] Search the friend list to filter (`userSubset` path) — verify the list still updates correctly and empty-search renders the empty component.

https://claude.ai/code/session_019PPwYX3LMTVauhUPi7rTUn

---
_Generated by [Claude Code](https://claude.ai/code/session_019PPwYX3LMTVauhUPi7rTUn)_