### PR TITLE
fix(ci): remove RUBYOPT=-rostruct so Bundler can resolve ostruct 0.6.3

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -99,7 +99,6 @@ jobs:
           max_attempts: 3
           command: bundle exec fastlane android ${{ inputs.SHOULD_DEPLOY_PRODUCTION && 'production' || 'beta' }}
         env:
-          RUBYOPT: '-rostruct'
           MYAPP_UPLOAD_STORE_PASSWORD: ${{ secrets.MYAPP_UPLOAD_STORE_PASSWORD }}
           MYAPP_UPLOAD_KEY_PASSWORD: ${{ secrets.MYAPP_UPLOAD_KEY_PASSWORD }}
           VERSION: ${{ env.VERSION_CODE }}


### PR DESCRIPTION
## Summary

- Removes `RUBYOPT: '-rostruct'` from the Android Fastlane step in `platformDeploy.yml`.
- This is the actual root cause of the recurring `Gem::LoadError: You have already activated ostruct 0.6.0, but your Gemfile requires ostruct 0.6.3` failures on master deploys (latest: [run 26396535325](https://github.com/PetrCala/Kiroku/actions/runs/26396535325/job/77698466425)).

## Why the two previous fixes didn't help

The two bundler bumps (`2.4.22 → 2.7.2`, then `→ 2.5.23` in `Gemfile.lock`) target the wrong layer. The Bundler version is a red herring while `RUBYOPT: -rostruct` is set:

1. Ruby starts → `-rostruct` does `require 'ostruct'`, which activates the **default-gem** `ostruct 0.6.0` shipped with Ruby 3.3.4.
2. `bundle exec` runs `Bundler.setup`. Gemfile.lock pins `ostruct 0.6.3` (a transitive dep that fastlane 2.234.0 started declaring).
3. Bundler refuses to swap an already-activated default gem → `Gem::LoadError`.

Bundler 2.5+ does handle default-gem version overrides — but only when the gem hasn't been pre-required. `-rostruct` short-circuits whatever Bundler could do, no matter the Bundler version.

The `-rostruct` workaround was originally added in `aafa9f7d` to paper over an earlier "ostruct missing" error. It's no longer needed: fastlane now declares `ostruct` as a real gem dependency, so Bundler installs 0.6.3 into the bundle and `bundle exec fastlane` finds it without any preload. The Bundler 2.5.23 bump in `bab2ed6d` is necessary and stays — it's just not sufficient by itself.

## Test plan

- [ ] CI lint/typecheck pass on this PR
- [ ] Manually trigger `testBuild.yml` against this branch and confirm the Android Fastlane step gets past the previous failure point (`bundler: failed to load command: fastlane`)
- [ ] After merge, watch the next `Deploy code to staging or production` run for a green Android job
- [ ] If a different ostruct-related error appears (e.g. missing at runtime), revert is one-line — restore the `RUBYOPT` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)