### PR TITLE
feat(stats-v2): widen drink data shape (volume_ml + abv) [Phase 1/A of #576]

### DIFF
--- a/__tests__/unit/libs/DataHandling.test.ts
+++ b/__tests__/unit/libs/DataHandling.test.ts
@@ -32,6 +32,7 @@ import type {
   UnitsToColors,
 } from '@src/types/onyx';
 import CONST from '@src/CONST';
+import {getDrinkCount} from '@libs/DrinkEntryUtils';
 import {PALETTES} from '@libs/SessionColorPalettes';
 import {randDrinkingSession} from '../../utils/collections/drinkingSessions';
 
@@ -336,16 +337,13 @@ describe('sumAllDrinks', () => {
     const sampleDrinks: DrinksList = getRandomDrinksList();
 
     const result = sumAllDrinks(sampleDrinks);
-    const expectedSum = Object.values(sampleDrinks).reduce(
-      (total, drinkTypes) => {
-        return (
-          total +
-          Object.values(drinkTypes).reduce(
-            (subTotal, drinkCount) => subTotal + (drinkCount || 0),
-            0,
-          )
-        );
-      },
+    const expectedSum = Object.values(sampleDrinks).reduce<number>(
+      (total, drinkTypes) =>
+        total +
+        Object.values(drinkTypes).reduce<number>(
+          (subTotal, drinkEntry) => subTotal + getDrinkCount(drinkEntry),
+          0,
+        ),
       0,
     );
     expect(result).toBe(expectedSum);
@@ -403,6 +401,16 @@ describe('sumDrinksOfSingleType function', () => {
     };
     expect(sumDrinksOfSingleType(drinksData, 'beer')).toBe(2);
   });
+
+  it('should sum mixed numeric and object DrinkEntry shapes', () => {
+    drinksData[1632434223] = {
+      beer: {count: 3, volume_ml: 600},
+      wine: {count: 1, abv: 0.13},
+    };
+    expect(sumDrinksOfSingleType(drinksData, 'beer')).toBe(5);
+    expect(sumDrinksOfSingleType(drinksData, 'wine')).toBe(1);
+    expect(sumDrinksOfSingleType(drinksData, 'other')).toBe(3);
+  });
 });
 
 describe('sumDrinkTypes', () => {
@@ -444,6 +452,15 @@ describe('sumDrinkTypes', () => {
 
     const result = sumDrinkTypes(testDrinks);
     expect(result).toBe(5);
+  });
+
+  it('should sum object-shaped DrinkEntry values via the count field', () => {
+    const testDrinks: Drinks = {
+      beer: {count: 2, volume_ml: 500},
+      cocktail: 1,
+      wine: {count: 3},
+    };
+    expect(sumDrinkTypes(testDrinks)).toBe(6);
   });
 });
 

--- a/__tests__/unit/libs/DrinkEntryUtils.test.ts
+++ b/__tests__/unit/libs/DrinkEntryUtils.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  getDrinkAbv,
+  getDrinkCount,
+  getDrinkOverrides,
+  getDrinkVolumeMl,
+  makeDrinkEntry,
+} from '@libs/DrinkEntryUtils';
+import CONST from '@src/CONST';
+
+describe('getDrinkCount', () => {
+  it('returns the numeric value for the legacy form', () => {
+    expect(getDrinkCount(5)).toBe(5);
+  });
+
+  it('returns the count field for the object form', () => {
+    expect(getDrinkCount({count: 5})).toBe(5);
+    expect(getDrinkCount({count: 5, volume_ml: 600})).toBe(5);
+    expect(getDrinkCount({count: 5, volume_ml: 600, abv: 0.06})).toBe(5);
+  });
+
+  it('returns 0 for undefined', () => {
+    expect(getDrinkCount(undefined)).toBe(0);
+  });
+
+  it('returns 0 for the legacy zero', () => {
+    expect(getDrinkCount(0)).toBe(0);
+  });
+});
+
+describe('getDrinkVolumeMl', () => {
+  it('falls back to CONST.DRINK_DEFAULTS for numeric entries', () => {
+    expect(getDrinkVolumeMl('beer', 3)).toBe(CONST.DRINK_DEFAULTS.beer.ml);
+    expect(getDrinkVolumeMl('wine', 1)).toBe(CONST.DRINK_DEFAULTS.wine.ml);
+  });
+
+  it('falls back to defaults when the object form omits volume_ml', () => {
+    expect(getDrinkVolumeMl('beer', {count: 2})).toBe(
+      CONST.DRINK_DEFAULTS.beer.ml,
+    );
+    expect(getDrinkVolumeMl('beer', {count: 2, abv: 0.04})).toBe(
+      CONST.DRINK_DEFAULTS.beer.ml,
+    );
+  });
+
+  it('returns the override when present', () => {
+    expect(getDrinkVolumeMl('beer', {count: 1, volume_ml: 600})).toBe(600);
+  });
+
+  it('falls back to defaults for undefined entries', () => {
+    expect(getDrinkVolumeMl('beer', undefined)).toBe(
+      CONST.DRINK_DEFAULTS.beer.ml,
+    );
+  });
+});
+
+describe('getDrinkAbv', () => {
+  it('falls back to CONST.DRINK_DEFAULTS for numeric entries', () => {
+    expect(getDrinkAbv('beer', 3)).toBe(CONST.DRINK_DEFAULTS.beer.abv);
+    expect(getDrinkAbv('wine', 1)).toBe(CONST.DRINK_DEFAULTS.wine.abv);
+  });
+
+  it('falls back to defaults when the object form omits abv', () => {
+    expect(getDrinkAbv('beer', {count: 2})).toBe(CONST.DRINK_DEFAULTS.beer.abv);
+    expect(getDrinkAbv('beer', {count: 2, volume_ml: 600})).toBe(
+      CONST.DRINK_DEFAULTS.beer.abv,
+    );
+  });
+
+  it('returns the override when present', () => {
+    expect(getDrinkAbv('beer', {count: 1, abv: 0.07})).toBe(0.07);
+  });
+});
+
+describe('makeDrinkEntry', () => {
+  it('returns the bare number when no overrides are passed', () => {
+    expect(makeDrinkEntry(3)).toBe(3);
+  });
+
+  it('returns the bare number when overrides object has no fields set', () => {
+    expect(makeDrinkEntry(3, {})).toBe(3);
+    expect(makeDrinkEntry(3, {volume_ml: undefined})).toBe(3);
+  });
+
+  it('returns the object form when volume_ml is set', () => {
+    expect(makeDrinkEntry(3, {volume_ml: 600})).toEqual({
+      count: 3,
+      volume_ml: 600,
+    });
+  });
+
+  it('returns the object form when abv is set', () => {
+    expect(makeDrinkEntry(3, {abv: 0.07})).toEqual({count: 3, abv: 0.07});
+  });
+
+  it('returns the object form with both overrides', () => {
+    expect(makeDrinkEntry(2, {volume_ml: 600, abv: 0.07})).toEqual({
+      count: 2,
+      volume_ml: 600,
+      abv: 0.07,
+    });
+  });
+});
+
+describe('getDrinkOverrides', () => {
+  it('returns undefined for numeric entries', () => {
+    expect(getDrinkOverrides(5)).toBeUndefined();
+  });
+
+  it('returns undefined for the bare-count object form', () => {
+    expect(getDrinkOverrides({count: 5})).toBeUndefined();
+  });
+
+  it('returns only the override fields that are set', () => {
+    expect(getDrinkOverrides({count: 5, volume_ml: 600})).toEqual({
+      volume_ml: 600,
+    });
+    expect(getDrinkOverrides({count: 5, abv: 0.07})).toEqual({abv: 0.07});
+    expect(getDrinkOverrides({count: 5, volume_ml: 600, abv: 0.07})).toEqual({
+      volume_ml: 600,
+      abv: 0.07,
+    });
+  });
+});

