### PR TITLE
feat(stats): four-tab navigator shell (v2-F)

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -805,6 +805,26 @@ export default {
   },
   statistics: {
     title: 'Vaše statistiky',
+    tabs: {
+      overview: {
+        label: 'Přehled',
+        placeholder: 'Tady poroste tvoje série bez alkoholu a týdenní shrnutí.',
+      },
+      trends: {
+        label: 'Trendy',
+        placeholder:
+          'Týdenní trend a pásmo normálu se tu objeví, jak budou přibývat data.',
+      },
+      patterns: {
+        label: 'Vzorce',
+        placeholder: 'Kdy a jak — hodina dne a den v týdnu — bude tady.',
+      },
+      breakdown: {
+        label: 'Rozpis',
+        placeholder:
+          'Rozpis podle druhu pití a trendy podle typu přistanou tady.',
+      },
+    },
     charts: {
       weeklyBars: {
         title: 'Posledních 8 týdnů',
@@ -841,10 +861,6 @@ export default {
         comparisonToggle: 'Režim porovnání',
       },
     },
-  },
-  statisticsScreen: {
-    title: 'Statistiky',
-    comingSoon: 'Již brzy!',
   },
   achievementsScreen: {
     title: 'Odznaky',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -815,6 +815,28 @@ export default {
   },
   statistics: {
     title: 'Your stats',
+    tabs: {
+      overview: {
+        label: 'Overview',
+        placeholder:
+          'Your alcohol-free streak and weekly recap will live here.',
+      },
+      trends: {
+        label: 'Trends',
+        placeholder:
+          'Your weekly trend and band-of-normal will surface here as data builds.',
+      },
+      patterns: {
+        label: 'Patterns',
+        placeholder:
+          'Your when-and-how — hour of day and day of week — will live here.',
+      },
+      breakdown: {
+        label: 'Breakdown',
+        placeholder:
+          'Your drink-type breakdown and per-type trends will land here.',
+      },
+    },
     charts: {
       weeklyBars: {
         title: 'Last 8 weeks',
@@ -851,10 +873,6 @@ export default {
         comparisonToggle: 'Comparison mode',
       },
     },
-  },
-  statisticsScreen: {
-    title: 'Statistics',
-    comingSoon: 'Coming soon!',
   },
   achievementsScreen: {
     title: 'Badges',

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -1,30 +1,29 @@
 import React from 'react';
-import {View} from 'react-native';
-import Navigation from '@libs/Navigation/Navigation';
-import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import ScreenWrapper from '@components/ScreenWrapper';
+import StatsContextProvider from '@components/StatsContextProvider';
+import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import useLocalize from '@hooks/useLocalize';
-import Text from '@components/Text';
-import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@libs/Navigation/Navigation';
+import StatisticsTabs from './StatisticsTabs';
 
 function StatisticsScreen() {
   const {translate} = useLocalize();
-  const styles = useThemeStyles();
 
   return (
     <ScreenWrapper testID={StatisticsScreen.displayName}>
       <HeaderWithBackButton
-        title={translate('statisticsScreen.title')}
+        title={translate('statistics.title')}
         onBackButtonPress={Navigation.goBack}
       />
-      <View style={styles.flex1}>
-        <Text style={[styles.textLarge, styles.textAlignCenter]}>
-          {translate('statisticsScreen.comingSoon')}
-        </Text>
-      </View>
+      <StatsContextProvider>
+        <StatsFilterToolbar />
+        <StatisticsTabs />
+      </StatsContextProvider>
     </ScreenWrapper>
   );
 }
 
 StatisticsScreen.displayName = 'Statistics Screen';
+
 export default StatisticsScreen;

--- a/src/screens/Statistics/StatisticsTabs.tsx
+++ b/src/screens/Statistics/StatisticsTabs.tsx
@@ -1,0 +1,152 @@
+import type {TupleToUnion} from 'type-fest';
+import React, {useCallback, useMemo, useState} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {SceneMap, TabBar, TabView} from 'react-native-tab-view';
+import type {
+  NavigationState,
+  SceneRendererProps,
+  TabDescriptor,
+} from 'react-native-tab-view';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useWindowDimensions from '@hooks/useWindowDimensions';
+import type {TranslationPaths} from '@src/languages/types';
+import BreakdownTab from './tabs/BreakdownTab';
+import OverviewTab from './tabs/OverviewTab';
+import PatternsTab from './tabs/PatternsTab';
+import TrendsTab from './tabs/TrendsTab';
+
+// Tab order is locked per STATISTICS_V2.md and issue #582.
+const ROUTE_KEYS = ['overview', 'trends', 'patterns', 'breakdown'] as const;
+type RouteKey = TupleToUnion<typeof ROUTE_KEYS>;
+
+type TabRoute = {
+  key: RouteKey;
+  title: string;
+};
+
+const LABEL_KEYS: Record<RouteKey, TranslationPaths> = {
+  overview: 'statistics.tabs.overview.label',
+  trends: 'statistics.tabs.trends.label',
+  patterns: 'statistics.tabs.patterns.label',
+  breakdown: 'statistics.tabs.breakdown.label',
+};
+
+const renderScene = SceneMap({
+  overview: OverviewTab,
+  trends: TrendsTab,
+  patterns: PatternsTab,
+  breakdown: BreakdownTab,
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  tabBar: {
+    elevation: 0,
+    shadowOpacity: 0,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  tabBarIndicator: {
+    height: 2,
+  },
+  tabBarLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  lazyPlaceholder: {
+    flex: 1,
+  },
+});
+
+function renderTabLabel({
+  route,
+  color,
+}: {
+  route: TabRoute;
+  color: string;
+}): React.ReactNode {
+  return <Text style={[styles.tabBarLabel, {color}]}>{route.title}</Text>;
+}
+
+function renderLazyPlaceholder(): React.ReactNode {
+  return <View style={styles.lazyPlaceholder} />;
+}
+
+const COMMON_OPTIONS: TabDescriptor<TabRoute> = {
+  label: renderTabLabel,
+};
+
+function StatisticsTabs() {
+  const {translate} = useLocalize();
+  const theme = useTheme();
+  const {windowWidth} = useWindowDimensions();
+  const [index, setIndex] = useState(0);
+
+  const routes = useMemo<TabRoute[]>(
+    () =>
+      ROUTE_KEYS.map(key => ({
+        key,
+        title: translate(LABEL_KEYS[key]),
+      })),
+    [translate],
+  );
+
+  const renderTabBar = useCallback(
+    (
+      tabBarProps: SceneRendererProps & {
+        navigationState: NavigationState<TabRoute>;
+        options: Record<string, TabDescriptor<TabRoute>> | undefined;
+      },
+    ) => (
+      <TabBar
+        layout={tabBarProps.layout}
+        position={tabBarProps.position}
+        jumpTo={tabBarProps.jumpTo}
+        navigationState={tabBarProps.navigationState}
+        options={tabBarProps.options}
+        scrollEnabled={false}
+        style={[
+          styles.tabBar,
+          {backgroundColor: theme.appBG, borderBottomColor: theme.border},
+        ]}
+        indicatorStyle={[
+          styles.tabBarIndicator,
+          {backgroundColor: theme.success},
+        ]}
+        activeColor={theme.text}
+        inactiveColor={theme.textSupporting}
+        pressColor={theme.hoverComponentBG}
+      />
+    ),
+    [
+      theme.appBG,
+      theme.border,
+      theme.hoverComponentBG,
+      theme.success,
+      theme.text,
+      theme.textSupporting,
+    ],
+  );
+
+  return (
+    <TabView
+      style={[styles.container, {backgroundColor: theme.appBG}]}
+      navigationState={{index, routes}}
+      onIndexChange={setIndex}
+      renderScene={renderScene}
+      renderTabBar={renderTabBar}
+      initialLayout={{width: windowWidth}}
+      lazy
+      renderLazyPlaceholder={renderLazyPlaceholder}
+      commonOptions={COMMON_OPTIONS}
+    />
+  );
+}
+
+StatisticsTabs.displayName = 'StatisticsTabs';
+
+export default StatisticsTabs;

--- a/src/screens/Statistics/tabs/BreakdownTab.tsx
+++ b/src/screens/Statistics/tabs/BreakdownTab.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import TabPlaceholder from './TabPlaceholder';
+
+function BreakdownTab() {
+  return <TabPlaceholder copyKey="statistics.tabs.breakdown.placeholder" />;
+}
+
+BreakdownTab.displayName = 'BreakdownTab';
+
+export default BreakdownTab;

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import TabPlaceholder from './TabPlaceholder';
+
+function OverviewTab() {
+  return <TabPlaceholder copyKey="statistics.tabs.overview.placeholder" />;
+}
+
+OverviewTab.displayName = 'OverviewTab';
+
+export default OverviewTab;

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import TabPlaceholder from './TabPlaceholder';
+
+function PatternsTab() {
+  return <TabPlaceholder copyKey="statistics.tabs.patterns.placeholder" />;
+}
+
+PatternsTab.displayName = 'PatternsTab';
+
+export default PatternsTab;

--- a/src/screens/Statistics/tabs/TabPlaceholder.tsx
+++ b/src/screens/Statistics/tabs/TabPlaceholder.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {StyleSheet, View} from 'react-native';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import type {TranslationPaths} from '@src/languages/types';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+});
+
+type TabPlaceholderProps = {
+  copyKey: TranslationPaths;
+};
+
+function TabPlaceholder({copyKey}: TabPlaceholderProps) {
+  const {translate} = useLocalize();
+  const themeStyles = useThemeStyles();
+
+  return (
+    <View style={styles.container}>
+      <Text style={[themeStyles.textNormal, themeStyles.textAlignCenter]}>
+        {translate(copyKey)}
+      </Text>
+    </View>
+  );
+}
+
+TabPlaceholder.displayName = 'TabPlaceholder';
+
+export default TabPlaceholder;

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import TabPlaceholder from './TabPlaceholder';
+
+function TrendsTab() {
+  return <TabPlaceholder copyKey="statistics.tabs.trends.placeholder" />;
+}
+
+TrendsTab.displayName = 'TrendsTab';
+
+export default TrendsTab;


### PR DESCRIPTION
## Summary

- Replaces the placeholder `StatisticsScreen` with a navigator that mounts `StatsContextProvider` (v2-E) and the sticky `StatsFilterToolbar` above a `react-native-tab-view` `TabView`.
- Adds four separately-codesplit tabs in locked order — **Overview → Trends → Patterns → Breakdown** — each rendering a single additive copy line through a shared `TabPlaceholder`. Phase 4 (v2-G..J) fills the tab bodies in.
- Adds `statistics.tabs.*` translations to `en.ts` and `cs_cz.ts`; removes the now-unreferenced `statisticsScreen.*` keys.

Tab library choice: `react-native-tab-view@^4.1.0` (already a project dep); no `@react-navigation/material-top-tabs` added. Custom `TabBar` themed via `useTheme` to match `RangeSegmentedControl` look. `lazy` + `renderLazyPlaceholder` satisfy the "lazy mount permitted" criterion in the spec.

Navigation entry: untouched. The existing bottom-tab Statistics icon + `Statistics_Root` modal route already wire end-to-end — we only swap the screen mounted at that route. No new SCREENS / ROUTES / NAVIGATORS / linking entries.

Issue: #582
Part of: #576

## Test plan

- [ ] **iOS**: cold mount of Statistics opens on Overview with the toolbar visible.
- [ ] **iOS**: tap each tab (Trends, Patterns, Breakdown, back to Overview) — copy changes, toolbar stays in place.
- [ ] **iOS**: horizontal swipe across tabs works in both directions.
- [ ] **iOS**: **filter persistence** — change range to "M" on Overview, switch to Trends → Breakdown → back to Overview; the "M" preset is preserved. Repeat with comparison toggle and drink-type chip.
- [ ] **iOS**: back gesture from any tab dismisses the modal cleanly.
- [ ] **iOS**: dark theme renders correctly (tab bar bg / indicator / label colors all theme-driven).
- [ ] **Android**: repeat the above (cold mount, tap, swipe, filter persistence, hardware back, dark theme).
- [ ] **Locale**: switch to Czech in Preferences → all four labels and four placeholders render in cs_cz.
- [ ] **Static**: `grep -rn "Charts/|victory|skia|d3" src/screens/Statistics/` returns nothing (no chart imports leaked into the shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)