### PR TITLE
feat(calendar): side-swipe to change months and dismiss fullscreen

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -294,12 +294,18 @@ function SessionsCalendarView({
     <GestureDetector gesture={swipeGesture}>
       <View collapsable={false}>
         <Calendar
-          // Remount on theme change as a safety net. The library snapshots its
-          // derived stylesheet at first mount (patched in
-          // `patches/react-native-calendars+*.patch`); this `key` is belt-and-
-          // suspenders so the chrome still recovers if the patch ever fails to
-          // apply (e.g. a fresh `node_modules` before postinstall has run).
-          key={themePreference}
+          // Two remount triggers folded into one key:
+          //   • `themePreference` — belt-and-suspenders for the lib's first-
+          //     mount stylesheet snapshot (patched in
+          //     `patches/react-native-calendars+*.patch`).
+          //   • `visibleDate.dateString.slice(0, 7)` — the lib reads `current`
+          //     only on initial `useState`, so prop updates don't move its
+          //     internal cursor. Arrow presses sidestep this by calling
+          //     `subtractMonth`/`addMonth`; swipes have no such callback, so
+          //     we force a remount on month change to keep the grid in sync
+          //     with `visibleDate`. Slicing to 'YYYY-MM' avoids day-level
+          //     remounts when the date string changes within a month.
+          key={`${themePreference}-${visibleDate.dateString.slice(0, 7)}`}
           current={visibleDate.dateString}
           dayComponent={dayComponent}
           minDate={resolvedMinDate}

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -1,5 +1,7 @@
-import React, {memo, useCallback, useEffect, useRef} from 'react';
+import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
 import {ActivityIndicator, View} from 'react-native';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {runOnJS} from 'react-native-reanimated';
 import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -7,7 +9,7 @@ import {Calendar} from 'react-native-calendars';
 import type {DateData} from 'react-native-calendars';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
-import {format, startOfMonth} from 'date-fns';
+import {format, parseISO, startOfMonth} from 'date-fns';
 import useTheme from '@hooks/useTheme';
 import useThemePreference from '@hooks/useThemePreference';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -232,35 +234,95 @@ function SessionsCalendarView({
     ],
   );
 
+  // Side-swipe → change month. The library's built-in `enableSwipeMonths` is
+  // off because it bypasses the orchestrator's lazy-load hook; we feed the
+  // existing arrow handlers instead so the same prefetch path fires. The
+  // `subtractMonth/addMonth` callback they take is the lib's internal cursor
+  // updater — irrelevant here since `current` is driven by `visibleDate`.
+  const resolvedMinDate = minDate ?? CONST.DATE.MIN_DATE;
+  const resolvedMaxDate =
+    maxDate ?? format(new Date(), CONST.DATE.CALENDAR_FORMAT);
+  const goToPreviousMonth = useCallback(() => {
+    if (!onLeftArrowPress) {
+      return;
+    }
+    const visibleMonth = startOfMonth(new Date(visibleDate.timestamp));
+    if (visibleMonth <= startOfMonth(parseISO(resolvedMinDate))) {
+      return;
+    }
+    onLeftArrowPress(() => {});
+  }, [onLeftArrowPress, visibleDate.timestamp, resolvedMinDate]);
+  const goToNextMonth = useCallback(() => {
+    if (!onRightArrowPress) {
+      return;
+    }
+    const visibleMonth = startOfMonth(new Date(visibleDate.timestamp));
+    if (visibleMonth >= startOfMonth(parseISO(resolvedMaxDate))) {
+      return;
+    }
+    onRightArrowPress(() => {});
+  }, [onRightArrowPress, visibleDate.timestamp, resolvedMaxDate]);
+
+  const swipeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        // Activate only after clear horizontal intent so day-cell taps and
+        // scroll-locked vertical pans still win uncontested.
+        .activeOffsetX([-15, 15])
+        .failOffsetY([-20, 20])
+        .onEnd(e => {
+          'worklet';
+
+          const SWIPE_THRESHOLD = 60;
+          const VELOCITY_THRESHOLD = 400;
+          if (
+            e.translationX < -SWIPE_THRESHOLD ||
+            e.velocityX < -VELOCITY_THRESHOLD
+          ) {
+            runOnJS(goToNextMonth)();
+          } else if (
+            e.translationX > SWIPE_THRESHOLD ||
+            e.velocityX > VELOCITY_THRESHOLD
+          ) {
+            runOnJS(goToPreviousMonth)();
+          }
+        }),
+    [goToPreviousMonth, goToNextMonth],
+  );
+
   return (
-    <Calendar
-      // Remount on theme change as a safety net. The library snapshots its
-      // derived stylesheet at first mount (patched in
-      // `patches/react-native-calendars+*.patch`); this `key` is belt-and-
-      // suspenders so the chrome still recovers if the patch ever fails to
-      // apply (e.g. a fresh `node_modules` before postinstall has run).
-      key={themePreference}
-      current={visibleDate.dateString}
-      dayComponent={dayComponent}
-      minDate={minDate ?? CONST.DATE.MIN_DATE}
-      maxDate={maxDate ?? format(new Date(), CONST.DATE.CALENDAR_FORMAT)}
-      monthFormat={CONST.DATE.MONTH_YEAR_ABBR_FORMAT}
-      onPressArrowLeft={onLeftArrowPress}
-      onPressArrowRight={onRightArrowPress}
-      markedDates={markedDates}
-      markingType="period"
-      firstDay={CONST.WEEK_STARTS_ON}
-      enableSwipeMonths={false}
-      hideArrows={hideArrows}
-      hideDayNames={hideDayNames}
-      renderHeader={renderHeader}
-      disableAllTouchEventsForDisabledDays
-      renderArrow={(direction: Direction) => CalendarArrow(direction)}
-      style={styles.sessionsCalendarContainer}
-      theme={StyleUtils.getSessionsCalendarStyle()}
-      // @ts-expect-error locale prop exists at runtime but is not declared in types
-      locale={locale}
-    />
+    <GestureDetector gesture={swipeGesture}>
+      <View collapsable={false}>
+        <Calendar
+          // Remount on theme change as a safety net. The library snapshots its
+          // derived stylesheet at first mount (patched in
+          // `patches/react-native-calendars+*.patch`); this `key` is belt-and-
+          // suspenders so the chrome still recovers if the patch ever fails to
+          // apply (e.g. a fresh `node_modules` before postinstall has run).
+          key={themePreference}
+          current={visibleDate.dateString}
+          dayComponent={dayComponent}
+          minDate={resolvedMinDate}
+          maxDate={resolvedMaxDate}
+          monthFormat={CONST.DATE.MONTH_YEAR_ABBR_FORMAT}
+          onPressArrowLeft={onLeftArrowPress}
+          onPressArrowRight={onRightArrowPress}
+          markedDates={markedDates}
+          markingType="period"
+          firstDay={CONST.WEEK_STARTS_ON}
+          enableSwipeMonths={false}
+          hideArrows={hideArrows}
+          hideDayNames={hideDayNames}
+          renderHeader={renderHeader}
+          disableAllTouchEventsForDisabledDays
+          renderArrow={(direction: Direction) => CalendarArrow(direction)}
+          style={styles.sessionsCalendarContainer}
+          theme={StyleUtils.getSessionsCalendarStyle()}
+          // @ts-expect-error locale prop exists at runtime but is not declared in types
+          locale={locale}
+        />
+      </View>
+    </GestureDetector>
   );
 }
 

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -7,6 +7,8 @@ import React, {
   useState,
 } from 'react';
 import {ActivityIndicator, Dimensions, View} from 'react-native';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {runOnJS} from 'react-native-reanimated';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef} from '@shopify/flash-list';
 import {format, parseISO, startOfDay} from 'date-fns';
