### PR TITLE
feat(stats): Breakdown tab — donut + multiples + concentration (v2-J)

### DIFF
--- a/__tests__/unit/libs/Statistics/herfindahl.test.ts
+++ b/__tests__/unit/libs/Statistics/herfindahl.test.ts
@@ -1,0 +1,90 @@
+import {compareConcentration, computeHhi} from '@libs/Statistics/herfindahl';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+function mapOf(entries: Array<[DrinkKey, number]>): Map<DrinkKey, number> {
+  return new Map(entries);
+}
+
+describe('computeHhi', () => {
+  it('returns NaN for empty input', () => {
+    expect(computeHhi(new Map())).toBeNaN();
+  });
+
+  it('returns NaN when every key holds zero units', () => {
+    expect(
+      computeHhi(
+        mapOf([
+          ['beer', 0],
+          ['wine', 0],
+        ]),
+      ),
+    ).toBeNaN();
+  });
+
+  it('returns 1 for a single-type window', () => {
+    expect(computeHhi(mapOf([['beer', 12]]))).toBe(1);
+  });
+
+  it('returns 1/n for an even split', () => {
+    const result = computeHhi(
+      mapOf([
+        ['beer', 4],
+        ['wine', 4],
+        ['cocktail', 4],
+        ['other', 4],
+      ]),
+    );
+    expect(result).toBeCloseTo(0.25, 10);
+  });
+
+  it('matches Σ(share²) for an uneven split', () => {
+    // 6/10, 3/10, 1/10 → 0.36 + 0.09 + 0.01 = 0.46
+    const result = computeHhi(
+      mapOf([
+        ['beer', 6],
+        ['wine', 3],
+        ['cocktail', 1],
+      ]),
+    );
+    expect(result).toBeCloseTo(0.46, 10);
+  });
+
+  it('ignores zero-unit keys without throwing', () => {
+    const result = computeHhi(
+      mapOf([
+        ['beer', 6],
+        ['wine', 0],
+        ['cocktail', 4],
+      ]),
+    );
+    // 6/10, 4/10 → 0.36 + 0.16 = 0.52
+    expect(result).toBeCloseTo(0.52, 10);
+  });
+});
+
+describe('compareConcentration', () => {
+  it('returns moreFocused when current rises above the dead-band', () => {
+    expect(compareConcentration(0.6, 0.5, 0.05)).toBe('moreFocused');
+  });
+
+  it('returns moreVaried when current drops below the dead-band', () => {
+    expect(compareConcentration(0.4, 0.5, 0.05)).toBe('moreVaried');
+  });
+
+  it('returns aboutTheSame inside the dead-band', () => {
+    expect(compareConcentration(0.54, 0.5, 0.05)).toBe('aboutTheSame');
+    expect(compareConcentration(0.5, 0.5, 0.05)).toBe('aboutTheSame');
+    expect(compareConcentration(0.46, 0.5, 0.05)).toBe('aboutTheSame');
+  });
+
+  it('collapses NaN inputs to aboutTheSame', () => {
+    expect(compareConcentration(Number.NaN, 0.5)).toBe('aboutTheSame');
+    expect(compareConcentration(0.5, Number.NaN)).toBe('aboutTheSame');
+    expect(compareConcentration(Number.NaN, Number.NaN)).toBe('aboutTheSame');
+  });
+
+  it('defaults the dead-band to 0.05', () => {
+    expect(compareConcentration(0.6, 0.5)).toBe('moreFocused');
+    expect(compareConcentration(0.54, 0.5)).toBe('aboutTheSame');
+  });
+});

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -6,6 +6,11 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BreakdownCenterUnitsParams,
+  BreakdownDrinkLabelParams,
+  BreakdownPeriodParams,
+  BreakdownSliceCaptionParams,
+  BreakdownTileSubtitleParams,
   CommonFriendsLabelParams,
   DiscardSessionParams,
   DrinkingSessionsParams,
@@ -821,8 +826,40 @@ export default {
       },
       breakdown: {
         label: 'Rozpis',
-        placeholder:
-          'Rozpis podle druhu pití a trendy podle typu přistanou tady.',
+        donut: {
+          title: 'Jednotky podle druhu pití',
+          subtitle: 'Složení za aktuální období.',
+          centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
+          centerCaption: 'jednotek',
+          empty: 'V tomto období žádné záznamy.',
+          sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
+            `${label}: ${units} jednotek (${share} %)`,
+          a11y: 'Koláč složení podle druhu pití',
+        },
+        multiples: {
+          title: 'Týdenní trend podle druhu',
+          subtitle: 'Malý graf pro každý druh s daty v tomto období.',
+          empty: 'Zatím žádné trendy podle druhu — zkus širší období.',
+          tileSubtitle: ({units}: BreakdownTileSubtitleParams) =>
+            `${units} jednotek za období`,
+          a11yTile: ({label}: BreakdownDrinkLabelParams) =>
+            `Týdenní trend pro ${label}`,
+        },
+        concentration: {
+          moreVaried: ({period}: BreakdownPeriodParams) =>
+            `Tento ${period} jsi pil/a pestřeji než minulý.`,
+          moreFocused: ({period}: BreakdownPeriodParams) =>
+            `Tento ${period} jsi se zaměřil/a víc než minulý.`,
+          aboutTheSame: ({period}: BreakdownPeriodParams) =>
+            `Skladba pití je zhruba stejná jako minulý ${period}.`,
+          period: {
+            week: 'týden',
+            month: 'měsíc',
+            sixMonths: '6 měsíců',
+            year: 'rok',
+            window: 'interval',
+          },
+        },
       },
     },
     charts: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6,6 +6,11 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BreakdownCenterUnitsParams,
