### PR TITLE
fix(ci): bump bundler to 2.5.23 to resolve ostruct conflict

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,4 +329,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.4.22
+   2.5.23


### PR DESCRIPTION
## Summary

The staging/production deploy workflow is failing on the Android Fastlane step with:

```
You have already activated ostruct 0.6.0, but your Gemfile requires ostruct 0.6.3.
Since ostruct is a default gem, you can either remove your dependency on it or try
updating to a newer version of bundler that supports ostruct as a default gem.
(Gem::LoadError)
```

Failing run: https://github.com/PetrCala/Kiroku/actions/runs/26395091836/job/77693852120

### Root cause

[ba00ff87 (chore: update fastlane)](https://github.com/PetrCala/Kiroku/commit/ba00ff87) bumped Fastlane to 2.234.0, which introduced an explicit `ostruct (>= 0.1.0)` runtime dependency. That resolves to `ostruct 0.6.3` in `Gemfile.lock`. Ruby 3.3.4 ships `ostruct 0.6.0` as a *default gem*, and bundler 2.4.22 (pinned in `BUNDLED WITH`) cannot reactivate a default gem at a different version once it has been required. This is a known bundler 2.4.x limitation — the official remediation in the error message is to upgrade bundler.

`0.3.13-1` (the deploy immediately before the fastlane bump landed) was the last successful staging deploy, and every deploy after it has failed with the same error, which matches the diagnosis.

### Fix

Bump `BUNDLED WITH` in `Gemfile.lock` from `2.4.22` to `2.5.23`. Bundler 2.5+ properly handles default-gem version overrides. `ruby/setup-ruby@v1.190.0` reads `BUNDLED WITH` and will install the requested bundler automatically.

## Test plan

- [ ] Verify the workflow run succeeds on this branch (or via re-trigger after merge to staging)
- [ ] Android Fastlane lane (`bundle exec fastlane android beta`) gets past gem loading
- [ ] iOS Fastlane lane unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)