### PR TITLE
fix(bootsplash): stop yellow splash drawable from leaking through on stack swap

### DIFF
--- a/android/app/src/main/java/com/alcohol_tracker/bootsplash/BootSplashModule.java
+++ b/android/app/src/main/java/com/alcohol_tracker/bootsplash/BootSplashModule.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -169,6 +171,19 @@ public class BootSplashModule extends ReactContextBaseJavaModule {
         } else if (mDialog == null) {
           clearPromiseQueue();
         } else {
+          // The activity's windowBackground is the yellow bootsplash drawable
+          // (inherited from BootTheme in AndroidManifest). init() calls
+          // setTheme(R.style.AppTheme), but Activity.setTheme() does NOT swap an
+          // already-attached Window's background drawable — so without this the
+          // bootsplash stays under the React root view for the process lifetime
+          // and leaks through whenever the React surface is briefly transparent
+          // (e.g. the auth→public stack swap on sign-out from VerifyEmailModal,
+          // which manifests as a flash of yellow + logo).
+          final Window activityWindow = activity.getWindow();
+          if (activityWindow != null) {
+            activityWindow.setBackgroundDrawable(new ColorDrawable(Color.BLACK));
+          }
+
           // Capture the dialog and clear the static reference so a re-entrant
           // hide() (e.g. promise queued during the fade) takes the mDialog == null
           // branch above and resolves immediately, without starting a second


### PR DESCRIPTION
## Summary

- The activity's `windowBackground` is the yellow `bootsplash.xml` drawable (inherited from `BootTheme` in [AndroidManifest.xml:29](android/app/src/main/AndroidManifest.xml#L29)), and [`BootSplashModule.init()`](android/app/src/main/java/com/alcohol_tracker/bootsplash/BootSplashModule.java) never actually replaces it — `Activity.setTheme()` doesn't swap an already-attached Window's background drawable, so the bootsplash sits beneath the React root view for the whole process lifetime and bleeds through whenever the React surface is briefly transparent.
- This manifested as a flash of yellow + Kiroku logo after dismissing `VerifyEmailModal` via Sign out: React Navigation tears down the auth stack and mounts the public stack, and during the swap the activity windowBackground was exposed.
- Fix: when the splash hides, swap the activity's window background to a solid `ColorDrawable(Color.BLACK)`. The dialog is still on top during its 250ms fade, so the swap is invisible; after the dialog dismisses, any future transient gap in the React surface flashes black instead of yellow + logo.

## Notes / open questions

- **Color choice.** Hardcoded `Color.BLACK`. The app is overwhelmingly dark-themed, so black is a near-invisible fallback in practice. For light-theme users a brief black flash during a transition would look out of place — if that turns out to matter, swap to a theme-aware color (resolve `?attr/colorBackground` on the activity, or add an `R.color.app_background_*` and select per theme).
- **Cold-start path unchanged.** The pre-dialog frame at first launch still shows yellow (that's the intended splash).
- **Visual verification still pending.** The diagnosis combined runtime evidence (no MainActivity recreate around the sign-out tap) with structural code analysis; I didn't manage to capture a screen recording of the actual flash before this commit (screenrecord errored, and re-reproducing the bug needs an unverified account I don't have credentials for). The structural reasoning is solid but a side-by-side verification would close the loop.

## Test plan

- [ ] Rebuild dev APK (`npm run android`) and install on emulator
- [ ] Sign up a fresh account; do **not** click verification email
- [ ] Force-stop and re-launch — confirm `VerifyEmailModal` appears
- [ ] Tap **Sign out** — confirm the public stack appears with **no** yellow flash
- [ ] Tap **Skip verification (dev only)** in a separate run — confirm same (no yellow flash on modal dismiss)
- [ ] Confirm cold-start splash still appears yellow and fades normally
- [ ] Smoke-check light theme: trigger a navigation transition and confirm the (now black) background isn't visibly jarring; if it is, revisit color choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)