### PR TITLE
feat(stats): Patterns tab — hour polar, day×hour heatmap, histograms (v2-I)

### DIFF
--- a/__tests__/unit/libs/Statistics/bucketers.test.ts
+++ b/__tests__/unit/libs/Statistics/bucketers.test.ts
@@ -7,6 +7,7 @@ import {
   byIsoWeek,
   byMonth,
   byQuarter,
+  bySessionId,
   byUserId,
   byYear,
   composeBuckets,
@@ -77,6 +78,10 @@ describe('bucketers', () => {
 
   it('byUserId returns userId', () => {
     expect(byUserId(event({userId: 'alice'}))).toBe('alice');
+  });
+
+  it('bySessionId returns sessionId', () => {
+    expect(bySessionId(event({sessionId: 'sess-42'}))).toBe('sess-42');
   });
 
   it('composeBuckets joins keys with the unit-separator', () => {

--- a/__tests__/unit/libs/Statistics/filters.test.ts
+++ b/__tests__/unit/libs/Statistics/filters.test.ts
@@ -1,4 +1,5 @@
 import {
+  composeFilters,
   dateRange,
   drinkTypeSubset,
   excludeBlackouts,
@@ -95,5 +96,36 @@ describe('forUsers', () => {
     const filter = forUsers(new Set(['carol']));
     expect(filter(event({userId: 'carol'}))).toBe(true);
     expect(filter(event({userId: 'alice'}))).toBe(false);
+  });
+});
+
+describe('composeFilters', () => {
+  it('returns undefined when all inputs are undefined', () => {
+    expect(composeFilters(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns the lone filter when only one is provided', () => {
+    const only = weekendsOnly;
+    expect(composeFilters(undefined, only)).toBe(only);
+  });
+
+  it('ANDs multiple filters', () => {
+    const filter = composeFilters(weekendsOnly, drinkTypeSubset(['beer']));
+    expect(filter?.(event({isWeekend: true, drinkKey: 'beer'}))).toBe(true);
+    expect(filter?.(event({isWeekend: false, drinkKey: 'beer'}))).toBe(false);
+    expect(filter?.(event({isWeekend: true, drinkKey: 'wine'}))).toBe(false);
+  });
+
+  it('short-circuits on the first failing predicate', () => {
+    let secondCalled = false;
+    const composed = composeFilters(
+      () => false,
+      () => {
+        secondCalled = true;
+        return true;
+      },
+    );
+    composed?.(event({}));
+    expect(secondCalled).toBe(false);
   });
 });

--- a/__tests__/unit/libs/Statistics/reducers.test.ts
+++ b/__tests__/unit/libs/Statistics/reducers.test.ts
@@ -9,6 +9,7 @@ import {
   p25,
   p75,
   p90,
+  sessionDurationMin,
   stddev,
   sumSdu,
   sumUnits,
@@ -161,5 +162,28 @@ describe('firstEvent / lastEvent', () => {
     const b = event({ts: 100, sessionId: 'b'});
     expect(firstEvent([a, b])?.sessionId).toBe('a');
     expect(lastEvent([a, b])?.sessionId).toBe('a');
+  });
+});
+
+describe('sessionDurationMin', () => {
+  it('returns the first event sessionDurationMin', () => {
+    expect(
+      sessionDurationMin([
+        event({sessionDurationMin: 45}),
+        event({sessionDurationMin: 45}),
+      ]),
+    ).toBe(45);
+  });
+
+  it('returns NaN when no events have a duration', () => {
+    expect(
+      Number.isNaN(
+        sessionDurationMin([event({sessionDurationMin: undefined})]),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns NaN for empty input', () => {
+    expect(Number.isNaN(sessionDurationMin([]))).toBe(true);
   });
 });

--- a/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
+++ b/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
@@ -1,0 +1,230 @@
+import {useMemo, useState} from 'react';
+import {View} from 'react-native';
+import {Canvas, RoundedRect} from '@shopify/react-native-skia';
+import {useChartTheme} from '@components/Charts/BaseChart';
+import Text from '@components/Text';
+import useThemeStyles from '@hooks/useThemeStyles';
+import type {WeekStart} from '@libs/Statistics';
+
+type DowHourHeatmapProps = {
+  /**
+   * Bucket value (units) keyed by `${dow}${COMPOSITE_KEY_SEP}${hour}` —
+   * exactly the shape produced by
+   * `aggregate(events, composeBuckets(byDow, byHour), sumUnits)`. The
+   * component splits the key with the unit separator itself.
+   */
+  buckets: ReadonlyMap<string, number>;
+  /**
+   * 0..6, Sun..Sat. The `localDow` field on `DrinkEvent` is already rotated
+   * so that 0 = the user's `WeekStart`; passing the same value here lets the
+   * heatmap label rows with the correct weekday names.
+   */
+  weekStart: WeekStart;
+  accessibilityLabel: string;
+  /** Pixel gap between cells. Default 1 (denser than CalendarHeatmap's 2). */
+  gap?: number;
+};
+
+const HOURS = 24;
+const DAYS = 7;
+const LABEL_GUTTER = 32;
+const HOUR_LABEL_HEIGHT = 16;
+const COMPOSITE_SEP = '\x1f';
+const SHORT_DAY_NAMES = [
+  'Sun',
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+] as const;
+
+function formatHourTick(hour: number): string {
+  if (hour === 0) {
+    return '12a';
+  }
+  if (hour === 12) {
+    return '12p';
+  }
+  const label = hour > 12 ? hour - 12 : hour;
+  const suffix = hour < 12 ? 'a' : 'p';
+  return `${label}${suffix}`;
+}
+
+function intensityFor(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
+  if (max <= 0 || value <= 0) {
+    return 0;
+  }
+  const r = value / max;
+  if (r < 0.25) {
+    return 1;
+  }
+  if (r < 0.5) {
+    return 2;
+  }
+  if (r < 0.75) {
+    return 3;
+  }
+  return 4;
+}
+
+/**
+ * 7×24 heatmap of drinking activity by day-of-week × hour-of-day. Direct
+ * Skia draw, modelled on `CalendarHeatmap` — one RoundedRect per cell, color
+ * from the shared 5-stop yellow→orange ramp. Invisible RN View overlays
+ * carry per-cell `accessibilityLabel` since Skia draws to canvas with no
+ * native a11y handles.
+ */
+function DowHourHeatmap({
+  buckets,
+  weekStart,
+  accessibilityLabel,
+  gap = 1,
+}: DowHourHeatmapProps) {
+  const [width, setWidth] = useState(0);
+  const theme = useChartTheme();
+  const styles = useThemeStyles();
+
+  const dayLabels = useMemo(() => {
+    const out: string[] = [];
+    for (let i = 0; i < DAYS; i++) {
+      out.push(SHORT_DAY_NAMES[(weekStart + i) % DAYS]);
+    }
+    return out;
+  }, [weekStart]);
+
+  const gridWidth = Math.max(0, width - LABEL_GUTTER);
+  const cellSize = gridWidth > 0 ? Math.floor(gridWidth / HOURS) : 0;
+  const innerSize = Math.max(0, cellSize - gap);
+  const gridHeight = cellSize * DAYS;
+  const totalHeight = gridHeight + HOUR_LABEL_HEIGHT;
+
+  const cells = useMemo(() => {
+    const out: Array<{
+      dow: number;
+      hour: number;
+      value: number;
+      intensity: 0 | 1 | 2 | 3 | 4;
+    }> = [];
+    let max = 0;
+    buckets.forEach(v => {
+      if (v > max) {
+        max = v;
+      }
+    });
+    for (let dow = 0; dow < DAYS; dow++) {
+      for (let hour = 0; hour < HOURS; hour++) {
+        const value = buckets.get(`${dow}${COMPOSITE_SEP}${hour}`) ?? 0;
+        out.push({dow, hour, value, intensity: intensityFor(value, max)});
+      }
+    }
+    return out;
+  }, [buckets]);
+
+  const hasData = cells.some(c => c.value > 0);
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={accessibilityLabel}
+      style={{width: '100%', height: totalHeight || 8}}
+      onLayout={e => setWidth(e.nativeEvent.layout.width)}>
+      {cellSize > 0 ? (
+        <>
+          {/* Left-edge day labels, one per row. */}
+          {dayLabels.map((label, dow) => (
+            <View
+              key={label}
+              pointerEvents="none"
+              style={{
+                position: 'absolute',
+                left: 0,
+                top: dow * cellSize,
+                width: LABEL_GUTTER,
+                height: cellSize,
+                justifyContent: 'center',
+              }}>
+              <Text style={[styles.textMicroSupporting]}>{label}</Text>
+            </View>
+          ))}
+          <Canvas
+            style={{
+              width: gridWidth,
+              height: gridHeight,
+              position: 'absolute',
+              left: LABEL_GUTTER,
+              top: 0,
+            }}>
+            {cells.map(cell => (
+              <RoundedRect
+                key={`${cell.dow}-${cell.hour}`}
+                x={cell.hour * cellSize + gap / 2}
+                y={cell.dow * cellSize + gap / 2}
+                width={innerSize}
+                height={innerSize}
+                r={2}
+                color={theme.intensityRamp[cell.intensity]}
+              />
+            ))}
+          </Canvas>
+          {/* Per-cell a11y overlays — mirrors CalendarHeatmap's pattern. */}
+          {cells.map(cell => (
+            <View
+              key={`a11y-${cell.dow}-${cell.hour}`}
+              accessible
+              accessibilityRole="text"
+              accessibilityLabel={`${dayLabels[cell.dow]} ${cell.hour}:00, ${Math.round(cell.value * 10) / 10} units`}
+              style={{
+                position: 'absolute',
+                left: LABEL_GUTTER + cell.hour * cellSize,
+                top: cell.dow * cellSize,
+                width: cellSize,
+                height: cellSize,
+              }}
+            />
+          ))}
+          {/* Hour ticks below the grid at 0 / 6 / 12 / 18. */}
+          {[0, 6, 12, 18].map(hour => (
+            <View
+              key={`tick-${hour}`}
+              pointerEvents="none"
+              style={{
+                position: 'absolute',
+                left: LABEL_GUTTER + hour * cellSize - 12,
+                top: gridHeight + 2,
+                width: 24,
+                alignItems: 'center',
+              }}>
+              <Text style={[styles.textMicroSupporting]}>
+                {formatHourTick(hour)}
+              </Text>
+            </View>
+          ))}
+          {!hasData ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.alignItemsCenter,
+                styles.justifyContentCenter,
+                {
+                  position: 'absolute',
+                  left: LABEL_GUTTER,
+                  top: 0,
+                  width: gridWidth,
+                  height: gridHeight,
+                },
+              ]}>
+              <Text style={[styles.textSupporting, styles.textAlignCenter]}>
+                No drinks recorded in this range.
+              </Text>
+            </View>
+          ) : null}
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+export default DowHourHeatmap;
+export type {DowHourHeatmapProps};

--- a/src/components/Charts/DowHourHeatmap/index.ts
+++ b/src/components/Charts/DowHourHeatmap/index.ts
@@ -1,0 +1,2 @@
+export {default as DowHourHeatmap} from './DowHourHeatmap';
+export type {DowHourHeatmapProps} from './DowHourHeatmap';

--- a/src/components/Charts/Histogram/Histogram.tsx
+++ b/src/components/Charts/Histogram/Histogram.tsx
@@ -1,0 +1,58 @@
+import {useMemo} from 'react';
+import {Bar, BaseChart} from '@components/Charts/BaseChart';
+import type {ChartDatum} from '@libs/Statistics';
+
+type HistogramBin = {label: string; count: number};
+
+type HistogramProps = {
+  /**
+   * Pre-binned data. The caller owns binning so each histogram can pick
+   * intuitive fixed bins (e.g. drinks: 1, 2, 3, 4, 5+; duration: 0–30m,
+   * 30–60m, 1–2h, 2–4h, 4h+).
+   */
+  bins: HistogramBin[];
+  accessibilityLabel: string;
+  /** Shown via `BaseChart` when every bin is zero. */
+  emptyLabel?: string;
+  height?: number;
+};
+
+/**
+ * Vertical bar histogram. Thin wrapper around `BaseChart` so concrete
+ * histograms stay close to the data layer and far from Victory. Bars use the
+ * primary fill color and rounded top corners to match `WeeklyBars`.
+ */
+function Histogram({
+  bins,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+}: HistogramProps) {
+  const data = useMemo<ChartDatum[]>(() => {
+    if (bins.every(b => b.count === 0)) {
+      return [];
+    }
+    return bins.map(b => ({x: b.label, y: b.count}));
+  }, [bins]);
+
+  return (
+    <BaseChart
+      data={data}
+      range="allTime"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}>
+      {({points, chartBounds, theme}) => (
+        <Bar
+          points={points.y}
+          chartBounds={chartBounds}
+          color={theme.primaryFill}
+          roundedCorners={{topLeft: 4, topRight: 4}}
+        />
+      )}
+    </BaseChart>
+  );
+}
+
+export default Histogram;
+export type {HistogramBin, HistogramProps};

--- a/src/components/Charts/Histogram/index.ts
+++ b/src/components/Charts/Histogram/index.ts
@@ -1,0 +1,2 @@
+export {default as Histogram} from './Histogram';
+export type {HistogramBin, HistogramProps} from './Histogram';

--- a/src/components/Charts/HourPolar/HourPolar.tsx
+++ b/src/components/Charts/HourPolar/HourPolar.tsx
@@ -1,0 +1,243 @@
+import {useMemo, useState} from 'react';
+import {View} from 'react-native';
+import {Canvas, Circle, Path, Skia} from '@shopify/react-native-skia';
+import {useChartTheme} from '@components/Charts/BaseChart';
+import {PressableWithoutFeedback} from '@components/Pressable';
+import Text from '@components/Text';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+type HourPolarProps = {
+  /** Bucket value (units) keyed by `localHour` 0..23. Missing hours = 0. */
+  buckets: ReadonlyMap<number, number>;
+  accessibilityLabel: string;
+  /** Optional label for hour 12 / 0 / 6 / 18; defaults to '12 AM' etc. */
+  labelForHour?: (hour: number) => string;
+  /** Optional spoke tap. v1 wires the prop; no-op until v2-K drill-down lands. */
+  onSpokePress?: (hour: number) => void;
+  /** Square canvas size in dp; defaults to the parent width. */
+  size?: number;
+};
+
+const TAU = Math.PI * 2;
+const WEDGE_COUNT = 24;
+const WEDGE_RAD = TAU / WEDGE_COUNT;
+const ARC_SEGMENTS = 6;
+const CENTER_PADDING = 18;
+const RIM_INSET = 4;
+const MIN_TAP_TARGET = 44;
+
+function intensityFor(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
+  if (max <= 0 || value <= 0) {
+    return 0;
+  }
+  const r = value / max;
+  if (r < 0.25) {
+    return 1;
+  }
+  if (r < 0.5) {
+    return 2;
+  }
+  if (r < 0.75) {
+    return 3;
+  }
+  return 4;
+}
+
+function defaultLabelForHour(hour: number): string {
+  if (hour === 0) {
+    return '12 AM';
+  }
+  if (hour === 12) {
+    return '12 PM';
+  }
+  if (hour < 12) {
+    return `${hour} AM`;
+  }
+  return `${hour - 12} PM`;
+}
+
+/**
+ * Hour-of-day polar chart. 24 filled wedges around a 360° dial, each spanning
+ * 15° clockwise from midnight at top. Wedge outer radius encodes the bucket
+ * value; fill color picks from the shared 5-stop yellow→orange ramp (never
+ * red — design doc §3) so the encoding is redundant for color-blind users.
+ *
+ * Drawn directly with Skia, mirroring `CalendarHeatmap`. Hour labels and tap
+ * targets live as RN overlays — no Skia font assets to wire up.
+ */
+function HourPolar({
+  buckets,
+  accessibilityLabel,
+  labelForHour = defaultLabelForHour,
+  onSpokePress,
+  size,
+}: HourPolarProps) {
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const theme = useChartTheme();
+  const styles = useThemeStyles();
+
+  const side = size ?? measuredWidth;
+  const cx = side / 2;
+  const cy = side / 2;
+  const radius = Math.max(0, side / 2 - CENTER_PADDING);
+
+  const maxValue = useMemo(() => {
+    let max = 0;
+    buckets.forEach(v => {
+      if (v > max) {
+        max = v;
+      }
+    });
+    return max;
+  }, [buckets]);
+
+  const wedges = useMemo(() => {
+    if (radius <= 0) {
+      return [];
+    }
+    const out: Array<{
+      hour: number;
+      path: ReturnType<typeof Skia.Path.Make>;
+      color: string;
+    }> = [];
+    for (let hour = 0; hour < WEDGE_COUNT; hour++) {
+      const value = buckets.get(hour) ?? 0;
+      const intensity = intensityFor(value, maxValue);
+      const ratio = maxValue > 0 ? value / maxValue : 0;
+      // Always draw a hair-thin rim wedge when intensity > 0 but ratio < some
+      // floor, so a non-zero bucket is visible even with one tiny event.
+      const drawRatio = intensity === 0 ? 0 : Math.max(ratio, 0.08);
+      const r = drawRatio * radius;
+      if (r <= 0) {
+        continue;
+      }
+      // Wedge centered on hour. Rotate so 0° = 12 o'clock (top), clockwise.
+      const center = -Math.PI / 2 + hour * WEDGE_RAD;
+      const a0 = center - WEDGE_RAD / 2;
+      const a1 = center + WEDGE_RAD / 2;
+      const path = Skia.Path.Make();
+      path.moveTo(cx, cy);
+      for (let s = 0; s <= ARC_SEGMENTS; s++) {
+        const t = s / ARC_SEGMENTS;
+        const a = a0 + (a1 - a0) * t;
+        path.lineTo(cx + r * Math.cos(a), cy + r * Math.sin(a));
+      }
+      path.close();
+      out.push({
+        hour,
+        path,
+        color: theme.intensityRamp[intensity],
+      });
+    }
+    return out;
+  }, [buckets, cx, cy, maxValue, radius, theme.intensityRamp]);
+
+  const axisRadius = Math.max(0, radius - RIM_INSET);
+
+  const hasData = maxValue > 0;
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={accessibilityLabel}
+      style={{
+        width: '100%',
+        aspectRatio: 1,
+        maxHeight: size,
+      }}
+      onLayout={e => setMeasuredWidth(e.nativeEvent.layout.width)}>
+      {side > 0 ? (
+        <>
+          <Canvas style={{width: side, height: side, position: 'absolute'}}>
+            {axisRadius > 0 ? (
+              <Circle
+                cx={cx}
+                cy={cy}
+                r={axisRadius}
+                color={theme.gridLine}
+                // eslint-disable-next-line react/style-prop-object -- Skia uses string literal for `style`
+                style="stroke"
+                strokeWidth={1}
+              />
+            ) : null}
+            {wedges.map(w => (
+              <Path key={w.hour} path={w.path} color={w.color} />
+            ))}
+          </Canvas>
+          {/* Cardinal hour labels — 12 AM at top, 6 AM right, 12 PM bottom, 6 PM left. */}
+          {[0, 6, 12, 18].map(hour => {
+            const angle = -Math.PI / 2 + hour * WEDGE_RAD;
+            const labelR = radius + 4;
+            const lx = cx + labelR * Math.cos(angle);
+            const ly = cy + labelR * Math.sin(angle);
+            return (
+              <View
+                key={`label-${hour}`}
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: lx - 24,
+                  top: ly - 8,
+                  width: 48,
+                  alignItems: 'center',
+                }}>
+                <Text style={[styles.textMicroSupporting]}>
+                  {labelForHour(hour)}
+                </Text>
+              </View>
+            );
+          })}
+          {/* Invisible per-spoke tap + a11y targets. Bounding-box rectangles
+              around each wedge's outer arc — exact wedge shape isn't worth
+              the geometry for tap. */}
+          {Array.from({length: WEDGE_COUNT}, (_, hour) => {
+            const value = buckets.get(hour) ?? 0;
+            const angle = -Math.PI / 2 + hour * WEDGE_RAD;
+            // Anchor the touchable mid-radius so the thumb hits comfortably.
+            const anchorR = radius * 0.5;
+            const ax = cx + anchorR * Math.cos(angle);
+            const ay = cy + anchorR * Math.sin(angle);
+            const targetSize = Math.max(MIN_TAP_TARGET, radius / 4);
+            return (
+              <PressableWithoutFeedback
+                key={`spoke-${hour}`}
+                role="button"
+                accessibilityLabel={`${labelForHour(hour)}, ${Math.round(value * 10) / 10} units`}
+                onPress={() => onSpokePress?.(hour)}
+                style={{
+                  position: 'absolute',
+                  left: ax - targetSize / 2,
+                  top: ay - targetSize / 2,
+                  width: targetSize,
+                  height: targetSize,
+                }}
+              />
+            );
+          })}
+          {!hasData ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.alignItemsCenter,
+                styles.justifyContentCenter,
+                {
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  width: side,
+                  height: side,
+                },
+              ]}>
+              <Text style={[styles.textSupporting, styles.textAlignCenter]}>
+                No drinks recorded in this range.
+              </Text>
+            </View>
+          ) : null}
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+export default HourPolar;
+export type {HourPolarProps};

--- a/src/components/Charts/HourPolar/index.ts
+++ b/src/components/Charts/HourPolar/index.ts
@@ -1,0 +1,2 @@
+export {default as HourPolar} from './HourPolar';
+export type {HourPolarProps} from './HourPolar';

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -832,6 +832,26 @@ export default {
       calendarHeatmap: {
         title: 'Tento měsíc',
       },
+      hourOfDay: {
+        title: 'Hodina dne',
+        empty: 'V tomto období žádné pití.',
+      },
+      dowHour: {
+        title: 'Den v týdnu × hodina',
+        empty: 'V tomto období žádné pití.',
+      },
+      drinksPerSession: {
+        title: 'Nápojů na relaci',
+        empty: 'V tomto období žádné relace.',
+        p75Copy: ({value}: {value: number}) =>
+          `75 % tvých relací má ${value} nápojů nebo méně.`,
+      },
+      sessionDuration: {
+        title: 'Délka relace',
+        empty: 'V tomto období žádné relace.',
+        p75Copy: ({value}: {value: string}) =>
+          `75 % tvých relací je kratších než ${value}.`,
+      },
     },
     filters: {
       range: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -844,6 +844,26 @@ export default {
       calendarHeatmap: {
         title: 'This month',
       },
+      hourOfDay: {
+        title: 'Hour of day',
+        empty: 'No drinks recorded in this range.',
+      },
+      dowHour: {
+        title: 'Day of week × hour',
+        empty: 'No drinks recorded in this range.',
+      },
+      drinksPerSession: {
+        title: 'Drinks per session',
+        empty: 'No sessions in this range.',
+        p75Copy: ({value}: {value: number}) =>
+          `75% of your sessions are ${value} drinks or fewer.`,
+      },
+      sessionDuration: {
+        title: 'Session length',
+        empty: 'No sessions in this range.',
+        p75Copy: ({value}: {value: string}) =>
+          `75% of your sessions are ${value} or shorter.`,
+      },
     },
     filters: {
       range: {

--- a/src/libs/Statistics/bucketers.ts
+++ b/src/libs/Statistics/bucketers.ts
@@ -35,6 +35,8 @@ const byBlackout: Bucketer<boolean> = event => event.blackoutSession;
 
 const byUserId: Bucketer<UserID> = event => event.userId;
 
+const bySessionId: Bucketer<string> = event => event.sessionId;
+
 /**
  * Combine two bucketers into one whose key is the joined `${a}\x1f${b}`. The
  * literal spec sketch returns a tuple, but tuple identity defeats `Map`
@@ -58,6 +60,7 @@ export {
   byIsoWeek,
   byMonth,
   byQuarter,
+  bySessionId,
   byUserId,
   byYear,
   composeBuckets,

--- a/src/libs/Statistics/filters.ts
+++ b/src/libs/Statistics/filters.ts
@@ -27,7 +27,37 @@ function forUsers(ids: readonly UserID[] | ReadonlySet<UserID>): EventFilter {
   return event => set.has(event.userId);
 }
 
+/**
+ * AND together any number of filters. `undefined` entries are ignored so
+ * callers can pass conditional filters without a wrapping ternary
+ * (e.g. `composeFilters(dateRange(...), set.size ? drinkTypeSubset(set) : undefined)`).
+ * Returns `undefined` if no real filters remain — `aggregate`'s `filter?`
+ * param then short-circuits the per-event branch.
+ */
+function composeFilters(
+  ...filters: Array<EventFilter | undefined>
+): EventFilter | undefined {
+  const active = filters.filter(
+    (f): f is EventFilter => typeof f === 'function',
+  );
+  if (active.length === 0) {
+    return undefined;
+  }
+  if (active.length === 1) {
+    return active[0];
+  }
+  return event => {
+    for (const f of active) {
+      if (!f(event)) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+
 export {
+  composeFilters,
   dateRange,
   drinkTypeSubset,
   excludeBlackouts,

--- a/src/libs/Statistics/index.ts
+++ b/src/libs/Statistics/index.ts
@@ -9,6 +9,7 @@ export {
   byIsoWeek,
   byMonth,
   byQuarter,
+  bySessionId,
   byUserId,
   byYear,
   composeBuckets,
@@ -17,6 +18,7 @@ export {
 export {default as buildDrinkEvents} from './events';
 export type {DrinkDefaults} from './events';
 export {
+  composeFilters,
   dateRange,
   drinkTypeSubset,
   excludeBlackouts,
@@ -35,6 +37,8 @@ export {
   p25,
   p75,
   p90,
+  percentile,
+  sessionDurationMin,
   stddev,
   sumSdu,
   sumUnits,

--- a/src/libs/Statistics/reducers.ts
+++ b/src/libs/Statistics/reducers.ts
@@ -107,6 +107,15 @@ const stddev: Reducer<number> = events => {
   return Math.sqrt(sumSquares / events.length);
 };
 
+/**
+ * Session length in minutes. Every event in a session bucket shares the same
+ * `sessionDurationMin`, so reading the first event is sufficient. Returns
+ * `NaN` for buckets whose session has no resolvable duration (ongoing,
+ * unended); callers must filter NaN before binning.
+ */
+const sessionDurationMin: Reducer<number> = events =>
+  events[0]?.sessionDurationMin ?? Number.NaN;
+
 const firstEvent: Reducer<DrinkEvent | undefined> = events => {
   if (events.length === 0) {
     return undefined;
@@ -144,6 +153,8 @@ export {
   p25,
   p75,
   p90,
+  percentile,
+  sessionDurationMin,
   stddev,
   sumSdu,
   sumUnits,

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -1,8 +1,251 @@
-import React from 'react';
-import TabPlaceholder from './TabPlaceholder';
+import React, {useMemo} from 'react';
+import {StyleSheet, View} from 'react-native';
+import ScrollView from '@components/ScrollView';
+import {DowHourHeatmap} from '@components/Charts/DowHourHeatmap';
+import {Histogram} from '@components/Charts/Histogram';
+import type {HistogramBin} from '@components/Charts/Histogram';
+import {HourPolar} from '@components/Charts/HourPolar';
+import {ChartCard} from '@components/Charts/ChartCard';
+import Text from '@components/Text';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useLocalize from '@hooks/useLocalize';
+import useStatsContext from '@hooks/useStatsContext';
+import {useAggregate, useDrinkEvents} from '@hooks/useStatistics';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {
+  byHour,
+  bySessionId,
+  byDow,
+  composeBuckets,
+  composeFilters,
+  countEvents,
+  dateRange,
+  drinkTypeSubset,
+  percentile,
+  sessionDurationMin,
+  sumUnits,
+} from '@libs/Statistics';
+import type {WeekStart} from '@libs/Statistics';
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 32,
+    paddingHorizontal: 16,
+  },
+  histogramRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  histogramCell: {
+    flex: 1,
+  },
+});
+
+const WEEK_START_BY_LABEL: Record<string, WeekStart> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+const DEFAULT_WEEK_START: WeekStart = 1;
+
+function resolveWeekStart(label: string | undefined): WeekStart {
+  if (!label) {
+    return DEFAULT_WEEK_START;
+  }
+  return WEEK_START_BY_LABEL[label] ?? DEFAULT_WEEK_START;
+}
+
+const DRINK_BIN_LABELS = ['1', '2', '3', '4', '5+'] as const;
+
+function binDrinksPerSession(values: number[]): HistogramBin[] {
+  const counts = [0, 0, 0, 0, 0];
+  for (const v of values) {
+    if (v <= 0) {
+      continue;
+    }
+    if (v >= 5) {
+      counts[4] += 1;
+    } else {
+      counts[Math.floor(v) - 1] += 1;
+    }
+  }
+  return DRINK_BIN_LABELS.map((label, i) => ({label, count: counts[i]}));
+}
+
+const DURATION_BIN_LABELS = ['0–30m', '30–60m', '1–2h', '2–4h', '4h+'] as const;
+
+function binSessionDuration(minutes: number[]): HistogramBin[] {
+  const counts = [0, 0, 0, 0, 0];
+  for (const m of minutes) {
+    if (!Number.isFinite(m) || m < 0) {
+      continue;
+    }
+    if (m < 30) {
+      counts[0] += 1;
+    } else if (m < 60) {
+      counts[1] += 1;
+    } else if (m < 120) {
+      counts[2] += 1;
+    } else if (m < 240) {
+      counts[3] += 1;
+    } else {
+      counts[4] += 1;
+    }
+  }
+  return DURATION_BIN_LABELS.map((label, i) => ({label, count: counts[i]}));
+}
+
+function formatDurationMin(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return '0m';
+  }
+  if (minutes < 60) {
+    return `${Math.round(minutes)}m`;
+  }
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  return `${hours}h`;
+}
 
 function PatternsTab() {
-  return <TabPlaceholder copyKey="statistics.tabs.patterns.placeholder" />;
+  const {range, drinkTypeFilter, userIds} = useStatsContext();
+  const {preferences} = useDatabaseData();
+  const {events} = useDrinkEvents(
+    userIds.length > 0 ? [...userIds] : undefined,
+  );
+  const {translate} = useLocalize();
+  const themeStyles = useThemeStyles();
+
+  const weekStart = resolveWeekStart(preferences?.first_day_of_week);
+
+  const eventFilter = useMemo(
+    () =>
+      composeFilters(
+        dateRange(range.start.getTime(), range.end.getTime()),
+        drinkTypeFilter.size > 0 ? drinkTypeSubset(drinkTypeFilter) : undefined,
+      ),
+    [range, drinkTypeFilter],
+  );
+
+  const hourBuckets = useAggregate(events, byHour, sumUnits, eventFilter);
+  const dowHourBuckets = useAggregate(
+    events,
+    composeBuckets(byDow, byHour),
+    sumUnits,
+    eventFilter,
+  );
+  const perSessionCounts = useAggregate(
+    events,
+    bySessionId,
+    countEvents,
+    eventFilter,
+  );
+  const perSessionDuration = useAggregate(
+    events,
+    bySessionId,
+    sessionDurationMin,
+    eventFilter,
+  );
+
+  const drinkBins = useMemo(
+    () => binDrinksPerSession([...perSessionCounts.values()]),
+    [perSessionCounts],
+  );
+
+  const durationSeries = useMemo(
+    () => [...perSessionDuration.values()].filter(Number.isFinite),
+    [perSessionDuration],
+  );
+
+  const durationBins = useMemo(
+    () => binSessionDuration(durationSeries),
+    [durationSeries],
+  );
+
+  // Quantile copy only renders once there's a meaningful sample (>=4) — under
+  // that, a p75 is just the max and the copy reads as a tautology.
+  const drinkP75 =
+    perSessionCounts.size >= 4
+      ? percentile([...perSessionCounts.values()], 0.75)
+      : null;
+  const durationP75 =
+    durationSeries.length >= 4 ? percentile(durationSeries, 0.75) : null;
+
+  return (
+    <ScrollView
+      style={[styles.scroll, {backgroundColor: undefined}]}
+      contentContainerStyle={styles.scrollContent}>
+      <ChartCard title={translate('statistics.charts.hourOfDay.title')}>
+        <HourPolar
+          buckets={hourBuckets}
+          accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
+          onSpokePress={() => {
+            // Drill-down handler — v2-K wires this to StatsDrillDownSheet.
+          }}
+        />
+      </ChartCard>
+      <ChartCard title={translate('statistics.charts.dowHour.title')}>
+        <DowHourHeatmap
+          buckets={dowHourBuckets}
+          weekStart={weekStart}
+          accessibilityLabel={translate('statistics.charts.dowHour.title')}
+        />
+      </ChartCard>
+      <View style={styles.histogramRow}>
+        <View style={styles.histogramCell}>
+          <ChartCard
+            title={translate('statistics.charts.drinksPerSession.title')}
+            footer={
+              drinkP75 !== null ? (
+                <Text style={[themeStyles.textMicroSupporting]}>
+                  {translate('statistics.charts.drinksPerSession.p75Copy', {
+                    value: Math.round(drinkP75),
+                  })}
+                </Text>
+              ) : null
+            }>
+            <Histogram
+              bins={drinkBins}
+              accessibilityLabel={translate(
+                'statistics.charts.drinksPerSession.title',
+              )}
+              emptyLabel={translate('statistics.charts.drinksPerSession.empty')}
+              height={160}
+            />
+          </ChartCard>
+        </View>
+        <View style={styles.histogramCell}>
+          <ChartCard
+            title={translate('statistics.charts.sessionDuration.title')}
+            footer={
+              durationP75 !== null ? (
+                <Text style={[themeStyles.textMicroSupporting]}>
+                  {translate('statistics.charts.sessionDuration.p75Copy', {
+                    value: formatDurationMin(durationP75),
+                  })}
+                </Text>
+              ) : null
+            }>
+            <Histogram
+              bins={durationBins}
+              accessibilityLabel={translate(
+                'statistics.charts.sessionDuration.title',
+              )}
+              emptyLabel={translate('statistics.charts.sessionDuration.empty')}
+              height={160}
+            />
+          </ChartCard>
+        </View>
+      </View>
+    </ScrollView>
+  );
 }
 
 PatternsTab.displayName = 'PatternsTab';


### PR DESCRIPTION
## Summary

Replaces the Patterns placeholder with the four charts from STATISTICS_V2 §6.3:

- **HourPolar** — 24 filled wedges around a 360° dial (clockwise from midnight at top), outer radius and color both encoded from `sumUnits` per `localHour`. Direct Skia, modeled on `CalendarHeatmap`.
- **DowHourHeatmap** — 7×24 grid of `RoundedRect`s, rotated to the user's first-day-of-week preference, per-cell a11y overlays.
- **Histogram (drinks-per-session)** — fixed bins `1, 2, 3, 4, 5+`. p75 copy in the footer (≥4 sessions).
- **Histogram (session-duration)** — fixed bins `0–30m, 30–60m, 1–2h, 2–4h, 4h+`. p75 copy in the footer.

All four respect the active range + drink-type filter from `useStatsContext()`. Drill-down on the polar is a no-op stub until v2-K lands.

### Resolves §13.2 open question

Polar rendering is **direct Skia**, not Victory radial. Reasons:

- Victory's radial support is shallow and would require shimming.
- The 7×24 heatmap is naturally a Skia rect-grid — same component family as the polar.
- `Path` + 24 wedges + 168 rects is well within Skia's static-draw envelope; no animation needed.

### What's new in the data layer

- `bySessionId` bucketer (mechanically identical to `byUserId`).
- `sessionDurationMin` reducer — returns the first event's `sessionDurationMin` (every event in a session bucket shares it) or `NaN` for unended sessions; chart layer filters out NaN before binning.
- `composeFilters(...filters)` — ANDs filters, drops `undefined`, returns `undefined` if no real filters remain so `aggregate`'s `filter?` short-circuits.

### i18n

New keys under `statistics.charts.{hourOfDay,dowHour,drinksPerSession,sessionDuration}` in `en.ts` and `cs_cz.ts`. Wording is provisional — final tone audit is v2-M.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `npx eslint --fix` on all touched files clean
- [x] `npm run prettier` applied
- [x] `npx jest __tests__/unit/libs/Statistics/{bucketers,reducers,filters}.test.ts` — 51 tests pass, including new coverage for `bySessionId`, `sessionDurationMin`, `composeFilters`
- [ ] Manual QA on iOS — empty / sparse / dense data; dark theme; VoiceOver swipe across polar spokes and heatmap cells; polar spoke tap fires `onSpokePress` stub
- [ ] Manual QA on Android — same matrix
- [ ] Confirm cold-mount of the Patterns tab is <100ms on a mid-tier device (target from plan; profile if jank)

Manual QA is outstanding — the next person to pick this up should run it before merge.

## Dependencies

- ✅ v2-C (event stream + bucketers/reducers/filters)
- ✅ v2-D (`useDrinkEvents` / `useAggregate`)
- ✅ v2-E (`StatsContext` + filter toolbar)
- ✅ v2-F (four-tab navigator)
- ✅ v2-L (`percentile` helper)

Closes #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)