@@ -81,6 +83,10 @@ type SessionsCalendarWeekListViewProps = {
   /** Fires once the initial scroll has been applied (or determined that no
    *  scroll is needed). The parent screen uses this to unhide the calendar. */
   onInitialScrollReady?: () => void;
+  /** Called when the user swipes right past the threshold — the parent maps
+   *  this to a navigation back so the fullscreen view feels dismissable on
+   *  Android (which has no built-in stack swipe-back). */
+  onSwipeBack?: () => void;
 };
 
 type LabelItem = {
@@ -122,6 +128,7 @@ function SessionsCalendarWeekListView({
   initialMonthYear,
   initialFirstWeekY,
   onInitialScrollReady,
+  onSwipeBack,
 }: SessionsCalendarWeekListViewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -443,38 +450,72 @@ function SessionsCalendarWeekListView({
       ? targetIndex
       : Math.max(0, items.length - 1);
 
+  // Side-swipe-right → dismiss the fullscreen view. The Pan gesture only
+  // activates on a clear horizontal drift, and fails the moment a vertical
+  // drift takes the lead, so the FlashList's vertical scroll wins every
+  // intra-list pan. `enabled` keeps the gesture inert when no handler is
+  // wired up (e.g. a future reuse of this view outside the modal stack).
+  const swipeBackGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(!!onSwipeBack)
+        // Only positive translation (rightward swipe) should be a candidate;
+        // we leave a generous failOffset on the left so dragging the
+        // scrollbar / horizontal day-row never accidentally trips it.
+        .activeOffsetX(20)
+        .failOffsetY([-20, 20])
+        .onEnd(e => {
+          'worklet';
+
+          const SWIPE_THRESHOLD = 80;
+          const VELOCITY_THRESHOLD = 500;
+          if (!onSwipeBack) {
+            return;
+          }
+          if (
+            e.translationX > SWIPE_THRESHOLD ||
+            e.velocityX > VELOCITY_THRESHOLD
+          ) {
+            runOnJS(onSwipeBack)();
+          }
+        }),
+    [onSwipeBack],
+  );
+
   return (
-    <View style={styles.flex1}>
-      <View style={styles.sessionsCalendarDayNamesRow}>
-        {dayNames.map((name, idx) => (
-          <View
-            // eslint-disable-next-line react/no-array-index-key
-            key={`day-name-${idx}`}
-            style={styles.sessionsCalendarDayNameCell}>
-            <Text style={styles.sessionsCalendarDayNameText}>{name}</Text>
-          </View>
-        ))}
+    <GestureDetector gesture={swipeBackGesture}>
+      <View style={styles.flex1}>
+        <View style={styles.sessionsCalendarDayNamesRow}>
+          {dayNames.map((name, idx) => (
+            <View
+              // eslint-disable-next-line react/no-array-index-key
+              key={`day-name-${idx}`}
+              style={styles.sessionsCalendarDayNameCell}>
+              <Text style={styles.sessionsCalendarDayNameText}>{name}</Text>
+            </View>
+          ))}
+        </View>
+        <View
+          ref={flashListWrapperRef}
+          onLayout={onFlashListWrapperLayout}
+          style={styles.flex1}
+          collapsable={false}>
+          <FlashList
+            ref={listRef}
+            data={items}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            stickyHeaderIndices={stickyHeaderIndices}
+            initialScrollIndex={initialScrollIndex}
+            showsVerticalScrollIndicator
+            ListHeaderComponent={listHeader}
+            ListFooterComponent={ListFooter}
+            onViewableItemsChanged={onViewableItemsChanged}
+            viewabilityConfig={VIEWABILITY_CONFIG}
+          />
+        </View>
       </View>
-      <View
-        ref={flashListWrapperRef}
-        onLayout={onFlashListWrapperLayout}
-        style={styles.flex1}
-        collapsable={false}>
-        <FlashList
-          ref={listRef}
-          data={items}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          stickyHeaderIndices={stickyHeaderIndices}
-          initialScrollIndex={initialScrollIndex}
-          showsVerticalScrollIndicator
-          ListHeaderComponent={listHeader}
-          ListFooterComponent={ListFooter}
-          onViewableItemsChanged={onViewableItemsChanged}
-          viewabilityConfig={VIEWABILITY_CONFIG}
-        />
-      </View>
-    </View>
+    </GestureDetector>
   );
 }
 

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -177,6 +177,7 @@ function SessionsCalendar({
         initialMonthYear={initialMonthYear}
         initialFirstWeekY={initialFirstWeekY}
         onInitialScrollReady={onInitialScrollReady}
+        onSwipeBack={Navigation.goBack}
       />
     );
   }

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -208,9 +208,15 @@ const ProfileModalStackNavigator =
 
 const SessionsCalendarModalStackNavigator =
   createModalStackNavigator<SessionsCalendarNavigatorParamList>({
-    [SCREENS.SESSIONS_CALENDAR.FULLSCREEN]: () =>
-      require<ReactComponentModule>('@screens/SessionsCalendar/SessionsCalendarScreen')
-        .default,
+    [SCREENS.SESSIONS_CALENDAR.FULLSCREEN]: {
+      getComponent: () =>
+        require<ReactComponentModule>('@screens/SessionsCalendar/SessionsCalendarScreen')
+          .default,
+      // The screen owns a horizontal swipe-back gesture (see
+      // SessionsCalendarWeekListView). Disable the stack's own swipe-back so
+      // the two don't race on iOS — our gesture works on both platforms.
+      options: {gestureEnabled: false},
+    },
   });
 
 const SocialModalStackNavigator =


### PR DESCRIPTION
## Summary
- **Compact calendar** (HomeScreen, ProfileScreen): horizontal swipe changes months — left swipe → next, right swipe → previous. Swipes call through the existing arrow handlers so the lazy-load prefetch path still fires before navigating past the loaded floor. Bounds clamp against `minDate` (tracking-start) and `maxDate` (today).
- **Fullscreen week-list calendar**: rightward swipe dismisses the view. The Pan gesture is tuned with `activeOffsetX(20)` / `failOffsetY([-20, 20])` so the FlashList's vertical scroll keeps winning every intra-list pan.
- The stack's built-in swipe-back is disabled for `SessionsCalendarScreen` so the new custom gesture doesn't race with the native one on iOS — the behaviour is now consistent across iOS and Android.

## Test plan
- [ ] On Home screen, swipe the calendar left → next month; swipe right → previous month
- [ ] On Profile screen, same swipe behaviour works
- [ ] Swiping right at the first tracked month does nothing (no past-floor overshoot)
- [ ] Swiping left at the current month does nothing (no future overshoot)
- [ ] Day-cell taps still register (gesture only activates after ~15px of horizontal motion)
- [ ] Tap the month header to enter the fullscreen calendar
- [ ] In fullscreen, vertical FlashList scrolling is unimpeded
- [ ] In fullscreen, swipe right anywhere → returns to the previous screen on both iOS and Android
- [ ] Swipe left in fullscreen does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)