+  BreakdownDrinkLabelParams,
+  BreakdownPeriodParams,
+  BreakdownSliceCaptionParams,
+  BreakdownTileSubtitleParams,
   CommonFriendsLabelParams,
   ConfirmWithProviderPromptParams,
   DiscardSessionParams,
@@ -833,8 +838,40 @@ export default {
       },
       breakdown: {
         label: 'Breakdown',
-        placeholder:
-          'Your drink-type breakdown and per-type trends will land here.',
+        donut: {
+          title: 'Units by drink type',
+          subtitle: 'Composition over the current range.',
+          centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
+          centerCaption: 'units',
+          empty: 'No drinks logged in this range.',
+          sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
+            `${label}: ${units} units (${share}%)`,
+          a11y: 'Drink-type composition donut',
+        },
+        multiples: {
+          title: 'Weekly trend by type',
+          subtitle: 'One mini chart per drink type with data in this range.',
+          empty: 'No per-type trends yet — try a wider range.',
+          tileSubtitle: ({units}: BreakdownTileSubtitleParams) =>
+            `${units} units this range`,
+          a11yTile: ({label}: BreakdownDrinkLabelParams) =>
+            `Weekly trend for ${label}`,
+        },
+        concentration: {
+          moreVaried: ({period}: BreakdownPeriodParams) =>
+            `You've been more varied this ${period} than last.`,
+          moreFocused: ({period}: BreakdownPeriodParams) =>
+            `You've been more focused this ${period} than last.`,
+          aboutTheSame: ({period}: BreakdownPeriodParams) =>
+            `Your mix of drinks is about the same as last ${period}.`,
+          period: {
+            week: 'week',
+            month: 'month',
+            sixMonths: '6 months',
+            year: 'year',
+            window: 'window',
+          },
+        },
       },
     },
     charts: {

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -50,6 +50,28 @@ type UnitCountParams = {
   unitCount: number;
 };
 
+type BreakdownCenterUnitsParams = {
+  count: number;
+};
+
+type BreakdownTileSubtitleParams = {
+  units: number;
+};
+
+type BreakdownSliceCaptionParams = {
+  label: string;
+  units: number;
+  share: number;
+};
+
+type BreakdownDrinkLabelParams = {
+  label: string;
+};
+
+type BreakdownPeriodParams = {
+  period: string;
+};
+
 type UpdateEmailSentEmailParams = {
   email: string;
 };
@@ -59,6 +81,11 @@ type VerifyEmailScreenEmailParmas = {
 };
 
 export type {
+  BreakdownCenterUnitsParams,
+  BreakdownDrinkLabelParams,
+  BreakdownPeriodParams,
+  BreakdownSliceCaptionParams,
+  BreakdownTileSubtitleParams,
   CommonFriendsLabelParams,
   ConfirmWithProviderPromptParams,
   DiscardSessionParams,

--- a/src/libs/Statistics/herfindahl.ts
+++ b/src/libs/Statistics/herfindahl.ts
@@ -1,0 +1,54 @@
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+/**
+ * Herfindahl–Hirschman Index over drink-type shares: `Σ(units_i / total)²`.
+ * 1/n for an even split across n keys; 1 when a single key holds everything.
+ * Returns `NaN` for an empty or all-zero input — callers decide what to render.
+ */
+function computeHhi(unitsByDrinkKey: ReadonlyMap<DrinkKey, number>): number {
+  let total = 0;
+  for (const units of unitsByDrinkKey.values()) {
+    if (units > 0) {
+      total += units;
+    }
+  }
+  if (total === 0) {
+    return Number.NaN;
+  }
+  let hhi = 0;
+  for (const units of unitsByDrinkKey.values()) {
+    if (units > 0) {
+      const share = units / total;
+      hhi += share * share;
+    }
+  }
+  return hhi;
+}
+
+type ConcentrationVerdict = 'moreVaried' | 'moreFocused' | 'aboutTheSame';
+
+/**
+ * Compare two HHI values within a dead-band. HHI ↑ = more focused (one type
+ * dominating); HHI ↓ = more varied. NaN inputs collapse to `aboutTheSame`
+ * so the rendered copy stays neutral when either window is empty.
+ */
+function compareConcentration(
+  current: number,
+  prior: number,
+  deadBand = 0.05,
+): ConcentrationVerdict {
+  if (!Number.isFinite(current) || !Number.isFinite(prior)) {
+    return 'aboutTheSame';
+  }
+  const delta = current - prior;
+  if (delta > deadBand) {
+    return 'moreFocused';
+  }
+  if (delta < -deadBand) {
+    return 'moreVaried';
+  }
+  return 'aboutTheSame';
+}
+
+export {computeHhi, compareConcentration};
+export type {ConcentrationVerdict};

--- a/src/libs/Statistics/index.ts
+++ b/src/libs/Statistics/index.ts
@@ -41,6 +41,8 @@ export {
 } from './reducers';
 export {default as buildSessionCountsByDay} from './sessionCounts';
 export {gramsOfAlcohol, sduFrom} from './sdu';
+export {compareConcentration, computeHhi} from './herfindahl';
+export type {ConcentrationVerdict} from './herfindahl';
 export type {
   ChartDatum,
   ChartRange,

--- a/src/screens/Statistics/tabs/BreakdownTab.tsx
+++ b/src/screens/Statistics/tabs/BreakdownTab.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
-import {ScrollView, View} from 'react-native';
+import {View} from 'react-native';
+import ScrollView from '@components/ScrollView';
 import ChartCard from '@components/Charts/ChartCard/ChartCard';
 import useLocalize from '@hooks/useLocalize';
 import useStatsContext from '@hooks/useStatsContext';

--- a/src/screens/Statistics/tabs/BreakdownTab.tsx
+++ b/src/screens/Statistics/tabs/BreakdownTab.tsx
@@ -1,8 +1,96 @@
-import React from 'react';
-import TabPlaceholder from './TabPlaceholder';
+import React, {useMemo} from 'react';
+import {ScrollView, View} from 'react-native';
+import ChartCard from '@components/Charts/ChartCard/ChartCard';
+import useLocalize from '@hooks/useLocalize';
+import useStatsContext from '@hooks/useStatsContext';
+import {useAggregate, useDrinkEvents} from '@hooks/useStatistics';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {
+  byDrinkKey,
+  byIsoWeek,
+  composeBuckets,
+  dateRange,
+  sumUnits,
+} from '@libs/Statistics';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import DrinkTypeDonut from './breakdown/DrinkTypeDonut';
+import PerTypeWeeklyMultiples from './breakdown/PerTypeWeeklyMultiples';
+import TypeConcentrationSentence from './breakdown/TypeConcentrationSentence';
+
+const drinkKeyByIsoWeek = composeBuckets(byDrinkKey, byIsoWeek);
 
 function BreakdownTab() {
-  return <TabPlaceholder copyKey="statistics.tabs.breakdown.placeholder" />;
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const {range, drinkTypeFilter, userIds} = useStatsContext();
+  const {events} = useDrinkEvents(
+    userIds.length > 0 ? [...userIds] : undefined,
+  );
+
+  const currentStartMs = range.start.getTime();
+  const currentEndMs = range.end.getTime();
+  const priorEndMs = currentStartMs - 1;
+  const priorStartMs = currentStartMs - (currentEndMs - currentStartMs) - 1;
+
+  const currentFilter = useMemo(
+    () => dateRange(currentStartMs, currentEndMs),
+    [currentStartMs, currentEndMs],
+  );
+  const priorFilter = useMemo(
+    () => dateRange(priorStartMs, priorEndMs),
+    [priorStartMs, priorEndMs],
+  );
+
+  const currentUnitsByDrinkKey = useAggregate<DrinkKey, number>(
+    events,
+    byDrinkKey,
+    sumUnits,
+    currentFilter,
+  );
+  const priorUnitsByDrinkKey = useAggregate<DrinkKey, number>(
+    events,
+    byDrinkKey,
+    sumUnits,
+    priorFilter,
+  );
+  const unitsByDrinkKeyAndWeek = useAggregate<string, number>(
+    events,
+    drinkKeyByIsoWeek,
+    sumUnits,
+    currentFilter,
+  );
+
+  return (
+    <ScrollView contentContainerStyle={[styles.p3, styles.pb5]}>
+      <ChartCard
+        title={translate('statistics.tabs.breakdown.donut.title')}
+        subtitle={translate('statistics.tabs.breakdown.donut.subtitle')}>
+        <View style={styles.alignItemsCenter}>
+          <DrinkTypeDonut
+            unitsByDrinkKey={currentUnitsByDrinkKey}
+            drinkTypeFilter={drinkTypeFilter}
+          />
+        </View>
+      </ChartCard>
+
+      <ChartCard
+        title={translate('statistics.tabs.breakdown.multiples.title')}
+        subtitle={translate('statistics.tabs.breakdown.multiples.subtitle')}>
+        <PerTypeWeeklyMultiples
+          unitsByDrinkKeyAndWeek={unitsByDrinkKeyAndWeek}
+          drinkTypeFilter={drinkTypeFilter}
+          rangeStart={range.start}
+          rangeEnd={range.end}
+        />
+      </ChartCard>
+
+      <TypeConcentrationSentence
+        currentUnitsByDrinkKey={currentUnitsByDrinkKey}
+        priorUnitsByDrinkKey={priorUnitsByDrinkKey}
+        preset={range.preset}
+      />
+    </ScrollView>
+  );
 }
 
 BreakdownTab.displayName = 'BreakdownTab';

--- a/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
+++ b/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
@@ -201,6 +201,7 @@ function DrinkTypeDonut({
                 Math.PI * 1.5,
               )}
               color={theme.borderLighter}
+              // eslint-disable-next-line react/style-prop-object -- Skia <Path> takes a string style discriminator ('fill' | 'stroke').
               style="fill"
             />
           ) : (
@@ -218,6 +219,7 @@ function DrinkTypeDonut({
                     slice.endAngle,
                   )}
                   color={DRINK_KEY_COLORS[slice.key]}
+                  // eslint-disable-next-line react/style-prop-object -- Skia <Path> takes a string style discriminator ('fill' | 'stroke').
                   style="fill"
                 />
               );

--- a/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
+++ b/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
@@ -1,0 +1,295 @@
+import {useMemo, useState} from 'react';
+import {View} from 'react-native';
+import type {GestureResponderEvent} from 'react-native';
+import {Canvas, Path, Skia} from '@shopify/react-native-skia';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import type {TranslationPaths} from '@src/languages/types';
+import {DRINK_KEY_COLORS, DRINK_KEY_ORDER} from './drinkKeyColors';
+
+const DEFAULT_SIZE = 220;
+const INNER_RADIUS_RATIO = 0.6;
+const SELECTED_LIFT_PX = 4;
+
+const DRINK_LABEL_KEY: Readonly<Record<DrinkKey, TranslationPaths>> = {
+  small_beer: 'drinks.smallBeer',
+  beer: 'drinks.beer',
+  wine: 'drinks.wine',
+  weak_shot: 'drinks.weakShot',
+  strong_shot: 'drinks.strongShot',
+  cocktail: 'drinks.cocktail',
+  other: 'drinks.other',
+};
+
+type Slice = {
+  key: DrinkKey;
+  units: number;
+  share: number;
+  startAngle: number;
+  endAngle: number;
+};
+
+type DrinkTypeDonutProps = {
+  unitsByDrinkKey: ReadonlyMap<DrinkKey, number>;
+  /** Set of keys the user has chip-filtered to. Empty Set = all keys. */
+  drinkTypeFilter: ReadonlySet<DrinkKey>;
+  size?: number;
+};
+
+function buildSlices(
+  unitsByDrinkKey: ReadonlyMap<DrinkKey, number>,
+  drinkTypeFilter: ReadonlySet<DrinkKey>,
+): {slices: Slice[]; total: number} {
+  const filter = drinkTypeFilter.size === 0 ? null : drinkTypeFilter;
+  let total = 0;
+  const filtered: Array<{key: DrinkKey; units: number}> = [];
+  for (const key of DRINK_KEY_ORDER) {
+    if (filter && !filter.has(key)) {
+      continue;
+    }
+    const units = unitsByDrinkKey.get(key) ?? 0;
+    if (units > 0) {
+      filtered.push({key, units});
+      total += units;
+    }
+  }
+  if (total === 0) {
+    return {slices: [], total: 0};
+  }
+  let cursor = -Math.PI / 2; // start at 12 o'clock
+  const slices = filtered.map(({key, units}) => {
+    const share = units / total;
+    const startAngle = cursor;
+    const endAngle = cursor + share * Math.PI * 2;
+    cursor = endAngle;
+    return {key, units, share, startAngle, endAngle};
+  });
+  return {slices, total};
+}
+
+function arcSectorPath(
+  cx: number,
+  cy: number,
+  outerR: number,
+  innerR: number,
+  startAngle: number,
+  endAngle: number,
+) {
+  const path = Skia.Path.Make();
+  const startDeg = (startAngle * 180) / Math.PI;
+  const sweepDeg = ((endAngle - startAngle) * 180) / Math.PI;
+
+  const outerRect = Skia.XYWHRect(
+    cx - outerR,
+    cy - outerR,
+    outerR * 2,
+    outerR * 2,
+  );
+  const innerRect = Skia.XYWHRect(
+    cx - innerR,
+    cy - innerR,
+    innerR * 2,
+    innerR * 2,
+  );
+
+  // Outer arc, start → end (clockwise).
+  path.addArc(outerRect, startDeg, sweepDeg);
+  // Line from outer-end to inner-end.
+  path.lineTo(
+    cx + innerR * Math.cos(endAngle),
+    cy + innerR * Math.sin(endAngle),
+  );
+  // Inner arc, end → start (anticlockwise).
+  path.addArc(innerRect, startDeg + sweepDeg, -sweepDeg);
+  path.close();
+  return path;
+}
+
+function hitTestSlice(
+  slices: Slice[],
+  cx: number,
+  cy: number,
+  innerR: number,
+  outerR: number,
+  x: number,
+  y: number,
+): number {
+  const dx = x - cx;
+  const dy = y - cy;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist < innerR || dist > outerR + SELECTED_LIFT_PX) {
+    return -1;
+  }
+  // Normalize angle to [-π/2, 3π/2) so it matches our slice start at 12 o'clock.
+  let angle = Math.atan2(dy, dx);
+  if (angle < -Math.PI / 2) {
+    angle += Math.PI * 2;
+  }
+  for (let i = 0; i < slices.length; i++) {
+    if (angle >= slices[i].startAngle && angle < slices[i].endAngle) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function DrinkTypeDonut({
+  unitsByDrinkKey,
+  drinkTypeFilter,
+  size = DEFAULT_SIZE,
+}: DrinkTypeDonutProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const [selectedIdx, setSelectedIdx] = useState<number>(-1);
+
+  const {slices, total} = useMemo(
+    () => buildSlices(unitsByDrinkKey, drinkTypeFilter),
+    [unitsByDrinkKey, drinkTypeFilter],
+  );
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const outerR = size / 2 - SELECTED_LIFT_PX;
+  const innerR = outerR * INNER_RADIUS_RATIO;
+
+  const isEmpty = slices.length === 0;
+  const selected = selectedIdx >= 0 ? slices[selectedIdx] : undefined;
+
+  const handlePress = (
+    event?: GestureResponderEvent | KeyboardEvent,
+  ): void => {
+    if (isEmpty || !event || !('nativeEvent' in event)) {
+      return;
+    }
+    const {locationX, locationY} = event.nativeEvent;
+    const idx = hitTestSlice(
+      slices,
+      cx,
+      cy,
+      innerR,
+      outerR,
+      locationX,
+      locationY,
+    );
+    setSelectedIdx(prev => (prev === idx ? -1 : idx));
+  };
+
+  const a11yLabel = translate('statistics.tabs.breakdown.donut.a11y');
+
+  return (
+    <View style={styles.alignItemsCenter}>
+      <PressableWithoutFeedback
+        accessible
+        accessibilityLabel={a11yLabel}
+        accessibilityRole="image"
+        onPress={handlePress}
+        style={{width: size, height: size}}>
+        <Canvas style={{width: size, height: size}}>
+          {isEmpty ? (
+            <Path
+              path={arcSectorPath(
+                cx,
+                cy,
+                outerR,
+                innerR,
+                -Math.PI / 2,
+                Math.PI * 1.5,
+              )}
+              color={theme.borderLighter}
+              style="fill"
+            />
+          ) : (
+            slices.map((slice, i) => {
+              const lift = i === selectedIdx ? SELECTED_LIFT_PX : 0;
+              return (
+                <Path
+                  key={slice.key}
+                  path={arcSectorPath(
+                    cx,
+                    cy,
+                    outerR + lift,
+                    innerR,
+                    slice.startAngle,
+                    slice.endAngle,
+                  )}
+                  color={DRINK_KEY_COLORS[slice.key]}
+                  style="fill"
+                />
+              );
+            })
+          )}
+        </Canvas>
+        <View
+          pointerEvents="none"
+          style={[
+            styles.alignItemsCenter,
+            styles.justifyContentCenter,
+            {
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: size,
+              height: size,
+            },
+          ]}>
+          {isEmpty ? (
+            <Text
+              style={[
+                styles.textSupporting,
+                styles.textAlignCenter,
+                {paddingHorizontal: 16},
+              ]}>
+              {translate('statistics.tabs.breakdown.donut.empty')}
+            </Text>
+          ) : (
+            <>
+              <Text style={[styles.textHeadline]}>
+                {translate('statistics.tabs.breakdown.donut.centerUnits', {
+                  count: Math.round(total * 10) / 10,
+                })}
+              </Text>
+              <Text style={[styles.textMicroSupporting]}>
+                {translate('statistics.tabs.breakdown.donut.centerCaption')}
+              </Text>
+            </>
+          )}
+        </View>
+      </PressableWithoutFeedback>
+      {selected ? (
+        <View
+          style={[
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.mt2,
+            {columnGap: 8},
+          ]}>
+          <View
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 5,
+              backgroundColor: DRINK_KEY_COLORS[selected.key],
+            }}
+          />
+          <Text style={[styles.textLabelSupporting]}>
+            {translate('statistics.tabs.breakdown.donut.sliceCaption', {
+              label: translate(DRINK_LABEL_KEY[selected.key]),
+              units: Math.round(selected.units * 10) / 10,
+              share: Math.round(selected.share * 100),
+            })}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+DrinkTypeDonut.displayName = 'DrinkTypeDonut';
+
+export default DrinkTypeDonut;
+export type {DrinkTypeDonutProps};

--- a/src/screens/Statistics/tabs/breakdown/MiniLineChart.tsx
+++ b/src/screens/Statistics/tabs/breakdown/MiniLineChart.tsx
@@ -1,0 +1,63 @@
+import {View} from 'react-native';
+import {BaseChart, Line} from '@components/Charts/BaseChart';
+import Text from '@components/Text';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import type {ChartDatum} from '@libs/Statistics';
+
+type MiniLineChartProps = {
+  title: string;
+  caption: string;
+  data: ChartDatum[];
+  accessibilityLabel: string;
+  strokeColor: string;
+};
+
+/**
+ * Small-multiple tile: header (drink-type label + period total) over a
+ * compact axis-less line chart in the drink-type's brand color. Each tile
+ * is independently y-scaled — the spec calls for shared y "only when
+ * meaningful," and per-tile scaling reads better when one type dominates
+ * the window.
+ */
+function MiniLineChart({
+  title,
+  caption,
+  data,
+  accessibilityLabel,
+  strokeColor,
+}: MiniLineChartProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.p3,
+        {
+          backgroundColor: theme.highlightBG,
+          borderRadius: 10,
+        },
+      ]}>
+      <Text style={[styles.textLabelSupporting, styles.textStrong]}>
+        {title}
+      </Text>
+      <Text style={[styles.textMicroSupporting, styles.mb1]}>{caption}</Text>
+      <BaseChart
+        data={data}
+        range="rolling8w"
+        accessibilityLabel={accessibilityLabel}
+        height={48}
+        hideAxes>
+        {({points}) => (
+          <Line points={points.y} color={strokeColor} strokeWidth={1.5} />
+        )}
+      </BaseChart>
+    </View>
+  );
+}
+
+MiniLineChart.displayName = 'MiniLineChart';
+
+export default MiniLineChart;
+export type {MiniLineChartProps};

--- a/src/screens/Statistics/tabs/breakdown/PerTypeWeeklyMultiples.tsx
+++ b/src/screens/Statistics/tabs/breakdown/PerTypeWeeklyMultiples.tsx
@@ -1,0 +1,152 @@
+import {useMemo} from 'react';
+import {View} from 'react-native';
+import {addWeeks, format, startOfISOWeek} from 'date-fns';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {COMPOSITE_KEY_SEP} from '@libs/Statistics';
+import type {ChartDatum} from '@libs/Statistics';
+import type {TranslationPaths} from '@src/languages/types';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import {DRINK_KEY_COLORS, DRINK_KEY_ORDER} from './drinkKeyColors';
+import MiniLineChart from './MiniLineChart';
+
+const DRINK_LABEL_KEY: Readonly<Record<DrinkKey, TranslationPaths>> = {
+  small_beer: 'drinks.smallBeer',
+  beer: 'drinks.beer',
+  wine: 'drinks.wine',
+  weak_shot: 'drinks.weakShot',
+  strong_shot: 'drinks.strongShot',
+  cocktail: 'drinks.cocktail',
+  other: 'drinks.other',
+};
+
+type PerTypeWeeklyMultiplesProps = {
+  unitsByDrinkKeyAndWeek: ReadonlyMap<string, number>;
+  drinkTypeFilter: ReadonlySet<DrinkKey>;
+  rangeStart: Date;
+  rangeEnd: Date;
+};
+
+function isoWeekKey(d: Date): string {
+  // Matches the `localIsoWeek` format produced by buildDrinkEvents (`yyyy-Www`).
+  return format(d, "RRRR-'W'II");
+}
+
+function listWeekKeys(start: Date, end: Date): string[] {
+  if (end < start) {
+    return [];
+  }
+  const keys: string[] = [];
+  let cursor = startOfISOWeek(start);
+  while (cursor <= end) {
+    keys.push(isoWeekKey(cursor));
+    cursor = addWeeks(cursor, 1);
+  }
+  return keys;
+}
+
+function buildSeriesByDrinkKey(
+  composite: ReadonlyMap<string, number>,
+  weekKeys: string[],
+): Map<DrinkKey, ChartDatum[]> {
+  const series = new Map<DrinkKey, ChartDatum[]>();
+  for (const key of DRINK_KEY_ORDER) {
+    series.set(
+      key,
+      weekKeys.map(w => ({x: w, y: 0})),
+    );
+  }
+  const weekIdx = new Map(weekKeys.map((k, i) => [k, i]));
+  for (const [compositeKey, units] of composite.entries()) {
+    const [drinkPart, weekPart] = compositeKey.split(COMPOSITE_KEY_SEP);
+    const dk = drinkPart as DrinkKey;
+    const idx = weekIdx.get(weekPart);
+    const data = series.get(dk);
+    if (idx === undefined || !data) {
+      continue;
+    }
+    data[idx] = {x: weekPart, y: units};
+  }
+  return series;
+}
+
+function PerTypeWeeklyMultiples({
+  unitsByDrinkKeyAndWeek,
+  drinkTypeFilter,
+  rangeStart,
+  rangeEnd,
+}: PerTypeWeeklyMultiplesProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const {shouldUseNarrowLayout} = useResponsiveLayout();
+  const columns = shouldUseNarrowLayout ? 2 : 3;
+  const widthPercent = `${100 / columns}%` as const;
+
+  const weekKeys = useMemo(
+    () => listWeekKeys(rangeStart, rangeEnd),
+    [rangeStart, rangeEnd],
+  );
+
+  const seriesByKey = useMemo(
+    () => buildSeriesByDrinkKey(unitsByDrinkKeyAndWeek, weekKeys),
+    [unitsByDrinkKeyAndWeek, weekKeys],
+  );
+
+  const filter = drinkTypeFilter.size === 0 ? null : drinkTypeFilter;
+  const tiles = DRINK_KEY_ORDER.flatMap(key => {
+    if (filter && !filter.has(key)) {
+      return [];
+    }
+    const data = seriesByKey.get(key) ?? [];
+    const total = data.reduce((sum, d) => sum + d.y, 0);
+    if (total === 0) {
+      return [];
+    }
+    return [{key, data, total}];
+  });
+
+  if (tiles.length === 0) {
+    return (
+      <View style={[styles.alignItemsCenter, styles.p3]}>
+        <Text style={[styles.textSupporting, styles.textAlignCenter]}>
+          {translate('statistics.tabs.breakdown.multiples.empty')}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.flexRow, styles.flexWrap, {marginHorizontal: -4}]}>
+      {tiles.map(({key, data, total}) => (
+        <View
+          key={key}
+          style={{
+            width: widthPercent,
+            paddingHorizontal: 4,
+            paddingVertical: 4,
+          }}>
+          <MiniLineChart
+            title={translate(DRINK_LABEL_KEY[key])}
+            caption={translate(
+              'statistics.tabs.breakdown.multiples.tileSubtitle',
+              {units: Math.round(total * 10) / 10},
+            )}
+            data={data}
+            accessibilityLabel={translate(
+              'statistics.tabs.breakdown.multiples.a11yTile',
+              {label: translate(DRINK_LABEL_KEY[key])},
+            )}
+            strokeColor={DRINK_KEY_COLORS[key]}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+PerTypeWeeklyMultiples.displayName = 'PerTypeWeeklyMultiples';
+
+export default PerTypeWeeklyMultiples;
+export type {PerTypeWeeklyMultiplesProps};

--- a/src/screens/Statistics/tabs/breakdown/TypeConcentrationSentence.tsx
+++ b/src/screens/Statistics/tabs/breakdown/TypeConcentrationSentence.tsx
@@ -1,0 +1,108 @@
+import {useMemo} from 'react';
+import {View} from 'react-native';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {compareConcentration, computeHhi} from '@libs/Statistics/herfindahl';
+import type {ConcentrationVerdict} from '@libs/Statistics/herfindahl';
+import type {RangePreset} from '@src/types/onyx/StatisticsFilters';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+function renderVerdict(
+  translate: ReturnType<typeof useLocalize>['translate'],
+  verdict: ConcentrationVerdict,
+  period: string,
+): string {
+  switch (verdict) {
+    case 'moreVaried':
+      return translate('statistics.tabs.breakdown.concentration.moreVaried', {
+        period,
+      });
+    case 'moreFocused':
+      return translate('statistics.tabs.breakdown.concentration.moreFocused', {
+        period,
+      });
+    case 'aboutTheSame':
+    default:
+      return translate('statistics.tabs.breakdown.concentration.aboutTheSame', {
+        period,
+      });
+  }
+}
+
+function renderPeriod(
+  translate: ReturnType<typeof useLocalize>['translate'],
+  preset: RangePreset,
+): string {
+  switch (preset) {
+    case 'W':
+      return translate('statistics.tabs.breakdown.concentration.period.week');
+    case 'M':
+      return translate('statistics.tabs.breakdown.concentration.period.month');
+    case '6M':
+      return translate(
+        'statistics.tabs.breakdown.concentration.period.sixMonths',
+      );
+    case 'Y':
+      return translate('statistics.tabs.breakdown.concentration.period.year');
+    case 'All':
+    case 'Custom':
+    default:
+      return translate('statistics.tabs.breakdown.concentration.period.window');
+  }
+}
+
+type TypeConcentrationSentenceProps = {
+  /** All-key units in the current window (filter-independent). */
+  currentUnitsByDrinkKey: ReadonlyMap<DrinkKey, number>;
+  /** All-key units in the equal-duration window immediately before. */
+  priorUnitsByDrinkKey: ReadonlyMap<DrinkKey, number>;
+  preset: RangePreset;
+};
+
+function sumValues(map: ReadonlyMap<DrinkKey, number>): number {
+  let total = 0;
+  for (const v of map.values()) {
+    if (v > 0) {
+      total += v;
+    }
+  }
+  return total;
+}
+
+function TypeConcentrationSentence({
+  currentUnitsByDrinkKey,
+  priorUnitsByDrinkKey,
+  preset,
+}: TypeConcentrationSentenceProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  const verdict = useMemo<ConcentrationVerdict | null>(() => {
+    if (sumValues(currentUnitsByDrinkKey) === 0) {
+      // No honest claim possible when the current window is empty.
+      return null;
+    }
+    const currentHhi = computeHhi(currentUnitsByDrinkKey);
+    const priorHhi = computeHhi(priorUnitsByDrinkKey);
+    return compareConcentration(currentHhi, priorHhi);
+  }, [currentUnitsByDrinkKey, priorUnitsByDrinkKey]);
+
+  if (verdict === null) {
+    return null;
+  }
+
+  const period = renderPeriod(translate, preset);
+  return (
+    <View style={[styles.p3]}>
+      <Text style={[styles.textSupporting]}>
+        {renderVerdict(translate, verdict, period)}
+      </Text>
+    </View>
+  );
+}
+
+TypeConcentrationSentence.displayName = 'TypeConcentrationSentence';
+
+export default TypeConcentrationSentence;
+export type {TypeConcentrationSentenceProps};

--- a/src/screens/Statistics/tabs/breakdown/drinkKeyColors.ts
+++ b/src/screens/Statistics/tabs/breakdown/drinkKeyColors.ts
@@ -20,7 +20,7 @@ const DRINK_KEY_COLORS: Readonly<Record<DrinkKey, string>> = {
   [CONST.DRINKS.KEYS.OTHER]: colors.orange900,
 };
 
-const DRINK_KEY_ORDER: ReadonlyArray<DrinkKey> = [
+const DRINK_KEY_ORDER: readonly DrinkKey[] = [
   CONST.DRINKS.KEYS.SMALL_BEER,
   CONST.DRINKS.KEYS.BEER,
   CONST.DRINKS.KEYS.WINE,

--- a/src/screens/Statistics/tabs/breakdown/drinkKeyColors.ts
+++ b/src/screens/Statistics/tabs/breakdown/drinkKeyColors.ts
@@ -1,0 +1,37 @@
+import colors from '@styles/theme/colors';
+import CONST from '@src/CONST';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+/**
+ * Seven shades from the yellow→orange family — one per `DrinkKey`. Order
+ * matches the chip-row order in `DrinkTypeChipRow` so the donut legend and
+ * the toolbar chips read top-to-bottom the same way. Theme-independent on
+ * purpose: the yellow→orange palette is the brand's stats palette, and
+ * stays identical across light and dark themes (text and frame contrast
+ * adapts around it).
+ */
+const DRINK_KEY_COLORS: Readonly<Record<DrinkKey, string>> = {
+  [CONST.DRINKS.KEYS.SMALL_BEER]: colors.yellow300,
+  [CONST.DRINKS.KEYS.BEER]: colors.yellow500,
+  [CONST.DRINKS.KEYS.WINE]: colors.yellow600,
+  [CONST.DRINKS.KEYS.WEAK_SHOT]: colors.orange300,
+  [CONST.DRINKS.KEYS.STRONG_SHOT]: colors.orange500,
+  [CONST.DRINKS.KEYS.COCKTAIL]: colors.orange700,
+  [CONST.DRINKS.KEYS.OTHER]: colors.orange900,
+};
+
+const DRINK_KEY_ORDER: ReadonlyArray<DrinkKey> = [
+  CONST.DRINKS.KEYS.SMALL_BEER,
+  CONST.DRINKS.KEYS.BEER,
+  CONST.DRINKS.KEYS.WINE,
+  CONST.DRINKS.KEYS.WEAK_SHOT,
+  CONST.DRINKS.KEYS.STRONG_SHOT,
+  CONST.DRINKS.KEYS.COCKTAIL,
+  CONST.DRINKS.KEYS.OTHER,
+];
+
+function getDrinkKeyColor(key: DrinkKey): string {
+  return DRINK_KEY_COLORS[key];
+}
+
+export {DRINK_KEY_COLORS, DRINK_KEY_ORDER, getDrinkKeyColor};


### PR DESCRIPTION
## Summary

Fills the **Breakdown** tab (v2-J / #586) per `mockups/STATISTICS_V2.md` §6.4 over the existing event-stream layer:

- **Hero donut** — Skia `<Path>` arcs, one slice per `DrinkKey` in the active range. Tap to highlight + show `{label}: {units} ({share}%)` caption. Center total = sum of **visible** (chip-filtered) slices.
- **Per-type weekly small-multiples** — 2-col on phone / 3-col on tablet grid of mini line charts, one per active `DrinkKey`. Composed bucketer (`byDrinkKey × byIsoWeek`); tiles with zero units in window are hidden.
- **Type-concentration sentence** — HHI computed over **all** drink keys (chip-filter ignored — concentration semantics are about the full mix). Compared to an equal-duration prior window; ±0.05 dead-band gates "about the same".

Sankey-lite (open question §13.5) is **deferred to v1.x** as the issue allows. Drill-down (v2-K) is a no-op: slice tap shows a caption, no navigation.

## Out of scope (deferred)

- Sankey-lite drink-type transitions — v1.x
- Drill-down sheet — v2-K
- Final tone audit — v2-M

## Changes

- `src/libs/Statistics/herfindahl.ts` — pure HHI math + verdict comparator (NaN-safe).
- `src/screens/Statistics/tabs/breakdown/` — `DrinkTypeDonut`, `PerTypeWeeklyMultiples`, `MiniLineChart`, `TypeConcentrationSentence`, `drinkKeyColors`.
- `src/screens/Statistics/tabs/BreakdownTab.tsx` — placeholder → three composed sections.
- `src/languages/{en,cs_cz,params}.ts` — namespace extended; placeholder key removed.
- `__tests__/unit/libs/Statistics/herfindahl.test.ts` — 11 tests covering even split, single-type, empty, dead-band, NaN handling.

## Static gates

- [x] `npx prettier --write` (all touched files)
- [x] `npm run lint-changed`
- [x] `npm run typecheck-tsgo`
- [x] ESLint `react-compiler/react-compiler` (enforced via `eslint.config.mjs`)
- [x] `npm test -- libs/Statistics` (8 suites, 99 tests)

## Test plan

- [ ] **Golden path** — 30-day range, mixed sessions across all 7 types. Donut renders 7 slices in chip-row order; slice colors are from the yellow→orange family; center label = total units. Each type has a small-multiples tile.
- [ ] **Single-type** — window with only `beer`. Donut collapses to a full ring; one multiples tile.
- [ ] **Empty window** — fresh account on W preset. Donut shows empty-state copy; multiples render the empty-state line; concentration sentence is hidden.
- [ ] **Dark theme** — yellow→orange ramp stays readable, no red bleeds in.
- [ ] **Chip filter responds (donut + multiples)** — select beer + wine only → donut shows 2 slices, center total = sum of visible, multiples grid shows 2 tiles. Concentration sentence does **not** change.
- [ ] **Chip filter cleared** — Set size 0 → donut + multiples return to all-types view.
- [ ] **Concentration copy flips** — switch range from M to W over a dataset where last week was beer-heavy and this week is mixed; sentence flips between "more varied" / "more focused".
- [ ] **Slice tap** — caption updates; tapping the same slice again clears.
- [ ] **iPad / tablet** — multiples grid switches to 3-col.
- [ ] **iOS + Android** — both platforms verified manually.

Closes #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)