### PR TITLE
stats-v2: EWMA + Mann–Kendall + percentile pure-function utilities (v2-L)

### DIFF
--- a/__tests__/unit/Statistics/stats/ewma.test.ts
+++ b/__tests__/unit/Statistics/stats/ewma.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+import {ewma} from '@src/libs/Statistics/stats';
+
+describe('ewma', () => {
+  test('returns empty array for empty input', () => {
+    expect(ewma([])).toEqual([]);
+  });
+
+  test('seed equals mean of first 4 values when n >= 4', () => {
+    const series = [10, 20, 30, 40, 100, 200, 300];
+    const result = ewma(series, 0.3);
+    // (10 + 20 + 30 + 40) / 4 = 25
+    expect(result[0]).toBeCloseTo(25, 10);
+  });
+
+  test('seed equals mean of all values when n < 4', () => {
+    expect(ewma([8])[0]).toBeCloseTo(8, 10);
+    expect(ewma([4, 6])[0]).toBeCloseTo(5, 10);
+    expect(ewma([3, 6, 9])[0]).toBeCloseTo(6, 10);
+  });
+
+  test('lambda = 0 returns a flat array at the seed value', () => {
+    const series = [1, 2, 3, 4, 5, 6, 7, 8];
+    const seed = (1 + 2 + 3 + 4) / 4; // 2.5
+    const result = ewma(series, 0);
+    expect(result).toHaveLength(series.length);
+    result.forEach(v => expect(v).toBeCloseTo(seed, 10));
+  });
+
+  test('lambda = 1 yields seed at index 0 and identity copy from index 1', () => {
+    const series = [1, 2, 3, 4, 5, 6, 7, 8];
+    const seed = 2.5;
+    const result = ewma(series, 1);
+    expect(result[0]).toBeCloseTo(seed, 10);
+    for (let i = 1; i < series.length; i += 1) {
+      expect(result[i]).toBeCloseTo(series[i], 10);
+    }
+  });
+
+  test('smoothed series is bounded by the input min and max', () => {
+    const series = [1, 5, 3, 7, 2, 8, 4, 6, 9, 5];
+    const inputMin = Math.min(...series);
+    const inputMax = Math.max(...series);
+    const result = ewma(series, 0.3);
+    result.forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(inputMin);
+      expect(v).toBeLessThanOrEqual(inputMax);
+    });
+  });
+
+  test('default lambda is 0.3', () => {
+    const series = [1, 2, 3, 4, 5, 6, 7, 8];
+    expect(ewma(series)).toEqual(ewma(series, 0.3));
+  });
+});

