### PR TITLE
feat(stats): useDrinkEvents + useAggregate hooks (v2-D)

### DIFF
--- a/__tests__/unit/useAggregate.test.ts
+++ b/__tests__/unit/useAggregate.test.ts
@@ -1,0 +1,104 @@
+import {renderHook} from '@testing-library/react-native';
+import useAggregate from '@hooks/useStatistics/useAggregate';
+import {
+  aggregate,
+  byDay,
+  byDrinkKey,
+  countEvents,
+  sumUnits,
+  weekendsOnly,
+} from '@libs/Statistics';
+import type {DrinkEvent} from '@libs/Statistics';
+
+function makeEvent(overrides: Partial<DrinkEvent>): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts: 0,
+    localDay: '2025-06-12',
+    localIsoWeek: '2025-W24',
+    localMonth: '2025-06',
+    localHour: 12,
+    localDow: 3,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    sdu: undefined,
+    blackoutSession: false,
+    sessionDurationMin: undefined,
+    ...overrides,
+  };
+}
+
+const EVENTS: DrinkEvent[] = [
+  makeEvent({
+    ts: Date.UTC(2025, 5, 12, 15),
+    localDay: '2025-06-12',
+    isWeekend: false,
+    drinkKey: 'beer',
+    units: 3,
+  }),
+  makeEvent({
+    ts: Date.UTC(2025, 5, 13, 15),
+    localDay: '2025-06-13',
+    isWeekend: false,
+    drinkKey: 'wine',
+    units: 2,
+  }),
+  makeEvent({
+    ts: Date.UTC(2025, 5, 14, 20),
+    localDay: '2025-06-14',
+    isWeekend: true,
+    drinkKey: 'cocktail',
+    units: 4,
+  }),
+];
+
+describe('useAggregate', () => {
+  test('delegates to aggregate() — by-day sum of units', () => {
+    const {result} = renderHook(() => useAggregate(EVENTS, byDay, sumUnits));
+
+    const expected = aggregate(EVENTS, byDay, sumUnits);
+
+    expect(Array.from(result.current.entries())).toEqual(
+      Array.from(expected.entries()),
+    );
+  });
+
+  test('filter passthrough — weekendsOnly restricts to weekend buckets', () => {
+    const {result} = renderHook(() =>
+      useAggregate(EVENTS, byDay, sumUnits, weekendsOnly),
+    );
+
+    expect(Array.from(result.current.keys())).toEqual(['2025-06-14']);
+    expect(result.current.get('2025-06-14')).toBe(4);
+  });
+
+  test('different bucketer produces different shape', () => {
+    const {result} = renderHook(() =>
+      useAggregate(EVENTS, byDrinkKey, countEvents),
+    );
+
+    expect(result.current.get('beer')).toBe(1);
+    expect(result.current.get('wine')).toBe(1);
+    expect(result.current.get('cocktail')).toBe(1);
+  });
+
+  test('empty events yields empty map', () => {
+    const {result} = renderHook(() => useAggregate([], byDay, sumUnits));
+
+    expect(result.current.size).toBe(0);
+  });
+
+  test('content is identical when re-rendered with the same inputs', () => {
+    const {result, rerender} = renderHook(() =>
+      useAggregate(EVENTS, byDay, sumUnits),
+    );
+    const firstEntries = Array.from(result.current.entries());
+
+    rerender(undefined);
+
+    expect(Array.from(result.current.entries())).toEqual(firstEntries);
+  });
+});

