### PR TITLE
feat(home): re-skin calendar header + stats to Mockup C

### DIFF
--- a/__tests__/unit/useHomeMonthStats.test.ts
+++ b/__tests__/unit/useHomeMonthStats.test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+import {renderHook} from '@testing-library/react-native';
+import {addMonths, endOfMonth, startOfMonth, subMonths} from 'date-fns';
+import type {DateData} from 'react-native-calendars';
+import useHomeMonthStats from '@components/Home/useHomeMonthStats';
+import {dateToDateData} from '@libs/DataHandling';
+import type {DrinkingSession, Preferences} from '@src/types/onyx';
+
+function makePreferences(): Preferences {
+  return {
+    first_day_of_week: 'Monday',
+    units_to_colors: {orange: 10, yellow: 5},
+    drinks_to_units: {
+      small_beer: 0.5,
+      beer: 1,
+      cocktail: 1.5,
+      other: 1,
+      strong_shot: 1,
+      weak_shot: 0.5,
+      wine: 1,
+    },
+    theme: 'system',
+  } as unknown as Preferences;
+}
+
+function makeSession(id: string, when: Date): DrinkingSession {
+  return {
+    id,
+    start_time: when.getTime(),
+    end_time: when.getTime(),
+    blackout: false,
+    note: '',
+    type: 'edit',
+    timezone: 'UTC',
+    drinks: {[when.getTime()]: {beer: 1}},
+  } as unknown as DrinkingSession;
+}
+
+function visibleDateOf(d: Date): DateData {
+  return dateToDateData(d);
+}
+
+describe('useHomeMonthStats — alcohol-free days clamping', () => {
+  // Pin "today" via a Date spy. Fake timers conflict with
+  // @testing-library/react-native's act() cleanup (which depends on real
+  // microtask scheduling), so we mock the system clock directly instead.
+  const FIXED_NOW = new Date('2026-05-15T12:00:00Z');
+  const RealDate = global.Date;
+  let currentNow = FIXED_NOW.getTime();
+
+  function setNow(d: Date) {
+    currentNow = d.getTime();
+  }
+
+  beforeAll(() => {
+    function MockDate(
+      this: Date,
+      arg1?: number | string | Date,
+      ...rest: number[]
+    ): Date {
+      if (arg1 === undefined) {
+        return new RealDate(currentNow);
+      }
+      if (rest.length === 0) {
+        return new RealDate(arg1);
+      }
+      const [m = 0, d = 1, h = 0, mi = 0, s = 0, ms = 0] = rest;
+      return new RealDate(arg1 as number, m, d, h, mi, s, ms);
+    }
+    MockDate.now = () => currentNow;
+    MockDate.parse = RealDate.parse;
+    MockDate.UTC = RealDate.UTC;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as unknown as {Date: any}).Date = MockDate;
+  });
+
+  afterAll(() => {
+    (globalThis as unknown as {Date: typeof RealDate}).Date = RealDate;
+  });
+
+  beforeEach(() => {
+    setNow(FIXED_NOW);
+  });
+
+  test('mid-month with sessions: only elapsed days count', () => {
+    // May 1, May 3, May 10 — 3 drink days, today is May 15 (day 15 of 31).
+    const sessions = {
+      a: makeSession('a', new Date('2026-05-01T12:00:00Z')),
+      b: makeSession('b', new Date('2026-05-03T12:00:00Z')),
+      c: makeSession('c', new Date('2026-05-10T12:00:00Z')),
+    };
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(FIXED_NOW), sessions, makePreferences()),
+    );
+    // Elapsed days = 15. Drink days = 3. Alcohol-free = 12.
+    expect(result.current.alcoholFreeDays).toBe(12);
+    expect(result.current.drinkingSessionsCount).toBe(3);
+  });
+
+  test('first-of-month, no sessions: alcohol-free = 1 (today only)', () => {
+    const firstOfMonth = new Date('2026-05-01T08:00:00Z');
+    setNow(firstOfMonth);
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(firstOfMonth), {}, makePreferences()),
+    );
+    // Without sessions on day 1, alcohol-free = 1 (only May 1 elapsed).
+    // It must NOT equal daysInMonth (31).
+    expect(result.current.alcoholFreeDays).toBe(1);
+    setNow(FIXED_NOW);
+  });
+
+  test('past month: full month counts', () => {
+    // April 2026 — 30 days, fully past. Two drink days.
+    const aprilDate = subMonths(FIXED_NOW, 1);
+    const sessions = {
+      a: makeSession('a', new Date('2026-04-05T12:00:00Z')),
+      b: makeSession('b', new Date('2026-04-20T12:00:00Z')),
+    };
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(aprilDate), sessions, makePreferences()),
+    );
+    expect(result.current.alcoholFreeDays).toBe(30 - 2);
+  });
+
+  test('future month: alcohol-free days = 0 (no time has elapsed)', () => {
+    const juneDate = addMonths(FIXED_NOW, 1);
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(juneDate), {}, makePreferences()),
+    );
+    expect(result.current.alcoholFreeDays).toBe(0);
+  });
+
+  test('end of past month: clamping does not eat days', () => {
+    // Look at March 31 — we are in May, so March is fully past.
+    const marchEnd = endOfMonth(subMonths(FIXED_NOW, 2));
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(marchEnd), {}, makePreferences()),
+    );
+    // March = 31 days, zero sessions.
+    expect(result.current.alcoholFreeDays).toBe(31);
+  });
+
+  test('returns zero stats with undefined preferences', () => {
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(FIXED_NOW), {}, undefined),
+    );
+    expect(result.current.alcoholFreeDays).toBe(0);
+    expect(result.current.drinkingSessionsCount).toBe(0);
+    expect(result.current.unitsConsumed).toBe(0);
+  });
+
+  test('start-of-month with today on day 1 (consistency with first-of-month test)', () => {
+    // Sanity: today on May 1 with no sessions == 1 alcohol-free day, not 31.
+    const may1 = startOfMonth(FIXED_NOW);
+    setNow(may1);
+    const {result} = renderHook(() =>
+      useHomeMonthStats(visibleDateOf(may1), {}, makePreferences()),
+    );
+    expect(result.current.alcoholFreeDays).toBe(1);
+    setNow(FIXED_NOW);
+  });
+});