--- a/__tests__/unit/Statistics/stats/index.test.ts
+++ b/__tests__/unit/Statistics/stats/index.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+
+import * as stats from '@src/libs/Statistics/stats';
+import type {MannKendallResult} from '@src/libs/Statistics/stats';
+
+describe('stats barrel', () => {
+  test('re-exports the public functions', () => {
+    expect(typeof stats.ewma).toBe('function');
+    expect(typeof stats.mannKendall).toBe('function');
+    expect(typeof stats.percentile).toBe('function');
+    expect(typeof stats.stddev).toBe('function');
+    expect(typeof stats.mean).toBe('function');
+  });
+
+  test('MannKendallResult type is consumable', () => {
+    const r: MannKendallResult = stats.mannKendall([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+    expect(r.trend).toBe('up');
+  });
+});

--- a/__tests__/unit/Statistics/stats/mannKendall.test.ts
+++ b/__tests__/unit/Statistics/stats/mannKendall.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+
+import {mannKendall} from '@src/libs/Statistics/stats';
+
+describe('mannKendall', () => {
+  test('empty input returns neutral result', () => {
+    const r = mannKendall([]);
+    expect(r.tau).toBe(0);
+    expect(r.sScore).toBe(0);
+    expect(r.p).toBe(1);
+    expect(r.trend).toBe('none');
+  });
+
+  test('n < 8 always returns trend: none regardless of monotonicity', () => {
+    for (let n = 0; n < 8; n += 1) {
+      const series = Array.from({length: n}, (_, i) => i + 1);
+      expect(mannKendall(series).trend).toBe('none');
+    }
+  });
+
+  test('perfect monotonic increasing (n=10) → tau=1, sScore=45, trend=up', () => {
+    const series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const r = mannKendall(series);
+    expect(r.sScore).toBe(45);
+    expect(r.tau).toBeCloseTo(1, 10);
+    expect(r.p).toBeLessThan(0.05);
+    expect(r.trend).toBe('up');
+  });
+
+  test('perfect monotonic decreasing (n=10) → tau=-1, sScore=-45, trend=down', () => {
+    const series = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    const r = mannKendall(series);
+    expect(r.sScore).toBe(-45);
+    expect(r.tau).toBeCloseTo(-1, 10);
+    expect(r.p).toBeLessThan(0.05);
+    expect(r.trend).toBe('down');
+  });
+
+  test('flat constant series (n=10) → tau=0, sScore=0, p=1, trend=none', () => {
+    const r = mannKendall([5, 5, 5, 5, 5, 5, 5, 5, 5, 5]);
+    expect(r.sScore).toBe(0);
+    expect(r.tau).toBe(0);
+    expect(r.p).toBe(1);
+    expect(r.trend).toBe('none');
+  });
+
+  test('near-monotone with a single inversion (n=12) still trends up', () => {
+    const series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 11];
+    const r = mannKendall(series);
+    expect(r.sScore).toBe(64); // 66 pairs, one inversion contributes -1 (net -2 vs all-positive)
+    expect(r.p).toBeLessThan(0.05);
+    expect(r.trend).toBe('up');
+  });
+
+  test('noisy series with p > 0.05 returns trend: none even when sScore > 0', () => {
+    // [1,5,2,6,3,7,4,8] gives S=16, Z≈1.86, p≈0.063 — just above the gate.
+    const r = mannKendall([1, 5, 2, 6, 3, 7, 4, 8]);
+    expect(r.sScore).toBe(16);
+    expect(r.p).toBeGreaterThan(0.05);
+    expect(r.trend).toBe('none');
+  });
+
+  test('tie correction: tied series has smaller |tau| than tie-free counterpart', () => {
+    const tieFree = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const tied = [1, 2, 3, 4, 5, 5, 7, 8, 9, 10];
+    const tauFree = Math.abs(mannKendall(tieFree).tau);
+    const tauTied = Math.abs(mannKendall(tied).tau);
+    expect(tauFree).toBeCloseTo(1, 10);
+    expect(tauTied).toBeLessThan(tauFree);
+    // sanity: should still be very close to 1 (only one tied pair)
+    expect(tauTied).toBeGreaterThan(0.95);
+  });
+
+  test('reference jagged-up series [10,12,11,14,13,16,15,18,17,20] (n=10)', () => {
+    // Hand-computed: S = 37, Var = 125, Z = 36/sqrt(125) ≈ 3.2199, tau = 37/45 ≈ 0.8222.
+    const r = mannKendall([10, 12, 11, 14, 13, 16, 15, 18, 17, 20]);
+    expect(r.sScore).toBe(37);
+    expect(r.tau).toBeCloseTo(37 / 45, 10);
+    expect(r.p).toBeLessThan(0.005);
+    expect(r.trend).toBe('up');
+  });
+
+  test('p is clamped into [0, 1]', () => {
+    const r = mannKendall([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(r.p).toBeGreaterThanOrEqual(0);
+    expect(r.p).toBeLessThanOrEqual(1);
+  });
+});

--- a/__tests__/unit/Statistics/stats/percentile.test.ts
+++ b/__tests__/unit/Statistics/stats/percentile.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+
+import {percentile} from '@src/libs/Statistics/stats';
+
+describe('percentile', () => {
+  const ten = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  test('returns NaN for empty input', () => {
+    expect(percentile([], 0.5)).toBeNaN();
+  });
+
+  test('q = 0 returns the minimum', () => {
+    expect(percentile([7, 1, 5, 3, 9], 0)).toBe(1);
+  });
+
+  test('q = 1 returns the maximum', () => {
+    expect(percentile([7, 1, 5, 3, 9], 1)).toBe(9);
+  });
+
+  test('q = 0.5 on odd-length series returns the middle element', () => {
+    expect(percentile([1, 2, 3, 4, 5], 0.5)).toBe(3);
+  });
+
+  test('q = 0.5 on even-length series returns mean of the two middle elements', () => {
+    expect(percentile([1, 2, 3, 4], 0.5)).toBe(2.5);
+  });
+
+  test('q = 0.25 / 0.5 / 0.75 / 0.9 on [1..10] match numpy.percentile defaults', () => {
+    // Reference values from numpy.percentile([1..10], [25, 50, 75, 90])
+    expect(percentile(ten, 0.25)).toBeCloseTo(3.25, 10);
+    expect(percentile(ten, 0.5)).toBeCloseTo(5.5, 10);
+    expect(percentile(ten, 0.75)).toBeCloseTo(7.75, 10);
+    expect(percentile(ten, 0.9)).toBeCloseTo(9.1, 10);
+  });
+
+  test('n = 1 returns that single value for any q', () => {
+    [0, 0.25, 0.5, 0.75, 1].forEach(q => {
+      expect(percentile([42], q)).toBe(42);
+    });
+  });
+
+  test('n = 2 with q = 0.5 returns the midpoint', () => {
+    expect(percentile([10, 20], 0.5)).toBe(15);
+  });
+
+  test('q outside [0, 1] is clamped', () => {
+    expect(percentile(ten, -1)).toBe(1);
+    expect(percentile(ten, 2)).toBe(10);
+  });
+
+  test('does not mutate the input array', () => {
+    const input = [5, 2, 8, 1, 4];
+    const snapshot = [...input];
+    percentile(input, 0.5);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/__tests__/unit/Statistics/stats/stddev.test.ts
+++ b/__tests__/unit/Statistics/stats/stddev.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import {mean, stddev} from '@src/libs/Statistics/stats';
+
+describe('stddev', () => {
+  test('empty input returns 0', () => {
+    expect(stddev([])).toBe(0);
+  });
+
+  test('single-value input returns 0', () => {
+    expect(stddev([42])).toBe(0);
+  });
+
+  test('constant series returns 0', () => {
+    expect(stddev([7, 7, 7, 7, 7])).toBe(0);
+  });
+
+  test('matches numpy std(ddof=1) on a known series', () => {
+    // Reference: numpy.std([2, 4, 4, 4, 5, 5, 7, 9], ddof=1) ≈ 2.13809
+    expect(stddev([2, 4, 4, 4, 5, 5, 7, 9])).toBeCloseTo(2.13809, 5);
+  });
+
+  test('matches numpy std(ddof=1) on [1..10]', () => {
+    // Reference: numpy.std(range(1,11), ddof=1) ≈ 3.02765
+    expect(stddev([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBeCloseTo(3.02765, 5);
+  });
+});
+
+describe('mean', () => {
+  test('empty input returns 0', () => {
+    expect(mean([])).toBe(0);
+  });
+
+  test('arithmetic mean of [1, 2, 3, 4] is 2.5', () => {
+    expect(mean([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  test('handles negative and positive values', () => {
+    expect(mean([-5, 0, 5])).toBe(0);
+  });
+});

--- a/src/libs/Statistics/stats/ewma.ts
+++ b/src/libs/Statistics/stats/ewma.ts
@@ -1,0 +1,39 @@
+import {mean} from './stddev';
+
+const DEFAULT_LAMBDA = 0.3;
+const SEED_WINDOW = 4;
+
+/**
+ * Exponentially-weighted moving average over `series`.
+ *
+ * Seed: the returned series starts at `mean(series[0 .. min(4, n) - 1])`,
+ * then iterates `s_i = lambda * x_i + (1 - lambda) * s_{i-1}` for i >= 1.
+ * λ = 0.3 default per STATISTICS_V2.md §8.
+ *
+ * Edge cases:
+ *   - empty input          → []
+ *   - lambda = 0           → flat array at the seed value
+ *   - lambda = 1           → seed at index 0, identity copy of input from i = 1
+ *   - lambda outside [0,1] → caller error; not validated (consumer is internal)
+ *
+ * Gap handling: callers must pre-fill gaps before invoking. Every element is
+ * treated as a real observation.
+ */
+function ewma(series: number[], lambda: number = DEFAULT_LAMBDA): number[] {
+  const n = series.length;
+  if (n === 0) {
+    return [];
+  }
+
+  const seedWindow = Math.min(SEED_WINDOW, n);
+  const seed = mean(series.slice(0, seedWindow));
+
+  const out = new Array<number>(n);
+  out[0] = seed;
+  for (let i = 1; i < n; i += 1) {
+    out[i] = lambda * series[i] + (1 - lambda) * out[i - 1];
+  }
+  return out;
+}
+
+export default ewma;

--- a/src/libs/Statistics/stats/helpers.ts
+++ b/src/libs/Statistics/stats/helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal numerical helpers for the stats module. Not re-exported via the
+ * barrel — keep the public surface limited to ewma/mannKendall/percentile/
+ * stddev/mean.
+ */
+
+/** Sign of a number, with 0 mapped to 0 (not +0/-0). */
+function signum(x: number): -1 | 0 | 1 {
+  if (x > 0) {
+    return 1;
+  }
+  if (x < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * Error function approximation per Abramowitz & Stegun §7.1.26.
+ * Max absolute error ≈ 1.5e-7 — far tighter than the `p < 0.05` gate needs.
+ */
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const t = 1 / (1 + p * absX);
+  const y =
+    1 -
+    ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
+
+  return sign * y;
+}
+
+/** Standard normal cumulative distribution function Φ(z). */
+function normalCdf(z: number): number {
+  return 0.5 * (1 + erf(z / Math.SQRT2));
+}
+
+export {signum, erf, normalCdf};

--- a/src/libs/Statistics/stats/index.ts
+++ b/src/libs/Statistics/stats/index.ts
@@ -1,0 +1,5 @@
+export {default as ewma} from './ewma';
+export {mannKendall} from './mannKendall';
+export type {MannKendallResult} from './mannKendall';
+export {default as percentile} from './percentile';
+export {mean, stddev} from './stddev';

--- a/src/libs/Statistics/stats/mannKendall.ts
+++ b/src/libs/Statistics/stats/mannKendall.ts
@@ -1,0 +1,124 @@
+import {normalCdf, signum} from './helpers';
+
+const MIN_N = 8;
+const ALPHA = 0.05;
+
+type MannKendallResult = {
+  /** Kendall's tau-b (tie-corrected). */
+  tau: number;
+  /** Raw S statistic. */
+  sScore: number;
+  /** Two-sided p-value via continuity-corrected normal approximation. */
+  p: number;
+  /**
+   * Caption gate per STATISTICS_V2.md §8. Consumers MUST only render UI from
+   * this field — `tau` and `p` are never to be displayed numerically.
+   */
+  trend: 'up' | 'down' | 'none';
+};
+
+/**
+ * Sum of t*(t-1)*(2t+5) across all tie groups — used in Var(S) correction.
+ */
+function tieTermVariance(tieCounts: number[]): number {
+  let sum = 0;
+  for (const t of tieCounts) {
+    sum += t * (t - 1) * (2 * t + 5);
+  }
+  return sum;
+}
+
+/**
+ * Sum of t*(t-1)/2 across all tie groups — used in the tau-b denominator.
+ */
+function tieTermTau(tieCounts: number[]): number {
+  let sum = 0;
+  for (const t of tieCounts) {
+    sum += (t * (t - 1)) / 2;
+  }
+  return sum;
+}
+
+/** Return the size of every tie group with size >= 2. */
+function tieGroupSizes(series: number[]): number[] {
+  if (series.length === 0) {
+    return [];
+  }
+  const sorted = [...series].sort((a, b) => a - b);
+  const groups: number[] = [];
+  let run = 1;
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i] === sorted[i - 1]) {
+      run += 1;
+    } else {
+      if (run >= 2) {
+        groups.push(run);
+      }
+      run = 1;
+    }
+  }
+  if (run >= 2) {
+    groups.push(run);
+  }
+  return groups;
+}
+
+/**
+ * Mann–Kendall trend test with tie correction and continuity-corrected
+ * normal approximation. References:
+ *   - Helsel & Hirsch, *Statistical Methods in Water Resources* (USGS Book
+ *     4-A3, 2002), §12.4.3.
+ *   - Hipel & McLeod, *Time Series Modelling of Water Resources and
+ *     Environmental Systems* (1994), Ch. 23.
+ *
+ * The `trend` field is the only field consumers should render. `tau` and `p`
+ * are returned for tests/debugging only — never display them numerically per
+ * STATISTICS_V2.md §8.
+ *
+ * Trend gate: `trend = 'up' | 'down'` iff `p < 0.05` AND `n >= 8` AND
+ * `sScore != 0`. Otherwise `'none'`. `n < 8` always returns `'none'`
+ * regardless of p, per spec.
+ */
+function mannKendall(series: number[]): MannKendallResult {
+  const n = series.length;
+  if (n < 2) {
+    return {tau: 0, sScore: 0, p: 1, trend: 'none'};
+  }
+
+  let sScore = 0;
+  for (let i = 0; i < n - 1; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      sScore += signum(series[j] - series[i]);
+    }
+  }
+
+  const ties = tieGroupSizes(series);
+  const variance = (n * (n - 1) * (2 * n + 5) - tieTermVariance(ties)) / 18;
+
+  let p: number;
+  if (variance <= 0 || sScore === 0) {
+    // No directional evidence — p is exactly 1 by definition. Skip the
+    // normal-approximation path so erf rounding doesn't drift it to 0.9999…
+    p = 1;
+  } else {
+    const z =
+      sScore > 0
+        ? (sScore - 1) / Math.sqrt(variance)
+        : (sScore + 1) / Math.sqrt(variance);
+    p = Math.min(1, Math.max(0, 2 * (1 - normalCdf(Math.abs(z)))));
+  }
+
+  const d0 = (n * (n - 1)) / 2;
+  const denom = (d0 - tieTermTau(ties)) * d0;
+  const tau = denom > 0 ? sScore / Math.sqrt(denom) : 0;
+
+  let trend: 'up' | 'down' | 'none' = 'none';
+  if (n >= MIN_N && p < ALPHA && sScore !== 0) {
+    trend = sScore > 0 ? 'up' : 'down';
+  }
+
+  return {tau, sScore, p, trend};
+}
+
+export {mannKendall};
+export type {MannKendallResult};

--- a/src/libs/Statistics/stats/percentile.ts
+++ b/src/libs/Statistics/stats/percentile.ts
@@ -1,0 +1,39 @@
+/**
+ * Linear-interpolation percentile, matching `numpy.percentile` defaults and
+ * R `quantile(type=7)`.
+ *
+ * `q` is a fraction in [0, 1] (values outside are clamped).
+ *
+ * Algorithm: sort ascending, then with `h = (n - 1) * q`,
+ * `i = floor(h)`, `f = h - i`:
+ *   result = sorted[i] + f * (sorted[i + 1] - sorted[i])
+ * When q = 1, i = n - 1 and f = 0 so no out-of-bounds read.
+ *
+ * Edge cases:
+ *   - empty input → NaN (callers — e.g. v2-H band-of-normal — skip render)
+ *   - n = 1       → that single value for any q
+ *   - q = 0       → min; q = 1 → max
+ */
+function percentile(series: number[], q: number): number {
+  const n = series.length;
+  if (n === 0) {
+    return Number.NaN;
+  }
+  if (n === 1) {
+    return series[0];
+  }
+
+  const clampedQ = Math.min(1, Math.max(0, q));
+  const sorted = [...series].sort((a, b) => a - b);
+
+  const h = (n - 1) * clampedQ;
+  const i = Math.floor(h);
+  const f = h - i;
+
+  if (f === 0) {
+    return sorted[i];
+  }
+  return sorted[i] + f * (sorted[i + 1] - sorted[i]);
+}
+
+export default percentile;

--- a/src/libs/Statistics/stats/stddev.ts
+++ b/src/libs/Statistics/stats/stddev.ts
@@ -1,0 +1,36 @@
+/**
+ * Arithmetic mean of a numeric series.
+ * Returns 0 on empty input (matches stddev's degradation rule so callers can
+ * treat both safely without guarding for NaN).
+ */
+function mean(series: number[]): number {
+  if (series.length === 0) {
+    return 0;
+  }
+  let sum = 0;
+  for (const v of series) {
+    sum += v;
+  }
+  return sum / series.length;
+}
+
+/**
+ * Sample standard deviation (Bessel-corrected: divide by n - 1).
+ * Returns 0 if n < 2 (covers empty and single-value inputs).
+ * Constant series → 0 trivially.
+ */
+function stddev(series: number[]): number {
+  const n = series.length;
+  if (n < 2) {
+    return 0;
+  }
+  const mu = mean(series);
+  let sumSquared = 0;
+  for (const v of series) {
+    const d = v - mu;
+    sumSquared += d * d;
+  }
+  return Math.sqrt(sumSquared / (n - 1));
+}
+
+export {mean, stddev};


### PR DESCRIPTION
## Summary

Ships the math layer used by Trends (v2-H) and Patterns (v2-I): pure-function `ewma`, `mannKendall`, `percentile`, `stddev`, plus a `mean` helper. No React, no Onyx — this PR is math + tests only.

Public surface (`src/libs/Statistics/stats/index.ts`):
- `ewma(series, lambda = 0.3)` — seed = mean of first `min(4, n)` values, then `s_i = λx_i + (1-λ)s_{i-1}`
- `mannKendall(series): { tau, sScore, p, trend }` — tie-corrected variance + tau-b, continuity-corrected normal-approx p, trend gated on `p < 0.05 ∧ n ≥ 8`
- `percentile(series, q)` — linear interpolation (numpy.percentile default / R `quantile(type=7)`); empty → NaN
- `stddev(series)` — sample stddev (n−1), 0 for n<2
- `mean(series)` — 0 for empty

References for the math:
- Helsel & Hirsch (2002), *Statistical Methods in Water Resources*, USGS Techniques Book 4-A3, §12.4.3
- Abramowitz & Stegun §7.1.26 (inline erf polynomial, ~1.5e-7 max abs error — no math dep added)

## ⚠️ Display rule for downstream consumers

Per [STATISTICS_V2.md §8](https://github.com/PetrCala/Kiroku/blob/claude/elegant-darwin-ad9da8/mockups/STATISTICS_V2.md#8-statistical-sophistication--concrete-rules), the numeric `tau` and `p` returned by `mannKendall` are **never to be displayed to users**. Future tab PRs (v2-G/H/I/J) must consume only the `trend: 'up' | 'down' | 'none'` field and map it to the §8-prescribed captions:

- `'up' | 'down'` → "your weekly units are trending up/down."
- `'none'` → "your weeks vary as usual."

The doc comment on `mannKendall` calls this out as well.

## Test plan

- [x] `npx jest __tests__/unit/Statistics` — 37 passing tests across 5 files
- [x] ≥95% line coverage on `src/libs/Statistics/stats/` (achieved: 99% lines, 95% branches)
- [x] `npm run typecheck-tsgo` clean
- [x] `./scripts/lint.sh` clean on new files
- [x] `npx prettier --write` clean
- Hand-computed reference cases for Mann–Kendall include: monotone up/down (n=10), flat tie series, near-monotone with one inversion (n=12), tie-correction sanity check, a noisy series with p≈0.063 verifying the gate rejects it, and a hand-checked jagged-up reference (S=37, tau≈0.822 on n=10)

## Scope

In: pure math + unit tests. Out: gap-filling (v2-C), hooks (v2-D), filter toolbar (v2-E), any UI/captions/colors (v2-G/H/I/J), i18n (v2-M), change-point detection (deferred to v2.x).

Closes #588. Part of #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)