--- a/__tests__/unit/useDrinkEvents.test.ts
+++ b/__tests__/unit/useDrinkEvents.test.ts
@@ -1,0 +1,230 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+import {renderHook} from '@testing-library/react-native';
+import {useOnyx} from 'react-native-onyx';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
+import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
+import type {Preferences, UserData} from '@src/types/onyx';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  useOnyx: jest.fn(),
+  default: {},
+}));
+
+jest.mock('@context/global/FirebaseContext', () => ({
+  useFirebase: jest.fn(),
+}));
+
+jest.mock('@context/global/DatabaseDataContext', () => ({
+  useDatabaseData: jest.fn(),
+}));
+
+jest.mock('@hooks/useCurrentUserData', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedUseFirebase = jest.mocked(useFirebase);
+const mockedUseDatabaseData = jest.mocked(useDatabaseData);
+const mockedUseCurrentUserData = jest.mocked(useCurrentUserData);
+
+function makePreferences(): Preferences {
+  return {
+    first_day_of_week: 'Monday',
+    units_to_colors: {orange: 10, yellow: 5},
+    drinks_to_units: {
+      small_beer: 0.5,
+      beer: 1,
+      cocktail: 1.5,
+      other: 1,
+      strong_shot: 1,
+      weak_shot: 0.5,
+      wine: 1,
+    },
+    theme: 'system',
+  } as unknown as Preferences;
+}
+
+function makeUserData(): UserData {
+  return {
+    timezone: {selected: 'Africa/Abidjan', automatic: true},
+  } as unknown as UserData;
+}
+
+function setAuth(uid: string | undefined): void {
+  mockedUseFirebase.mockReturnValue({
+    auth: uid ? {currentUser: {uid}} : {currentUser: null},
+  } as unknown as ReturnType<typeof useFirebase>);
+}
+
+function setOnyx(
+  value: UserDrinkingSessionsList | undefined,
+  status: 'loading' | 'loaded',
+): void {
+  mockedUseOnyx.mockReturnValue([value, {status}] as ReturnType<
+    typeof useOnyx
+  >);
+}
+
+function setContexts(
+  preferences: Preferences | undefined = makePreferences(),
+  userData: UserData | undefined = makeUserData(),
+): void {
+  mockedUseDatabaseData.mockReturnValue({
+    preferences,
+    isFetchingOlderMonths: false,
+  });
+  mockedUseCurrentUserData.mockReturnValue(userData ?? {});
+}
+
+// A fixed UTC timestamp: 2025-06-12T15:00:00Z (Thursday).
+const TS_U1_A = Date.UTC(2025, 5, 12, 15, 0, 0);
+const TS_U1_B = Date.UTC(2025, 5, 12, 16, 30, 0);
+const TS_U2_A = Date.UTC(2025, 5, 13, 20, 0, 0);
+
+function makeSessions(): UserDrinkingSessionsList {
+  return {
+    u1: {
+      s1: {
+        start_time: TS_U1_A,
+        end_time: TS_U1_A + 90 * 60_000,
+        timezone: 'Africa/Abidjan',
+        drinks: {
+          [TS_U1_A]: {beer: 3},
+          [TS_U1_B]: {wine: {count: 2, volume_ml: 400, abv: 0.06}},
+        },
+      },
+    },
+    u2: {
+      s2: {
+        start_time: TS_U2_A,
+        timezone: 'Africa/Abidjan',
+        drinks: {
+          [TS_U2_A]: {cocktail: 1},
+        },
+      },
+    },
+  };
+}
+
+describe('useDrinkEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setAuth('u1');
+    setContexts();
+    setOnyx(makeSessions(), 'loaded');
+  });
+
+  test('hydration: loading status surfaces as isLoading=true with empty events', () => {
+    setOnyx(undefined, 'loading');
+
+    const {result} = renderHook(() => useDrinkEvents());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.events).toEqual([]);
+  });
+
+  test('hydration: loaded status surfaces as isLoading=false', () => {
+    setOnyx(makeSessions(), 'loaded');
+
+    const {result} = renderHook(() => useDrinkEvents());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.events.length).toBeGreaterThan(0);
+  });
+
+  test('defaults to current user when userIds is omitted', () => {
+    setAuth('u1');
+
+    const {result} = renderHook(() => useDrinkEvents());
+
+    const userIds = new Set(result.current.events.map(e => e.userId));
+    expect(userIds).toEqual(new Set(['u1']));
+  });
+
+  test('explicit single userId returns only that user', () => {
+    const {result} = renderHook(() => useDrinkEvents(['u2']));
+
+    const userIds = new Set(result.current.events.map(e => e.userId));
+    expect(userIds).toEqual(new Set(['u2']));
+  });
+
+  test('multi-user pass-through returns events from all requested users', () => {
+    const {result} = renderHook(() => useDrinkEvents(['u1', 'u2']));
+
+    const userIds = new Set(result.current.events.map(e => e.userId));
+    expect(userIds).toEqual(new Set(['u1', 'u2']));
+  });
+
+  test('empty userIds array returns no events', () => {
+    const {result} = renderHook(() => useDrinkEvents([]));
+
+    expect(result.current.events).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('no current user with omitted userIds returns no events', () => {
+    setAuth(undefined);
+
+    const {result} = renderHook(() => useDrinkEvents());
+
+    expect(result.current.events).toEqual([]);
+  });
+
+  test('legacy numeric and v2-A object entries both materialise', () => {
+    const {result} = renderHook(() => useDrinkEvents(['u1']));
+
+    const beer = result.current.events.find(e => e.drinkKey === 'beer');
+    const wine = result.current.events.find(e => e.drinkKey === 'wine');
+
+    expect(beer).toBeDefined();
+    expect(beer?.count).toBe(3);
+    expect(beer?.units).toBe(3);
+    expect(beer?.sdu).toBeDefined();
+
+    expect(wine).toBeDefined();
+    expect(wine?.count).toBe(2);
+    expect(wine?.units).toBe(2);
+    expect(wine?.sdu).toBeDefined();
+  });
+
+  test('events are stable in content across renders with unchanged inputs', () => {
+    const sessions = makeSessions();
+    setOnyx(sessions, 'loaded');
+
+    const {result, rerender} = renderHook(() => useDrinkEvents(['u1']));
+    const firstEvents = result.current.events;
+
+    rerender(undefined);
+
+    expect(result.current.events).toEqual(firstEvents);
+  });
+
+  test('missing timezone falls back to default without crashing', () => {
+    setContexts(makePreferences(), {
+      timezone: undefined,
+    } as unknown as UserData);
+
+    const {result} = renderHook(() => useDrinkEvents(['u1']));
+
+    expect(result.current.events.length).toBeGreaterThan(0);
+  });
+
+  test('missing preferences still produces events (units default to 0)', () => {
+    mockedUseDatabaseData.mockReturnValue({
+      preferences: undefined,
+      isFetchingOlderMonths: false,
+    });
+    mockedUseCurrentUserData.mockReturnValue(makeUserData());
+
+    const {result} = renderHook(() => useDrinkEvents(['u1']));
+
+    expect(result.current.events.length).toBeGreaterThan(0);
+    expect(result.current.events.every(e => e.units === 0)).toBe(true);
+  });
+});

