### PR TITLE
fix(android): disable stack swipe-back so vertical scroll works again

### DIFF
--- a/src/libs/Navigation/AppNavigator/ModalNavigatorScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/ModalNavigatorScreenOptions.ts
@@ -13,7 +13,7 @@ const ModalNavigatorScreenOptions = (
 ): StackNavigationOptions => ({
   headerShown: false,
   gestureDirection: 'horizontal',
-  gestureEnabled: Platform.OS !== 'web',
+  gestureEnabled: Platform.OS === 'ios',
   gestureResponseDistance: 10000,
   cardStyle: themeStyles.navigationScreenCardStyle,
   cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalScreenOptions.ts
@@ -32,7 +32,7 @@ function useModalScreenOptions(
       cardStyle: styles.navigationScreenCardStyle,
       headerShown: false,
       cardStyleInterpolator,
-      gestureEnabled: Platform.OS !== 'web',
+      gestureEnabled: Platform.OS === 'ios',
       gestureResponseDistance: 10000,
     }),
     [styles, cardStyleInterpolator],

--- a/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
+++ b/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
@@ -104,7 +104,7 @@ const getRootNavigatorScreenOptions: GetRootNavigatorScreenOptions = (
     rightModalNavigator: ({route}) => ({
       ...rightModalStaticOptions,
       gestureEnabled:
-        Platform.OS !== 'web' &&
+        Platform.OS === 'ios' &&
         !hasPoppableInnerStack((route as {state?: NestedState}).state),
     }),
     onboardingModalNavigator: (shouldUseNarrowLayout: boolean) => ({


### PR DESCRIPTION
### Details

The recent *iOS-style swipe-back across mobile* PR ([4dd5afd6](https://github.com/PetrCala/Kiroku/commit/4dd5afd6) + follow-ups [ad3b3383](https://github.com/PetrCala/Kiroku/commit/ad3b3383), [01db2a29](https://github.com/PetrCala/Kiroku/commit/01db2a29), [a2425a0d](https://github.com/PetrCala/Kiroku/commit/a2425a0d)) set `gestureEnabled: Platform.OS !== 'web'` and `gestureResponseDistance: 10000` on every RHP/modal stack. On iOS this gives the intended *swipe-from-anywhere* dismiss; on Android the same configuration silently broke vertical scrolling on every RHP child screen — Settings, Preferences, Profile, the Friends list, Achievements list, About sub-screens, etc.

**Why scroll broke on Android.** An RHP child sits inside three nested @react-navigation/stack cards (root RHP card → outer modal stack card → inner sub-route card). Each card mounts its own `PanGestureHandler`. With `gestureResponseDistance: 10000` the handler's effective hitSlop extends across the full screen, and on Android RNGH's coordination keeps all three handlers in the touch chain — even though their activation criteria (`minOffsetX: 5`, `maxDeltaY: 20`) say *"yield to vertical scrolls"*, the inner `ScrollView` / `FlashList` can't claim the touch while the outer handlers are still arbitrating. The result: scrolling locks up. The two screens that kept working (`DRINKING_SESSION.LIVE`, `SOCIAL.ROOT`) are precisely the ones that already had `options: {gestureEnabled: false}` set per-screen.

`gestureResponseDistance` only narrows where the gesture *activates*, not whether the handler is mounted. Tuning it down (e.g. to `30`) restricts swipe-back to a left-edge strip but does not free the inner scrollables — the handlers are still in the touch chain. The only reliable fix is to remove the handler on Android.

**Fix.** Replace `Platform.OS !== 'web'` with `Platform.OS === 'ios'` in the three places `gestureEnabled` is set:
- [ModalNavigatorScreenOptions.ts](https://github.com/PetrCala/Kiroku/blob/test/swipe-back-scroll-block/src/libs/Navigation/AppNavigator/ModalNavigatorScreenOptions.ts)
- [ModalStackNavigators/useModalScreenOptions.ts](https://github.com/PetrCala/Kiroku/blob/test/swipe-back-scroll-block/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalScreenOptions.ts)
- [getRootNavigatorScreenOptions.tsx](https://github.com/PetrCala/Kiroku/blob/test/swipe-back-scroll-block/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx) (compound `Platform.OS !== 'web' && !hasPoppableInnerStack(...)`)

iOS keeps the swipe-back-from-anywhere behavior the original PR introduced. Android no longer has a stack swipe-back gesture; users have the system back gesture / back button, which is the platform-native way. `gestureResponseDistance: 10000` is left in place — it only takes effect when the gesture is enabled (i.e. iOS).

### Tests

1. On **Android**, log in and verify vertical scrolling works on:
   - Settings list (Profile, Preferences, Report a bug, … all the way to Admin tools)
   - Preferences → Drinks to Units (form)
   - Profile Details
   - Friends list (bottom tab)
   - Friends list within a friend's profile
   - About sub-screens (Terms of Service, Privacy Policy)
   - Any other RHP screen with a list / form
2. On **Android**, confirm swipe-back from the left edge of an RHP card **no longer dismisses** the card — that's expected. Use the system back button / back gesture instead.
3. On **iOS**, confirm swipe-back from anywhere on an RHP card still dismisses it (unchanged behavior).
4. On **iOS**, confirm vertical scrolling on the same screens still works (unchanged behavior).

### Offline tests

No network behavior touched; gesture and scroll behavior is identical online vs. offline.

### QA Steps

Same as **Tests** above, on the staging build. Pay particular attention to RHP screens with long lists.

### PR Author Checklist

- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android (vertical scroll restored on every RHP screen; swipe-back disabled — system back works)
  - [ ] iOS (not re-verified locally; behavior should be unchanged because the change is gated to non-iOS)
- [x] I verified there are no console errors
- [x] I followed proper code patterns
- [x] I tested other components that can be impacted by my changes

### Screenshots/Videos

<details>
<summary>Android</summary>

Manual verification performed on emulator (1080×2424). Before the fix, lists in RHP screens (Settings, Preferences, Profile, etc.) did not respond to vertical drags; only `DRINKING_SESSION.LIVE` and `SOCIAL.ROOT` scrolled, because those screens already had `gestureEnabled: false` set per-screen. After the fix, all RHP child screens scroll. Swipe-back gesture no longer fires on Android.

</details>

<details>
<summary>iOS</summary>

No code path on iOS is altered by this PR — `Platform.OS === 'ios'` evaluates to the same `true` that `Platform.OS !== 'web'` did on iOS.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)