### PR TITLE
fix(ci): bump bundler to 2.7.2 to fix ostruct default-gem conflict

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,4 +329,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.4.22
+   2.7.2


### PR DESCRIPTION
## Summary
- CI's Android/iOS deploys have been failing with `Gem::LoadError: You have already activated ostruct 0.6.0, but your Gemfile requires ostruct 0.6.3` (see [run 26396535325](https://github.com/PetrCala/Kiroku/actions/runs/26396535325/job/77698466425)).
- Root cause: Ruby 3.3.4 ships `ostruct 0.6.0` as a default gem. Bundler 2.4.22 (what `Gemfile.lock`'s `BUNDLED WITH` pins) activates the default gem before resolving the lockfile-pinned `ostruct 0.6.3` (pulled in transitively by `fastlane 2.234.0`), so the require blows up. Bundler ≥2.6 handles default gems and swaps to the locked version cleanly.
- Fix: bump `BUNDLED WITH` to `2.7.2`. `ruby/setup-ruby@v1.190.0` with `bundler-cache: true` reads this and installs the matching bundler, so no workflow changes are needed.

## Test plan
- [ ] CI: `Build and deploy Android` and `Build and deploy iOS` jobs succeed past `Run Fastlane`.
- [ ] Local: `bundle exec fastlane --version` runs without `Gem::LoadError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)