--- a/src/components/Home/ThisWeekCard.tsx
+++ b/src/components/Home/ThisWeekCard.tsx
@@ -1,0 +1,107 @@
+import React, {useMemo} from 'react';
+import {View} from 'react-native';
+import {format} from 'date-fns';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useTheme from '@hooks/useTheme';
+import useResolvedPalette from '@hooks/useResolvedPalette';
+import {convertUnitsToColors} from '@libs/DataHandling';
+import {isLightHex} from '@libs/SessionColorPalettes';
+import CONST from '@src/CONST';
+import type {Preferences} from '@src/types/onyx';
+import type {WeekDay, WeekSummary} from './useHomeWeekStats';
+
+type ThisWeekCardProps = {
+  days: WeekDay[];
+  summary: WeekSummary;
+  preferences: Preferences;
+};
+
+function ThisWeekCard({days, summary, preferences}: ThisWeekCardProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const palette = useResolvedPalette(preferences);
+
+  // Locale-aware short day name (M/T/W/T/F/S/S). Cached per day so we don't
+  // recreate an Intl.DateTimeFormat on every render.
+  const dayLetters = useMemo(
+    () => days.map(d => format(d.date, 'EEEEE')),
+    [days],
+  );
+
+  return (
+    <View style={styles.homeWeekCard}>
+      <Text style={styles.homeWeekCardTitle}>
+        {translate('homeScreen.stats.thisWeek')}
+      </Text>
+      <View style={styles.homeWeekRow}>
+        {days.map((d, i) => {
+          const hasUnits = d.units > 0;
+          const color = hasUnits
+            ? convertUnitsToColors(
+                d.units,
+                preferences.units_to_colors,
+                preferences.session_color_palette,
+              )
+            : null;
+          let textColor: string = theme.textSupporting;
+          if (color) {
+            textColor = isLightHex(color)
+              ? CONST.CALENDAR_COLORS.TEXT.BLACK
+              : CONST.CALENDAR_COLORS.TEXT.WHITE;
+          }
+
+          const pillStyles = [
+            styles.homeWeekDayPill,
+            d.isFuture && styles.homeWeekDayPillFuture,
+            color ? {backgroundColor: color} : null,
+            d.isToday && {borderColor: palette.yellow},
+            d.isToday && styles.homeWeekDayPillToday,
+          ];
+
+          return (
+            <View key={d.date.toISOString()} style={pillStyles}>
+              <Text style={[styles.homeWeekDayName, {color: textColor}]}>
+                {dayLetters[i]}
+              </Text>
+              {!d.isFuture && (
+                <Text style={[styles.homeWeekDayValue, {color: textColor}]}>
+                  {format(d.date, 'd')}
+                </Text>
+              )}
+            </View>
+          );
+        })}
+      </View>
+      <View style={styles.homeWeekSummary}>
+        <View style={styles.homeWeekSummaryItem}>
+          <Text style={styles.homeWeekSummaryValue}>{summary.sessions}</Text>
+          <Text style={styles.homeWeekSummaryLabel}>
+            {translate('homeScreen.stats.weekSummary.sessions')}
+          </Text>
+        </View>
+        <View style={styles.homeWeekSummaryItem}>
+          <Text style={styles.homeWeekSummaryValue}>
+            {Math.round(summary.units * 10) / 10}
+          </Text>
+          <Text style={styles.homeWeekSummaryLabel}>
+            {translate('homeScreen.stats.weekSummary.units')}
+          </Text>
+        </View>
+        <View style={styles.homeWeekSummaryItem}>
+          <Text style={[styles.homeWeekSummaryValue, {color: theme.success}]}>
+            {summary.quietDays}
+          </Text>
+          <Text style={[styles.homeWeekSummaryLabel, {color: theme.success}]}>
+            {translate('homeScreen.stats.weekSummary.quietDays')}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+ThisWeekCard.displayName = 'ThisWeekCard';
+export default ThisWeekCard;

--- a/src/components/Home/useHomeMonthStats.ts
+++ b/src/components/Home/useHomeMonthStats.ts
@@ -1,0 +1,103 @@
+import {useMemo} from 'react';
+import type {DateData} from 'react-native-calendars';
+import {eachDayOfInterval, endOfMonth, format, startOfMonth} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
+import {calculateThisMonthUnits, timestampToDate} from '@libs/DataHandling';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
+import CONST from '@src/CONST';
+import type {
+  DrinkingSessionArray,
+  DrinkingSessionList,
+  Preferences,
+} from '@src/types/onyx';
+
+type HomeMonthStats = {
+  drinkingSessionsCount: number;
+  unitsConsumed: number;
+  alcoholFreeDays: number;
+};
+
+const EMPTY_STATS: HomeMonthStats = {
+  drinkingSessionsCount: 0,
+  unitsConsumed: 0,
+  alcoholFreeDays: 0,
+};
+
+/**
+ * Compute the home-screen month statistics: sessions logged, total units, and
+ * alcohol-free days for the visible month.
+ *
+ * Alcohol-free days clamps the day interval to `min(monthEnd, today)` so we
+ * never count future days as alcohol-free — fixes the inflation bug called
+ * out in `mockups/DIRECTION_REVIEW.md` §3.
+ */
+function useHomeMonthStats(
+  visibleDate: DateData,
+  drinkingSessionData: DrinkingSessionList | undefined,
+  preferences: Preferences | undefined,
+): HomeMonthStats {
+  const drinksToUnits = preferences?.drinks_to_units;
+
+  return useMemo(() => {
+    if (!drinksToUnits || !drinkingSessionData) {
+      return EMPTY_STATS;
+    }
+    const sessionsArray: DrinkingSessionArray =
+      Object.values(drinkingSessionData);
+    const monthDate = timestampToDate(visibleDate.timestamp);
+    const monthSessions = DSUtils.getSingleMonthDrinkingSessions(
+      monthDate,
+      sessionsArray,
+      false,
+    );
+    const unitsConsumed = calculateThisMonthUnits(
+      visibleDate,
+      sessionsArray,
+      drinksToUnits,
+    );
+
+    const tz = CONST.DEFAULT_TIME_ZONE.selected;
+    const today = toZonedTime(new Date(), tz);
+    const monthStart = startOfMonth(toZonedTime(monthDate, tz));
+    const monthEnd = endOfMonth(monthStart);
+
+    // Future month: nothing has happened yet — render 0, not days-in-month.
+    if (monthStart > today) {
+      return {
+        drinkingSessionsCount: monthSessions.length,
+        unitsConsumed,
+        alcoholFreeDays: 0,
+      };
+    }
+
+    const intervalEnd = monthEnd < today ? monthEnd : today;
+    const elapsedDays = eachDayOfInterval({
+      start: monthStart,
+      end: intervalEnd,
+    });
+
+    const drinkDayKeys = new Set<string>();
+    monthSessions.forEach(session => {
+      const sessionTz = session.timezone ?? tz;
+      const zoned = toZonedTime(session.start_time, sessionTz);
+      drinkDayKeys.add(format(zoned, CONST.DATE.FNS_FORMAT_STRING));
+    });
+
+    let alcoholFreeDays = 0;
+    elapsedDays.forEach(day => {
+      const key = format(day, CONST.DATE.FNS_FORMAT_STRING);
+      if (!drinkDayKeys.has(key)) {
+        alcoholFreeDays += 1;
+      }
+    });
+
+    return {
+      drinkingSessionsCount: monthSessions.length,
+      unitsConsumed,
+      alcoholFreeDays,
+    };
+  }, [drinkingSessionData, visibleDate, drinksToUnits]);
+}
+
+export default useHomeMonthStats;
+export type {HomeMonthStats};

--- a/src/components/Home/useHomeWeekStats.ts
+++ b/src/components/Home/useHomeWeekStats.ts
@@ -1,0 +1,126 @@
+import {useMemo} from 'react';
+import {addDays, endOfWeek, format, isSameDay, startOfWeek} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
+import CONST from '@src/CONST';
+import type {
+  DrinkingSessionArray,
+  DrinkingSessionList,
+  Preferences,
+} from '@src/types/onyx';
+
+type WeekDay = {
+  date: Date;
+  units: number;
+  isToday: boolean;
+  isFuture: boolean;
+};
+
+type WeekSummary = {
+  sessions: number;
+  units: number;
+  quietDays: number;
+};
+
+type HomeWeekStats = {
+  days: WeekDay[];
+  summary: WeekSummary;
+};
+
+const EMPTY_WEEK: HomeWeekStats = {
+  days: [],
+  summary: {sessions: 0, units: 0, quietDays: 0},
+};
+
+function parseFirstDayOfWeek(raw: string | undefined): 0 | 1 {
+  // date-fns' weekStartsOn is 0–6. Kiroku currently only ships Mon/Sun; default Monday.
+  if (raw === '0' || raw === 'sunday' || raw === 'Sunday') {
+    return 0;
+  }
+  return 1;
+}
+
+/**
+ * Day-by-day breakdown of the current week for the "This week" home card.
+ *
+ * Reuses `convertUnitsToColors` so the day-pill colors match the main calendar's
+ * yellow→orange ramp exactly. Future days are flagged (`isFuture`) so the view
+ * renders them transparently rather than as "0".
+ */
+function useHomeWeekStats(
+  drinkingSessionData: DrinkingSessionList | undefined,
+  preferences: Preferences | undefined,
+): HomeWeekStats {
+  return useMemo(() => {
+    if (!drinkingSessionData || !preferences) {
+      return EMPTY_WEEK;
+    }
+    const tz = CONST.DEFAULT_TIME_ZONE.selected;
+    const today = toZonedTime(new Date(), tz);
+    const weekStartsOn = parseFirstDayOfWeek(preferences.first_day_of_week);
+    const weekStart = startOfWeek(today, {weekStartsOn});
+    const weekEnd = endOfWeek(today, {weekStartsOn});
+
+    // Bucket sessions to local day keys.
+    const unitsByDay = new Map<string, number>();
+    const sessionsByDay = new Map<string, number>();
+    let weekSessions = 0;
+    let weekUnits = 0;
+
+    const sessionsArray: DrinkingSessionArray =
+      Object.values(drinkingSessionData);
+    sessionsArray.forEach(session => {
+      const sessionTz = session.timezone ?? tz;
+      const zoned = toZonedTime(session.start_time, sessionTz);
+      if (zoned < weekStart || zoned > weekEnd) {
+        return;
+      }
+      const key = format(zoned, CONST.DATE.FNS_FORMAT_STRING);
+      const sessionUnits = DSUtils.calculateTotalUnits(
+        session.drinks,
+        preferences.drinks_to_units,
+      );
+      unitsByDay.set(key, (unitsByDay.get(key) ?? 0) + sessionUnits);
+      sessionsByDay.set(key, (sessionsByDay.get(key) ?? 0) + 1);
+      weekSessions += 1;
+      weekUnits += sessionUnits;
+    });
+
+    const days: WeekDay[] = Array.from({length: 7}, (_, i) => {
+      const date = addDays(weekStart, i);
+      const key = format(date, CONST.DATE.FNS_FORMAT_STRING);
+      const units = unitsByDay.get(key) ?? 0;
+      const isFuture = date > today && !isSameDay(date, today);
+      return {
+        date,
+        units,
+        isToday: isSameDay(date, today),
+        isFuture,
+      };
+    });
+
+    // Quiet days = elapsed (up to & including today) days with zero units.
+    // Future days don't count either way — we only know quiet *so far*.
+    let quietDays = 0;
+    days.forEach(d => {
+      if (d.isFuture) {
+        return;
+      }
+      if (d.units === 0) {
+        quietDays += 1;
+      }
+    });
+
+    return {
+      days,
+      summary: {
+        sessions: weekSessions,
+        units: weekUnits,
+        quietDays,
+      },
+    };
+  }, [drinkingSessionData, preferences]);
+}
+
+export default useHomeWeekStats;
+export type {HomeWeekStats, WeekDay, WeekSummary};

--- a/src/components/Items/StatItem.tsx
+++ b/src/components/Items/StatItem.tsx
@@ -1,14 +1,20 @@
 import Text from '@components/Text';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {View} from 'react-native';
+
+type StatTone = 'neutral' | 'celebratory';
 
 type StatItemProps = {
   header: string;
   content: string;
+  tone?: StatTone;
 };
 
-function StatItem({header, content}: StatItemProps) {
+function StatItem({header, content, tone = 'neutral'}: StatItemProps) {
   const styles = useThemeStyles();
+  const theme = useTheme();
+  const accent = tone === 'celebratory' ? {color: theme.success} : null;
 
   return (
     <View
@@ -17,7 +23,7 @@ function StatItem({header, content}: StatItemProps) {
         styles.alignItemsCenter,
         styles.justifyContentCenter,
       ]}>
-      <Text style={[styles.statItemText]}>{content}</Text>
+      <Text style={[styles.statItemText, accent]}>{content}</Text>
       <Text
         style={styles.statItemLabelText}
         numberOfLines={2}
@@ -29,3 +35,4 @@ function StatItem({header, content}: StatItemProps) {
 }
 
 export default StatItem;
+export type {StatTone};

--- a/src/components/Items/StatOverview.tsx
+++ b/src/components/Items/StatOverview.tsx
@@ -1,10 +1,12 @@
 import {View} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
 import StatItem from './StatItem';
+import type {StatTone} from './StatItem';
 
 type StatData = Array<{
   header: string;
   content: string;
+  tone?: StatTone;
 }>;
 
 type StatsOverviewProps = {
@@ -21,6 +23,7 @@ function StatOverview({statsData}: StatsOverviewProps) {
           key={stat.header}
           header={stat.header}
           content={stat.content}
+          tone={stat.tone}
         />
       ))}
     </View>

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -21,9 +21,9 @@ import type {DateString, UserID} from '@src/types/onyx/OnyxCommon';
 import Text from '@components/Text';
 import DayComponent from './DayComponent';
 import type {DayComponentProps} from './types';
-import CalendarArrow from './CalendarArrow';
-import type {Direction} from './CalendarArrow';
 import setCalendarLocale from './setCalendarLocale';
+
+const NOOP_STEP = () => {};
 
 type SessionsCalendarViewProps = {
   /** Owning user — required to deep-link to the full-screen calendar route
@@ -129,12 +129,12 @@ function SessionsCalendarView({
     [unitsMap, onDayPress, registerMeasureRef],
   );
 
-  // Custom header: matches the default month-text styling but reserves space
-  // for an inline spinner shown only while an older-months fetch is in flight.
-  // Keeping the header always-customized (not just when fetching) avoids a
-  // layout jump between native-header and custom-header rendering.
-  // The lib passes an `XDate` (no published d.ts; treated as `any` here). All we
-  // need is its epoch — extract via `getTime()` and rebuild a native `Date`.
+  // Custom header: mockup-C-style nav bar with circular ‹ / › arrow buttons
+  // flanking the month label. The forward arrow renders at 40% opacity and
+  // is non-interactive when the visible month is the current calendar month.
+  // The lib's own arrows are hidden via `hideArrows={true}`; the header now
+  // owns both controls so the maxDate-block logic can sit alongside the
+  // disabled-state styling.
   const isHeaderTappable =
     !!userID && FeatureFlags.isEnabled('FULLSCREEN_CALENDAR');
 
@@ -173,6 +173,21 @@ function SessionsCalendarView({
     day1Ref.current.measureInWindow((_x, y) => navigate(y));
   }, [userID, visibleDate.timestamp]);
 
+  const isAtCurrentMonth =
+    startOfMonth(new Date(visibleDate.timestamp)).getTime() >=
+    startOfMonth(new Date()).getTime();
+
+  const onPrevPress = useCallback(() => {
+    onLeftArrowPress?.(NOOP_STEP);
+  }, [onLeftArrowPress]);
+
+  const onNextPress = useCallback(() => {
+    if (isAtCurrentMonth) {
+      return;
+    }
+    onRightArrowPress?.(NOOP_STEP);
+  }, [isAtCurrentMonth, onRightArrowPress]);
+
   const renderHeader = useCallback(
     (date?: {getTime(): number}) => {
       if (hideMonthHeader || !date) {
@@ -183,7 +198,7 @@ function SessionsCalendarView({
         CONST.DATE.MONTH_YEAR_ABBR_FORMAT,
       );
       const monthText = (
-        <Text style={styles.sessionsCalendarHeaderMonthText}>{formatted}</Text>
+        <Text style={styles.homeMonthNavLabel}>{formatted}</Text>
       );
       const expandIcon = isHeaderTappable ? (
         <Icon
@@ -194,38 +209,92 @@ function SessionsCalendarView({
           additionalStyles={styles.sessionsCalendarExpandIcon}
         />
       ) : null;
+      const labelNode = isHeaderTappable ? (
+        <PressableWithFeedback
+          onPress={onHeaderPress}
+          role={CONST.ROLE.BUTTON}
+          accessibilityLabel={formatted}
+          style={styles.sessionsCalendarHeader}>
+          {monthText}
+          {expandIcon}
+        </PressableWithFeedback>
+      ) : (
+        <View style={styles.sessionsCalendarHeader}>{monthText}</View>
+      );
+
+      const arrowSpacer = (
+        <View
+          style={[styles.homeMonthNavArrow, styles.homeMonthNavArrowSpacer]}
+        />
+      );
       return (
-        <View style={styles.sessionsCalendarHeader}>
-          {isHeaderTappable ? (
-            <PressableWithFeedback
-              onPress={onHeaderPress}
-              role={CONST.ROLE.BUTTON}
-              accessibilityLabel={formatted}
-              style={styles.sessionsCalendarHeader}>
-              {monthText}
-              {expandIcon}
-            </PressableWithFeedback>
+        <View style={styles.homeMonthNav}>
+          {hideArrows ? (
+            arrowSpacer
           ) : (
-            monthText
+            <PressableWithFeedback
+              onPress={onPrevPress}
+              role={CONST.ROLE.BUTTON}
+              accessibilityLabel="Previous month"
+              style={styles.homeMonthNavArrow}>
+              <Icon
+                src={KirokuIcons.BackArrow}
+                fill={theme.textSupporting}
+                width={14}
+                height={14}
+              />
+            </PressableWithFeedback>
           )}
-          {isFetchingOlderMonths && (
-            <ActivityIndicator
-              size="small"
-              color={theme.spinner}
-              style={styles.sessionsCalendarHeaderSpinner}
-            />
+          <View style={styles.sessionsCalendarHeader}>
+            {labelNode}
+            {isFetchingOlderMonths && (
+              <ActivityIndicator
+                size="small"
+                color={theme.spinner}
+                style={styles.sessionsCalendarHeaderSpinner}
+              />
+            )}
+          </View>
+          {hideArrows ? (
+            arrowSpacer
+          ) : (
+            <PressableWithFeedback
+              onPress={onNextPress}
+              disabled={isAtCurrentMonth}
+              role={CONST.ROLE.BUTTON}
+              accessibilityLabel="Next month"
+              accessibilityState={{disabled: isAtCurrentMonth}}
+              style={[
+                styles.homeMonthNavArrow,
+                isAtCurrentMonth && styles.homeMonthNavArrowDisabled,
+              ]}>
+              <Icon
+                src={KirokuIcons.ArrowRight}
+                fill={theme.textSupporting}
+                width={14}
+                height={14}
+              />
+            </PressableWithFeedback>
           )}
         </View>
       );
     },
     [
       hideMonthHeader,
+      hideArrows,
+      isAtCurrentMonth,
       isFetchingOlderMonths,
       isHeaderTappable,
       onHeaderPress,
+      onNextPress,
+      onPrevPress,
+      styles.homeMonthNav,
+      styles.homeMonthNavArrow,
+      styles.homeMonthNavArrowDisabled,
+      styles.homeMonthNavArrowSpacer,
+      styles.homeMonthNavLabel,
       styles.sessionsCalendarExpandIcon,
       styles.sessionsCalendarHeader,
-      styles.sessionsCalendarHeaderMonthText,
       styles.sessionsCalendarHeaderSpinner,
       theme.spinner,
       theme.textSupporting,
@@ -251,11 +320,10 @@ function SessionsCalendarView({
       markingType="period"
       firstDay={CONST.WEEK_STARTS_ON}
       enableSwipeMonths={false}
-      hideArrows={hideArrows}
+      hideArrows
       hideDayNames={hideDayNames}
       renderHeader={renderHeader}
       disableAllTouchEventsForDisabledDays
-      renderArrow={(direction: Direction) => CalendarArrow(direction)}
       style={styles.sessionsCalendarContainer}
       theme={StyleUtils.getSessionsCalendarStyle()}
       // @ts-expect-error locale prop exists at runtime but is not declared in types

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -1,4 +1,7 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
+import {View} from 'react-native';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {runOnJS} from 'react-native-reanimated';
 import type {DateData} from 'react-native-calendars';
 import {
   differenceInMonths,
@@ -22,6 +25,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import SessionsCalendarView from './SessionsCalendarView';
 import SessionsCalendarWeekListView from './SessionsCalendarWeekListView';
 import type SessionsCalendarProps from './types';
+
+const NOOP_STEP = () => {};
 
 // How many months of pre-loaded buffer to keep ahead of the user's scroll in
 // fullscreen mode. When the earliest in-range visible day is within this
@@ -181,18 +186,52 @@ function SessionsCalendar({
     );
   }
 
+  // Horizontal swipe-to-change-month. Same handler path as the arrow taps so
+  // the Onyx pagination machinery (loadMoreMonths) keeps firing on swipe.
+  // `failOffsetY` hands back to the parent ScrollView for vertical drags.
+  const triggerPreviousMonth = () => handleLeftArrowPress(NOOP_STEP);
+  const triggerNextMonth = () => handleRightArrowPress(NOOP_STEP);
+
+  const isAtCurrentMonth =
+    startOfMonth(new Date(visibleDate.timestamp)).getTime() >=
+    startOfMonth(new Date()).getTime();
+
+  /* eslint-disable react-hooks/immutability */
+  const pan = Gesture.Pan()
+    .activeOffsetX([-15, 15])
+    .failOffsetY([-25, 25])
+    .onEnd(e => {
+      const SWIPE_THRESHOLD = 60;
+      const VELOCITY_THRESHOLD = 500;
+      const dx = e.translationX;
+      const vx = e.velocityX;
+      if (dx > SWIPE_THRESHOLD || vx > VELOCITY_THRESHOLD) {
+        runOnJS(triggerPreviousMonth)();
+      } else if (
+        (dx < -SWIPE_THRESHOLD || vx < -VELOCITY_THRESHOLD) &&
+        !isAtCurrentMonth
+      ) {
+        runOnJS(triggerNextMonth)();
+      }
+    });
+  /* eslint-enable react-hooks/immutability */
+
   return (
-    <SessionsCalendarView
-      userID={userID}
-      markedDates={markedDates}
-      unitsMap={unitsMap}
-      visibleDate={visibleDate}
-      minDate={minDate}
-      onDayPress={onDayPress}
-      onLeftArrowPress={handleLeftArrowPress}
-      onRightArrowPress={handleRightArrowPress}
-      isFetchingOlderMonths={isFetchingOlderMonths}
-    />
+    <GestureDetector gesture={pan}>
+      <View>
+        <SessionsCalendarView
+          userID={userID}
+          markedDates={markedDates}
+          unitsMap={unitsMap}
+          visibleDate={visibleDate}
+          minDate={minDate}
+          onDayPress={onDayPress}
+          onLeftArrowPress={handleLeftArrowPress}
+          onRightArrowPress={handleRightArrowPress}
+          isFetchingOlderMonths={isFetchingOlderMonths}
+        />
+      </View>
+    </GestureDetector>
   );
 }
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -832,6 +832,17 @@ export default {
     currentlyInSession: 'Právě se nacházíte v relaci!',
     currentlyInSessionButton:
       'Tlačítko, které informuje, že se právě nacházíte v relaci',
+    stats: {
+      alcoholFreeDays: 'dnů bez\nalkoholu',
+      sessionsLogged: 'záznamů\nrelací',
+      unitsConsumed: 'spotřebovaných\njednotek',
+      thisWeek: 'Tento týden',
+      weekSummary: {
+        sessions: 'záznamů',
+        units: 'jednotek',
+        quietDays: 'klidných dnů',
+      },
+    },
   },
   sessionsCalendar: {
     dayOverviewButton: 'Přehled dne',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -842,6 +842,17 @@ export default {
     currentlyInSession: 'You are currently in a session!',
     currentlyInSessionButton:
       'A button indicating you are currently in session',
+    stats: {
+      alcoholFreeDays: 'alcohol-free\ndays',
+      sessionsLogged: 'sessions\nlogged',
+      unitsConsumed: 'units\nconsumed',
+      thisWeek: 'This week',
+      weekSummary: {
+        sessions: 'sessions',
+        units: 'units',
+        quietDays: 'quiet days',
+      },
+    },
   },
   sessionsCalendar: {
     dayOverviewButton: "Day's overview",

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,19 +1,14 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import SessionsCalendar from '@components/SessionsCalendar';
 import type {DateData} from 'react-native-calendars';
-import {
-  calculateThisMonthUnits,
-  timestampToDate,
-  dateToDateData,
-} from '@libs/DataHandling';
+import {dateToDateData} from '@libs/DataHandling';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import UserOffline from '@components/UserOfflineModal';
 import {synchronizeUserStatus} from '@userActions/User';
 import {useFirebase} from '@context/global/FirebaseContext';
 import ProfileImage from '@components/ProfileImage';
 import CONST from '@src/CONST';
-import type {DrinkingSessionArray} from '@src/types/onyx';
 import ROUTES from '@src/ROUTES';
 import Navigation from '@navigation/Navigation';
 import type {StackScreenProps} from '@react-navigation/stack';
@@ -23,6 +18,9 @@ import type SCREENS from '@src/SCREENS';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import type {StatData} from '@components/Items/StatOverview';
 import StatOverview from '@components/Items/StatOverview';
+import ThisWeekCard from '@components/Home/ThisWeekCard';
+import useHomeMonthStats from '@components/Home/useHomeMonthStats';
+import useHomeWeekStats from '@components/Home/useHomeWeekStats';
 import ScreenWrapper from '@components/ScreenWrapper';
 import MessageBanner from '@components/Info/MessageBanner';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -69,43 +67,22 @@ function HomeScreen({route}: HomeScreenProps) {
   );
   const hasMarkedReadyRef = useRef(false);
 
-  // Derive stats synchronously from the visible month + drink unit mapping.
-  // Narrowed to `drinksToUnits` so unrelated preference updates (e.g. picking
-  // a color palette) don't recompute the stats.
-  const drinksToUnits = preferences?.drinks_to_units;
-  const {drinkingSessionsCount, unitsConsumed} = useMemo(() => {
-    if (!drinksToUnits || !drinkingSessionData) {
-      return {drinkingSessionsCount: 0, unitsConsumed: 0};
-    }
-    const drinkingSessionArray: DrinkingSessionArray =
-      Object.values(drinkingSessionData);
-    const monthUnits = calculateThisMonthUnits(
-      visibleDate,
-      drinkingSessionArray,
-      drinksToUnits,
-    );
-    const monthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
-      timestampToDate(visibleDate.timestamp),
-      drinkingSessionArray,
-      false,
-    ).length;
-    return {
-      drinkingSessionsCount: monthSessionCount,
-      unitsConsumed: monthUnits,
-    };
-  }, [drinkingSessionData, visibleDate, drinksToUnits]);
+  const {drinkingSessionsCount, unitsConsumed, alcoholFreeDays} =
+    useHomeMonthStats(visibleDate, drinkingSessionData, preferences);
+  const weekStats = useHomeWeekStats(drinkingSessionData, preferences);
 
   const statsData: StatData = [
     {
-      header: translate('profileScreen.drinkingSessions', {
-        sessionsCount: drinkingSessionsCount,
-      }),
+      header: translate('homeScreen.stats.alcoholFreeDays'),
+      content: String(alcoholFreeDays),
+      tone: 'celebratory',
+    },
+    {
+      header: translate('homeScreen.stats.sessionsLogged'),
       content: String(drinkingSessionsCount),
     },
     {
-      header: translate('profileScreen.unitsConsumed', {
-        unitCount: roundToTwoDecimalPlaces(unitsConsumed),
-      }),
+      header: translate('homeScreen.stats.unitsConsumed'),
       content: String(roundToTwoDecimalPlaces(unitsConsumed)),
     },
   ];
@@ -183,7 +160,6 @@ function HomeScreen({route}: HomeScreenProps) {
     }
     return (
       <>
-        <StatOverview statsData={statsData} />
         <SessionsCalendar
           userID={user.uid}
           visibleDate={visibleDate}
@@ -191,6 +167,12 @@ function HomeScreen({route}: HomeScreenProps) {
           drinkingSessionData={drinkingSessionData}
           preferences={preferences}
           isFetchingOlderMonths={isFetchingOlderMonths}
+        />
+        <StatOverview statsData={statsData} />
+        <ThisWeekCard
+          days={weekStats.days}
+          summary={weekStats.summary}
+          preferences={preferences}
         />
       </>
     );

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1447,11 +1447,136 @@ const styles = (theme: ThemeColors) =>
     },
 
     statOverviewContainer: {
-      height: variables.statOverviewHeight,
-      ...sizing.mw100,
       flexDirection: 'row',
-      flex: 1,
+      ...sizing.mw100,
       justifyContent: 'space-evenly',
+      alignItems: 'flex-start',
+      paddingTop: 12,
+      marginTop: 12,
+      marginHorizontal: 14,
+      borderTopWidth: 1,
+      borderTopColor: theme.border,
+    },
+
+    statOverviewCard: {
+      backgroundColor: theme.cardBG,
+      borderRadius: 14,
+      marginHorizontal: 0,
+      marginBottom: 14,
+      paddingHorizontal: 14,
+      paddingTop: 14,
+      paddingBottom: 14,
+    },
+
+    homeMonthNav: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 4,
+      paddingVertical: 4,
+    },
+
+    homeMonthNavLabel: {
+      ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
+      color: theme.text,
+      fontSize: variables.fontSizeLarge,
+      letterSpacing: -0.2,
+    },
+
+    homeMonthNavArrow: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: theme.highlightBG,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+
+    homeMonthNavArrowDisabled: {
+      opacity: 0.4,
+    },
+
+    homeMonthNavArrowSpacer: {
+      backgroundColor: 'transparent',
+    },
+
+    homeWeekCard: {
+      backgroundColor: theme.cardBG,
+      borderRadius: 14,
+      paddingHorizontal: 14,
+      paddingTop: 12,
+      paddingBottom: 14,
+      marginBottom: 14,
+    },
+
+    homeWeekCardTitle: {
+      fontSize: variables.fontSizeNormal,
+      fontWeight: '600',
+      color: theme.text,
+      marginBottom: 10,
+    },
+
+    homeWeekRow: {
+      flexDirection: 'row',
+      gap: 6,
+      alignItems: 'flex-end',
+    },
+
+    homeWeekDayPill: {
+      flex: 1,
+      aspectRatio: 1 / 1.4,
+      borderRadius: 8,
+      backgroundColor: theme.highlightBG,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 2,
+      borderColor: 'transparent',
+    },
+
+    homeWeekDayPillFuture: {
+      opacity: 0.4,
+    },
+
+    homeWeekDayPillToday: {
+      // Border color is applied inline (brand yellow from resolved palette).
+    },
+
+    homeWeekDayName: {
+      fontSize: 9,
+      color: theme.textSupporting,
+      marginBottom: 2,
+      letterSpacing: 0.3,
+    },
+
+    homeWeekDayValue: {
+      fontSize: 11,
+      fontWeight: '600',
+    },
+
+    homeWeekSummary: {
+      flexDirection: 'row',
+      gap: 14,
+      marginTop: 12,
+      paddingTop: 10,
+      borderTopWidth: 1,
+      borderTopColor: theme.border,
+    },
+
+    homeWeekSummaryItem: {
+      flex: 1,
+      alignItems: 'center',
+    },
+
+    homeWeekSummaryValue: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: theme.text,
+    },
+
+    homeWeekSummaryLabel: {
+      fontSize: 11,
+      color: theme.textSupporting,
+      marginTop: 2,
     },
 
     rightLabelMenuItem: {
@@ -2071,15 +2196,19 @@ const styles = (theme: ThemeColors) =>
     },
 
     statItemText: {
-      fontSize: variables.fontSizeXXXXLarge,
+      fontSize: 22,
       ...FontUtils.fontFamily.platform.EXP_NEUE_BOLD,
       textAlign: 'center',
-      color: theme.appColor,
+      color: theme.text,
+      lineHeight: 22,
     },
 
     statItemLabelText: {
-      fontSize: variables.fontSizeNormal,
+      fontSize: 10,
+      lineHeight: 13,
+      color: theme.textSupporting,
       textAlign: 'center',
+      marginTop: 4,
       width: variables.statItemTextMaxWidth,
       flexWrap: 'wrap',
     },


### PR DESCRIPTION
### Details

Re-skins the home-screen calendar header and stats area to match `mockups/C_calendar_first/index.html` (in worktree `elegant-darwin-ad9da8`) and adds a "This week" card below the stats row.

**Scope is intentionally narrow.** The main calendar day-tile rendering (`DayComponent`) is untouched — only the surrounding chrome and the stats area change. This is separate from the dedicated Statistics screen on `feature/statistics` (PR #519).

**What changed:**

- **Calendar month header** — circular ‹ / › arrow buttons flank a bold centered month label. The forward arrow renders at 40% opacity and is non-interactive when the visible month is the current calendar month. Lives in `SessionsCalendarView.tsx`; library's own arrows are now hidden (`hideArrows={true}`).
- **Horizontal swipe-to-change-month** — `Gesture.Pan()` wraps the calendar in `SessionsCalendar/index.tsx`. `failOffsetY` hands back vertical drags to the parent `ScrollView`. Swipes reuse the existing arrow handlers, so the Onyx pagination machinery (`SESSIONS_CALENDAR_MONTHS_BY_USER_ID`, `loadMoreMonths`) keeps firing on swipe. Left-swipe (forward) is blocked when already at the current month.
- **3-tile stats row** — replaces the previous 2-tile strip. New tile: alcohol-free days, rendered in `theme.success` (brand yellow) via a new `tone: 'celebratory'` prop on `StatItem` / `StatOverview`.
- **"This week" card** — new `ThisWeekCard` with 7 day-pills (today ringed in brand yellow, days with sessions colored using the existing `convertUnitsToColors` ramp) and a sessions/units/quiet-days summary footer. Future days in the current week render transparently (40% opacity, no number) — not as "0".
- **Stats hooks** — new `useHomeMonthStats` and `useHomeWeekStats` under `src/components/Home/`. Intentionally **not** in `src/libs/Statistics/` — that's `feature/statistics` territory. When PR #519 lands these collapse to one-line selector calls.

**Alcohol-free-days bug fix.** `mockups/DIRECTION_REVIEW.md` §3 calls out that PR #519's selector counts future days as alcohol-free (`eachDayOfInterval(monthStart, monthEnd)` regardless of today). We clamp to `min(monthEnd, today)` here so we don't repeat that bug. Future-month tiles render `0` alcohol-free days. Covered by 7 cases in `__tests__/unit/useHomeMonthStats.test.ts`.

**Tone constraints** from `contributingGuides/STATISTICS.md` §3 (on `feature/statistics`): lead with alcohol-free days, success color, no red, "quiet days" framing on the week card, no "0" for empty/future cells.

### Tests

**Unit:**
- ✓ `__tests__/unit/useHomeMonthStats.test.ts` — 7 cases pinning the clamping logic (mid-month, first-of-month, past month, future month, end-of-past-month, undefined preferences, today-on-day-1).
- ✓ Nearby suites (`useLazyMarkedDates`, `buildMonthSections`) still pass.

**Lint / typecheck:**
- ✓ `npx prettier --write` on changed files.
- ✓ `./scripts/lint.sh` on all changed files.
- ✓ `npm run typecheck-tsgo` clean.

**Manual UI verification (TODO before merge — I didn't boot the app in this session):**

1. Open Home screen on iOS and Android.
2. Verify the month nav reads "‹ May 2026 ›" with two small circular arrow buttons. Forward arrow is dimmed and tap-no-op when visible month is current.
3. Tap left arrow: month decrements; if past the loaded window, the inline spinner appears while older months fetch (existing behavior preserved).
4. Tap right arrow on a past month: month increments back toward today; arrow dims and stops at the current month.
5. Horizontal-swipe right on the calendar → previous month. Horizontal-swipe left → next month (unless at current month). Try swiping forward past current → blocked.
6. Vertical-swipe inside the calendar must still scroll the parent ScrollView (failOffsetY check).
7. Below calendar, verify the 3-tile stat row:
   - alcohol-free days (yellow numeral, lowercase soft-wrapped label)
   - sessions logged
   - units consumed
   Alcohol-free count must never exceed today's day-of-month. On the 1st of a fresh test month with no sessions it must equal 1, not the days-in-month.
8. Verify "This week" card: 7 day-pills, today's pill has a yellow border, sessions days are colored using the same palette as the main calendar, future days are dimmed with no number.
9. Toggle dark theme (Settings → Preferences → Theme) and re-verify cards, text, and success color.

### Offline tests

- [ ] Disable network on Home; verify cached calendar data still renders, swipe gestures still work locally, no console errors.
- [ ] Re-enable network and confirm pagination kicks in on left-arrow / right-swipe past the loaded floor.

### QA Steps

1. Sign in as a user with a few weeks of session history.
2. Repeat steps 1–9 from the Tests section on the staging build.
3. Sign in as a brand-new user (zero sessions) — confirm alcohol-free days shows "today only" count (typically the day-of-month), week card shows N quiet days, no numbers crash to "NaN" / "0" misleadingly.
4. Set a different `first_day_of_week` in preferences (Sunday) and confirm the "This week" card rotates accordingly.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Reference (mockup)</summary>

`mockups/C_calendar_first/index.html` in worktree `elegant-darwin-ad9da8` is the source of truth.

</details>

<details>
<summary>Android</summary>

<!-- TODO: add post-build screenshots -->

</details>

<details>
<summary>iOS</summary>

<!-- TODO: add post-build screenshots -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)