### PR TITLE
feat(stats-v2): drink-add UI — optional Adjust disclosure for volume + ABV [Phase 1/B of #576]

### DIFF
--- a/src/components/DrinkTypeRow.tsx
+++ b/src/components/DrinkTypeRow.tsx
@@ -1,0 +1,235 @@
+import React, {useState} from 'react';
+import {LayoutAnimation, TextInput, View} from 'react-native';
+import type {DrinkingSession, DrinkKey} from '@src/types/onyx';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import * as DS from '@userActions/DrinkingSession';
+import type {DrinkOverrides} from '@libs/DrinkEntryUtils';
+import {findDrinkNameTranslationKey} from '@libs/DataHandling';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import CONST from '@src/CONST';
+import type IconAsset from '@src/types/utils/IconAsset';
+import * as KirokuIcons from './Icon/KirokuIcons';
+import Icon from './Icon';
+import SessionDrinksInputWindow from './Buttons/SessionDrinksInputWindow';
+import Button from './Button';
+import Text from './Text';
+
+type DrinkTypeRowProps = {
+  /** The session this row belongs to */
+  session: DrinkingSession;
+
+  /** The drink type rendered by this row */
+  drink: {key: DrinkKey; icon: IconAsset};
+};
+
+function DrinkTypeRow({session, drink}: DrinkTypeRowProps) {
+  const {translate} = useLocalize();
+  const {preferences} = useDatabaseData();
+  const styles = useThemeStyles();
+  const theme = useTheme();
+
+  const drinkKey = drink.key;
+  const defaults = CONST.DRINK_DEFAULTS[drinkKey];
+  const drinkName = translate(findDrinkNameTranslationKey(drinkKey));
+  const iconSize = drinkKey === CONST.DRINKS.KEYS.SMALL_BEER ? 22 : 28;
+
+  const [isAdjustOpen, setIsAdjustOpen] = useState(false);
+  const [volumeMl, setVolumeMl] = useState<string>(() => String(defaults.ml));
+  const [abvPercent, setAbvPercent] = useState<string>(() =>
+    String(Math.round(defaults.abv * 100)),
+  );
+
+  const parsedVolume = volumeMl.trim() === '' ? null : parseFloat(volumeMl);
+  const parsedAbv = abvPercent.trim() === '' ? null : parseFloat(abvPercent);
+
+  const volumeError =
+    parsedVolume !== null && (Number.isNaN(parsedVolume) || parsedVolume <= 0);
+  const abvError =
+    parsedAbv !== null &&
+    (Number.isNaN(parsedAbv) || parsedAbv <= 0 || parsedAbv > 100);
+
+  const isAddDisabled = isAdjustOpen && (volumeError || abvError);
+
+  const toggleAdjust = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setIsAdjustOpen(prev => {
+      const next = !prev;
+      if (next) {
+        setVolumeMl(String(defaults.ml));
+        setAbvPercent(String(Math.round(defaults.abv * 100)));
+      }
+      return next;
+    });
+  };
+
+  const buildOverrides = (): DrinkOverrides | undefined => {
+    if (!isAdjustOpen) {
+      return undefined;
+    }
+    const effectiveVolume = parsedVolume ?? defaults.ml;
+    const effectiveAbvFraction =
+      parsedAbv === null ? defaults.abv : parsedAbv / 100;
+    const overrides: DrinkOverrides = {};
+    if (effectiveVolume !== defaults.ml) {
+      overrides.volume_ml = effectiveVolume;
+    }
+    if (effectiveAbvFraction !== defaults.abv) {
+      overrides.abv = effectiveAbvFraction;
+    }
+    return Object.keys(overrides).length > 0 ? overrides : undefined;
+  };
+
+  const handleAdd = () => {
+    if (isAddDisabled) {
+      return;
+    }
+    DS.updateDrinks(
+      session?.id,
+      drinkKey,
+      1,
+      CONST.DRINKS.ACTIONS.ADD,
+      preferences?.drinks_to_units,
+      buildOverrides(),
+    );
+  };
+
+  const handleRemove = () => {
+    DS.updateDrinks(
+      session?.id,
+      drinkKey,
+      1,
+      CONST.DRINKS.ACTIONS.REMOVE,
+      preferences?.drinks_to_units,
+    );
+  };
+
+  return (
+    <View>
+      <View
+        style={[
+          styles.pv1,
+          styles.mh3,
+          styles.flexRow,
+          styles.justifyContentCenter,
+          styles.alignItemsCenter,
+        ]}>
+        <View style={styles.drinkTypesViewIconContainer}>
+          <Icon
+            fill={theme.text}
+            src={drink.icon}
+            height={iconSize}
+            width={iconSize}
+          />
+        </View>
+        <Text style={[styles.flexGrow1, styles.ml1]}>{drinkName}</Text>
+        <Button
+          style={[styles.bgTransparent, styles.p1]}
+          onPress={handleRemove}
+          icon={KirokuIcons.Minus}
+          iconFill={theme.text}
+        />
+        <SessionDrinksInputWindow
+          drinks={session?.drinks}
+          drinkKey={drinkKey}
+          sessionId={session?.id}
+        />
+        <Button
+          style={[styles.bgTransparent, styles.p1]}
+          onPress={handleAdd}
+          icon={KirokuIcons.Plus}
+          iconFill={theme.text}
+          isDisabled={isAddDisabled}
+        />
+      </View>
+
+      <View
+        style={[
+          styles.flexRow,
+          styles.alignItemsCenter,
+          styles.mh3,
+          styles.pb1,
+        ]}>
+        <View style={styles.flexGrow1} />
+        <Button
+          small
+          style={[styles.bgTransparent]}
+          onPress={toggleAdjust}
+          text={translate('drinks.adjust')}
+          textStyles={[styles.textSupporting, styles.fontSizeLabel]}
+          iconRight={KirokuIcons.ArrowDown}
+          iconFill={theme.textSupporting}
+          iconRightStyles={
+            isAdjustOpen ? {transform: [{rotate: '180deg'}]} : undefined
+          }
+        />
+      </View>
+
+      {isAdjustOpen ? (
+        <View
+          style={[
+            styles.mh3,
+            styles.pb2,
+            styles.flexRow,
+            styles.alignItemsStart,
+            styles.justifyContentBetween,
+          ]}>
+          <View style={[styles.flex1, styles.mr2]}>
+            <Text style={[styles.textLabel, styles.textSupporting]}>
+              {`${translate('drinks.volumeLabel')} (${translate(
+                'drinks.volumeUnit',
+              )})`}
+            </Text>
+            <TextInput
+              accessibilityLabel={translate('drinks.volumeLabel')}
+              value={volumeMl}
+              onChangeText={setVolumeMl}
+              keyboardType="numeric"
+              style={[
+                styles.textInputContainer,
+                styles.pv1,
+                styles.ph2,
+                styles.textPlainColor,
+              ]}
+            />
+            {volumeError ? (
+              <Text style={styles.textLabelError}>
+                {translate('drinks.adjustErrors.volumeMustBePositive')}
+              </Text>
+            ) : null}
+          </View>
+          <View style={styles.flex1}>
+            <Text style={[styles.textLabel, styles.textSupporting]}>
+              {`${translate('drinks.abvLabel')} (${translate(
+                'drinks.abvUnit',
+              )})`}
+            </Text>
+            <TextInput
+              accessibilityLabel={translate('drinks.abvLabel')}
+              value={abvPercent}
+              onChangeText={setAbvPercent}
+              keyboardType="numeric"
+              style={[
+                styles.textInputContainer,
+                styles.pv1,
+                styles.ph2,
+                styles.textPlainColor,
+              ]}
+            />
+            {abvError ? (
+              <Text style={styles.textLabelError}>
+                {translate('drinks.adjustErrors.abvOutOfRange')}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+DrinkTypeRow.displayName = 'DrinkTypeRow';
+
+export default React.memo(DrinkTypeRow);
+export type {DrinkTypeRowProps};

--- a/src/components/DrinkTypesView.tsx
+++ b/src/components/DrinkTypesView.tsx
@@ -1,17 +1,9 @@
 import {View} from 'react-native';
-import type {DrinkingSession, DrinkKey} from '@src/types/onyx';
+import type {DrinkingSession} from '@src/types/onyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useLocalize from '@hooks/useLocalize';
 import DrinkData from '@libs/DrinkData';
-import * as DS from '@userActions/DrinkingSession';
-import {findDrinkNameTranslationKey} from '@libs/DataHandling';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
-import CONST from '@src/CONST';
-import useTheme from '@hooks/useTheme';
-import * as KirokuIcons from './Icon/KirokuIcons';
-import Icon from './Icon';
-import SessionDrinksInputWindow from './Buttons/SessionDrinksInputWindow';
-import Button from './Button';
+import DrinkTypeRow from './DrinkTypeRow';
 import Text from './Text';
 
 type DrinkTypesViewProps = {
@@ -21,29 +13,7 @@ type DrinkTypesViewProps = {
 
 function DrinkTypesView({session}: DrinkTypesViewProps) {
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
   const styles = useThemeStyles();
-  const theme = useTheme();
-
-  const handleAddDrinks = (drinkKey: DrinkKey, amount: number) => {
-    DS.updateDrinks(
-      session?.id,
-      drinkKey,
-      amount,
-      CONST.DRINKS.ACTIONS.ADD,
-      preferences?.drinks_to_units,
-    );
-  };
-
-  const handleRemoveDrinks = (drinkKey: DrinkKey, amount: number) => {
-    DS.updateDrinks(
-      session?.id,
-      drinkKey,
-      amount,
-      CONST.DRINKS.ACTIONS.REMOVE,
-      preferences?.drinks_to_units,
-    );
-  };
 
   return (
     <View style={[styles.w100, styles.pb1]}>
@@ -58,51 +28,9 @@ function DrinkTypesView({session}: DrinkTypesViewProps) {
         </Text>
       </View>
       <View>
-        {DrinkData.map(drink => {
-          const drinkKey = drink.key;
-          const iconSource = drink.icon;
-          const drinkName = translate(findDrinkNameTranslationKey(drinkKey));
-          const iconSize = drinkKey === CONST.DRINKS.KEYS.SMALL_BEER ? 22 : 28;
-
-          return (
-            <View
-              key={drink.key}
-              style={[
-                styles.pv1,
-                styles.mh3,
-                styles.flexRow,
-                styles.justifyContentCenter,
-                styles.alignItemsCenter,
-              ]}>
-              <View style={styles.drinkTypesViewIconContainer}>
-                <Icon
-                  fill={theme.text}
-                  src={iconSource}
-                  height={iconSize}
-                  width={iconSize}
-                />
-              </View>
-              <Text style={[styles.flexGrow1, styles.ml1]}>{drinkName}</Text>
-              <Button
-                style={[styles.bgTransparent, styles.p1]}
-                onPress={() => handleRemoveDrinks(drinkKey, 1)}
-                icon={KirokuIcons.Minus}
-                iconFill={theme.text}
-              />
-              <SessionDrinksInputWindow
-                drinks={session?.drinks}
-                drinkKey={drinkKey}
-                sessionId={session?.id}
-              />
-              <Button
-                style={[styles.bgTransparent, styles.p1]}
-                onPress={() => handleAddDrinks(drinkKey, 1)}
-                icon={KirokuIcons.Plus}
-                iconFill={theme.text}
-              />
-            </View>
-          );
-        })}
+        {DrinkData.map(drink => (
+          <DrinkTypeRow key={drink.key} session={session} drink={drink} />
+        ))}
       </View>
     </View>
   );

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -316,6 +316,15 @@ export default {
     strongShot: 'Velký panák',
     cocktail: 'Koktejl',
     other: 'Ostatní',
+    adjust: 'Upravit',
+    volumeLabel: 'Objem',
+    volumeUnit: 'ml',
+    abvLabel: 'Obsah alkoholu',
+    abvUnit: '%',
+    adjustErrors: {
+      volumeMustBePositive: 'Objem musí být větší než 0',
+      abvOutOfRange: 'Obsah alkoholu musí být mezi 0 a 100',
+    },
   },
   units: {
     yellow: 'Žlutá',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -318,6 +318,15 @@ export default {
     strongShot: 'Strong Shot',
     cocktail: 'Cocktail',
     other: 'Other',
+    adjust: 'Adjust',
+    volumeLabel: 'Volume',
+    volumeUnit: 'ml',
+    abvLabel: 'ABV',
+    abvUnit: '%',
+    adjustErrors: {
+      volumeMustBePositive: 'Volume must be greater than 0',
+      abvOutOfRange: 'ABV must be between 0 and 100',
+    },
   },
   units: {
     yellow: 'Yellow',

--- a/src/libs/DrinkingSessionUtils.ts
+++ b/src/libs/DrinkingSessionUtils.ts
@@ -35,6 +35,7 @@ import {
   getDrinkOverrides,
   makeDrinkEntry,
 } from './DrinkEntryUtils';
+import type {DrinkOverrides} from './DrinkEntryUtils';
 import {roundToTwoDecimalPlaces} from './NumberUtils';
 import {getFirebaseAuth} from './Firebase/FirebaseApp';
 import {numberToVerboseString} from './TimeUtils';
@@ -230,6 +231,9 @@ function calculateAvailableUnits(
  * @param drinksList - The existing DrinksList object.
  * @param drinksToUnits - A mapping from DrinkKey to unit conversion factors.
  * @param options - Options to specify the timestamp behavior.
+ * @param overrides - Optional per-event volume_ml / abv overrides applied to
+ *   the newly-added entry. When provided on a merged slot, replaces whatever
+ *   overrides the slot previously had (the most recent user intent wins).
  * @param maxUnits - The maximum allowed units. Defaults to CONST.MAX_ALLOWED_UNITS.
  * @returns The updated DrinksList object.
  */
@@ -239,6 +243,7 @@ function addDrinksToList(
   drinksList: DrinksList | undefined,
   drinksToUnits: DrinksToUnits,
   options: AddDrinksOptions,
+  overrides?: DrinkOverrides,
 ): DrinksList {
   // Create a shallow copy of drinksList to avoid mutating the original
   const updatedDrinksList = drinksList ? {...drinksList} : {};
@@ -280,17 +285,17 @@ function addDrinksToList(
 
     const existingEntry = mergedDrinks[drinkKey];
     const newCount = getDrinkCount(existingEntry) + (amount ?? 0);
-    // Preserve any existing volume_ml / abv overrides on this slot when only
-    // the count changes; the v2-B UI is the only producer of overrides.
-    mergedDrinks[drinkKey] = makeDrinkEntry(
-      newCount,
-      getDrinkOverrides(existingEntry),
-    );
+    // If the caller passed new overrides, they win (latest user intent);
+    // otherwise preserve whatever overrides the slot already carried.
+    const mergedOverrides = overrides ?? getDrinkOverrides(existingEntry);
+    mergedDrinks[drinkKey] = makeDrinkEntry(newCount, mergedOverrides);
 
     updatedDrinksList[timestamp] = mergedDrinks;
   } else {
     // Timestamp does not exist, add the drinks
-    updatedDrinksList[timestamp] = {[drinkKey]: makeDrinkEntry(amount)};
+    updatedDrinksList[timestamp] = {
+      [drinkKey]: makeDrinkEntry(amount, overrides),
+    };
   }
 
   return updatedDrinksList;
@@ -409,6 +414,7 @@ function modifySessionDrinks(
   amount: number,
   action: ValueOf<typeof CONST.DRINKS.ACTIONS>,
   drinksToUnits: DrinksToUnits,
+  overrides?: DrinkOverrides,
 ): DrinksList | undefined {
   let drinksList = _.cloneDeep(session?.drinks);
   if (action === 'add') {
@@ -419,6 +425,7 @@ function modifySessionDrinks(
       drinksList,
       drinksToUnits,
       options,
+      overrides,
     );
   } else if (action === 'remove') {
     const options: RemoveDrinksOptions = 'removeFromLatest';

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -18,6 +18,7 @@ import type {
 } from '@src/types/onyx';
 import * as Localize from '@libs/Localize';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
+import type {DrinkOverrides} from '@libs/DrinkEntryUtils';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import type {User} from 'firebase/auth';
 import CONST from '@src/CONST';
@@ -357,6 +358,8 @@ async function removeDrinkingSessionData(
  * @param drinks The drinks to add or remove.
  * @param drinksToUnits Drink to units mapping.
  * @param action The action to perform (i.e., add, remove,...).
+ * @param overrides Optional per-event volume_ml / abv overrides. Only honoured
+ *   on the ADD path; ignored on REMOVE.
  */
 function updateDrinks(
   sessionId: DrinkingSessionId | undefined,
@@ -364,6 +367,7 @@ function updateDrinks(
   amount: number,
   action: ValueOf<typeof CONST.DRINKS.ACTIONS>,
   drinksToUnits: DrinksToUnits | undefined,
+  overrides?: DrinkOverrides,
 ): void {
   if (!drinksToUnits || !sessionId) {
     return;
@@ -377,6 +381,7 @@ function updateDrinks(
       amount,
       action,
       drinksToUnits,
+      overrides,
     );
 
     // const drinks = drinksList ? Object.values(drinksList)[0] : null;


### PR DESCRIPTION
## Summary

Phase 1/B of the Statistics v2 epic ([#576](https://github.com/PetrCala/Kiroku/issues/576)). Adds a small "Adjust" disclosure to each drink-type row in the live/edit session screen that reveals Volume (ml) and ABV (%) inputs. When the disclosure is open and the user changes either value off its default, the next "+" tap writes the new entry as the `{count, volume_ml?, abv?}` shape introduced in v2-A; otherwise entries stay a plain numeric count, so users who never engage the disclosure see no behavioural change.

- "Adjust" toggle per drink row, collapsed by default (zero layout cost on first paint), `LayoutAnimation` on open/close.
- Defaults prefilled from `CONST.DRINK_DEFAULTS[drinkKey]` each time the disclosure opens.
- Validation: Volume must be > 0; ABV must be > 0 and ≤ 100. While invalid, the "+" button is disabled.
- ABV is rendered 0..100 and stored as a 0..1 fraction (per AC).
- "−" button, absolute-count input, and any "+" tap while collapsed bypass the override path — legacy entries are never promoted unless the user explicitly engages Adjust + adds.
- en + cs_cz strings under the existing `drinks` namespace.

Closes [#578](https://github.com/PetrCala/Kiroku/issues/578).

## Dependency

**Stacked on [#591](https://github.com/PetrCala/Kiroku/pull/591)** (v2-A: drink data shape). The base of this PR is \`feature/stats-v2-a-drink-shape\`. After v2-A merges, this branch should be rebased onto \`master\`.

## Files

- New: \`src/components/DrinkTypeRow.tsx\` — per-row component owning disclosure + override state.
- \`src/components/DrinkTypesView.tsx\` — slimmed to just header + map over \`DrinkTypeRow\`.
- \`src/libs/actions/DrinkingSession.ts\` — \`updateDrinks\` gains optional \`overrides\` arg.
- \`src/libs/DrinkingSessionUtils.ts\` — \`modifySessionDrinks\` / \`addDrinksToList\` plumb overrides; caller-provided overrides win over preserved slot overrides on merge.
- \`src/languages/en.ts\` + \`src/languages/cs_cz.ts\` — \`drinks.adjust\`, \`drinks.volumeLabel\`/\`volumeUnit\`, \`drinks.abvLabel\`/\`abvUnit\`, \`drinks.adjustErrors.*\`.

## Test plan

Author has not driven the UI end-to-end on a simulator — visual verification deferred to reviewer per CLAUDE.md "say so explicitly". Suggested manual passes:

- [ ] Live session: tap "+" five times on beer without touching Adjust. Layout matches existing behaviour; Onyx writes are plain numeric counts.
- [ ] Open Adjust on wine. Fields appear with \`150\` and \`12\` pre-filled; chevron rotates.
- [ ] Change beer Volume to \`500\`, ABV to \`8\`, tap "+". Entry stored as \`{count: 1, volume_ml: 500, abv: 0.08}\`. Tap again → second entry, same shape.
- [ ] Open Adjust, leave defaults, tap "+". Entry stored as plain \`1\`, not an object.
- [ ] Validation: Volume \`0\` or \`-5\` → error + "+" disabled. ABV \`0\` or \`100.5\` → error + "+" disabled. Clearing a field → treated as default, "+" enabled again.
- [ ] Tap "−" after an overridden add. Slot decrements without corruption.
- [ ] Count input (the existing absolute-total input) bypasses the override path even when Adjust is open with custom values.
- [ ] Dark theme: Adjust affordance, chevron, input borders, error text all legible.
- [ ] Edit a past session via the calendar. Adding with overrides only promotes the merged slot; other drink types' legacy entries untouched.
- [ ] cs_cz locale: labels and error strings render in Czech.

CI gates already passed: \`prettier\`, \`lint\` (via \`./scripts/lint.sh\` on touched files), \`typecheck-tsgo\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)