--- a/src/hooks/useStatistics/index.ts
+++ b/src/hooks/useStatistics/index.ts
@@ -1,0 +1,3 @@
+export {default as useDrinkEvents} from './useDrinkEvents';
+export type {UseDrinkEventsResult} from './useDrinkEvents';
+export {default as useAggregate} from './useAggregate';

--- a/src/hooks/useStatistics/useAggregate.ts
+++ b/src/hooks/useStatistics/useAggregate.ts
@@ -1,0 +1,25 @@
+import {aggregate} from '@libs/Statistics';
+import type {
+  Bucketer,
+  DrinkEvent,
+  EventFilter,
+  Reducer,
+} from '@libs/Statistics';
+
+/**
+ * Thin hook that runs `aggregate` over an event stream. Exists so chart code
+ * has a single import surface and the React Compiler has a clean reactive
+ * scope keyed on `(events, bucketer, reducer, filter)` identity. Callers
+ * pass referentially-stable bucketers and reducers — the v2-C library
+ * exports both as top-level constants, so this is free in practice.
+ */
+function useAggregate<TKey, TAgg>(
+  events: DrinkEvent[],
+  bucketer: Bucketer<TKey>,
+  reducer: Reducer<TAgg>,
+  filter?: EventFilter,
+): Map<TKey, TAgg> {
+  return aggregate(events, bucketer, reducer, filter);
+}
+
+export default useAggregate;

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -1,0 +1,89 @@
+import {useOnyx} from 'react-native-onyx';
+import {buildDrinkEvents} from '@libs/Statistics';
+import type {DrinkEvent, WeekStart} from '@libs/Statistics';
+import {useFirebase} from '@context/global/FirebaseContext';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+type UseDrinkEventsResult = {
+  events: DrinkEvent[];
+  isLoading: boolean;
+};
+
+const WEEK_START_BY_LABEL: Record<string, WeekStart> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+const DEFAULT_WEEK_START: WeekStart = 1;
+
+function resolveWeekStart(label: string | undefined): WeekStart {
+  if (!label) {
+    return DEFAULT_WEEK_START;
+  }
+  return WEEK_START_BY_LABEL[label] ?? DEFAULT_WEEK_START;
+}
+
+/**
+ * Subscribe to the inputs of the Statistics v2 event stream and return the
+ * materialised `DrinkEvent[]` for the requested users.
+ *
+ * Sessions live on Onyx (`CACHED_DRINKING_SESSIONS`); preferences and the
+ * user's timezone flow through `DatabaseDataContext` / `useCurrentUserData`.
+ * The full event list is built once over the entire Onyx value so
+ * `buildDrinkEvents`'s identity cache keeps hitting; the per-call `userIds`
+ * filter is applied last.
+ *
+ * `isLoading` is true until the Onyx subscription has hydrated. During that
+ * window `events` is `[]` — callers should render a skeleton, not the
+ * empty-state.
+ */
+function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
+  const {auth} = useFirebase();
+  const {preferences} = useDatabaseData();
+  const userData = useCurrentUserData();
+  const [allSessions, allSessionsMeta] = useOnyx(
+    ONYXKEYS.CACHED_DRINKING_SESSIONS,
+  );
+
+  const currentUserID = auth?.currentUser?.uid;
+  const timezone =
+    userData?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected;
+  const weekStart = resolveWeekStart(preferences?.first_day_of_week);
+
+  const allEvents = buildDrinkEvents(
+    allSessions,
+    preferences?.drinks_to_units,
+    CONST.DRINK_DEFAULTS,
+    timezone,
+    weekStart,
+  );
+
+  const resolvedUserIds = userIds ?? (currentUserID ? [currentUserID] : []);
+
+  let events: DrinkEvent[];
+  if (resolvedUserIds.length === 0) {
+    events = [];
+  } else if (resolvedUserIds.length === 1) {
+    const only = resolvedUserIds[0];
+    events = allEvents.filter(e => e.userId === only);
+  } else {
+    const ids = new Set(resolvedUserIds);
+    events = allEvents.filter(e => ids.has(e.userId));
+  }
+
+  const isLoading = allSessionsMeta.status !== 'loaded';
+
+  return {events, isLoading};
+}
+
+export default useDrinkEvents;
+export type {UseDrinkEventsResult};


