### PR TITLE
fix(android): pin colorPrimary to brand yellow so recent-apps card stops looking green

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -8,6 +8,8 @@
         <item name="android:colorEdgeEffect">@color/gray4</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="colorAccent">@color/accent</item>
+        <item name="colorPrimary">@color/bootsplash_background</item>
+        <item name="colorPrimaryDark">@color/bootsplash_background</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
         <item name="popupTheme">@style/AppTheme.Popup</item>
         <item name="android:spinnerDropDownItemStyle">@style/TextViewSpinnerDropDownItem</item>


### PR DESCRIPTION
## Summary

- `BaseAppTheme` extends `Theme.AppCompat.NoActionBar` but never sets `colorPrimary` / `colorPrimaryDark`. On older Android versions and some OEM skins (Samsung One UI, Xiaomi MIUI), the **recent-apps card chrome** reads `colorPrimary` directly — and AppCompat's historical default is a teal/green, which is what was leaking through and making the backgrounded app look Expensify-green.
- Pin both to `@color/bootsplash_background` (`#F5C400`) so the task-switcher chrome matches the launcher icon and splash background. Two lines in [android/app/src/main/res/values/styles.xml](https://github.com/PetrCala/Kiroku/blob/claude/nostalgic-kalam-1e9b69/android/app/src/main/res/values/styles.xml).

No JS / theme changes; everything else (`appColor`, `splashBG`, `success`, launcher PNGs) was already brand yellow.

## Test plan

- [ ] Build a fresh Android app (`npm run android`) on a device or emulator.
- [ ] Open the app, then swipe up / tap recent-apps — Kiroku's card header band should read brand yellow `#F5C400`, not green.
- [ ] Sanity-check a screen with a `Switch` / `Checkbox` (Settings > Preferences) — accent tints still look correct.
- [ ] Verify status bar remains transparent (unchanged).
- [ ] Spot-check splash on cold start (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)