### PR TITLE
ci: drop redundant Ruby tool-cache step; bump setup-ruby; fix screenshot device matrix

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -56,7 +56,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
 
@@ -141,18 +141,8 @@ jobs:
         id: setup-node
         uses: ./.github/actions/composite/setupNode
 
-      - name: Install Ruby into tool cache (self-hosted runner)
-        run: |
-          RUBY_VERSION="3.3.4"
-          RUBY_PATH="${RUNNER_TOOL_CACHE}/Ruby/${RUBY_VERSION}/arm64"
-          if [[ ! -f "${RUBY_PATH}.complete" ]]; then
-            brew install ruby-build 2>/dev/null || true
-            ruby-build "$RUBY_VERSION" "$RUBY_PATH"
-            touch "${RUBY_PATH}.complete"
-          fi
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/composite/setupNode
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -43,16 +43,6 @@ jobs:
         id: setup-node
         uses: ./.github/actions/composite/setupNode
 
-      - name: Install Ruby into tool cache (self-hosted runner)
-        run: |
-          RUBY_VERSION="3.3.4"
-          RUBY_PATH="${RUNNER_TOOL_CACHE}/Ruby/${RUBY_VERSION}/arm64"
-          if [[ ! -f "${RUBY_PATH}.complete" ]]; then
-            brew install ruby-build 2>/dev/null || true
-            ruby-build "$RUBY_VERSION" "$RUBY_PATH"
-            touch "${RUBY_PATH}.complete"
-          fi
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.190.0
         with:

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -65,7 +65,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
 
@@ -127,18 +127,8 @@ jobs:
         id: setup-node
         uses: ./.github/actions/composite/setupNode
 
-      - name: Install Ruby into tool cache (self-hosted runner)
-        run: |
-          RUBY_VERSION="3.3.4"
-          RUBY_PATH="${RUNNER_TOOL_CACHE}/Ruby/${RUBY_VERSION}/arm64"
-          if [[ ! -f "${RUBY_PATH}.complete" ]]; then
-            brew install ruby-build 2>/dev/null || true
-            ruby-build "$RUBY_VERSION" "$RUBY_PATH"
-            touch "${RUBY_PATH}.complete"
-          fi
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.190.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           bundler-cache: true
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,14 +1,17 @@
 # Device matrix for App Store screenshots.
-# Sizes are picked to satisfy App Store Connect's required resolutions:
-#   6.9" — iPhone 16 Pro Max
-#   6.5" — iPhone 15 Pro Max (covers 6.7" requirement too)
-#   5.5" — iPhone 8 Plus (still required for legacy listings)
-#   13"  — iPad Pro M4 (required if the app supports iPad)
+# Sizes are picked to satisfy App Store Connect's required resolutions and to
+# match what the macos-26 GitHub-hosted runner ships (Xcode 26 / iOS 26 SDK).
+# Run `xcrun simctl list devicetypes` on a macos-26 runner to see options.
+#
+#   6.9" — iPhone 17 Pro Max (also satisfies the 6.7" tier)
+#   13"  — iPad Pro 13-inch (M5)  (required if the app supports iPad)
+#
+# Note: the legacy 5.5" tier (iPhone 8 Plus) was deprecated by Apple in 2024
+# and is no longer in the runner image. Add an `iPhone Air` or `iPhone 17e`
+# entry if/when we want to cover the smaller "standard" phone form factor.
 devices([
-  "iPhone 16 Pro Max",
-  "iPhone 15 Pro Max",
-  "iPhone 8 Plus",
-  "iPad Pro 13-inch (M4)",
+  "iPhone 17 Pro Max",
+  "iPad Pro 13-inch (M5)",
 ])
 
 # Kiroku uses an in-app locale switcher (Settings -> Language), not OS locale.

--- a/scripts/trim-snapfile-devices.rb
+++ b/scripts/trim-snapfile-devices.rb
@@ -9,13 +9,9 @@
 
 SNAPFILE = File.expand_path('../fastlane/Snapfile', __dir__)
 
-PHONE_ONLY = [
-  'iPhone 16 Pro Max',
-  'iPhone 15 Pro Max',
-  'iPhone 8 Plus',
-].freeze
+PHONE_ONLY = ['iPhone 17 Pro Max'].freeze
 
-IPAD_ONLY = ['iPad Pro 13-inch (M4)'].freeze
+IPAD_ONLY = ['iPad Pro 13-inch (M5)'].freeze
 
 subset = ARGV[0].to_s
 case subset


### PR DESCRIPTION
## Summary

Three coordinated fixes that came out of the first run of `screenshots.yml` on master:

### 1. Drop the redundant manual `ruby-build` step on `macos-26` jobs (3 workflows)
Applied to `.github/workflows/{screenshots,testBuild,platformDeploy}.yml`. The manual step compiled Ruby from source (~8-12 min) every run because the hosted-runner tool cache doesn't persist between invocations. With `ruby/setup-ruby` bumped (see #2), the action installs Ruby itself in ~30s.

### 2. Bump `ruby/setup-ruby` v1.190.0 → v1.310.0
v1.190.0 (Sep 2024) predates the `macos-26` hosted runner label. When run on `macos-26`, it errored with:
```
##[error]The current runner (macos--arm64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
```
v1.310.0 (May 2026) recognizes `macos-26` natively. Bumped on all 6 `setup-ruby` instances across the three workflows (including the `ubuntu-latest` ones, for consistency).

### 3. Update screenshot device matrix to match the `macos-26` runner image
The Snapfile / trim script listed simulators that no longer ship on `macos-26` (iPhone 16/15/8, iPad Pro M4). Run [26402108913](https://github.com/PetrCala/Kiroku/actions/runs/26402108913) crashed with:
```
[!] Device 'iPhone 16 Pro Max' not in list of available simulators
    'iPhone 17 Pro, iPhone 17 Pro Max, iPhone Air, iPhone 17, ...'
```
Switched to `iPhone 17 Pro Max` + `iPad Pro 13-inch (M5)`. Apple deprecated the 5.5\" tier in 2024 so iPhone 8 Plus is dropped entirely.

## Validation

- Ran `screenshots.yml` from this branch with `device_subset=phone-only` ([run 26402748677](https://github.com/PetrCala/Kiroku/actions/runs/26402748677)). Ruby setup + CocoaPods install both succeeded — confirming v1.310.0 of `setup-ruby` no longer needs the manual prefab on `macos-26`. (Whether the fastlane lane itself succeeds is a separate concern — that's the brittle-matcher territory PR #447's description already flagged.)

## Test plan

- [ ] After merge, watch the next PR's `testBuild.yml` run — Ruby setup should complete in ~30s (not ~10 min)
- [ ] Confirm `platformDeploy.yml` still works on the next deploy
- [ ] Re-trigger `screenshots.yml` from master with `device_subset=phone-only` and observe the fastlane lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)