--- a/__tests__/unit/libs/DrinkingSessionUtils.test.ts
+++ b/__tests__/unit/libs/DrinkingSessionUtils.test.ts
@@ -97,6 +97,32 @@ describe('calculateTotalUnits', () => {
     );
     expect(result).toBe(2 * 5 + 1 * 10 + 3 * 1);
   });
+
+  it('should use the count field when entries are object-shaped', () => {
+    const mixedDrinks: DrinksList = {
+      1632423423: {
+        beer: 2,
+        cocktail: {count: 1, volume_ml: 250, abv: 0.1},
+      },
+      1632434223: {
+        other: {count: 3},
+      },
+    };
+    const sampleDrinksToUnits: DrinksToUnits = {
+      small_beer: 3,
+      beer: 5,
+      cocktail: 10,
+      other: 1,
+      strong_shot: 15,
+      weak_shot: 5,
+      wine: 7,
+    };
+    const result = DSUtils.calculateTotalUnits(
+      mixedDrinks,
+      sampleDrinksToUnits,
+    );
+    expect(result).toBe(2 * 5 + 1 * 10 + 3 * 1);
+  });
 });
 
 // TODO

--- a/__tests__/unit/libs/migrations/HydrateLegacyDrinkEntries.test.ts
+++ b/__tests__/unit/libs/migrations/HydrateLegacyDrinkEntries.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  convertDrinksList,
+  convertSession,
+} from '@libs/migrations/HydrateLegacyDrinkEntries';
+import type {DrinkingSession, DrinksList} from '@src/types/onyx';
+import {getDrinkCount} from '@libs/DrinkEntryUtils';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+// The migration is two layers: pure conversion + Onyx writes. These tests
+// pin down the conversion layer end-to-end. The Onyx layer is a straight
+// `merge`/`set` over the converted result — exercising it here would
+// require booting Onyx inside Jest and is well-covered by the existing
+// integration paths in the app.
+
+const makeSession = (
+  id: string,
+  drinks: DrinksList | undefined,
+): DrinkingSession => ({
+  id,
+  start_time: 1_700_000_000_000,
+  drinks,
+});
+
+describe('convertDrinksList', () => {
+  it('returns undefined when input is undefined', () => {
+    expect(convertDrinksList(undefined)).toBeUndefined();
+  });
+
+  it('hydrates legacy numeric entries to {count: N}', () => {
+    const input: DrinksList = {
+      1_700_000_000_000: {beer: 2, wine: 1},
+    };
+    const result = convertDrinksList(input);
+    expect(result?.changed).toBe(true);
+    expect(result?.drinks).toEqual({
+      1_700_000_000_000: {beer: {count: 2}, wine: {count: 1}},
+    });
+  });
+
+  it('is a no-op when every entry is already object-shaped', () => {
+    const input: DrinksList = {
+      1_700_000_000_000: {
+        beer: {count: 2, volume_ml: 600},
+        wine: {count: 1, abv: 0.13},
+      },
+    };
+    const result = convertDrinksList(input);
+    expect(result?.changed).toBe(false);
+    expect(result?.drinks).toEqual(input);
+  });
+
+  it('preserves overrides on object entries when sibling entries hydrate', () => {
+    const input: DrinksList = {
+      1_700_000_000_000: {
+        beer: 3,
+        wine: {count: 1, volume_ml: 200},
+      },
+    };
+    const result = convertDrinksList(input);
+    expect(result?.changed).toBe(true);
+    expect(result?.drinks[1_700_000_000_000]).toEqual({
+      beer: {count: 3},
+      wine: {count: 1, volume_ml: 200},
+    });
+  });
+
+  it('is idempotent — running on its own output is a no-op', () => {
+    const input: DrinksList = {
+      1_700_000_000_000: {beer: 2, wine: 1, cocktail: 3},
+    };
+    const first = convertDrinksList(input);
+    expect(first?.changed).toBe(true);
+    if (!first) {
+      return;
+    }
+    const second = convertDrinksList(first.drinks);
+    expect(second?.changed).toBe(false);
+    expect(second?.drinks).toEqual(first.drinks);
+  });
+
+  it('keeps total counts identical pre- and post-conversion', () => {
+    const input: DrinksList = {
+      1_700_000_000_000: {beer: 2, wine: 1},
+      1_700_000_010_000: {
+        beer: {count: 4, volume_ml: 600},
+        cocktail: 1,
+      },
+    };
+    const sumViaCounts = (drinks: DrinksList) =>
+      Object.values(drinks).reduce<number>(
+        (sum, day) =>
+          sum +
+          Object.values(day).reduce<number>(
+            (s, entry) => s + getDrinkCount(entry),
+            0,
+          ),
+        0,
+      );
+    const result = convertDrinksList(input);
+    expect(result).toBeDefined();
+    if (!result) {
+      return;
+    }
+    expect(sumViaCounts(result.drinks)).toBe(sumViaCounts(input));
+  });
+});
+
+describe('convertSession', () => {
+  it('returns undefined for a session with no drinks', () => {
+    expect(convertSession({id: 's', start_time: 0})).toBeUndefined();
+  });
+
+  it('returns undefined when nothing changed', () => {
+    const session: DrinkingSession = makeSession('s', {
+      1_700_000_000_000: {beer: {count: 2}},
+    });
+    expect(convertSession(session)).toBeUndefined();
+  });
+
+  it('returns a fresh session object when any entry hydrated', () => {
+    const session = makeSession('s', {1_700_000_000_000: {beer: 2}});
+    const result = convertSession(session);
+    expect(result?.changed).toBe(true);
+    expect(result?.session).not.toBe(session);
+    expect(result?.session.drinks).toEqual({
+      1_700_000_000_000: {beer: {count: 2}},
+    });
+  });
+
+  it('preserves all other session fields verbatim', () => {
+    const session: DrinkingSession = {
+      id: 's',
+      start_time: 1,
+      end_time: 2,
+      note: 'hello',
+      blackout: true,
+      ongoing: false,
+      drinks: {1_700_000_000_000: {beer: 1}},
+    };
+    const result = convertSession(session);
+    expect(result?.session).toEqual({
+      ...session,
+      drinks: {1_700_000_000_000: {beer: {count: 1}}},
+    });
+  });
+});

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -646,7 +646,6 @@
 "__mocks__/react-native-safe-area-context.tsx"	"react-hooks/refs"	2
 "__mocks__/react-native.ts"	"@typescript-eslint/no-unused-vars"	1
 "__tests__/unit/context/ConfigContext.test.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"__tests__/unit/libs/DataHandling.test.ts"	"arrow-body-style"	1
 "__tests__/unit/useOnboardingFlow.test.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "__tests__/utils/firebase/connections.ts"	"arrow-body-style"	1
 "__tests__/utils/firebase/mockAuth.ts"	"@typescript-eslint/switch-exhaustiveness-check"	1

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -1003,6 +1003,20 @@ const CONST = {
     },
   },
 
