### PR TITLE
feat(calendar): open fullscreen aligned to the clicked month

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -136,7 +136,17 @@ const ROUTES = {
 
   SESSIONS_CALENDAR_FULLSCREEN: {
     route: 'sessions-calendar/:userID',
-    getRoute: (userID: UserID) => `sessions-calendar/${userID}` as const,
+    getRoute: (userID: UserID, monthYear?: string, firstWeekY?: number) => {
+      const parts: string[] = [];
+      if (monthYear) {
+        parts.push(`monthYear=${monthYear}`);
+      }
+      if (firstWeekY !== undefined) {
+        parts.push(`firstWeekY=${firstWeekY.toFixed(2)}`);
+      }
+      const qs = parts.length > 0 ? `?${parts.join('&')}` : '';
+      return `sessions-calendar/${userID}${qs}` as const;
+    },
   },
 
   SOCIAL: 'social',

--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -29,8 +29,10 @@ function DayComponent({
   // Android — Fabric/Paper view-flattening can otherwise drop the View and
   // invalidate the ref.
   const viewRef = useRef<View | null>(null);
-  const shouldRegister =
-    !!registerMeasureRef && !!date && date.day === 1 && !isDisabled;
+  // Disabled day-1 cells (e.g. minDate boundary months) still sit in the
+  // first week-row at the same Y — register regardless so the fullscreen
+  // never silently falls through to "latest at bottom" for those months.
+  const shouldRegister = !!registerMeasureRef && !!date && date.day === 1;
   useEffect(() => {
     if (!registerMeasureRef || !date) {
       return undefined;

--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useRef} from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
 import {PressableWithoutFeedback} from '@components/Pressable';
@@ -11,6 +12,7 @@ function DayComponent({
   marking,
   theme, // eslint-disable-line @typescript-eslint/no-unused-vars
   onPress,
+  registerMeasureRef,
 }: DayComponentProps) {
   const StyleUtils = useStyleUtils();
   const isDisabled = state === 'disabled';
@@ -19,27 +21,53 @@ function DayComponent({
       ? (Number.isInteger(units) ? units : units.toFixed(1)).toString()
       : '';
 
+  // Register this cell's measure ref with the parent so the parent can call
+  // `measureInWindow` on it later (used to seed the fullscreen calendar's
+  // initial scroll). We only need a single anchor per visible month; day 1
+  // is always in the first week-row of the rendered grid, so that's the cell
+  // we expose. The wrapping `<View collapsable={false}>` is required on
+  // Android — Fabric/Paper view-flattening can otherwise drop the View and
+  // invalidate the ref.
+  const viewRef = useRef<View | null>(null);
+  const shouldRegister =
+    !!registerMeasureRef && !!date && date.day === 1 && !isDisabled;
+  useEffect(() => {
+    if (!registerMeasureRef || !date) {
+      return undefined;
+    }
+    if (!shouldRegister) {
+      return undefined;
+    }
+    registerMeasureRef(date.day, viewRef.current);
+    return () => registerMeasureRef(date.day, null);
+  }, [registerMeasureRef, date, shouldRegister]);
+
   return (
-    <PressableWithoutFeedback
-      accessibilityLabel=""
-      onPress={() => onPress && date && onPress(date)}>
-      <View
-        style={StyleUtils.getSessionsCalendarDayCellStyle(marking, isDisabled)}>
-        <Text
-          style={StyleUtils.getSessionsCalendarDayLabelStyle(
+    <View ref={viewRef} collapsable={false}>
+      <PressableWithoutFeedback
+        accessibilityLabel=""
+        onPress={() => onPress && date && onPress(date)}>
+        <View
+          style={StyleUtils.getSessionsCalendarDayCellStyle(
             marking,
             isDisabled,
           )}>
-          {date?.day}
-        </Text>
-        {unitsText !== '' && (
           <Text
-            style={StyleUtils.getSessionsCalendarDayUnitsTextStyle(marking)}>
-            {unitsText}
+            style={StyleUtils.getSessionsCalendarDayLabelStyle(
+              marking,
+              isDisabled,
+            )}>
+            {date?.day}
           </Text>
-        )}
-      </View>
-    </PressableWithoutFeedback>
+          {unitsText !== '' && (
+            <Text
+              style={StyleUtils.getSessionsCalendarDayUnitsTextStyle(marking)}>
+              {unitsText}
+            </Text>
+          )}
+        </View>
+      </PressableWithoutFeedback>
+    </View>
   );
 }
 

--- a/src/components/SessionsCalendar/DayComponent/types.ts
+++ b/src/components/SessionsCalendar/DayComponent/types.ts
@@ -1,3 +1,4 @@
+import type {View} from 'react-native';
 import type {DayState, DateData, Theme} from 'react-native-calendars/src/types';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 
@@ -12,6 +13,10 @@ type DayComponentProps = {
   marking?: MarkingProps;
   theme?: Theme;
   onPress?: (day: DateData) => void;
+  /** Optional registration callback for the cell's wrapper View ref. Used by
+   *  the small calendar to anchor a `measureInWindow` for the first-week-row
+   *  Y position; the day-1 cell is always in row 0 of the rendered grid. */
+  registerMeasureRef?: (day: number, view: View | null) => void;
 };
 
 export type {DayComponentProps, CalendarColors};

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useEffect} from 'react';
+import React, {memo, useCallback, useEffect, useRef} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
@@ -7,7 +7,7 @@ import {Calendar} from 'react-native-calendars';
 import type {DateData} from 'react-native-calendars';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
-import {format} from 'date-fns';
+import {format, startOfMonth} from 'date-fns';
 import useTheme from '@hooks/useTheme';
 import useThemePreference from '@hooks/useThemePreference';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -104,6 +104,16 @@ function SessionsCalendarView({
     setCalendarLocale(locale);
   }, [locale]);
 
+  // Ref to the day-1 cell of the visible month. Used to measure the
+  // first-week-row's window-Y so the fullscreen calendar can position the
+  // clicked month at the same screen position. Stable across renders.
+  const day1Ref = useRef<View | null>(null);
+  const registerMeasureRef = useCallback((day: number, view: View | null) => {
+    if (day === 1) {
+      day1Ref.current = view;
+    }
+  }, []);
+
   const dayComponent = useCallback(
     ({date, state, marking, theme: dayTheme}: DayComponentProps) => (
       <DayComponent
@@ -113,9 +123,10 @@ function SessionsCalendarView({
         marking={marking}
         theme={dayTheme}
         onPress={onDayPress}
+        registerMeasureRef={registerMeasureRef}
       />
     ),
-    [unitsMap, onDayPress],
+    [unitsMap, onDayPress, registerMeasureRef],
   );
 
   // Custom header: matches the default month-text styling but reserves space
@@ -131,8 +142,36 @@ function SessionsCalendarView({
     if (!userID) {
       return;
     }
-    Navigation.navigate(ROUTES.SESSIONS_CALENDAR_FULLSCREEN.getRoute(userID));
-  }, [userID]);
+    // Clamp the target to current month if the user is viewing a future
+    // month. The measured Y stays the same regardless — what we're matching
+    // is the small calendar's first-week-row position, not its month.
+    const visible = new Date(visibleDate.timestamp);
+    const today = new Date();
+    const clamped =
+      startOfMonth(visible).getTime() > startOfMonth(today).getTime()
+        ? today
+        : visible;
+    const monthYear = format(clamped, 'yyyy-MM');
+
+    // `measureInWindow` is async with a callback. If the day-1 cell hasn't
+    // mounted yet (very rare — the press requires a tap on the header which
+    // sits above the grid), fall through to navigating without a Y, which
+    // falls back to "latest at bottom".
+    const navigate = (firstWeekY?: number) => {
+      Navigation.navigate(
+        ROUTES.SESSIONS_CALENDAR_FULLSCREEN.getRoute(
+          userID,
+          monthYear,
+          firstWeekY,
+        ),
+      );
+    };
+    if (!day1Ref.current) {
+      navigate();
+      return;
+    }
+    day1Ref.current.measureInWindow((_x, y) => navigate(y));
+  }, [userID, visibleDate.timestamp]);
 
   const renderHeader = useCallback(
     (date?: {getTime(): number}) => {

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -1,5 +1,12 @@
-import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {ActivityIndicator, Dimensions, View} from 'react-native';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef} from '@shopify/flash-list';
 import {format, parseISO, startOfDay} from 'date-fns';
@@ -23,6 +30,10 @@ import setCalendarLocale from './setCalendarLocale';
 // many weeks of index 0. Generous so the parent's prefetch starts well
 // before the user catches up to the loaded floor.
 const LOAD_AHEAD_BUFFER_WEEKS = 12;
+
+// One viewport-height of empty space below the latest month so the
+// current/recent month can still be scrolled flush to the top.
+const listFooterStyle = {height: Dimensions.get('window').height};
 // 50% threshold is generous enough to fire well before the lazy-load buffer
 // runs out, but quiet enough not to thrash on every pixel of scroll. The
 // previous `1` value was a major contributor to deceleration jitter.
@@ -48,6 +59,15 @@ type SessionsCalendarWeekListViewProps = {
    *  visible. The parent decides (via `computeLoadTarget`) whether to
    *  actually widen the loaded window. */
   onRequestOlder?: (earliestVisible: Date) => void;
+  /** Target month ('YYYY-MM') to land at on first render, with its first
+   *  week-row positioned at window-Y `initialFirstWeekY`. When omitted, the
+   *  list falls back to "latest at bottom". */
+  initialMonthYear?: string;
+  /** Window-Y (px) where the target month's first week-row should land. */
+  initialFirstWeekY?: number;
+  /** Fires once the initial scroll has been applied (or determined that no
+   *  scroll is needed). The parent screen uses this to unhide the calendar. */
+  onInitialScrollReady?: () => void;
 };
 
 type LabelItem = {
@@ -84,6 +104,9 @@ function SessionsCalendarWeekListView({
   isFetchingOlderMonths,
   onDayPress,
   onRequestOlder,
+  initialMonthYear,
+  initialFirstWeekY,
+  onInitialScrollReady,
 }: SessionsCalendarWeekListViewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -110,10 +133,13 @@ function SessionsCalendarWeekListView({
   );
 
   // Flatten the per-month sections into a single list of items. Labels
-  // sit between sections and double as FlashList sticky headers.
-  const {items, stickyHeaderIndices} = useMemo(() => {
+  // sit between sections and double as FlashList sticky headers. We also
+  // build a `monthYear → first-week-row index` map in the same pass for
+  // the initial-scroll lookup.
+  const {items, stickyHeaderIndices, firstWeekIndexByMonth} = useMemo(() => {
     const out: ListItem[] = [];
     const sticky: number[] = [];
+    const monthIndex = new Map<string, number>();
 
     monthSections.forEach(section => {
       const labelDate = new Date(section.year, section.month, 1);
@@ -123,7 +149,13 @@ function SessionsCalendarWeekListView({
         key: `label-${section.year}-${section.month}`,
         label: format(labelDate, CONST.DATE.MONTH_YEAR_ABBR_FORMAT),
       });
-      section.weeks.forEach(week => {
+      section.weeks.forEach((week, weekIdx) => {
+        if (weekIdx === 0) {
+          // The first week-row of each section is what we anchor the
+          // initial-scroll lookup against. Key by 'YYYY-MM'.
+          const key = `${section.year}-${String(section.month + 1).padStart(2, '0')}`;
+          monthIndex.set(key, out.length);
+        }
         // Section-qualified key — two halves of a calendar week that spans
         // a month boundary share the same `week.key` (the Monday's ISO
         // date), so without the section prefix React reconciliation would
@@ -137,7 +169,11 @@ function SessionsCalendarWeekListView({
       });
     });
 
-    return {items: out, stickyHeaderIndices: sticky};
+    return {
+      items: out,
+      stickyHeaderIndices: sticky,
+      firstWeekIndexByMonth: monthIndex,
+    };
   }, [monthSections]);
 
   const dayNames = useMemo(() => {
@@ -165,6 +201,88 @@ function SessionsCalendarWeekListView({
   }, [locale]);
 
   const listRef = useRef<FlashListRef<ListItem>>(null);
+
+  // Window-Y (px) of the FlashList's top edge, captured via the wrapper
+  // View's onLayout. `null` until first layout pass. Stored in state (not
+  // a ref) so the apply-scroll effect re-runs once it's known.
+  const flashListWrapperRef = useRef<View | null>(null);
+  const [flashTopY, setFlashTopY] = useState<number | null>(null);
+  const hasAppliedInitialScrollRef = useRef(false);
+
+  const onFlashListWrapperLayout = useCallback(() => {
+    // `onLayout` reports local coordinates — measure against the window so
+    // we can compare against the small calendar's measured Y.
+    if (!flashListWrapperRef.current) {
+      return;
+    }
+    flashListWrapperRef.current.measureInWindow((_x, y) => {
+      setFlashTopY(y);
+    });
+  }, []);
+
+  // Resolve the target index — undefined while data hasn't loaded enough
+  // months yet (the items memo widens as `loadedFromDate` extends).
+  const targetIndex = useMemo(() => {
+    if (!initialMonthYear) {
+      return undefined;
+    }
+    return firstWeekIndexByMonth.get(initialMonthYear);
+  }, [initialMonthYear, firstWeekIndexByMonth]);
+
+  const wantsInitialScroll =
+    !!initialMonthYear && initialFirstWeekY !== undefined;
+
+  useEffect(() => {
+    if (hasAppliedInitialScrollRef.current) {
+      return;
+    }
+    if (!wantsInitialScroll) {
+      hasAppliedInitialScrollRef.current = true;
+      onInitialScrollReady?.();
+      return;
+    }
+    if (flashTopY === null) {
+      return;
+    }
+    if (targetIndex === undefined) {
+      // Waiting for the data fetcher to widen the loaded range so the
+      // target month enters `items`. The effect will re-fire on `items`.
+      return;
+    }
+    if (initialFirstWeekY === undefined) {
+      return;
+    }
+    // FlashList's `scrollToIndex({viewPosition: 0, viewOffset})` lands the
+    // row at the top of the visible area, then shifts the final offset by
+    // `viewOffset` (positive = item moves up = scroll further). We want
+    // the row at window-Y `initialFirstWeekY`, i.e. `flashTopY + delta`
+    // below the FlashList's top. To move the row *down* by `delta`, pass
+    // `viewOffset: -delta`.
+    const delta = initialFirstWeekY - flashTopY;
+    listRef.current?.scrollToIndex({
+      index: targetIndex,
+      animated: false,
+      viewPosition: 0,
+      viewOffset: -delta,
+    });
+    hasAppliedInitialScrollRef.current = true;
+    onInitialScrollReady?.();
+  }, [
+    items,
+    flashTopY,
+    targetIndex,
+    initialFirstWeekY,
+    wantsInitialScroll,
+    onInitialScrollReady,
+  ]);
+
+  // Bottom spacer — without it the FlashList runs out of content below the
+  // latest month, and we can't push the current/recent month to the top of
+  // the viewport. One viewport-height of empty space is plenty.
+  const ListFooter = useMemo(
+    () => <View style={listFooterStyle} />,
+    [],
+  );
 
   // Lazy-load older months when the user scrolls within the buffer of the
   // loaded floor. Walk forward from the lowest visible index to the first
@@ -258,6 +376,16 @@ function SessionsCalendarWeekListView({
     translate,
   ]);
 
+  // When we have a target, seed `initialScrollIndex` to it so we land close
+  // to the right place even before the corrective `scrollToIndex` lands —
+  // avoids a noticeable pre-scroll flash from the latest month on Android.
+  // The `opacity: 0` parent on the screen hides this entirely, but it's
+  // good belt-and-suspenders.
+  const initialScrollIndex =
+    wantsInitialScroll && targetIndex !== undefined
+      ? targetIndex
+      : Math.max(0, items.length - 1);
+
   return (
     <View style={styles.flex1}>
       <View style={styles.sessionsCalendarDayNamesRow}>
@@ -270,18 +398,25 @@ function SessionsCalendarWeekListView({
           </View>
         ))}
       </View>
-      <FlashList
-        ref={listRef}
-        data={items}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        stickyHeaderIndices={stickyHeaderIndices}
-        initialScrollIndex={Math.max(0, items.length - 1)}
-        showsVerticalScrollIndicator
-        ListHeaderComponent={listHeader}
-        onViewableItemsChanged={onViewableItemsChanged}
-        viewabilityConfig={VIEWABILITY_CONFIG}
-      />
+      <View
+        ref={flashListWrapperRef}
+        onLayout={onFlashListWrapperLayout}
+        style={styles.flex1}
+        collapsable={false}>
+        <FlashList
+          ref={listRef}
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          stickyHeaderIndices={stickyHeaderIndices}
+          initialScrollIndex={initialScrollIndex}
+          showsVerticalScrollIndicator
+          ListHeaderComponent={listHeader}
+          ListFooterComponent={ListFooter}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={VIEWABILITY_CONFIG}
+        />
+      </View>
     </View>
   );
 }

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -31,9 +31,19 @@ import setCalendarLocale from './setCalendarLocale';
 // before the user catches up to the loaded floor.
 const LOAD_AHEAD_BUFFER_WEEKS = 12;
 
-// One viewport-height of empty space below the latest month so the
-// current/recent month can still be scrolled flush to the top.
-const listFooterStyle = {height: Dimensions.get('window').height};
+// Mirrors `styles.sessionsCalendarWeekRow.paddingVertical`. The compact
+// calendar's row uses *marginVertical*, so a measured day cell sits at the
+// row frame's top; the fullscreen row's *paddingVertical* offsets cells by
+// this amount inside the frame. We subtract it from the scroll math so the
+// compact and fullscreen tile rows overlay pixel-perfectly.
+const WEEK_ROW_VERTICAL_PADDING = 6;
+
+// Rough per-item heights used only for sizing the bottom spacer. Deliberate
+// over-estimates so the spacer math errs toward 0 (rather than leaving an
+// over-tall tail of empty space below the latest month).
+const APPROX_WEEK_ROW_HEIGHT = 48;
+const APPROX_LABEL_HEIGHT = 56;
+
 // 50% threshold is generous enough to fire well before the lazy-load buffer
 // runs out, but quiet enough not to thrash on every pixel of scroll. The
 // previous `1` value was a major contributor to deceleration jitter.
@@ -254,11 +264,13 @@ function SessionsCalendarWeekListView({
     }
     // FlashList's `scrollToIndex({viewPosition: 0, viewOffset})` lands the
     // row at the top of the visible area, then shifts the final offset by
-    // `viewOffset` (positive = item moves up = scroll further). We want
-    // the row at window-Y `initialFirstWeekY`, i.e. `flashTopY + delta`
-    // below the FlashList's top. To move the row *down* by `delta`, pass
-    // `viewOffset: -delta`.
-    const delta = initialFirstWeekY - flashTopY;
+    // `viewOffset` (positive = item moves up = scroll further). We want the
+    // tile row's *cells* — not the row frame — at window-Y
+    // `initialFirstWeekY`. The frame top sits `WEEK_ROW_VERTICAL_PADDING`
+    // above the cells, so we land the frame top at
+    // `initialFirstWeekY - WEEK_ROW_VERTICAL_PADDING`, i.e. an effective
+    // delta of `(initialFirstWeekY - WEEK_ROW_VERTICAL_PADDING) - flashTopY`.
+    const delta = initialFirstWeekY - WEEK_ROW_VERTICAL_PADDING - flashTopY;
     listRef.current?.scrollToIndex({
       index: targetIndex,
       animated: false,
@@ -276,12 +288,40 @@ function SessionsCalendarWeekListView({
     onInitialScrollReady,
   ]);
 
-  // Bottom spacer — without it the FlashList runs out of content below the
-  // latest month, and we can't push the current/recent month to the top of
-  // the viewport. One viewport-height of empty space is plenty.
+  // Bottom spacer — only needed when there isn't enough content below the
+  // target row to scroll it up to `initialFirstWeekY`. For past targets the
+  // months below the target already fill the screen, so this clamps to 0.
+  // For the latest month we add just enough headroom — the distance from
+  // the target Y to the bottom of the screen, minus the (approximate)
+  // height of the rows that already sit below the target in the list.
+  const footerHeight = useMemo(() => {
+    if (!wantsInitialScroll || initialFirstWeekY === undefined) {
+      return 0;
+    }
+    if (targetIndex === undefined) {
+      return 0;
+    }
+    let weeksBelow = 0;
+    let labelsBelow = 0;
+    for (let i = targetIndex + 1; i < items.length; i++) {
+      if (items[i].kind === 'week') {
+        weeksBelow++;
+      } else {
+        labelsBelow++;
+      }
+    }
+    const approxHeightBelowTarget =
+      weeksBelow * APPROX_WEEK_ROW_HEIGHT + labelsBelow * APPROX_LABEL_HEIGHT;
+    const windowHeight = Dimensions.get('window').height;
+    return Math.max(
+      0,
+      windowHeight - initialFirstWeekY - approxHeightBelowTarget,
+    );
+  }, [wantsInitialScroll, initialFirstWeekY, targetIndex, items]);
+
   const ListFooter = useMemo(
-    () => <View style={listFooterStyle} />,
-    [],
+    () => <View style={{height: footerHeight}} />,
+    [footerHeight],
   );
 
   // Lazy-load older months when the user scrolls within the buffer of the

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -1,6 +1,12 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
 import type {DateData} from 'react-native-calendars';
-import {differenceInMonths, format, subMonths} from 'date-fns';
+import {
+  differenceInMonths,
+  format,
+  parseISO,
+  startOfMonth,
+  subMonths,
+} from 'date-fns';
 import {getPreviousMonth, getNextMonth} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import {computeLoadTarget} from '@libs/SessionsCalendarUtils';
@@ -36,6 +42,9 @@ function SessionsCalendar({
   preferences,
   isFetchingOlderMonths,
   mode = 'compact',
+  initialMonthYear,
+  initialFirstWeekY,
+  onInitialScrollReady,
 }: SessionsCalendarProps) {
   const {auth} = useFirebase();
   const user = auth.currentUser;
@@ -124,8 +133,18 @@ function SessionsCalendar({
       return;
     }
     hasPrefetchedRef.current = true;
-    loadUpTo(subMonths(new Date(), INITIAL_PREFETCH_MONTHS));
-  }, [mode, loadUpTo]);
+    // If the user opened the fullscreen on a month older than our default
+    // 12-month buffer, deepen the prefetch to cover it. `loadUpTo` takes the
+    // deeper of any requested floor — calling it twice is fine.
+    const defaultFloor = subMonths(new Date(), INITIAL_PREFETCH_MONTHS);
+    loadUpTo(defaultFloor);
+    if (initialMonthYear) {
+      const targetFloor = startOfMonth(parseISO(`${initialMonthYear}-01`));
+      if (targetFloor < defaultFloor) {
+        loadUpTo(targetFloor);
+      }
+    }
+  }, [mode, loadUpTo, initialMonthYear]);
 
   const onDayPress = useCallback(
     (dateData: DateData) => {
@@ -153,6 +172,9 @@ function SessionsCalendar({
         isFetchingOlderMonths={isFetchingOlderMonths}
         onDayPress={onDayPress}
         onRequestOlder={handleRequestOlder}
+        initialMonthYear={initialMonthYear}
+        initialFirstWeekY={initialFirstWeekY}
+        onInitialScrollReady={onInitialScrollReady}
       />
     );
   }

--- a/src/components/SessionsCalendar/types.ts
+++ b/src/components/SessionsCalendar/types.ts
@@ -32,6 +32,20 @@ type SessionsCalendarProps = {
    *   dedicated full-screen calendar route.
    */
   mode?: 'compact' | 'fullscreen';
+
+  /** Fullscreen-only. Month to initially position at `initialFirstWeekY`,
+   *  formatted as 'YYYY-MM'. Carried from the small calendar's header tap. */
+  initialMonthYear?: string;
+
+  /** Fullscreen-only. Window-Y (px) where the clicked month's first week-row
+   *  should land — measured from the small calendar at click time so the
+   *  open looks seamless. */
+  initialFirstWeekY?: number;
+
+  /** Fullscreen-only. Fires once the WeekListView has applied its initial
+   *  scroll (or determined it doesn't need one). The screen uses this to
+   *  drop a loading overlay that hides the brief pre-scroll frame. */
+  onInitialScrollReady?: () => void;
 };
 
 type SessionsCalendarDayMarking = {

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -145,6 +145,13 @@ type ProfileNavigatorParamList = {
 type SessionsCalendarNavigatorParamList = {
   [SCREENS.SESSIONS_CALENDAR.FULLSCREEN]: {
     userID: string;
+    /** Month the user was viewing when they opened the fullscreen calendar,
+     *  formatted as 'YYYY-MM'. Used to position the FlashList so the clicked
+     *  month overlays the small calendar's grid. */
+    monthYear?: string;
+    /** Window-Y (px) of the small calendar's first week-row at the moment of
+     *  click. React Navigation passes query params as strings. */
+    firstWeekY?: string;
   };
 };
 

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {View} from 'react-native';
+import React, {useCallback, useMemo, useState} from 'react';
+import {StyleSheet, View} from 'react-native';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {DateData} from 'react-native-calendars';
 import SessionsCalendar from '@components/SessionsCalendar';
@@ -26,6 +26,12 @@ type SessionsCalendarScreenProps = StackScreenProps<
 
 const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
 
+const internalStyles = StyleSheet.create({
+  // Render the calendar mounted but invisible so FlashList can lay out and
+  // apply the initial scroll. Switched to visible by `onInitialScrollReady`.
+  hidden: {opacity: 0},
+});
+
 /**
  * Full-screen, scrollable sessions calendar.
  *
@@ -40,8 +46,12 @@ const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
  */
 function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
   const {auth} = useFirebase();
-  const {userID} = route.params;
+  const {userID, monthYear, firstWeekY: firstWeekYParam} = route.params;
   const user = auth.currentUser;
+  const firstWeekY = useMemo(
+    () => (firstWeekYParam ? Number(firstWeekYParam) : undefined),
+    [firstWeekYParam],
+  );
   const isSelf = user?.uid === userID;
   const {translate} = useLocalize();
   const styles = useThemeStyles();
@@ -72,6 +82,14 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
     dateToDateData(new Date()),
   );
 
+  // Hold the calendar invisible until the WeekListView has applied its
+  // initial scroll, so the user never sees a "latest at bottom → target"
+  // jump on open. With no `monthYear` (e.g. deep-link), we never wait.
+  const [isScrollReady, setIsScrollReady] = useState<boolean>(!monthYear);
+  const onInitialScrollReady = useCallback(() => setIsScrollReady(true), []);
+
+  const showLoader = isLoading || !preferences || !isScrollReady;
+
   return (
     <ScreenWrapper testID={SessionsCalendarScreen.displayName}>
       <HeaderWithBackButton
@@ -80,10 +98,8 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
         shouldShowCloseButton
         onCloseButtonPress={() => Navigation.goBack()}
       />
-      {isLoading || !preferences ? (
-        <FullScreenLoadingIndicator />
-      ) : (
-        <View style={styles.flex1}>
+      {!isLoading && preferences && (
+        <View style={[styles.flex1, !isScrollReady && internalStyles.hidden]}>
           <SessionsCalendar
             userID={userID}
             visibleDate={visibleDate}
@@ -92,9 +108,13 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
             preferences={preferences}
             isFetchingOlderMonths={isFetchingOlderMonths}
             mode="fullscreen"
+            initialMonthYear={monthYear}
+            initialFirstWeekY={firstWeekY}
+            onInitialScrollReady={onInitialScrollReady}
           />
         </View>
       )}
+      {showLoader && <FullScreenLoadingIndicator />}
     </ScreenWrapper>
   );
 }

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1289,6 +1289,58 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
   //  * Returns the style for the sessions calendar main component
   //  */
   getSessionsCalendarStyle(): RNCalendarsTheme {
+    // `react-native-calendars` resolves the overrides via the flat dot-keys
+    // `theme['stylesheet.calendar.main']` and `theme['stylesheet.calendar.header']`
+    // at runtime (see node_modules/react-native-calendars/src/calendar/style.js
+    // and header/style.js). The exported `Theme` type declares them as a nested
+    // `stylesheet.calendar.main` property, which doesn't match the runtime
+    // lookup — using the flat keys works and matches the library's own README
+    // examples. Cast through `unknown` so TS doesn't reject the extra keys.
+    // Property names are literal dot-keys required by the library's runtime
+    // (`theme['stylesheet.calendar.main']`), so the naming-convention rule
+    // doesn't apply here.
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const stylesheetOverrides = {
+      // Match the large calendar's tile spacing exactly so the clicked month
+      // overlays pixel-perfectly when opening the fullscreen variant. The
+      // numbers mirror `sessionsCalendarWeekRow` / `sessionsCalendarDayNamesRow`
+      // in src/styles/index.ts.
+      'stylesheet.calendar.main': {
+        container: {
+          paddingLeft: 0,
+          paddingRight: 0,
+          backgroundColor: theme.componentBG,
+        },
+        week: {
+          marginVertical: 6,
+          paddingHorizontal: 20,
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+        },
+      },
+      'stylesheet.calendar.header': {
+        // Day-name row inside the library header — needs the same horizontal
+        // inset and `flex: 1` column distribution as the week rows below it,
+        // otherwise the day names won't line up with the tile columns.
+        week: {
+          marginTop: 7,
+          paddingHorizontal: 20,
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+        },
+        dayHeader: {
+          flex: 1,
+          marginTop: 2,
+          marginBottom: 7,
+          textAlign: 'center',
+          fontSize: variables.fontSizeLabel,
+          ...FontUtils.fontFamily.platform.EXP_NEUE,
+          color: theme.textSupporting,
+        },
+      },
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+
     return {
       backgroundColor: theme.componentBG,
       calendarBackground: theme.componentBG,
@@ -1317,6 +1369,8 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
         FontUtils.fontFamily.platform.EXP_NEUE.fontWeight,
       textDayHeaderFontFamily:
         FontUtils.fontFamily.platform.EXP_NEUE.fontFamily,
+
+      ...(stylesheetOverrides as unknown as RNCalendarsTheme),
     };
   },
 


### PR DESCRIPTION
### Details

Today, tapping the compact calendar's month header opens the fullscreen calendar with the FlashList always positioned at the latest month (`initialScrollIndex={items.length - 1}`), regardless of which month the user was actually looking at. The visible "jump" undermines what would otherwise be a clean push.

This PR makes the open feel pixel-perfectly seamless: the **clicked month's first week-row lands at the same screen Y** the small grid's first week-row occupied at the moment of click — so the tiles in that row visually stay in place while the rest of the months unfold around them.

**What changed**

- **Tile spacing alignment.** The compact calendar now uses `paddingHorizontal: 20`, `marginVertical: 6` and `flex: 1` cells via `stylesheet.calendar.main` / `.header` overrides on the `react-native-calendars` theme. Day-name labels were re-flowed to `flex: 1` cells too (the library's hardcoded `width: 32` + `space-around` distribution didn't line up with `flex: 1` tile columns). Without this, even pixel-perfect Y alignment would have visibly shifted on X.
- **Route + nav types.** `ROUTES.SESSIONS_CALENDAR_FULLSCREEN.getRoute()` now takes optional `monthYear` (`YYYY-MM`) and `firstWeekY` (px) query params; `SessionsCalendarNavigatorParamList` updated to match. Both fields are optional, so deep-links / future entry points without them fall back to the previous "latest at bottom" behavior.
- **Measure on header press.** `DayComponent` accepts an optional `registerMeasureRef` (registers only when `date.day === 1` and the cell is in-month). The wrapping `<View>` is rendered with `collapsable={false}` so Fabric/Paper view-flattening doesn't drop it on Android and invalidate `measureInWindow`. `SessionsCalendarView` calls `measureInWindow` on header press, clamps to current month if the user was viewing a future month, and navigates with both params.
- **Screen-level loading gate.** `SessionsCalendarScreen` reads the new params, keeps the calendar mounted but `opacity: 0` until `onInitialScrollReady` fires, and overlays the existing `FullScreenLoadingIndicator`. The calendar is never conditionally unmounted — FlashList needs to lay out before the initial scroll can apply.
- **Initial scroll + bottom spacer.** `SessionsCalendarWeekListView` now builds a `firstWeekIndexByMonth` map during the existing items memo (cheap, same pass). It measures its own window-Y via `onLayout` + `measureInWindow`, and the apply-scroll effect (keyed on `items` / `flashTopY` / `targetIndex`) calls `listRef.current.scrollToIndex({index, viewPosition: 0, viewOffset: -(firstWeekY - flashTopY)})`. `initialScrollIndex` is also primed to the target index to avoid a noticeable pre-scroll flash on Android. A `ListFooterComponent` of one viewport-height gives the current / latest months enough scrollable room to be positioned flush at the top.
- **Deeper prefetch.** If the user opened the fullscreen on a month older than the existing 12-month buffer, the orchestrator now calls `loadUpTo(startOfMonth(target))` in addition to the default prefetch (`loadUpTo` is monotonic, so calling it twice is fine).

### Tests

1. On the home screen, navigate the compact calendar back several months using the left arrow, then tap the month header. Expect: the fullscreen opens and that month's first week-row is at the same screen Y as the compact grid's first week-row was. The tile X positions also align (no horizontal shift on the transition).
2. Tap the header while the compact calendar is on the **current** month. Expect: the fullscreen opens with current-month's grid at the same Y; the area below the last week is empty (bottom spacer) and you can freely scroll back up.
3. Navigate the compact calendar to a **future** month and tap the header. Expect: the fullscreen opens on the **current** month (clamped), positioned at the small calendar's measured Y.
4. Open the fullscreen calendar repeatedly. Expect: no visible flicker, no jump from "latest at bottom" → target on open. The loading indicator hides the brief pre-scroll frame.
5. With React Native's slow-animation toggle (Dev Menu → Slow Animations), watch the navigation transition frame by frame. The clicked-month tiles should not shift X or Y between the compact view and the fullscreen.
6. In the fullscreen calendar, verify the inline lazy-load behavior is unchanged: scroll up past the load-ahead buffer and confirm older months stream in.
7. Open the fullscreen via a deep link without `monthYear` (if available) — expect the previous behavior (latest at bottom).
8. Verify that no errors appear in the JS console.

### Offline tests

1. Go offline, open the fullscreen calendar from a past month. Expect: the initial scroll still applies (the data was already loaded by the home screen's compact calendar), and no errors are logged when older months can't be fetched.
2. Go offline, navigate the compact calendar back to a month near the loaded floor, then open the fullscreen. Expect: graceful behavior — the calendar opens, the data already loaded is shown, no crashes when the lazy-load attempt fails silently.

### QA Steps

1. From the home screen, tap the month header on the compact calendar. Verify the fullscreen opens with the same month visible at the same vertical position.
2. Repeat with the calendar showing several different months (past, current, future).
3. Verify the compact calendar's tile and day-name positions look normal on iOS and Android — no horizontal shift, day names sit centered over tile columns.
4. Verify scrolling within the fullscreen calendar is smooth — no regression in lazy-load, sticky labels, or scroll deceleration.
5. Verify that no errors appear in the JS console.

### PR Author Checklist

- [ ] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [ ] I verified there are no console errors
- [x] I followed proper code patterns
- [ ] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY
- [x] I verified that all code follows the ETC (easy-to-change) principle
- [x] I verified any variables that can be defined as constants are defined as such
- [x] If the PR modifies the UI, I verified that all the inputs inside a form are aligned with each other.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- pending device verification -->

</details>

<details>
<summary>iOS</summary>

<!-- pending device verification -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)