### PR TITLE
feat(calendar): show per-month unit totals; rename fullscreen header

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -20,6 +20,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
+import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 import buildMonthSections from './buildMonthSections';
 import type {MonthSection, MonthWeek} from './buildMonthSections';
@@ -54,6 +55,8 @@ type SessionsCalendarWeekListViewProps = {
   markedDates: MarkedDates;
   /** Per-day unit count, also keyed by `DateString`. */
   unitsMap: Map<DateString, number>;
+  /** Per-month unit totals keyed by 'YYYY-MM'. Rendered in the month label. */
+  monthlyTotalsMap: Map<string, number>;
   /** Earliest day currently loaded (drives the bottom of the list). */
   loadedFromDate: Date | null;
   /** Latest day to render (defaults to today). */
@@ -84,6 +87,7 @@ type LabelItem = {
   kind: 'label';
   key: string;
   label: string;
+  monthKey: string;
 };
 
 type WeekItem = {
@@ -109,6 +113,7 @@ type ListItem = LabelItem | WeekItem;
 function SessionsCalendarWeekListView({
   markedDates,
   unitsMap,
+  monthlyTotalsMap,
   loadedFromDate,
   endDate,
   isFetchingOlderMonths,
@@ -153,18 +158,19 @@ function SessionsCalendarWeekListView({
 
     monthSections.forEach(section => {
       const labelDate = new Date(section.year, section.month, 1);
+      const monthKey = `${section.year}-${String(section.month + 1).padStart(2, '0')}`;
       sticky.push(out.length);
       out.push({
         kind: 'label',
         key: `label-${section.year}-${section.month}`,
         label: format(labelDate, CONST.DATE.MONTH_YEAR_ABBR_FORMAT),
+        monthKey,
       });
       section.weeks.forEach((week, weekIdx) => {
         if (weekIdx === 0) {
           // The first week-row of each section is what we anchor the
           // initial-scroll lookup against. Key by 'YYYY-MM'.
-          const key = `${section.year}-${String(section.month + 1).padStart(2, '0')}`;
-          monthIndex.set(key, out.length);
+          monthIndex.set(monthKey, out.length);
         }
         // Section-qualified key — two halves of a calendar week that spans
         // a month boundary share the same `week.key` (the Monday's ISO
@@ -362,12 +368,20 @@ function SessionsCalendarWeekListView({
   const renderItem = useCallback(
     (args: {item: ListItem}) => {
       if (args.item.kind === 'label') {
+        const total = monthlyTotalsMap.get(args.item.monthKey);
         return (
           <View style={styles.sessionsCalendarMonthLabel}>
             <Text style={styles.sessionsCalendarMonthLabelText}>
               {args.item.label}
             </Text>
             <View style={styles.sessionsCalendarMonthLabelRule} />
+            {total !== undefined && total > 0 && (
+              <Text style={styles.sessionsCalendarMonthLabelTotal}>
+                {translate('calendar.monthTotalUnits', {
+                  unitCount: roundToTwoDecimalPlaces(total),
+                })}
+              </Text>
+            )}
           </View>
         );
       }
@@ -383,10 +397,13 @@ function SessionsCalendarWeekListView({
     [
       markedDates,
       unitsMap,
+      monthlyTotalsMap,
       onDayPress,
+      translate,
       styles.sessionsCalendarMonthLabel,
       styles.sessionsCalendarMonthLabelText,
       styles.sessionsCalendarMonthLabelRule,
+      styles.sessionsCalendarMonthLabelTotal,
     ],
   );
 

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -51,6 +51,7 @@ function SessionsCalendar({
   const {
     markedDates,
     unitsMap,
+    monthlyTotalsMap,
     loadedFrom,
     loadedFromDate,
     loadMoreMonths,
@@ -168,6 +169,7 @@ function SessionsCalendar({
       <SessionsCalendarWeekListView
         markedDates={markedDates}
         unitsMap={unitsMap}
+        monthlyTotalsMap={monthlyTotalsMap}
         loadedFromDate={loadedFromDate}
         isFetchingOlderMonths={isFetchingOlderMonths}
         onDayPress={onDayPress}

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -118,13 +118,15 @@ function useLazyMarkedDates(
     [preferences, palette],
   );
 
-  // Second pass — build markedDates + unitsMap from the pre-built index.
-  // This is the only memo that needs `preferences`; on a palette change it
-  // walks the day list (~30 entries) instead of re-filtering N sessions.
+  // Second pass — build markedDates + unitsMap + monthlyTotalsMap from the
+  // pre-built index. This is the only memo that needs `preferences`; on a
+  // palette change it walks the day list (~30 entries) instead of
+  // re-filtering N sessions. `monthlyTotalsMap` is keyed by 'YYYY-MM'.
   const paletteGreen = palette.green;
-  const {markedDatesMap, unitsMap} = useMemo(() => {
+  const {markedDatesMap, unitsMap, monthlyTotalsMap} = useMemo(() => {
     const newMarkedDatesMap = new Map<DateString, MarkingProps>();
     const newUnitsMap = new Map<DateString, number>();
+    const newMonthlyTotalsMap = new Map<string, number>();
 
     dayKeys.forEach(dayKey => {
       const dailySessions = sessionIndex.get(dayKey) ?? [];
@@ -138,9 +140,20 @@ function useLazyMarkedDates(
       }
       newMarkedDatesMap.set(dayKey, newMarking.marking);
       newUnitsMap.set(dayKey, newMarking.units);
+      // dayKey is 'YYYY-MM-DD' — slice the month bucket directly without
+      // re-parsing the date.
+      const monthKey = dayKey.slice(0, 7);
+      newMonthlyTotalsMap.set(
+        monthKey,
+        (newMonthlyTotalsMap.get(monthKey) ?? 0) + newMarking.units,
+      );
     });
 
-    return {markedDatesMap: newMarkedDatesMap, unitsMap: newUnitsMap};
+    return {
+      markedDatesMap: newMarkedDatesMap,
+      unitsMap: newUnitsMap,
+      monthlyTotalsMap: newMonthlyTotalsMap,
+    };
   }, [sessionIndex, dayKeys, effectivePreferences, paletteGreen]);
 
   const markedDates: MarkedDates = useMemo(
@@ -202,6 +215,7 @@ function useLazyMarkedDates(
   return {
     markedDates,
     unitsMap,
+    monthlyTotalsMap,
     loadedFrom,
     loadedFromDate,
     loadMoreMonths,

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -291,6 +291,8 @@ export default {
     today: 'Dnes',
     fullscreenTitle: 'Sezení',
     loadingOlderMonths: 'Načítání starších měsíců…',
+    monthTotalUnits: ({unitCount}: UnitCountParams) =>
+      `${unitCount} ${Str.pluralize('jednotka', 'jednotek', unitCount)}`,
   },
   textInput: {
     accessibilityLabel: 'Textové pole',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -289,7 +289,7 @@ export default {
     ],
     dayNamesShort: ['Ne', 'Po', 'Út', 'St', 'Čt', 'Pá', 'So'],
     today: 'Dnes',
-    fullscreenTitle: 'Sezení',
+    fullscreenTitle: 'Alkoholové relace',
     loadingOlderMonths: 'Načítání starších měsíců…',
     monthTotalUnits: ({unitCount}: UnitCountParams) =>
       `${unitCount} ${Str.pluralize('jednotka', 'jednotek', unitCount)}`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -293,6 +293,8 @@ export default {
     today: 'Today',
     fullscreenTitle: 'Sessions',
     loadingOlderMonths: 'Loading older months…',
+    monthTotalUnits: ({unitCount}: UnitCountParams) =>
+      `${unitCount} ${Str.pluralize('unit', 'units', unitCount)}`,
   },
   textInput: {
     accessibilityLabel: 'Text input',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -291,7 +291,7 @@ export default {
     ],
     dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     today: 'Today',
-    fullscreenTitle: 'Sessions',
+    fullscreenTitle: 'Drinking sessions',
     loadingOlderMonths: 'Loading older months…',
     monthTotalUnits: ({unitCount}: UnitCountParams) =>
       `${unitCount} ${Str.pluralize('unit', 'units', unitCount)}`,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1619,6 +1619,17 @@ const styles = (theme: ThemeColors) =>
       backgroundColor: theme.border,
     },
 
+    // Per-month unit total rendered on the right of the divider, mirroring
+    // the label's bold-uppercase styling so the two read as one row.
+    sessionsCalendarMonthLabelTotal: {
+      ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
+      color: theme.textSupporting,
+      fontSize: variables.fontSizeSmall,
+      letterSpacing: 0.6,
+      textTransform: 'uppercase',
+      marginLeft: 8,
+    },
+
     // ListHeaderComponent for the fullscreen calendar — sits at the very
     // top of the week list (above the oldest loaded month) only while a
     // data fetch is in flight, so the user knows more months are coming.


### PR DESCRIPTION
## Summary

- **Per-month unit totals** in the infinite-scroll fullscreen calendar. Each month label now ends with the month's total units (e.g. `MAR 2026 ──── 55 units`), so you can see month-level aggregates without tapping into a specific day. Totals are computed in the same memo pass as the per-day `unitsMap`, so there's no extra walk over the session list.
- **Header rename** for the fullscreen sessions screen: `Sessions` → `Drinking sessions` (EN) and `Sezení` → `Alkoholové relace` (CS, matching how the concept is already named elsewhere in `cs_cz.ts`).

Two commits, one per change.

## Test plan

- [ ] Open the fullscreen sessions calendar — every month with at least one session shows `N units` at the right end of the divider rule.
- [ ] Months with no sessions show no total (just the rule).
- [ ] Totals stay correct after scrolling further back (lazy-load extends the loaded window).
- [ ] Switch locale to Czech — header reads `Alkoholové relace`, totals read `N jednotek` (or `1 jednotka`).
- [ ] Plural form is correct for `1 unit` vs `12 units` in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)