### PR TITLE
fix(fastlane): point crashlytics gsp_path at config plist

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,8 +102,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled rootProject.ext.multiDexEnabled
-        versionCode 1000031226
-        versionName "0.3.12-26"
+        versionCode 1000031300
+        versionName "0.3.13-0"
         // Supported language variants must be declared here to avoid from being removed during the compilation.
         // This also helps us to not include unnecessary language variants in the APK.
         resConfigs "en", "cs"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -233,7 +233,7 @@ platform :ios do
       upload_symbols_to_crashlytics(
         app_id: "1:665512857657:ios:a07eeddf1f54bac2b4fde8",
         dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
-        gsp_path: "./ios/GoogleService-Info.plist",
+        gsp_path: "./ios/config/GoogleService-Info.prod.plist",
         binary_path: "./ios/Pods/FirebaseCrashlytics/upload-symbols",
       )
     rescue => e

--- a/ios/kiroku/Info.plist
+++ b/ios/kiroku/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.12</string>
+	<string>0.3.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.3.12.26</string>
+	<string>0.3.13.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationLaunchProhibited</key>

--- a/ios/kirokuTests/Info.plist
+++ b/ios/kirokuTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.12</string>
+	<string>0.3.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.3.12.26</string>
+	<string>0.3.13.0</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiroku",
-  "version": "0.3.12-26",
+  "version": "0.3.13-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiroku",
-      "version": "0.3.12-26",
+      "version": "0.3.13-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiroku",
-  "version": "0.3.12-26",
+  "version": "0.3.13-0",
   "private": true,
   "type": "commonjs",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- The iOS beta lane logged `Failed to upload dSYMs to Crashlytics: Couldn't find file at path '/Users/runner/work/Kiroku/Kiroku/ios/GoogleService-Info.plist'` at the end of every staging deploy.
- That path doesn't exist in the repo — the real plists are at `ios/config/GoogleService-Info.{dev,prod}.plist`, and an Xcode build phase in [project.pbxproj:803](ios/kiroku.xcodeproj/project.pbxproj#L803) copies the matching one into the built `.app` bundle.
- The beta lane builds the `Kiroku (production)` scheme with `.env.production`, so point `gsp_path` at the prod plist source. This unblocks Crashlytics dSYM uploads after TestFlight distribution.

## Test plan
- [ ] Next staging deploy on `master` reaches `upload_symbols_to_crashlytics` without the "invalid parameters" / "Couldn't find file" error.
- [ ] dSYMs land in the Crashlytics dashboard for the staging build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)