+  // Per-key serving-size + ABV defaults used when a DrinkEntry does not carry
+  // explicit `volume_ml` / `abv` overrides. SDU math falls back to these so the
+  // legacy numeric form produces the same result as an entry stamped with
+  // these values. Keyed by `CONST.DRINKS.KEYS` string values.
+  DRINK_DEFAULTS: {
+    small_beer: {ml: 330, abv: 0.05},
+    beer: {ml: 500, abv: 0.05},
+    wine: {ml: 150, abv: 0.12},
+    cocktail: {ml: 250, abv: 0.1},
+    strong_shot: {ml: 40, abv: 0.4},
+    weak_shot: {ml: 40, abv: 0.2},
+    other: {ml: 200, abv: 0.1},
+  },
+
   // 6 numeric digits
   VALIDATE_CODE_REGEX_STRING: /^\d{6}$/,
 

--- a/src/libs/DataHandling.ts
+++ b/src/libs/DataHandling.ts
@@ -21,6 +21,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import _ from 'lodash';
 import type {TranslationPaths} from '@src/languages/types';
 import * as DSUtils from './DrinkingSessionUtils';
+import {getDrinkCount} from './DrinkEntryUtils';
 import {getRandomInt} from './Choice';
 import {isLightHex, resolvePalette} from './SessionColorPalettes';
 