### PR DESCRIPTION
## Summary
- `useDrinkEvents(userIds?)`: subscribes to `CACHED_DRINKING_SESSIONS` + pulls preferences/timezone/currentUser from existing contexts, builds the full event list once via `buildDrinkEvents` (preserves the builder's identity cache), and filters by userIds last. Defaults to `[currentUserID]`. `isLoading` is true until the Onyx subscription hydrates.
- `useAggregate(events, bucketer, reducer, filter?)`: one-line wrapper over `libs/Statistics` `aggregate()`, giving the React Compiler a clean reactive scope keyed on the four argument identities.
- No manual `useMemo` / `useCallback` — the React Compiler memoizes both hooks. Bucketers/reducers from v2-C are top-level constants so caller-side identity is naturally stable.
- 16 new tests cover hydration transition, userIds defaulting and switching, empty / no-current-user inputs, legacy + v2-A drink-entry compatibility, missing-timezone and missing-preferences fallbacks, and aggregate filter/bucketer composition.

## Out of scope
- StatsContext / shared filter UI (v2-E).
- Any specific chart's data feed (Phase 4 tabs).
- No new Onyx keys, no new collections — read-only composition.

## Test plan
- [x] `./scripts/lint.sh` clean on all new files.
- [x] `npm run typecheck-tsgo` clean for our files (pre-existing victory-native/skia errors untouched).
- [x] `npx jest __tests__/unit/useDrinkEvents.test.ts __tests__/unit/useAggregate.test.ts` — 16/16 passing.
- [x] Lint passes under `eslint-plugin-react-compiler` (no compiler warnings on the new hooks).

Closes #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)