### PR TITLE
feat(ci): add workflow_dispatch screenshot capture

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Stage .env.production from secret
-        run: echo "${{ secrets.PROD_ENV_FILE }}" > .env.production
+        run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
 
       - name: Setup Node
         id: setup-node

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,133 @@
+name: Capture App Store / Play Store screenshots
+
+# Manual trigger only — App Store screenshots are infrequent, expensive
+# (~30-45 min cold build + UI test runs across the device matrix), and require
+# demo credentials. Never wire this to `pull_request` or any auto-trigger.
+#
+# Prerequisite: the demo account referenced by APPLE_DEMO_EMAIL /
+# APPLE_DEMO_PASSWORD MUST have at least one logged drinking session in the
+# current calendar month. The Day Overview screenshot taps the first
+# DayMarking cell in the calendar — if no session exists in-month, the test
+# fails. See contributingGuides/SCREENSHOTS.md.
+on:
+  workflow_dispatch:
+    inputs:
+      device_subset:
+        description: 'Which devices to capture (all | phone-only | ipad-only). Trims Snapfile devices for iteration speed.'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - phone-only
+          - ipad-only
+
+permissions:
+  contents: read
+
+jobs:
+  ios:
+    name: Capture iOS App Store screenshots
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stage .env.production from secret
+        run: echo "${{ secrets.PROD_ENV_FILE }}" > .env.production
+
+      - name: Setup Node
+        id: setup-node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Install Ruby into tool cache (self-hosted runner)
+        run: |
+          RUBY_VERSION="3.3.4"
+          RUBY_PATH="${RUNNER_TOOL_CACHE}/Ruby/${RUBY_VERSION}/arm64"
+          if [[ ! -f "${RUBY_PATH}.complete" ]]; then
+            brew install ruby-build 2>/dev/null || true
+            ruby-build "$RUBY_VERSION" "$RUBY_PATH"
+            touch "${RUBY_PATH}.complete"
+          fi
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1.190.0
+        with:
+          bundler-cache: true
+
+      - name: Cache Pod dependencies
+        uses: actions/cache@v4
+        id: pods-cache
+        with:
+          path: |
+            ios/Pods
+            ios/build/generated
+          key: ${{ runner.os }}-pods-cache-${{ hashFiles('ios/Podfile.lock', 'firebase.json', 'package-lock.json') }}
+          restore-keys: ${{ runner.os }}-pods-cache-
+
+      - name: Compare Podfile.lock and Manifest.lock
+        id: compare-podfile-and-manifest
+        run: echo "IS_PODFILE_SAME_AS_MANIFEST=${{ hashFiles('ios/Podfile.lock') == hashFiles('ios/Pods/Manifest.lock') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cocoapods
+        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: cd ios && bundle exec pod install
+
+      - name: Set up environment for Xcode
+        run: |
+          echo "export NODE_BINARY=$(which node)" >> "$HOME/.bash_profile"
+          source "$HOME/.bash_profile"
+
+      # Trim the Snapfile device matrix when the dispatcher asked for a subset.
+      # `Snapfile` resolves devices(...) eagerly so we rewrite the file in
+      # place — this is throwaway, not committed back.
+      - name: Trim Snapfile device matrix
+        if: ${{ github.event.inputs.device_subset != 'all' }}
+        env:
+          DEVICE_SUBSET: ${{ github.event.inputs.device_subset }}
+        run: bundle exec ruby scripts/trim-snapfile-devices.rb "$DEVICE_SUBSET"
+
+      - name: Run Fastlane - Capture iOS screenshots
+        run: bundle exec fastlane ios screenshots
+        env:
+          APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
+          APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
+          KIROKU_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
+          KIROKU_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
+
+      - name: Upload iOS screenshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-screenshots-${{ github.sha }}
+          path: fastlane/screenshots/ios/**/*.png
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload fastlane logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-fastlane-logs-${{ github.sha }}
+          path: |
+            ~/Library/Logs/gym/**
+            ~/Library/Logs/scan/**
+            ~/Library/Logs/snapshot/**
+            fastlane/report.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # TODO: Android screenshot capture. The fastlane `android :screenshots` lane
+  # (Fastfile + Screengrabfile) is in place, but Linux CI needs an Android
+  # emulator (reactivecircus/android-emulator-runner@v2 is the usual choice),
+  # the screengrab Gradle deps wired into android/app/build.gradle (still a
+  # manual step per SCREENSHOTS.md), and the CHANGE_CONFIGURATION permission
+  # in the debug manifest. None of those exist yet — wire them in a follow-up
+  # PR once the iOS flow is proven.

--- a/contributingGuides/SCREENSHOTS.md
+++ b/contributingGuides/SCREENSHOTS.md
@@ -1,21 +1,103 @@
-# Store screenshots — local setup
+# Store screenshots
 
-Fastlane `snapshot` (iOS) + `screengrab` (Android) capture App Store / Play Store
-screenshots across the device + locale matrix declared in
+Fastlane `snapshot` (iOS) + `screengrab` (Android) capture App Store / Play
+Store screenshots across the device + locale matrix declared in
 [`fastlane/Snapfile`](../fastlane/Snapfile) and
 [`fastlane/Screengrabfile`](../fastlane/Screengrabfile).
 
-This is **scaffolding** — the configuration and UI test code is in place, but a
-few manual steps are required before the first run will succeed. Treat this PR
-as the foundation; expect to iterate on the UI test selectors against the live
-app the first time you run it.
+The supported way to capture screenshots is the
+[`screenshots.yml`](../.github/workflows/screenshots.yml) GitHub Actions
+workflow. Running locally still works (see [Local fallback](#local-fallback)
+below) but requires hand-editing the Xcode project, which must NEVER be
+committed.
 
 ---
 
-## Prerequisites
+## Prerequisite: demo account must have a session this month
 
-Set demo credentials in your shell (a real Kiroku account with at least one
-recorded session, so screenshots have content):
+Both the CI and local flows log into a real Kiroku account using the
+`APPLE_DEMO_EMAIL` / `APPLE_DEMO_PASSWORD` credentials (the same demo account
+Apple uses for App Store Review). The Day Overview screenshot taps the first
+day cell with a recorded session — so **before triggering a capture, log in to
+the demo account and record at least one drinking session in the current
+calendar month**. Without an in-month session, the test fails with a missing
+`DayMarking` accessibility identifier.
+
+---
+
+## CI flow (recommended)
+
+1. Go to **Actions → "Capture App Store / Play Store screenshots" → Run
+   workflow**.
+2. Pick a branch (usually `master`) and a `device_subset`:
+   - `all` — full matrix (4 devices x 2 locales, ~30-45 min)
+   - `phone-only` — 3 iPhones x 2 locales (~20-30 min)
+   - `ipad-only` — 1 iPad x 2 locales (~10-15 min, fastest for iterating)
+3. When the run finishes, download the `ios-screenshots-<sha>` artifact from
+   the workflow summary page. PNGs are organized as
+   `ios/<locale>/<device>/*.png`.
+4. If the run failed, the `ios-fastlane-logs-<sha>` artifact contains
+   `gym`/`snapshot` logs for triage.
+
+### Required GitHub secrets
+
+| Secret                | Used for                                          |
+| --------------------- | ------------------------------------------------- |
+| `APPLE_DEMO_EMAIL`    | Demo account login (App Store Review credentials) |
+| `APPLE_DEMO_PASSWORD` | Demo account password                             |
+| `PROD_ENV_FILE`       | Contents of `.env.production`                     |
+
+`KIROKU_DEMO_EMAIL` / `KIROKU_DEMO_PASSWORD` (used inside the UI test) are
+aliased from `APPLE_DEMO_*` in the workflow, so you only need one set.
+
+### How it works
+
+The CI workflow:
+
+1. Checks out the branch, sets up Node + Ruby + CocoaPods.
+2. Runs [`scripts/setup-screenshots-test-target.rb`](../scripts/setup-screenshots-test-target.rb)
+   inside the `ios :screenshots` lane. The script:
+   - Generates a `KirokuUITests` UI Testing Bundle target in
+     `ios/kiroku.xcodeproj` programmatically via the `xcodeproj` Ruby gem.
+   - Copies `SnapshotHelper.swift` from the bundled fastlane gem into
+     `ios/KirokuUITests/`.
+   - Adds the target to the `Kiroku (production)` shared scheme's
+     `TestAction`.
+3. Runs `fastlane ios screenshots` → `capture_ios_screenshots` → boots
+   simulators and runs `ScreenshotTests`.
+4. Uploads the resulting PNGs as an artifact.
+
+The pbxproj/scheme/`SnapshotHelper.swift` diff produced by the setup script
+is **intentionally throwaway** — the workflow runs on a fresh checkout each
+time, so nothing leaks back into the repo.
+
+### Why we generate the target instead of committing it
+
+Adding a UI Testing Bundle target via Xcode's UI in Xcode 26:
+
+- Bumps `ios/kiroku.xcodeproj/project.pbxproj` to `objectVersion = 70`.
+- Restructures the file using `PBXFileSystemSynchronizedRootGroup` (Xcode
+  26's new format).
+
+The `xcodeproj` Ruby gem 1.27.0 (latest released) cannot parse
+`objectVersion = 70` and crashes with
+`ArgumentError - Unable to find compatibility version string for object
+version 70`. CocoaPods uses the `xcodeproj` gem internally, so committing
+the Xcode-generated pbxproj would break `bundle exec pod install` for every
+developer.
+
+The generation script preserves `objectVersion = 54` and uses the older
+PBXGroup-style layout, sidestepping the issue. See the script header for the
+full rationale.
+
+---
+
+## Local fallback
+
+Use this if you want to iterate on `ScreenshotTests.swift` against your own
+simulators without waiting for CI cycles.
+
+### Prerequisites
 
 ```bash
 export APPLE_DEMO_EMAIL="..."
@@ -24,41 +106,41 @@ export KIROKU_DEMO_EMAIL="$APPLE_DEMO_EMAIL"
 export KIROKU_DEMO_PASSWORD="$APPLE_DEMO_PASSWORD"
 ```
 
----
+### iOS
 
-## iOS — one-time setup
+```bash
+bundle install                              # one-time
+bundle exec fastlane ios screenshots
+```
 
-1. **Add a UI Testing Bundle target in Xcode.** Open
-   `ios/kiroku.xcworkspace`, then **File → New → Target → UI Testing Bundle**.
-   Name it exactly `KirokuUITests`, set the target to be tested to
-   `Kiroku (production)`. This step **must** be done in Xcode — editing
-   `project.pbxproj` by hand is risky.
+The `ios :screenshots` lane invokes `scripts/setup-screenshots-test-target.rb`
+automatically — you don't need to run it by hand. After capture, these files
+will be modified:
 
-2. **Drag `ios/KirokuUITests/ScreenshotTests.swift`** into the new target.
+- `ios/kiroku.xcodeproj/project.pbxproj`
+- `ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme`
+- `ios/KirokuUITests/SnapshotHelper.swift` (created)
 
-3. **Generate `SnapshotHelper.swift`:**
+> **Do NOT commit those changes.** Revert them when you're done:
+>
+> ```bash
+> git checkout -- \
+>   "ios/kiroku.xcodeproj/project.pbxproj" \
+>   "ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme"
+> rm -f ios/KirokuUITests/SnapshotHelper.swift
+> ```
 
-   ```bash
-   bundle exec fastlane snapshot init
-   ```
+Output PNGs land in `fastlane/screenshots/ios/<locale>/<device>/*.png`.
 
-   It drops `SnapshotHelper.swift` in the repo root — move it into
-   `ios/KirokuUITests/` and add it to the test target.
+If you want to add the target manually in Xcode anyway (e.g. to debug the
+test in the Xcode UI), be aware that **Xcode 26 will rewrite the pbxproj** in
+a way that breaks `pod install` for everyone. Do this only on a throwaway
+branch and never push the result.
 
-4. **Edit the `Kiroku (production)` scheme** → Test action → add the
-   `KirokuUITests` target. Make sure **Run tests in parallel** is OFF (snapshot
-   is sequential).
+### Android
 
-5. **Run:**
-   ```bash
-   bundle exec fastlane ios screenshots
-   ```
-   First run takes ~15–20 min (boots 4 simulators × 2 locales). Output lands in
-   `fastlane/screenshots/ios/<locale>/<device>/*.png`.
-
----
-
-## Android — one-time setup
+The `android :screenshots` lane still needs a few one-time setup steps that
+are documented but not yet wired into CI:
 
 1. **Add screengrab dependencies** to `android/app/build.gradle`:
 
@@ -87,7 +169,7 @@ export KIROKU_DEMO_PASSWORD="$APPLE_DEMO_PASSWORD"
    </manifest>
    ```
 
-3. **Boot the AVD you want to capture against** (a Pixel 7 emulator is a good
+3. **Boot the AVD you want to capture against** (Pixel 7 emulator is a good
    default for the phone bucket):
 
    ```bash
@@ -95,9 +177,13 @@ export KIROKU_DEMO_PASSWORD="$APPLE_DEMO_PASSWORD"
    ```
 
 4. **Run:**
+
    ```bash
    bundle exec fastlane android screenshots
    ```
+
+An Android CI job (using `reactivecircus/android-emulator-runner`) is a
+planned follow-up — see the TODO at the bottom of `screenshots.yml`.
 
 ---
 
@@ -107,47 +193,45 @@ The UI test code in
 [`ios/KirokuUITests/ScreenshotTests.swift`](../ios/KirokuUITests/ScreenshotTests.swift)
 and
 [`android/app/src/androidTest/.../ScreenshotTest.kt`](../android/app/src/androidTest/java/com/alcohol_tracker/screenshots/ScreenshotTest.kt)
-makes a few assumptions that may need adjustment after you watch the first run
-in the simulator:
+makes a few assumptions that may need adjustment after the first run:
 
 - **Inputs lack `testID`s.** The login fields are matched by `firstMatch` on
   text/secure text fields. If a future screen change reorders them, login
   breaks. Long-term fix: add `testID="loginEmail"` / `testID="loginPassword"`
   on the inputs in `src/screens/SignUp/AuthScreen.tsx`.
 
-- **Bottom tab bar buttons lack `testID`s.** Matched by their localized labels
-  (`"Start"`, `"Settings"`, `"Nastavení"`…). If translations change in
-  [`src/languages/en.ts`](../src/languages/en.ts) or
+- **Bottom tab bar buttons lack `testID`s.** Matched by their localized
+  labels (`"Start"`, `"Settings"`, `"Nastavení"`…). If translations change
+  in [`src/languages/en.ts`](../src/languages/en.ts) or
   [`src/languages/cs_cz.ts`](../src/languages/cs_cz.ts), update the matcher
   arrays in the test files to match.
 
 - **Submit button labels.** Same story — matched on `"Log In"` /
   `"Přihlásit se"`. Update if the strings change.
 
-- **Calendar day cells.** The test taps the first element with the accessibility
-  identifier `DayMarking`. If your demo account has no recorded sessions, this
-  selector will fail — make sure the demo account has at least one logged
-  session in the current month.
+- **Calendar day cells.** The test taps the first element with the
+  accessibility identifier `DayMarking`. If your demo account has no recorded
+  sessions in the current month, this selector will fail — see the
+  prerequisite at the top of this doc.
 
 - **In-app locale switch flow.** The test navigates
   Settings → Preferences → Language → (Czech/English). If the menu structure
   changes, update `switchLocaleIfNeeded()` in both test files.
 
-The pragmatic path: run it once, watch which step fails, either tweak the
-matcher or add a `testID` to the underlying RN component. Each round of
-iteration is cheap — single device, single locale — once the flow is stable,
-the full matrix runs unattended.
-
 ---
 
 ## What this doesn't include (yet)
 
-- **CI workflow** — `screenshots.yml` is a planned follow-up PR. Once the local
-  flow is reliable, lifting it into a `workflow_dispatch`-triggered job is
-  ~50 lines of YAML.
-- **`frameit` device bezels** — uncomment the line in the iOS lane once you've
-  installed it (`bundle exec fastlane frameit setup`).
+- **Android CI job** — the `android :screenshots` lane works locally but
+  needs the Gradle setup + AVD wiring + manifest permission landed on master
+  before it can be lifted into CI. Follow-up.
+- **`frameit` device bezels** — uncomment the line in the iOS lane once
+  you've installed it (`bundle exec fastlane frameit setup`).
 - **Auto-upload to App Store Connect / Play Console** — both lanes currently
-  stop after capturing PNGs. Wiring them into the existing `production` lanes
-  via `deliver` / `supply` with `skip_screenshots: false` is the natural next
-  step once you trust the output.
+  stop after capturing PNGs. Wiring them into the existing `production`
+  lanes via `deliver` / `supply` with `skip_screenshots: false` is the
+  natural next step once you trust the output.
+- **Underlying `kirokuTests` `SWIFT_VERSION` fix** — the workaround lives in
+  `fastlane/Snapfile` (`xcargs("SWIFT_VERSION=5.0")`). The root-cause fix
+  belongs in a separate PR that edits the `kirokuTests` target in
+  `ios/kiroku.xcodeproj`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -362,6 +362,14 @@ platform :ios do
     UI.user_error!("APPLE_DEMO_EMAIL not set") unless ENV["APPLE_DEMO_EMAIL"]
     UI.user_error!("APPLE_DEMO_PASSWORD not set") unless ENV["APPLE_DEMO_PASSWORD"]
 
+    # Generate the KirokuUITests target inside ios/kiroku.xcodeproj at runtime.
+    # The resulting pbxproj diff is intentionally throwaway and must not be
+    # committed — committing it bumps objectVersion via Xcode 26 and breaks
+    # `bundle exec pod install` for everyone. See the script header and
+    # contributingGuides/SCREENSHOTS.md for the full story.
+    # Fastlane runs lanes with cwd = ./fastlane, so step up one directory.
+    sh "bundle exec ruby ../scripts/setup-screenshots-test-target.rb"
+
     capture_ios_screenshots         # reads Snapfile
     # frame_screenshots(white: true) # uncomment once you've installed `frameit`
   end

--- a/scripts/setup-screenshots-test-target.rb
+++ b/scripts/setup-screenshots-test-target.rb
@@ -1,0 +1,267 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generates a `KirokuUITests` UI Testing Bundle target inside
+# ios/kiroku.xcodeproj at CI runtime so fastlane `snapshot` has something to
+# build/run. The resulting pbxproj diff is intentionally throwaway and must
+# NEVER be committed back into the repo:
+#
+#   * master pins `objectVersion = 54` so that xcodeproj 1.27.0 (and therefore
+#     `bundle exec pod install`) can parse the project file. Adding the target
+#     in Xcode 26's UI rewrites the project to objectVersion 70 +
+#     PBXFileSystemSynchronizedRootGroup, which breaks pod install for every
+#     developer (`ArgumentError - Unable to find compatibility version string
+#     for object version 70`).
+#   * Generating it programmatically with the xcodeproj gem preserves the
+#     existing objectVersion and keeps the older PBXGroup-style layout.
+#
+# Run once before invoking `fastlane ios screenshots`:
+#
+#     bundle exec ruby scripts/setup-screenshots-test-target.rb
+#
+# Idempotent — re-running is a no-op if the target already exists.
+
+require 'xcodeproj'
+require 'fileutils'
+require 'rexml/document'
+
+REPO_ROOT = File.expand_path('..', __dir__)
+PROJECT_PATH = File.join(REPO_ROOT, 'ios', 'kiroku.xcodeproj')
+UI_TESTS_DIR = File.join(REPO_ROOT, 'ios', 'KirokuUITests')
+UI_TESTS_TARGET_NAME = 'KirokuUITests'
+HOST_APP_TARGET_NAME = 'kiroku'
+SCHEME_PATH = File.join(
+  PROJECT_PATH,
+  'xcshareddata',
+  'xcschemes',
+  'Kiroku (production).xcscheme',
+)
+
+# --- Helpers ------------------------------------------------------------------
+
+def log(msg)
+  puts "[setup-screenshots-test-target] #{msg}"
+end
+
+def abort_with(msg)
+  warn "[setup-screenshots-test-target] ERROR: #{msg}"
+  exit 1
+end
+
+# Locate fastlane's bundled SnapshotHelper.swift. The gem ships it at
+# `<gem>/snapshot/lib/assets/SnapshotHelper.swift`. We use Bundler to ask
+# rubygems where the fastlane gem lives — same lookup the fastlane CLI uses.
+def find_snapshot_helper
+  spec = Gem::Specification.find_by_name('fastlane')
+  candidate = File.join(spec.gem_dir, 'snapshot', 'lib', 'assets', 'SnapshotHelper.swift')
+  return candidate if File.exist?(candidate)
+
+  # Some fastlane versions tuck it under a different prefix; do a wider search.
+  matches = Dir.glob(File.join(spec.gem_dir, '**', 'SnapshotHelper.swift'))
+  return matches.first if matches.any?
+
+  abort_with(
+    "could not locate SnapshotHelper.swift in fastlane gem at #{spec.gem_dir}. " \
+    "Is the fastlane gem installed via `bundle install`?",
+  )
+rescue Gem::MissingSpecError
+  abort_with('fastlane gem is not installed. Run `bundle install` first.')
+end
+
+def copy_snapshot_helper
+  FileUtils.mkdir_p(UI_TESTS_DIR)
+  dest = File.join(UI_TESTS_DIR, 'SnapshotHelper.swift')
+  if File.exist?(dest)
+    log "SnapshotHelper.swift already present at #{dest}"
+    return dest
+  end
+
+  source = find_snapshot_helper
+  FileUtils.cp(source, dest)
+  log "Copied SnapshotHelper.swift from #{source}"
+  dest
+end
+
+# Find the host app target named `kiroku` (the one whose product is kiroku.app).
+def find_host_target(project)
+  target = project.targets.find { |t| t.name == HOST_APP_TARGET_NAME }
+  abort_with("could not find host app target '#{HOST_APP_TARGET_NAME}' in project") unless target
+
+  target
+end
+
+# Pull a couple of build settings off the host target so the UI test target's
+# config matches (deployment target, dev team, etc.).
+def host_build_setting(host_target, key, fallback = nil)
+  host_target.build_configurations.each do |config|
+    value = config.build_settings[key]
+    return value if value && !value.to_s.empty?
+  end
+  fallback
+end
+
+# Build settings shared across all configurations of the UI test target.
+def base_ui_test_settings(host_target)
+  {
+    'PRODUCT_NAME'                 => '$(TARGET_NAME)',
+    'PRODUCT_BUNDLE_IDENTIFIER'    => 'com.alcohol-tracker.kirokuUITests',
+    'SWIFT_VERSION'                => '5.0',
+    'TEST_TARGET_NAME'             => HOST_APP_TARGET_NAME,
+    'IPHONEOS_DEPLOYMENT_TARGET'   => host_build_setting(host_target, 'IPHONEOS_DEPLOYMENT_TARGET', '15.1'),
+    'DEVELOPMENT_TEAM'             => host_build_setting(host_target, 'DEVELOPMENT_TEAM', 'L357YP9W28'),
+    'CODE_SIGN_STYLE'              => 'Automatic',
+    'TARGETED_DEVICE_FAMILY'       => '1,2',
+    'SDKROOT'                      => 'iphoneos',
+    'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'YES',
+    'LD_RUNPATH_SEARCH_PATHS'      => [
+      '$(inherited)',
+      '@executable_path/Frameworks',
+      '@loader_path/Frameworks',
+    ],
+    'CLANG_ENABLE_MODULES'         => 'YES',
+    'GENERATE_INFOPLIST_FILE'      => 'YES',
+  }
+end
+
+# --- Target creation ----------------------------------------------------------
+
+def ensure_ui_tests_group(project, ui_tests_dir_relative)
+  existing = project.main_group.find_subpath('KirokuUITests', false)
+  return existing if existing
+
+  group = project.main_group.new_group('KirokuUITests', ui_tests_dir_relative)
+  group.set_source_tree('<group>')
+  group
+end
+
+def add_source_file(group, project, abs_path)
+  rel_path = File.basename(abs_path)
+  file_ref = group.files.find { |f| f.path == rel_path }
+  file_ref ||= group.new_reference(rel_path)
+  file_ref.last_known_file_type = 'sourcecode.swift'
+  file_ref
+end
+
+def configure_ui_test_target(project, host_target)
+  target = project.targets.find { |t| t.name == UI_TESTS_TARGET_NAME }
+  if target
+    log "Target '#{UI_TESTS_TARGET_NAME}' already exists; leaving untouched."
+    return target
+  end
+
+  log "Creating PBXNativeTarget '#{UI_TESTS_TARGET_NAME}' (com.apple.product-type.bundle.ui-testing)"
+  target = project.new_target(
+    :ui_test_bundle,
+    UI_TESTS_TARGET_NAME,
+    :ios,
+    host_build_setting(host_target, 'IPHONEOS_DEPLOYMENT_TARGET', '15.1'),
+  )
+
+  # `new_target` defaults to a minimal config. Layer our shared settings on top.
+  base = base_ui_test_settings(host_target)
+  target.build_configurations.each do |config|
+    config.build_settings.merge!(base)
+  end
+
+  # Wire the host application via TargetAttributes (TestTargetID + CreatedOnToolsVersion).
+  project.root_object.attributes['TargetAttributes'] ||= {}
+  project.root_object.attributes['TargetAttributes'][target.uuid] = {
+    'CreatedOnToolsVersion' => '15.2',
+    'TestTargetID'          => host_target.uuid,
+  }
+
+  # Declare the host as an implicit dependency so xcodebuild builds it first.
+  target.add_dependency(host_target)
+
+  target
+end
+
+def attach_sources(project, target, source_files)
+  group = ensure_ui_tests_group(project, 'KirokuUITests')
+  sources_phase = target.source_build_phase
+
+  source_files.each do |abs|
+    ref = add_source_file(group, project, abs)
+    next if sources_phase.files_references.include?(ref)
+
+    sources_phase.add_file_reference(ref, true)
+  end
+end
+
+# --- Scheme wiring ------------------------------------------------------------
+
+# Add the UI test target to the shared `Kiroku (production)` scheme's
+# TestAction so `xcodebuild test -scheme "Kiroku (production)"` picks it up.
+# We edit the XML directly to avoid xcodeproj's scheme writer reformatting
+# every line in the file.
+def add_testable_to_scheme(target)
+  abort_with("scheme not found at #{SCHEME_PATH}") unless File.exist?(SCHEME_PATH)
+
+  doc = REXML::Document.new(File.read(SCHEME_PATH))
+  testables = REXML::XPath.first(doc, '//TestAction/Testables')
+  abort_with('no <Testables> node in scheme') unless testables
+
+  already_present = REXML::XPath.match(testables, "TestableReference/BuildableReference[@BlueprintName='#{UI_TESTS_TARGET_NAME}']").any?
+  if already_present
+    log "Scheme already references '#{UI_TESTS_TARGET_NAME}'"
+    return
+  end
+
+  log "Adding '#{UI_TESTS_TARGET_NAME}' to scheme's TestAction"
+
+  testable = REXML::Element.new('TestableReference')
+  testable.add_attribute('skipped', 'NO')
+
+  ref = REXML::Element.new('BuildableReference')
+  ref.add_attribute('BuildableIdentifier', 'primary')
+  ref.add_attribute('BlueprintIdentifier', target.uuid)
+  ref.add_attribute('BuildableName', "#{UI_TESTS_TARGET_NAME}.xctest")
+  ref.add_attribute('BlueprintName', UI_TESTS_TARGET_NAME)
+  ref.add_attribute('ReferencedContainer', 'container:kiroku.xcodeproj')
+
+  testable.add_element(ref)
+  testables.add_element(testable)
+
+  formatter = REXML::Formatters::Pretty.new(3)
+  formatter.compact = true
+  out = String.new
+  formatter.write(doc, out)
+  File.write(SCHEME_PATH, out)
+end
+
+# --- Main ---------------------------------------------------------------------
+
+def main
+  abort_with("project not found at #{PROJECT_PATH}") unless Dir.exist?(PROJECT_PATH)
+
+  copy_snapshot_helper
+
+  project = Xcodeproj::Project.open(PROJECT_PATH)
+  original_object_version = project.object_version
+
+  host_target = find_host_target(project)
+  target = configure_ui_test_target(project, host_target)
+
+  source_files = [
+    File.join(UI_TESTS_DIR, 'ScreenshotTests.swift'),
+    File.join(UI_TESTS_DIR, 'SnapshotHelper.swift'),
+  ].select { |p| File.exist?(p) }
+
+  attach_sources(project, target, source_files)
+
+  if project.object_version != original_object_version
+    abort_with(
+      "objectVersion was bumped from #{original_object_version} to #{project.object_version}; " \
+      "refusing to save. This would break `bundle exec pod install` for everyone — " \
+      "see commit history for context.",
+    )
+  end
+
+  project.save
+
+  add_testable_to_scheme(target)
+
+  log "Done. Target '#{UI_TESTS_TARGET_NAME}' is ready for `fastlane ios screenshots`."
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/scripts/trim-snapfile-devices.rb
+++ b/scripts/trim-snapfile-devices.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Rewrites fastlane/Snapfile's `devices([...])` block in place so the
+# screenshots workflow can capture a subset of the device matrix on demand.
+# Throwaway change — never committed back.
+#
+# Usage: ruby scripts/trim-snapfile-devices.rb <all|phone-only|ipad-only>
+
+SNAPFILE = File.expand_path('../fastlane/Snapfile', __dir__)
+
+PHONE_ONLY = [
+  'iPhone 16 Pro Max',
+  'iPhone 15 Pro Max',
+  'iPhone 8 Plus',
+].freeze
+
+IPAD_ONLY = ['iPad Pro 13-inch (M4)'].freeze
+
+subset = ARGV[0].to_s
+case subset
+when '', 'all'
+  puts "[trim-snapfile-devices] subset='#{subset}' — no-op"
+  exit 0
+when 'phone-only'
+  devices = PHONE_ONLY
+when 'ipad-only'
+  devices = IPAD_ONLY
+else
+  warn "[trim-snapfile-devices] unknown subset '#{subset}' — expected all|phone-only|ipad-only"
+  exit 1
+end
+
+abort "Snapfile not found at #{SNAPFILE}" unless File.exist?(SNAPFILE)
+
+src = File.read(SNAPFILE, encoding: 'UTF-8')
+replacement = "devices([\n  #{devices.map { |d| "\"#{d}\"" }.join(",\n  ")}\n])"
+new_src = src.sub(/devices\(\[.*?\]\)/m, replacement)
+
+if new_src == src
+  abort "[trim-snapfile-devices] failed to locate devices([...]) block in Snapfile"
+end
+
+File.write(SNAPFILE, new_src)
+puts "[trim-snapfile-devices] subset='#{subset}' — Snapfile now targets: #{devices.join(', ')}"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered GitHub Actions workflow that runs
`fastlane ios screenshots` on `macos-26` and uploads the captured PNGs as a
build artifact. Stacked on top of #447 — once that merges, GitHub will
auto-retarget this PR to `master`.

- **`.github/workflows/screenshots.yml`** — manual-only workflow with an
  optional `device_subset` input (`all` / `phone-only` / `ipad-only`) for
  iteration speed. 60-minute timeout, uploads `ios-screenshots-<sha>` plus
  `ios-fastlane-logs-<sha>` on failure. Mirrors the Node/Ruby/CocoaPods
  setup from `testBuild.yml`.
- **`scripts/setup-screenshots-test-target.rb`** — runtime generator that
  adds the `KirokuUITests` UI Testing Bundle target to
  `ios/kiroku.xcodeproj`, wires it into the `Kiroku (production)` shared
  scheme, and copies `SnapshotHelper.swift` out of the fastlane gem.
  Idempotent. Refuses to save if `objectVersion` was bumped.
- **`scripts/trim-snapfile-devices.rb`** — tiny helper invoked by the
  workflow when `device_subset != all`. Rewrites `fastlane/Snapfile`'s
  `devices([...])` block in place (throwaway).
- **`fastlane/Fastfile`** — `ios :screenshots` now `sh`-invokes the setup
  script before calling `capture_ios_screenshots`. No other lanes touched.
- **`contributingGuides/SCREENSHOTS.md`** — rewritten CI-first; local
  fallback documented with explicit "do not commit these files" guard.

## Why programmatic test-target generation (the core trick)

Adding a UI Testing Bundle target via Xcode 26's UI rewrites
`ios/kiroku.xcodeproj/project.pbxproj` two ways:

1. Bumps `objectVersion` from `54` to `70`.
2. Restructures the file using `PBXFileSystemSynchronizedRootGroup` (Xcode
   26's new format).

The `xcodeproj` Ruby gem 1.27.0 (latest released) cannot parse
`objectVersion = 70` — it crashes with
`ArgumentError - [Xcodeproj] Unable to find compatibility version string
for object version 70`. CocoaPods uses `xcodeproj` internally, so
committing the Xcode-generated pbxproj would break
`bundle exec pod install` for every developer. We've already verified this
the hard way.

Generating the target at CI time via `xcodeproj` itself preserves
`objectVersion = 54` and uses the older `PBXGroup` layout — sidestepping
the problem. The script saves the project file, the workflow uses it for
the test run, and the diff is discarded when the runner is torn down.

## Test plan

I cannot run the workflow (requires GitHub secrets + a `macos-26` runner),
but verified locally:

- [x] `bundle exec ruby scripts/setup-screenshots-test-target.rb` runs
      cleanly. Adds `KirokuUITests` PBXNativeTarget (productType
      `com.apple.product-type.bundle.ui-testing`), adds it to the
      `Kiroku (production)` scheme's TestAction, copies
      `SnapshotHelper.swift` from the fastlane 2.228.0 gem.
- [x] Re-running the script is a no-op (idempotent).
- [x] `grep objectVersion ios/kiroku.xcodeproj/project.pbxproj` still
      reports `54` after the script runs.
- [x] `Xcodeproj::Project.open` succeeds on the generated project
      (sanity-check that `pod install`'s entry-point parser is happy).
- [x] `bundle exec ruby scripts/trim-snapfile-devices.rb {phone-only,
      ipad-only, all}` all behave correctly; the matching regex tolerates
      the existing UTF-8 Snapfile comments.
- [x] `bundle exec fastlane lanes` parses; `ios screenshots` still appears
      in the list.
- [x] `.github/workflows/screenshots.yml` parses as valid YAML.

What a reviewer should manually verify:

- [ ] Trigger the workflow with `device_subset=ipad-only` first (cheapest
      smoke test, ~10-15 min). Confirm the artifact contains
      `cs-CZ/iPad Pro 13-inch (M4)/03_DayOverview.png` and friends.
- [ ] **Before triggering**, log in to the demo account
      (`APPLE_DEMO_EMAIL`) and record at least one drinking session in the
      current calendar month. The Day Overview test taps the first
      `DayMarking` cell — without an in-month session the run fails. This
      prerequisite is documented prominently in `SCREENSHOTS.md`.
- [ ] After a green run, trigger `device_subset=all` and confirm all 4
      devices x 2 locales produce PNGs.

## Required GitHub secrets

| Secret                | Used for                                          |
| --------------------- | ------------------------------------------------- |
| `APPLE_DEMO_EMAIL`    | Demo account login (already exists for App Store Review) |
| `APPLE_DEMO_PASSWORD` | Demo account password (already exists)            |
| `PROD_ENV_FILE`       | Contents of `.env.production` (already exists)    |

`KIROKU_DEMO_EMAIL` / `KIROKU_DEMO_PASSWORD` are aliased from
`APPLE_DEMO_*` inside the workflow, so no new secrets are required.

## Follow-ups (intentionally not in this PR)

- **Underlying `kirokuTests` `SWIFT_VERSION` fix.** PR #447's Snapfile
  works around it via `xcargs("SWIFT_VERSION=5.0")`. The root-cause fix
  (set `SWIFT_VERSION = 5.0` on the `kirokuTests` target in
  `ios/kiroku.xcodeproj`) is its own commit and can land independently.
- **Android CI job.** The `android :screenshots` lane works locally but
  needs the screengrab Gradle deps + `CHANGE_CONFIGURATION` manifest entry
  landed on master before it can be lifted into CI. Tracked as a `TODO`
  comment at the bottom of `screenshots.yml`.
- **Auto-upload via `deliver` / `supply`.** Once the captured PNGs look
  good, wire `skip_screenshots: false` into the existing `production`
  lanes so App Store Connect / Play Console pick them up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)