@@ -278,8 +279,8 @@ function sumAllDrinks(drinks: DrinksList | undefined): number {
   return Object.values(drinks).reduce(
     (total, drinkTypes) =>
       total +
-      Object.values(drinkTypes).reduce(
-        (subTotal, drinkCount) => subTotal + (drinkCount ?? 0),
+      Object.values(drinkTypes).reduce<number>(
+        (subTotal, drinkEntry) => subTotal + getDrinkCount(drinkEntry),
         0,
       ),
     0,
@@ -298,8 +299,8 @@ function sumDrinksOfSingleType(
   if (!drinksObject) {
     return 0;
   }
-  return Object.values(drinksObject).reduce(
-    (total, session) => total + (session[drinkType] ?? 0),
+  return Object.values(drinksObject).reduce<number>(
+    (total, session) => total + getDrinkCount(session[drinkType]),
     0,
   );
 }
@@ -313,8 +314,8 @@ function sumDrinkTypes(drinkTypes: Drinks): number {
   if (!drinkTypes) {
     return 0;
   }
-  return Object.values(drinkTypes).reduce(
-    (total, drinksCount) => total + (drinksCount ?? 0),
+  return Object.values(drinkTypes).reduce<number>(
+    (total, drinkEntry) => total + getDrinkCount(drinkEntry),
     0,
   );
 }

--- a/src/libs/DrinkEntryUtils.ts
+++ b/src/libs/DrinkEntryUtils.ts
@@ -1,0 +1,97 @@
+import CONST from '@src/CONST';
+import type {DrinkEntry, DrinkKey} from '@src/types/onyx/Drinks';
+
+type DrinkOverrides = {volume_ml?: number; abv?: number};
+
+/**
+ * Pulls the count out of a `DrinkEntry`, accepting the legacy numeric form,
+ * the object form, and `undefined` (returns 0). Use this at every read site
+ * that previously did `drinks[key] ?? 0`.
+ */
+function getDrinkCount(entry: DrinkEntry | undefined): number {
+  if (entry === undefined) {
+    return 0;
+  }
+  if (typeof entry === 'number') {
+    return entry;
+  }
+  return entry.count;
+}
+
+/**
+ * Returns the per-event `volume_ml` if the entry carries one, otherwise the
+ * default for that drink key from `CONST.DRINK_DEFAULTS`.
+ */
+function getDrinkVolumeMl(
+  key: DrinkKey,
+  entry: DrinkEntry | undefined,
+): number {
+  if (typeof entry === 'object' && entry?.volume_ml !== undefined) {
+    return entry.volume_ml;
+  }
+  return CONST.DRINK_DEFAULTS[key].ml;
+}
+
+/**
+ * Returns the per-event `abv` if the entry carries one, otherwise the default
+ * for that drink key from `CONST.DRINK_DEFAULTS`. ABV is a fractional value
+ * (e.g. 0.05 for 5%).
+ */
+function getDrinkAbv(key: DrinkKey, entry: DrinkEntry | undefined): number {
+  if (typeof entry === 'object' && entry?.abv !== undefined) {
+    return entry.abv;
+  }
+  return CONST.DRINK_DEFAULTS[key].abv;
+}
+
+/**
+ * Returns the overrides carried by an entry, or undefined for the legacy
+ * numeric form. Used to preserve a slot's existing `volume_ml`/`abv` when only
+ * the count is changing (add / remove a drink).
+ */
+function getDrinkOverrides(
+  entry: DrinkEntry | undefined,
+): DrinkOverrides | undefined {
+  if (entry === undefined || typeof entry === 'number') {
+    return undefined;
+  }
+  const overrides: DrinkOverrides = {};
+  if (entry.volume_ml !== undefined) {
+    overrides.volume_ml = entry.volume_ml;
+  }
+  if (entry.abv !== undefined) {
+    overrides.abv = entry.abv;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+/**
+ * Builds a `DrinkEntry`. Returns the bare number when there are no overrides
+ * so Onyx storage stays compact for the common case; only widens to the
+ * object form when at least one of `volume_ml` / `abv` is set.
+ */
+function makeDrinkEntry(count: number, overrides?: DrinkOverrides): DrinkEntry {
+  if (
+    overrides === undefined ||
+    (overrides.volume_ml === undefined && overrides.abv === undefined)
+  ) {
+    return count;
+  }
+  const entry: {count: number; volume_ml?: number; abv?: number} = {count};
+  if (overrides.volume_ml !== undefined) {
+    entry.volume_ml = overrides.volume_ml;
+  }
+  if (overrides.abv !== undefined) {
+    entry.abv = overrides.abv;
+  }
+  return entry;
+}
+
+export {
+  getDrinkAbv,
+  getDrinkCount,
+  getDrinkOverrides,
+  getDrinkVolumeMl,
+  makeDrinkEntry,
+};
+export type {DrinkOverrides};

--- a/src/libs/DrinkingSessionUtils.ts
+++ b/src/libs/DrinkingSessionUtils.ts
@@ -30,6 +30,11 @@ import type {TranslationPaths} from '@src/languages/types';
 import type IconAsset from '@src/types/utils/IconAsset';
 import Log from './Log';
 import DateUtils from './DateUtils';
+import {
+  getDrinkCount,
+  getDrinkOverrides,
+  makeDrinkEntry,
+} from './DrinkEntryUtils';
 import {roundToTwoDecimalPlaces} from './NumberUtils';
 import {getFirebaseAuth} from './Firebase/FirebaseApp';
 import {numberToVerboseString} from './TimeUtils';
@@ -188,7 +193,7 @@ function calculateTotalUnits(
       if (!isDrinkTypeKey(DrinkKey)) {
         return;
       }
-      const typeDrinks = drinkTypes[DrinkKey] ?? 0;
+      const typeDrinks = getDrinkCount(drinkTypes[DrinkKey]);
       const typeUnits = drinksToUnits[DrinkKey] ?? 0;
       totalUnits += typeDrinks * typeUnits;
     });
@@ -273,12 +278,19 @@ function addDrinksToList(
     const existingDrinks = updatedDrinksList[timestamp];
     const mergedDrinks: Drinks = {...existingDrinks};
 
-    mergedDrinks[drinkKey] = (mergedDrinks[drinkKey] ?? 0) + (amount ?? 0);
+    const existingEntry = mergedDrinks[drinkKey];
+    const newCount = getDrinkCount(existingEntry) + (amount ?? 0);
+    // Preserve any existing volume_ml / abv overrides on this slot when only
+    // the count changes; the v2-B UI is the only producer of overrides.
+    mergedDrinks[drinkKey] = makeDrinkEntry(
+      newCount,
+      getDrinkOverrides(existingEntry),
+    );
 
     updatedDrinksList[timestamp] = mergedDrinks;
   } else {
     // Timestamp does not exist, add the drinks
-    updatedDrinksList[timestamp] = {[drinkKey]: amount};
+    updatedDrinksList[timestamp] = {[drinkKey]: makeDrinkEntry(amount)};
   }
 
   return updatedDrinksList;
@@ -316,17 +328,24 @@ function removeDrinksFromList(
     options === 'removeFromLatest' ? +b - +a : +a - +b,
   )) {
     const drinksAtTimestamp = updatedDrinksList[+timestamp];
-    const avaiableAmount = drinksAtTimestamp[drinkKey] ?? 0;
+    const existingEntry = drinksAtTimestamp[drinkKey];
+    const avaiableAmount = getDrinkCount(existingEntry);
 
     if (avaiableAmount > 0) {
       const amountRemoved = Math.min(remainingAmountToRemove, avaiableAmount);
+      const newCount = avaiableAmount - amountRemoved;
 
-      drinksAtTimestamp[drinkKey] = avaiableAmount - amountRemoved;
       remainingAmountToRemove -= amountRemoved;
 
       // Clean up if there are zero drinks left for this type at this timestamp
-      if (drinksAtTimestamp[drinkKey] === 0) {
+      if (newCount === 0) {
         delete drinksAtTimestamp[drinkKey];
+      } else {
+        // Preserve any existing volume_ml / abv overrides on the slot.
+        drinksAtTimestamp[drinkKey] = makeDrinkEntry(
+          newCount,
+          getDrinkOverrides(existingEntry),
+        );
       }
 
       // Clean up if there are zero drinks left at this timestamp
@@ -470,7 +489,8 @@ function determineSessionMostCommonDrink(
   const drinkCounts: Partial<Record<DrinkKey, number>> = {};
 
   Object.values(drinks).forEach(drinksAtTimestamp => {
-    Object.entries(drinksAtTimestamp).forEach(([drinkKey, count]) => {
+    Object.entries(drinksAtTimestamp).forEach(([drinkKey, entry]) => {
+      const count = getDrinkCount(entry);
       if (!count) {
         return;
       }

--- a/src/libs/migrateOnyx.ts
+++ b/src/libs/migrateOnyx.ts
@@ -1,5 +1,6 @@
 import Log from './Log';
 import DropLegacySessionsCalendarMonthsLoaded from './migrations/DropLegacySessionsCalendarMonthsLoaded';
+import HydrateLegacyDrinkEntries from './migrations/HydrateLegacyDrinkEntries';
 
 export default function () {
   const startTime = Date.now();
@@ -7,7 +8,10 @@ export default function () {
 
   return new Promise<void>(resolve => {
     // Add all migrations to an array so they are executed in order
-    const migrationPromises = [DropLegacySessionsCalendarMonthsLoaded];
+    const migrationPromises = [
+      DropLegacySessionsCalendarMonthsLoaded,
+      HydrateLegacyDrinkEntries,
+    ];
 
     // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the
     // previous promise to finish before moving onto the next one.

--- a/src/libs/migrations/HydrateLegacyDrinkEntries.ts
+++ b/src/libs/migrations/HydrateLegacyDrinkEntries.ts
@@ -1,0 +1,185 @@
+import Onyx from 'react-native-onyx';
+import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {
+  DrinkingSession,
+  DrinksList,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx';
+import Log from '@libs/Log';
+
+/**
+ * Phase-1 Statistics v2 storage migration. The Drinks shape widened from
+ * `Partial<Record<DrinkKey, number>>` to a `number | {count, volume_ml?, abv?}`
+ * union (see #577). This walks every Onyx target that carries `.drinks` and
+ * promotes legacy numeric entries to the object form `{count: N}`.
+ *
+ * Idempotent: the predicate `typeof entry === 'number'` is the marker — after
+ * one pass every entry is an object, so re-runs write nothing. The numeric
+ * arm of the union is intentionally still legal, so a partially-completed
+ * migration cannot corrupt reads: narrowing via `DrinkEntryUtils.getDrinkCount`
+ * handles both shapes.
+ */
+
+type ConvertedDrinksList = {drinks: DrinksList; changed: boolean};
+
+function convertDrinksList(
+  drinks: DrinksList | undefined,
+): ConvertedDrinksList | undefined {
+  if (!drinks) {
+    return undefined;
+  }
+  let changed = false;
+  const next: DrinksList = {};
+  for (const [timestamp, drinksAtTimestamp] of Object.entries(drinks)) {
+    const nextDrinks: DrinksList[number] = {};
+    for (const [key, entry] of Object.entries(drinksAtTimestamp)) {
+      if (typeof entry === 'number') {
+        nextDrinks[key as keyof typeof nextDrinks] = {count: entry};
+        changed = true;
+      } else {
+        nextDrinks[key as keyof typeof nextDrinks] = entry;
+      }
+    }
+    next[Number(timestamp)] = nextDrinks;
+  }
+  return {drinks: next, changed};
+}
+
+function convertSession(
+  session: OnyxEntry<DrinkingSession>,
+): {session: DrinkingSession; changed: boolean} | undefined {
+  if (!session) {
+    return undefined;
+  }
+  const converted = convertDrinksList(session.drinks);
+  if (!converted || !converted.changed) {
+    return undefined;
+  }
+  return {
+    session: {...session, drinks: converted.drinks},
+    changed: true,
+  };
+}
+
+// One-shot Onyx reads are the right tool inside a pre-auth migration step —
+// there is no React tree yet, so the useOnyx() pathway does not apply.
+function readCollectionOnce<T>(
+  key: typeof ONYXKEYS.COLLECTION.DRINKING_SESSION,
+): Promise<OnyxCollection<T> | undefined> {
+  return new Promise(resolve => {
+    // eslint-disable-next-line rulesdir/no-onyx-connect
+    const connection = Onyx.connect({
+      key,
+      waitForCollectionCallback: true,
+      callback: value => {
+        Onyx.disconnect(connection);
+        resolve(value as OnyxCollection<T> | undefined);
+      },
+    });
+  });
+}
+
+function readKeyOnce<T>(
+  key:
+    | typeof ONYXKEYS.ONGOING_SESSION_DATA
+    | typeof ONYXKEYS.EDIT_SESSION_DATA
+    | typeof ONYXKEYS.CACHED_DRINKING_SESSIONS,
+): Promise<T | undefined> {
+  return new Promise(resolve => {
+    // eslint-disable-next-line rulesdir/no-onyx-connect
+    const connection = Onyx.connect({
+      key,
+      callback: value => {
+        Onyx.disconnect(connection);
+        resolve(value as T | undefined);
+      },
+    });
+  });
+}
+
+async function migrateCollection(): Promise<number> {
+  const collection = await readCollectionOnce<DrinkingSession>(
+    ONYXKEYS.COLLECTION.DRINKING_SESSION,
+  );
+  if (!collection) {
+    return 0;
+  }
+  type CollectionUpdates = Parameters<
+    typeof Onyx.mergeCollection<typeof ONYXKEYS.COLLECTION.DRINKING_SESSION>
+  >[1];
+  const updates = {} as CollectionUpdates;
+  let touched = 0;
+  for (const [key, session] of Object.entries(collection)) {
+    const converted = convertSession(session ?? undefined);
+    if (converted) {
+      (updates as Record<string, DrinkingSession>)[key] = converted.session;
+      touched += 1;
+    }
+  }
+  if (touched > 0) {
+    // eslint-disable-next-line rulesdir/prefer-actions-set-data
+    await Onyx.mergeCollection(ONYXKEYS.COLLECTION.DRINKING_SESSION, updates);
+  }
+  return touched;
+}
+
+async function migrateSingleSession(
+  key: typeof ONYXKEYS.ONGOING_SESSION_DATA | typeof ONYXKEYS.EDIT_SESSION_DATA,
+): Promise<number> {
+  const session = await readKeyOnce<DrinkingSession>(key);
+  const converted = convertSession(session ?? undefined);
+  if (!converted) {
+    return 0;
+  }
+  // eslint-disable-next-line rulesdir/prefer-actions-set-data
+  await Onyx.merge(key, converted.session);
+  return 1;
+}
+
+async function migrateCachedDrinkingSessions(): Promise<number> {
+  const cached = await readKeyOnce<UserDrinkingSessionsList>(
+    ONYXKEYS.CACHED_DRINKING_SESSIONS,
+  );
+  if (!cached) {
+    return 0;
+  }
+  const next: UserDrinkingSessionsList = {};
+  let touched = 0;
+  for (const [userID, sessionList] of Object.entries(cached)) {
+    const nextSessionList: typeof sessionList = {};
+    let userChanged = false;
+    for (const [sessionId, session] of Object.entries(sessionList ?? {})) {
+      const converted = convertSession(session);
+      if (converted) {
+        nextSessionList[sessionId] = converted.session;
+        userChanged = true;
+        touched += 1;
+      } else {
+        nextSessionList[sessionId] = session;
+      }
+    }
+    next[userID] = userChanged ? nextSessionList : sessionList;
+  }
+  if (touched > 0) {
+    // eslint-disable-next-line rulesdir/prefer-actions-set-data
+    await Onyx.set(ONYXKEYS.CACHED_DRINKING_SESSIONS, next);
+  }
+  return touched;
+}
+
+export default async function HydrateLegacyDrinkEntries(): Promise<void> {
+  Log.info('[Migrate Onyx] HydrateLegacyDrinkEntries: start');
+  const counts = await Promise.all([
+    migrateCollection(),
+    migrateSingleSession(ONYXKEYS.ONGOING_SESSION_DATA),
+    migrateSingleSession(ONYXKEYS.EDIT_SESSION_DATA),
+    migrateCachedDrinkingSessions(),
+  ]);
+  const total = counts.reduce((sum, n) => sum + n, 0);
+  Log.info(
+    `[Migrate Onyx] HydrateLegacyDrinkEntries: hydrated ${total} session(s)`,
+  );
+}
+
+export {convertDrinksList, convertSession};

--- a/src/types/onyx/Drinks.ts
+++ b/src/types/onyx/Drinks.ts
@@ -8,11 +8,28 @@ type DrinksTimestamp = Timestamp;
 /** A drink identifier key */
 type DrinkKey = DeepValueOf<typeof CONST.DRINKS.KEYS>;
 
+/**
+ * A single drink record. Either a legacy numeric count, or an object form that
+ * can carry per-event `volume_ml` / `abv` overrides for SDU math. The numeric
+ * arm stays valid so on-disk legacy data (and an interrupted migration) keeps
+ * typechecking; reads must narrow via `DrinkEntryUtils.getDrinkCount`.
+ */
+type DrinkEntry =
+  | number
+  | {
+      /** Number of drinks of this type recorded at this timestamp */
+      count: number;
+      /** Per-event volume override in millilitres */
+      volume_ml?: number;
+      /** Per-event ABV override as a fraction (e.g. 0.05 for 5%) */
+      abv?: number;
+    };
+
 /** A collection of drink records, usually stored under a single timestamp */
-type Drinks = Partial<Record<DrinkKey, number>>;
+type Drinks = Partial<Record<DrinkKey, DrinkEntry>>;
 
 /** A list of timestamped drinks objects */
 type DrinksList = Record<DrinksTimestamp, Drinks>;
 
 export default Drinks;
-export type {DrinkKey, DrinksList, DrinksTimestamp};
+export type {DrinkEntry, DrinkKey, DrinksList, DrinksTimestamp};


### PR DESCRIPTION
## Summary

Phase 1 of the Statistics v2 epic (#576). Storage prerequisite for reachable SDU math — widens the per-drink record to optionally carry `volume_ml` and `abv` overrides.

- New union `DrinkEntry = number | { count: number; volume_ml?: number; abv?: number }` in `src/types/onyx/Drinks.ts`. Numeric arm intentionally kept legal so on-disk legacy data + an interrupted migration both keep typechecking.
- `CONST.DRINK_DEFAULTS` defaults table per §3.3 of `mockups/STATISTICS_V2.md` (beer 500ml@5%, wine 150ml@12%, …).
- `src/libs/DrinkEntryUtils.ts` narrowing helpers: `getDrinkCount`, `getDrinkVolumeMl`, `getDrinkAbv`, `getDrinkOverrides`, `makeDrinkEntry`. Read sites in `DataHandling.ts`, `DrinkingSessionUtils.ts`, and the add/remove paths now route through `getDrinkCount` and preserve any existing overrides on a slot when only the count changes.
- Pre-auth Onyx migration `HydrateLegacyDrinkEntries` walks the four targets that carry `.drinks` (`COLLECTION.DRINKING_SESSION`, `CACHED_DRINKING_SESSIONS`, `ONGOING_SESSION_DATA`, `EDIT_SESSION_DATA`) and promotes `5 → {count: 5}`. Idempotent — the predicate `typeof entry === 'number'` is the marker, so the second run writes nothing.
- Tests: new helper + migration unit tests plus mixed-shape cases added to the existing `DataHandling` / `DrinkingSessionUtils` math tests. 90 passing.

Out of scope (per the issue):
- Drink-add UI changes → v2-B (#578).
- DrinkEvent stream → v2-C (#579).
- User-overridable defaults table.

Closes #577.

## Test plan

- [x] `npx prettier --write` on touched files
- [x] `./scripts/lint.sh` on touched files — clean
- [x] `npm run typecheck-tsgo` — clean
- [x] `npx jest __tests__/unit/libs/{DrinkEntryUtils,DataHandling,DrinkingSessionUtils}.test.ts __tests__/unit/libs/migrations/HydrateLegacyDrinkEntries.test.ts` → 90 passed
- [ ] CI `lint.yml` and `typecheck.yml` green
- [ ] One-shot manual smoke on a profile with existing sessions to confirm session-summary numbers are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)