### PR TITLE
fix(profile): remove white border strip in profile image fullscreen modal

### DIFF
--- a/src/components/Modals/FullScreenModal.tsx
+++ b/src/components/Modals/FullScreenModal.tsx
@@ -45,6 +45,7 @@ function FullScreenModal({
       isVisible={modalVisible}
       fullscreen
       shouldUseModalPaddingStyle={false}
+      innerContainerStyle={{borderWidth: 0}}
       swipeDirection={['up', 'down']}
       animationIn="fadeIn"
       animationOut="fadeOut">


### PR DESCRIPTION
## Summary

When tapping the profile image to enlarge it, two narrow white strips were visible along the left and right edges of the otherwise dark fullscreen view.

**Root cause.** The shared `FullScreenModal` uses `MODAL_TYPE.CENTERED`. On small screens, `ModalStyleUtils.getCenteredModalStyles` returns `borderWidth: 1` and the underlying `defaultModalContainer` style supplies `backgroundColor: theme.componentBG` (white in light mode) with `borderColor: theme.transparent`. React Native paints the background under the full frame including the border region, so the 1px transparent border around the modal container exposed the white background — visible as the thin white strips on the sides of the enlarged image. The same gap exists on top/bottom but is hidden by the status bar and home indicator.

**Fix.** Pass `innerContainerStyle={{borderWidth: 0}}` from `FullScreenModal` so the inner `bgDark` view (`flex: 1`) covers the full frame. Other callers of `FullScreenModal` (e.g. `NumericSlider`) keep their default white container background intact — only the unnecessary 1px transparent border is removed.

## Test plan

- [ ] Open a profile, tap the profile image to enlarge it, confirm no white strips along the left/right edges in light mode.
- [ ] Repeat in dark mode (should look the same).
- [ ] Tap to close, confirm the close-out animation still works and the image returns to its original position.
- [ ] Open the `NumericSlider` (e.g. a drink-quantity slider) and confirm the modal still has its standard white background and behaves as before.
- [ ] Verify on iPhone with notch in both portrait and landscape.

https://claude.ai/code/session_01DayYPCsBCqjKPTm6cSfKU8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DayYPCsBCqjKPTm6cSfKU8)_