### PR TITLE
fix(screenshots): install iOS platform SDK + disable snapshot retry loop

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -75,6 +75,12 @@ jobs:
           echo "export NODE_BINARY=$(which node)" >> "$HOME/.bash_profile"
           source "$HOME/.bash_profile"
 
+      # Xcode 26.1.1 on the macos-26 runner image ships without the iOS
+      # simulator runtime — xcodebuild crashes with "iOS 26.1 is not installed"
+      # otherwise. Same step that testBuild.yml uses.
+      - name: Install iOS platform SDK
+        run: xcodebuild -downloadPlatform iOS
+
       # Trim the Snapfile device matrix when the dispatcher asked for a subset.
       # `Snapfile` resolves devices(...) eagerly so we rewrite the file in
       # place — this is throwaway, not committed back.

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -39,8 +39,13 @@ clear_previous_screenshots(true)
 # scheme is taken from the workspace; the test target is referenced by the scheme's Test action.
 
 # Stop the test run on the first failure so you don't waste 15 min finding out
-# screen 2 broke on every device.
+# screen 2 broke on every device. number_of_retries(0) is also needed because
+# stop_after_first_error only halts after a *test* error — for *build* errors,
+# snapshot retries `number_of_retries + 1` times per device/language combo by
+# default. Without the explicit 0, a single misconfigured Xcode SDK can loop
+# for 20+ minutes before the workflow times out.
 stop_after_first_error(true)
+number_of_retries(0)
 
 # Reinstall the app between runs so each capture starts from a clean state.
 reinstall_app(true)


### PR DESCRIPTION
## Problem

Both first runs of \`screenshots.yml\` after PR #570 merged ([26402748677](https://github.com/PetrCala/Kiroku/actions/runs/26402748677), [26403010837](https://github.com/PetrCala/Kiroku/actions/runs/26403010837)) had to be cancelled manually after looping for 30+ minutes on the same error:

\`\`\`
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
  { platform:iOS, ..., name:Any iOS Device,
    error:iOS 26.1 is not installed. Please download and install the platform
          from Xcode > Settings > Components. }
\`\`\`

## Two fixes

### 1. Install the iOS platform SDK in the workflow

Xcode 26.1.1 on the \`macos-26\` runner image ships **without** the iOS 26.1 simulator runtime — it has to be installed on-demand. \`testBuild.yml\` already does this exact step (line 185); \`screenshots.yml\` was missing it:

\`\`\`yaml
- name: Install iOS platform SDK
  run: xcodebuild -downloadPlatform iOS
\`\`\`

### 2. Stop fastlane snapshot from looping on build failures

\`stop_after_first_error(true)\` (already in Snapfile) only halts after a *test* error. For *build* errors, snapshot retries \`number_of_retries + 1\` times per device/language combo. The default 1 multiplied across the language matrix loops for 30+ minutes against a single bad SDK setup.

Adding \`number_of_retries(0)\` makes fastlane bail after the first build failure per combo, so the next misconfiguration fails in ~2-3 min instead of burning a full hour.

## Test plan

- [ ] Merge, re-trigger \`screenshots.yml\` from master with \`device_subset=phone-only\`
- [ ] Confirm \`Install iOS platform SDK\` step completes (it's a long download — may take 5-10 min the first time the runner sees it)
- [ ] Confirm \`Run Fastlane - Capture iOS screenshots\` either succeeds OR fails within ~5 min (no more looping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)