### PR TITLE
fix: unblock local Android dev build (slider + Windows alias)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const path = require('path');
 
 const IS_E2E_TESTING = process.env.E2E_TESTING === 'true';
 
@@ -13,7 +14,20 @@ const ReactCompilerConfig = {
 
 // ─── Shared alias list ────────────────────────────────────────────────────────
 // Single source of truth so metro and test configs don't drift.
+//
+// `@src/SCREENS` is declared *before* `@src` because babel-plugin-module-resolver
+// matches aliases in declaration order via Array.find(). The more specific
+// `@src/SCREENS` entry must win so we can route it around a Windows-only bug:
+// Node's `path.relative()` treats Windows paths as case-insensitive, so the
+// relative-path math inside the plugin folds `src/SCREENS.ts` into the sibling
+// `src/screens/` directory. From a file under `src/screens/` the plugin then
+// emits `./..` (one level up) instead of `../../SCREENS`, and Metro fails to
+// resolve. Pointing the alias at an absolute path makes the plugin skip
+// `mapToRelative` entirely and hand Metro the file path directly. macOS/Linux
+// behave the same way once the path is absolute, so the override is safe to
+// apply unconditionally.
 const moduleResolverAliases = {
+  '@src/SCREENS': path.resolve(__dirname, 'src/SCREENS.ts'),
   '@assets': './assets',
   '@auth': './src/auth',
   '@components': './src/components',

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@react-native-async-storage/async-storage": "^2.1.2",
         "@react-native-clipboard/clipboard": "^1.15.0",
         "@react-native-community/netinfo": "11.2.1",
-        "@react-native-community/slider": "^4.5.5",
+        "@react-native-community/slider": "^5.2.0",
         "@react-native-firebase/app": "^24.0.0",
         "@react-native-firebase/crashlytics": "^24.0.0",
         "@react-native-firebase/perf": "^24.0.0",
@@ -7326,9 +7326,10 @@
       }
     },
     "node_modules/@react-native-community/slider": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.5.tgz",
-      "integrity": "sha512-x2N415pg4ZxIltArOKczPwn7JEYh+1OxQ4+hTnafomnMsqs65HZuEWcX+Ch8c5r8V83DiunuQUf5hWGWlw8hQQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.2.0.tgz",
+      "integrity": "sha512-484sH8aWEaSjxaZ7HT3YZ8CKDcNes2synko1vdEz5DFEdvKAduxKJTj22L/qBMD7rtIkfbX69DMzWDAGbOAV6w==",
+      "license": "MIT"
     },
     "node_modules/@react-native-firebase/app": {
       "version": "24.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/netinfo": "11.2.1",
-    "@react-native-community/slider": "^4.5.5",
+    "@react-native-community/slider": "^5.2.0",
     "@react-native-firebase/app": "^24.0.0",
     "@react-native-firebase/crashlytics": "^24.0.0",
     "@react-native-firebase/perf": "^24.0.0",


### PR DESCRIPTION
## Summary

Two unrelated fixes uncovered while bringing up a local Android dev build on Windows. Both have been verified by running `developmentDebug` on a Pixel emulator — the app now mounts and Firebase auth initializes cleanly.

- **Slider 4.5.5 → 5.2.0**: Slider's `RNCSliderProps` destructor crashes during Fabric component registration. Manifested as a SIGSEGV on Android cold-start before any UI rendered. The 5.x line is the Fabric-first major; the `<Slider>` API at our one call site (`NumericSlider.tsx`) is unchanged.
- **Babel module-resolver alias for `@src/SCREENS`**: Node's `path.relative()` is case-insensitive on Windows, which makes `babel-plugin-module-resolver` fold the alias target `src/SCREENS.ts` into the sibling `src/screens/` directory. Files under `src/screens/` then end up with `./..` as the resolved import and Metro can't find a file at `src/screens`. Fixed by adding `@src/SCREENS` as a more specific alias pointing to an absolute path, which causes the plugin to skip relative-path math entirely.

Neither change has any effect on macOS/Linux behavior — the slider bump is the actively-maintained current release, and the absolute-path alias just hands Metro a fully resolved path regardless of platform.

## What changed

| File | Change |
|---|---|
| `package.json` / `package-lock.json` | `@react-native-community/slider` `^4.5.5` → `^5.2.0` |
| `babel.config.js` | Added `'@src/SCREENS': path.resolve(__dirname, 'src/SCREENS.ts')` as the first entry of `moduleResolverAliases`, plus a `const path = require('path')` import and a comment explaining the ordering requirement |

## Why the babel fix is unconditional

Considered making the alias Windows-only via `process.platform === 'win32'`, but:
- Absolute paths behave identically across platforms once they leave the plugin
- Conditional logic would mean Windows and Mac contributors get different bundles, which is a worse failure mode than the override
- Only one constant (`SCREENS`) in the repo case-collides with a sibling directory, so the cost is one extra alias entry

## Verification

- Built locally: `gradlew installDevelopmentDebug -PreactNativeArchitectures=x86_64 -x lint` succeeds
- Metro bundle: completes at `99.9%` (was failing at `~95%` with "Unable to resolve module ./.." from any `src/screens/` file before the babel fix)
- App on Pixel 10 emulator: process stays alive past Fabric init (was crashing in `RNCSliderProps::~RNCSliderProps` before the slider bump), Firebase Auth initializes with AsyncStorage persistence, JS bundle delivers

## Test plan

- [ ] iOS build still works (slider 5.x has been the latest for ~12 months; should be a no-op there but worth confirming)
- [ ] Android prod / release build picks up the new slider native code
- [ ] Existing `<NumericSlider>` UI still behaves the same (drag, value range, callback)
- [ ] No jest / typecheck / eslint regressions on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
