### PR TITLE
feat(stats): Overview tab content (v2-G)

### DIFF
--- a/__tests__/unit/components/Charts/CalendarHeatmap.test.tsx
+++ b/__tests__/unit/components/Charts/CalendarHeatmap.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
-import {render} from '@testing-library/react-native';
+import {fireEvent, render} from '@testing-library/react-native';
 import CalendarHeatmap from '@components/Charts/CalendarHeatmap/CalendarHeatmap';
 import type {HeatmapCell} from '@libs/Statistics';
 
@@ -55,5 +55,21 @@ describe('CalendarHeatmap', () => {
     const root = tree.toJSON();
     expect(root).not.toBeNull();
     expect(JSON.stringify(root)).toContain('This month');
+  });
+
+  it('marks future cells as "upcoming" in the a11y label', () => {
+    const cells: HeatmapCell[] = [
+      cell('2026-05-01', 0, 0),
+      {dateKey: '2026-05-31', totalSdu: 0, intensity: 0, isFuture: true},
+    ];
+    const tree = render(
+      <CalendarHeatmap cells={cells} accessibilityLabel="This month" />,
+    );
+    // RNTL doesn't fire onLayout automatically; supply a width so the inner
+    // per-cell views (which carry the a11y labels) render.
+    fireEvent(tree.root, 'layout', {nativeEvent: {layout: {width: 280}}});
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('2026-05-31, upcoming');
+    expect(json).toContain('2026-05-01, 0 units');
   });
 });

--- a/__tests__/unit/components/Charts/MiniTrendLine.test.tsx
+++ b/__tests__/unit/components/Charts/MiniTrendLine.test.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+import {render} from '@testing-library/react-native';
+import {MiniTrendLine} from '@components/Charts/MiniTrendLine';
+
+jest.mock('@components/Charts/BaseChart', () => ({
+  __esModule: true,
+  BaseChart: ({
+    data,
+    emptyLabel,
+    children,
+  }: {
+    data: unknown[];
+    emptyLabel?: string;
+    children?: (ctx: unknown) => unknown;
+  }) => {
+    if (data.length === 0 && emptyLabel) {
+      const ReactInner =
+        // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+        require('react') as typeof import('react');
+      const RNm =
+        // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+        require('react-native') as typeof import('react-native');
+      return ReactInner.createElement(RNm.Text, null, emptyLabel);
+    }
+    children?.({
+      points: {y: []},
+      chartBounds: {left: 0, top: 0, right: 100, bottom: 100},
+      theme: {
+        bandFill: '#000',
+        primaryFill: '#fff',
+        primaryStroke: '#fff',
+        intensityRamp: ['', '', '', '', ''],
+      },
+    });
+    return null;
+  },
+  Line: () => null,
+  Area: () => null,
+}));
+
+jest.mock('@shopify/react-native-skia', () => ({
+  __esModule: true,
+  Rect: () => null,
+}));
+
+describe('MiniTrendLine', () => {
+  it('renders the emptyLabel when points are empty', () => {
+    const tree = render(
+      <MiniTrendLine
+        points={[]}
+        band={{p25: 0, p75: 0}}
+        accessibilityLabel="trend"
+        emptyLabel="Nothing logged yet"
+      />,
+    ).toJSON();
+    expect(JSON.stringify(tree)).toContain('Nothing logged yet');
+  });
+
+  it('renders without throwing when points and band are present', () => {
+    const points = [
+      {x: '2026-W19', y: 1},
+      {x: '2026-W20', y: 2},
+      {x: '2026-W21', y: 3},
+    ];
+    expect(() =>
+      render(
+        <MiniTrendLine
+          points={points}
+          band={{p25: 1, p75: 2.5}}
+          ewma={[1, 1.5, 2.0]}
+          accessibilityLabel="trend"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('falls back to raw points when ewma length mismatches', () => {
+    const points = [
+      {x: 'a', y: 1},
+      {x: 'b', y: 2},
+    ];
+    expect(() =>
+      render(
+        <MiniTrendLine
+          points={points}
+          band={{p25: 0, p75: 0}}
+          ewma={[5]}
+          accessibilityLabel="trend"
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/__tests__/unit/libs/Statistics/overviewSelectors.test.ts
+++ b/__tests__/unit/libs/Statistics/overviewSelectors.test.ts
@@ -1,0 +1,169 @@
+import {
+  selectAfDaysThisMonth,
+  selectHasEverLogged,
+  selectIsSparse,
+  selectThisMonthHeatmapCells,
+  selectTrendSeries,
+  selectWeeklyKpis,
+} from '@libs/Statistics/overviewSelectors';
+import type {DrinkEvent} from '@libs/Statistics/types';
+
+function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's-default',
+    ts: new Date('2026-05-25T12:00:00Z').getTime(),
+    localDay: '2026-05-25',
+    localIsoWeek: '2026-W22',
+    localMonth: '2026-05',
+    localHour: 12,
+    localDow: 0,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    blackoutSession: false,
+    ...overrides,
+  };
+}
+
+describe('selectAfDaysThisMonth', () => {
+  it('clamps the denominator to elapsed days on day 1 of a month', () => {
+    // 2026-05-01 with zero events: 1/1, never 1/31.
+    const now = new Date(2026, 4, 1, 9, 0, 0);
+    expect(selectAfDaysThisMonth([], now)).toEqual({value: 1, total: 1});
+  });
+
+  it('counts elapsed-only when there is no data mid-month', () => {
+    const now = new Date(2026, 4, 25, 23, 30, 0);
+    expect(selectAfDaysThisMonth([], now)).toEqual({value: 25, total: 25});
+  });
+
+  it('subtracts distinct drink-days, not raw events', () => {
+    const now = new Date(2026, 4, 25, 23, 30, 0);
+    const events = [
+      event({localDay: '2026-05-03', sessionId: 's1'}),
+      event({localDay: '2026-05-03', sessionId: 's1'}),
+      event({localDay: '2026-05-10', sessionId: 's2'}),
+    ];
+    expect(selectAfDaysThisMonth(events, now)).toEqual({value: 23, total: 25});
+  });
+});
+
+describe('selectThisMonthHeatmapCells', () => {
+  it('marks cells past today as isFuture and renders them with intensity 0', () => {
+    const now = new Date(2026, 4, 5, 12, 0, 0); // 2026-05-05
+    const cells = selectThisMonthHeatmapCells([], now);
+    expect(cells).toHaveLength(31);
+    const may1 = cells.find(c => c.dateKey === '2026-05-01');
+    const may10 = cells.find(c => c.dateKey === '2026-05-10');
+    expect(may1?.isFuture).toBe(false);
+    expect(may1?.intensity).toBe(0);
+    expect(may10?.isFuture).toBe(true);
+    expect(may10?.intensity).toBe(0);
+  });
+
+  it('only ramps intensity against this-month days, not historical ones', () => {
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    const events = [
+      event({
+        localDay: '2026-05-10',
+        localMonth: '2026-05',
+        sdu: 4,
+        units: 4,
+      }),
+      // Way-higher SDU from an earlier month must not depress this-month
+      // intensity below the top of the ramp.
+      event({
+        localDay: '2026-03-10',
+        localMonth: '2026-03',
+        sdu: 200,
+        units: 200,
+      }),
+    ];
+    const cells = selectThisMonthHeatmapCells(events, now);
+    const may10 = cells.find(c => c.dateKey === '2026-05-10');
+    expect(may10?.totalSdu).toBe(4);
+    expect(may10?.intensity).toBeGreaterThan(0);
+  });
+});
+
+describe('selectWeeklyKpis', () => {
+  it('clamps this-week quiet days to elapsed days', () => {
+    // 2026-05-25 is a Monday. Only 1 elapsed day in the current ISO week.
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    const kpis = selectWeeklyKpis([], now);
+    expect(kpis.quietDaysThisWeek).toBe(1);
+    // Last week (May 18-24) has full 7 elapsed.
+    expect(kpis.quietDaysLastWeek).toBe(7);
+  });
+
+  it('counts sessions and units per ISO week label', () => {
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    const events = [
+      event({
+        localIsoWeek: '2026-W22',
+        sessionId: 's-a',
+        units: 2,
+      }),
+      event({
+        localIsoWeek: '2026-W22',
+        sessionId: 's-b',
+        units: 3,
+      }),
+      event({
+        localIsoWeek: '2026-W21',
+        sessionId: 's-c',
+        units: 1,
+      }),
+    ];
+    const kpis = selectWeeklyKpis(events, now);
+    expect(kpis.sessionsThisWeek).toBe(2);
+    expect(kpis.unitsThisWeek).toBe(5);
+    expect(kpis.sessionsLastWeek).toBe(1);
+    expect(kpis.unitsLastWeek).toBe(1);
+  });
+});
+
+describe('selectTrendSeries', () => {
+  it('returns 8 contiguous points oldest → newest with zero-fill', () => {
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    const series = selectTrendSeries([], now);
+    expect(series.points).toHaveLength(8);
+    expect(series.weeksWithData).toBe(0);
+    // No events ⇒ Mann–Kendall returns 'none' regardless of n.
+    expect(series.mannKendall.trend).toBe('none');
+  });
+
+  it('counts weeks with data and produces a band', () => {
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    const events = [
+      event({localIsoWeek: '2026-W22', units: 5}),
+      event({localIsoWeek: '2026-W21', units: 4}),
+      event({localIsoWeek: '2026-W20', units: 3}),
+      event({localIsoWeek: '2026-W19', units: 2}),
+      event({localIsoWeek: '2026-W18', units: 1}),
+    ];
+    const series = selectTrendSeries(events, now);
+    expect(series.weeksWithData).toBe(5);
+    expect(series.band.p25).toBeGreaterThanOrEqual(0);
+    expect(series.band.p75).toBeGreaterThanOrEqual(series.band.p25);
+    expect(series.ewma).toHaveLength(8);
+  });
+});
+
+describe('selectIsSparse / selectHasEverLogged', () => {
+  it('treats <4 weeks of data as sparse', () => {
+    expect(selectIsSparse([event({})], 3)).toBe(true);
+    expect(selectIsSparse([event({})], 4)).toBe(false);
+  });
+
+  it('treats zero events as sparse regardless of weeks count', () => {
+    expect(selectIsSparse([], 10)).toBe(true);
+  });
+
+  it('hasEverLogged flips on the first event', () => {
+    expect(selectHasEverLogged([])).toBe(false);
+    expect(selectHasEverLogged([event({})])).toBe(true);
+  });
+});

--- a/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -53,6 +53,9 @@ function CalendarHeatmap({
         <>
           <Canvas style={{width, height, position: 'absolute'}}>
             {cells.map((cell, i) => {
+              if (cell.isFuture) {
+                return null;
+              }
               const idx = layout.firstDayCol + i;
               const col = idx % 7;
               const row = Math.floor(idx / 7);
@@ -75,11 +78,14 @@ function CalendarHeatmap({
             const idx = layout.firstDayCol + i;
             const col = idx % 7;
             const row = Math.floor(idx / 7);
+            const a11yLabel = cell.isFuture
+              ? `${cell.dateKey}, upcoming`
+              : `${cell.dateKey}, ${cell.totalSdu} units`;
             return (
               <View
                 key={`a11y-${cell.dateKey}`}
                 accessible
-                accessibilityLabel={`${cell.dateKey}, ${cell.totalSdu} units`}
+                accessibilityLabel={a11yLabel}
                 accessibilityRole="text"
                 style={{
                   position: 'absolute',

--- a/src/components/Charts/MiniTrendLine/MiniTrendLine.tsx
+++ b/src/components/Charts/MiniTrendLine/MiniTrendLine.tsx
@@ -1,0 +1,92 @@
+import {useMemo} from 'react';
+import {Rect} from '@shopify/react-native-skia';
+import {BaseChart, Line} from '@components/Charts/BaseChart';
+import type {ChartDatum} from '@libs/Statistics';
+
+type MiniTrendLineProps = {
+  /** Weekly points oldest → newest. `x` is the ISO week label, `y` units. */
+  points: ChartDatum[];
+  /** 25th–75th percentile band over the same window. */
+  band: {p25: number; p75: number};
+  /** EWMA-smoothed series aligned to `points` by index. Optional. */
+  ewma?: number[];
+  accessibilityLabel: string;
+  emptyLabel?: string;
+  height?: number;
+};
+
+/**
+ * Whoop-style mini trend: a translucent band-of-normal stripe with an
+ * EWMA-smoothed line on top. The raw weekly values back the chart's x
+ * domain so the line aligns to real week buckets, but only the smoothed
+ * line is drawn — bars would compete with the Overview's heatmap above it.
+ */
+function MiniTrendLine({
+  points,
+  band,
+  ewma,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+}: MiniTrendLineProps) {
+  const smoothed = useMemo<ChartDatum[]>(() => {
+    if (!ewma || ewma.length !== points.length) {
+      return points;
+    }
+    return points.map((point, i) => ({x: point.x, y: ewma[i]}));
+  }, [ewma, points]);
+
+  // Stretch the Y domain to include both the raw points and the band, so a
+  // band that sits above every observed point still renders.
+  const maxY = useMemo(() => {
+    const values = [
+      ...points.map(p => p.y),
+      ...smoothed.map(p => p.y),
+      band.p75,
+    ];
+    return Math.max(...values, 1);
+  }, [points, smoothed, band.p75]);
+
+  return (
+    <BaseChart
+      data={smoothed}
+      range="rolling8w"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}
+      hideAxes>
+      {({points: chartPoints, chartBounds, theme}) => {
+        const top = chartBounds.top;
+        const bottom = chartBounds.bottom;
+        const yFor = (value: number) =>
+          top + (1 - value / maxY) * (bottom - top);
+        const bandTopY = yFor(band.p75);
+        const bandBottomY = yFor(band.p25);
+        const bandHeight = Math.max(0, bandBottomY - bandTopY);
+
+        return (
+          <>
+            {bandHeight > 0 ? (
+              <Rect
+                x={chartBounds.left}
+                y={bandTopY}
+                width={chartBounds.right - chartBounds.left}
+                height={bandHeight}
+                color={theme.bandFill}
+              />
+            ) : null}
+            <Line
+              points={chartPoints.y}
+              color={theme.primaryStroke}
+              strokeWidth={2}
+              curveType="natural"
+            />
+          </>
+        );
+      }}
+    </BaseChart>
+  );
+}
+
+export default MiniTrendLine;
+export type {MiniTrendLineProps};

--- a/src/components/Charts/MiniTrendLine/index.ts
+++ b/src/components/Charts/MiniTrendLine/index.ts
@@ -1,0 +1,2 @@
+export {default as MiniTrendLine} from './MiniTrendLine';
+export type {MiniTrendLineProps} from './MiniTrendLine';

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -21,6 +21,8 @@ import type {
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
   SessionWindowIdParams,
+  StatsAfDaysParams,
+  StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
@@ -813,7 +815,48 @@ export default {
     tabs: {
       overview: {
         label: 'Přehled',
-        placeholder: 'Tady poroste tvoje série bez alkoholu a týdenní shrnutí.',
+        hero: {
+          afDays: {
+            label: 'Dny bez alkoholu tento měsíc',
+            a11yLabel: ({value, total}: StatsAfDaysParams) =>
+              `${value} z ${total} dnů bez alkoholu tento měsíc`,
+          },
+        },
+        kpi: {
+          sessionsThisWeek: {
+            label: 'Relace tento týden',
+            delta: 'vs minulý týden',
+          },
+          quietDaysThisWeek: {
+            label: 'Klidné dny tento týden',
+            delta: 'vs minulý týden',
+          },
+          unitsThisWeek: {
+            label: 'Jednotky tento týden',
+            delta: 'vs minulý týden',
+          },
+        },
+        trend: {
+          title: '8týdenní trend',
+          bandCaption:
+            'Stínovaný pás je tam, kde se odehrála většina tvých posledních 8 týdnů.',
+          chip: {
+            down: 'Trend dolů — méně jednotek týden po týdnu.',
+            up: 'Trend nahoru — více jednotek týden po týdnu.',
+            none: 'Tvé týdny se proměňují jako obvykle.',
+          },
+          a11yLabel: 'Posledních 8 týdnů týdenních jednotek, vyhlazeno',
+        },
+        empty: {
+          neverLogged: {
+            title: 'Zatím není co zaznamenat — i to se počítá.',
+            body: 'Až zaznamenáš relaci, objeví se zde týdenní trendy a měsíční přehled. Do té doby je každý den klidný.',
+          },
+          noDataInWindow: ({quietDays}: StatsQuietDaysParams) =>
+            `${quietDays} klidných dnů a počítáme dál — tvé trendy se vyjasní, jak budeš přidávat data.`,
+        },
+        sparseFooter:
+          'Zatím jen pár týdnů historie — tvé trendy se vyjasní, jak budeš přidávat data.',
       },
       trends: {
         label: 'Trendy',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -22,6 +22,8 @@ import type {
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
   SessionWindowIdParams,
+  StatsAfDaysParams,
+  StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
@@ -823,8 +825,48 @@ export default {
     tabs: {
       overview: {
         label: 'Overview',
-        placeholder:
-          'Your alcohol-free streak and weekly recap will live here.',
+        hero: {
+          afDays: {
+            label: 'Alcohol-free days this month',
+            a11yLabel: ({value, total}: StatsAfDaysParams) =>
+              `${value} of ${total} days alcohol-free this month`,
+          },
+        },
+        kpi: {
+          sessionsThisWeek: {
+            label: 'Sessions this week',
+            delta: 'vs last week',
+          },
+          quietDaysThisWeek: {
+            label: 'Quiet days this week',
+            delta: 'vs last week',
+          },
+          unitsThisWeek: {
+            label: 'Units this week',
+            delta: 'vs last week',
+          },
+        },
+        trend: {
+          title: '8-week trend',
+          bandCaption:
+            'The shaded band is where most of your last 8 weeks landed.',
+          chip: {
+            down: 'Trending down — fewer units week over week.',
+            up: 'Trending up — more units week over week.',
+            none: 'Your weeks vary as usual.',
+          },
+          a11yLabel: 'Last 8 weeks of weekly units, smoothed',
+        },
+        empty: {
+          neverLogged: {
+            title: 'Nothing to log yet — that counts.',
+            body: 'When you log a session, your weekly trends and a monthly view will show up here. Until then, every day is a quiet one.',
+          },
+          noDataInWindow: ({quietDays}: StatsQuietDaysParams) =>
+            `${quietDays} quiet days and counting — your trends will sharpen as you log more.`,
+        },
+        sparseFooter:
+          'Only a few weeks of history yet — your trends will sharpen as you log more.',
       },
       trends: {
         label: 'Trends',

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -46,6 +46,15 @@ type SessionWindowIdParams = {
   sessionId: DrinkingSessionId;
 };
 
+type StatsAfDaysParams = {
+  value: number;
+  total: number;
+};
+
+type StatsQuietDaysParams = {
+  quietDays: number;
+};
+
 type UnitCountParams = {
   unitCount: number;
 };
@@ -97,6 +106,8 @@ export type {
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
   SessionWindowIdParams,
+  StatsAfDaysParams,
+  StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,

--- a/src/libs/Statistics/overviewSelectors.ts
+++ b/src/libs/Statistics/overviewSelectors.ts
@@ -1,0 +1,281 @@
+import {
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  endOfISOWeek,
+  endOfMonth,
+  format,
+  getISOWeek,
+  getISOWeekYear,
+  startOfDay,
+  startOfISOWeek,
+  startOfMonth,
+  subWeeks,
+} from 'date-fns';
+import aggregate from './aggregate';
+import {byDay, byIsoWeek} from './bucketers';
+import {countSessions, sumSdu, sumUnits} from './reducers';
+import {ewma, mannKendall, percentile} from './stats';
+import type {MannKendallResult} from './stats/mannKendall';
+import type {ChartDatum, DrinkEvent, HeatmapCell} from './types';
+
+const TREND_WINDOW_WEEKS = 8;
+const SPARSE_WEEK_THRESHOLD = 4;
+
+type AfDaysResult = {
+  /** Elapsed days alcohol-free in the current calendar month. */
+  value: number;
+  /** Denominator: days elapsed in the month, inclusive of today. */
+  total: number;
+};
+
+type WeeklyKpis = {
+  sessionsThisWeek: number;
+  sessionsLastWeek: number;
+  quietDaysThisWeek: number;
+  quietDaysLastWeek: number;
+  unitsThisWeek: number;
+  unitsLastWeek: number;
+};
+
+type TrendSeries = {
+  /** 8 weekly points, oldest → newest, units summed per ISO week. */
+  points: ChartDatum[];
+  band: {p25: number; p75: number};
+  ewma: number[];
+  mannKendall: MannKendallResult;
+  /** Weeks in the window with at least one event. */
+  weeksWithData: number;
+};
+
+function isoWeekLabel(date: Date): string {
+  const year = getISOWeekYear(date);
+  const week = getISOWeek(date);
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Pick a 1..4 intensity for a day's SDU value. Uses quartiles of the
+ * non-zero days when there's enough samples (≥4); otherwise falls back to
+ * fixed SDU thresholds so a 1-day-into-the-month user still sees variation.
+ * Days with zero SDU map to 0 unconditionally.
+ */
+function computeIntensity(
+  sdu: number,
+  sortedNonZero: readonly number[],
+): 0 | 1 | 2 | 3 | 4 {
+  if (sdu <= 0) {
+    return 0;
+  }
+  if (sortedNonZero.length < 4) {
+    if (sdu <= 1) {
+      return 1;
+    }
+    if (sdu <= 3) {
+      return 2;
+    }
+    if (sdu <= 6) {
+      return 3;
+    }
+    return 4;
+  }
+  const sorted = [...sortedNonZero];
+  const q1 = percentile(sorted, 0.25);
+  const q2 = percentile(sorted, 0.5);
+  const q3 = percentile(sorted, 0.75);
+  if (sdu <= q1) {
+    return 1;
+  }
+  if (sdu <= q2) {
+    return 2;
+  }
+  if (sdu <= q3) {
+    return 3;
+  }
+  return 4;
+}
+
+/**
+ * One `HeatmapCell` per calendar day of `now`'s month. Days beyond today
+ * carry `isFuture: true` so the renderer can skip drawing per
+ * DIRECTION_REVIEW.md §6.2. SDU per day comes from `aggregate(events,
+ * byDay, sumSdu)`.
+ */
+function selectThisMonthHeatmapCells(
+  events: readonly DrinkEvent[],
+  now: Date,
+): HeatmapCell[] {
+  const monthStart = startOfMonth(now);
+  const monthEnd = endOfMonth(now);
+  const today = startOfDay(now);
+
+  // Bucket every event by its `localDay`; out-of-month events simply never
+  // match the `dateKey` lookup below, so filtering by ts is unnecessary and
+  // would re-introduce the device-vs-user timezone seam.
+  const sduByDay = aggregate(events, byDay, sumSdu);
+
+  const days = eachDayOfInterval({start: monthStart, end: monthEnd});
+  const monthPrefix = format(monthStart, 'yyyy-MM');
+
+  // Intensity ramp is relative to this month's own non-zero days so a fresh
+  // month never inherits last month's scale.
+  const nonZeroSdu: number[] = [];
+  for (const [key, value] of sduByDay) {
+    if (value > 0 && key.startsWith(monthPrefix)) {
+      nonZeroSdu.push(value);
+    }
+  }
+  nonZeroSdu.sort((a, b) => a - b);
+
+  return days.map(day => {
+    const dateKey = format(day, 'yyyy-MM-dd');
+    const isFuture = day.getTime() > today.getTime();
+    const totalSdu = sduByDay.get(dateKey) ?? 0;
+    const intensity = isFuture ? 0 : computeIntensity(totalSdu, nonZeroSdu);
+    return {dateKey, totalSdu, intensity, isFuture};
+  });
+}
+
+/**
+ * Alcohol-free days in the current month, clamped to elapsed days per
+ * DIRECTION_REVIEW.md §3 (so a fresh month on day 1 reads 1/1, not 1/31).
+ */
+function drinkDayKeysInRange(
+  events: readonly DrinkEvent[],
+  startKey: string,
+  endKey: string,
+): Set<string> {
+  const set = new Set<string>();
+  for (const event of events) {
+    if (event.localDay >= startKey && event.localDay <= endKey) {
+      set.add(event.localDay);
+    }
+  }
+  return set;
+}
+
+function selectAfDaysThisMonth(
+  events: readonly DrinkEvent[],
+  now: Date,
+): AfDaysResult {
+  const monthStart = startOfMonth(now);
+  const today = startOfDay(now);
+  const total = differenceInCalendarDays(today, monthStart) + 1;
+  const drinkDays = drinkDayKeysInRange(
+    events,
+    format(monthStart, 'yyyy-MM-dd'),
+    format(today, 'yyyy-MM-dd'),
+  ).size;
+  const value = Math.max(0, total - drinkDays);
+  return {value, total};
+}
+
+function quietDaysInRange(
+  events: readonly DrinkEvent[],
+  start: Date,
+  end: Date,
+): number {
+  const elapsed = differenceInCalendarDays(end, start) + 1;
+  if (elapsed <= 0) {
+    return 0;
+  }
+  const drinkDays = drinkDayKeysInRange(
+    events,
+    format(start, 'yyyy-MM-dd'),
+    format(end, 'yyyy-MM-dd'),
+  ).size;
+  return Math.max(0, elapsed - drinkDays);
+}
+
+function selectWeeklyKpis(
+  events: readonly DrinkEvent[],
+  now: Date,
+): WeeklyKpis {
+  const today = startOfDay(now);
+  const thisWeekStart = startOfISOWeek(now);
+  const thisWeekEnd = endOfISOWeek(now);
+  const lastWeekStart = subWeeks(thisWeekStart, 1);
+  const lastWeekEnd = subWeeks(thisWeekEnd, 1);
+
+  const sessionsBy = aggregate(events, byIsoWeek, countSessions);
+  const unitsBy = aggregate(events, byIsoWeek, sumUnits);
+
+  const thisLabel = isoWeekLabel(now);
+  const lastLabel = isoWeekLabel(lastWeekStart);
+
+  // For "this week" quiet days, clamp the upper bound to today so days that
+  // haven't elapsed yet don't auto-count as quiet (mirrors the AF-days fix).
+  const thisWeekClampedEnd = today < thisWeekEnd ? today : thisWeekEnd;
+
+  return {
+    sessionsThisWeek: sessionsBy.get(thisLabel) ?? 0,
+    sessionsLastWeek: sessionsBy.get(lastLabel) ?? 0,
+    quietDaysThisWeek: quietDaysInRange(
+      events,
+      thisWeekStart,
+      thisWeekClampedEnd,
+    ),
+    quietDaysLastWeek: quietDaysInRange(events, lastWeekStart, lastWeekEnd),
+    unitsThisWeek: unitsBy.get(thisLabel) ?? 0,
+    unitsLastWeek: unitsBy.get(lastLabel) ?? 0,
+  };
+}
+
+/**
+ * Last 8 ISO weeks ending with the current week, oldest → newest. Missing
+ * weeks fill in as 0 so EWMA and Mann–Kendall see a contiguous series.
+ */
+function selectTrendSeries(
+  events: readonly DrinkEvent[],
+  now: Date,
+): TrendSeries {
+  const unitsBy = aggregate(events, byIsoWeek, sumUnits);
+  const currentWeekStart = startOfISOWeek(now);
+
+  const points: ChartDatum[] = [];
+  const values: number[] = [];
+  let weeksWithData = 0;
+
+  for (let i = TREND_WINDOW_WEEKS - 1; i >= 0; i -= 1) {
+    const weekDate = subWeeks(currentWeekStart, i);
+    const label = isoWeekLabel(weekDate);
+    const value = unitsBy.get(label) ?? 0;
+    if (value > 0) {
+      weeksWithData += 1;
+    }
+    points.push({x: label, y: value});
+    values.push(value);
+  }
+
+  const band = {
+    p25: percentile(values, 0.25),
+    p75: percentile(values, 0.75),
+  };
+  const smoothed = ewma(values);
+  const trend = mannKendall(values);
+
+  return {points, band, ewma: smoothed, mannKendall: trend, weeksWithData};
+}
+
+function selectIsSparse(
+  events: readonly DrinkEvent[],
+  weeksWithData: number,
+): boolean {
+  return events.length === 0 || weeksWithData < SPARSE_WEEK_THRESHOLD;
+}
+
+function selectHasEverLogged(events: readonly DrinkEvent[]): boolean {
+  return events.length > 0;
+}
+
+export {
+  isoWeekLabel,
+  SPARSE_WEEK_THRESHOLD,
+  selectAfDaysThisMonth,
+  selectHasEverLogged,
+  selectIsSparse,
+  selectThisMonthHeatmapCells,
+  selectTrendSeries,
+  selectWeeklyKpis,
+  TREND_WINDOW_WEEKS,
+};
+export type {AfDaysResult, TrendSeries, WeeklyKpis};

--- a/src/libs/Statistics/types.ts
+++ b/src/libs/Statistics/types.ts
@@ -68,6 +68,11 @@ type HeatmapCell = {
   dateKey: string;
   totalSdu: number;
   intensity: 0 | 1 | 2 | 3 | 4;
+  /**
+   * Reserves the grid slot but skips the rect so future days don't look
+   * identical to logged-but-quiet ones. Per DIRECTION_REVIEW.md §6.2.
+   */
+  isFuture?: boolean;
 };
 
 type KpiDelta = {

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import StatsContextProvider from '@components/StatsContextProvider';
-import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import useLocalize from '@hooks/useLocalize';
 import Navigation from '@libs/Navigation/Navigation';
 import StatisticsTabs from './StatisticsTabs';
@@ -17,7 +16,8 @@ function StatisticsScreen() {
         onBackButtonPress={Navigation.goBack}
       />
       <StatsContextProvider>
-        <StatsFilterToolbar />
+        {/* The filter toolbar lives per-tab (Trends/Patterns/Breakdown);
+            Overview uses fixed this-month/this-week semantics. */}
         <StatisticsTabs />
       </StatsContextProvider>
     </ScreenWrapper>

--- a/src/screens/Statistics/tabs/BreakdownTab.tsx
+++ b/src/screens/Statistics/tabs/BreakdownTab.tsx
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import {View} from 'react-native';
 import ScrollView from '@components/ScrollView';
 import ChartCard from '@components/Charts/ChartCard/ChartCard';
+import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import useLocalize from '@hooks/useLocalize';
 import useStatsContext from '@hooks/useStatsContext';
 import {useAggregate, useDrinkEvents} from '@hooks/useStatistics';
@@ -62,35 +63,38 @@ function BreakdownTab() {
   );
 
   return (
-    <ScrollView contentContainerStyle={[styles.p3, styles.pb5]}>
-      <ChartCard
-        title={translate('statistics.tabs.breakdown.donut.title')}
-        subtitle={translate('statistics.tabs.breakdown.donut.subtitle')}>
-        <View style={styles.alignItemsCenter}>
-          <DrinkTypeDonut
-            unitsByDrinkKey={currentUnitsByDrinkKey}
+    <View style={styles.flex1}>
+      <StatsFilterToolbar />
+      <ScrollView contentContainerStyle={[styles.p3, styles.pb5]}>
+        <ChartCard
+          title={translate('statistics.tabs.breakdown.donut.title')}
+          subtitle={translate('statistics.tabs.breakdown.donut.subtitle')}>
+          <View style={styles.alignItemsCenter}>
+            <DrinkTypeDonut
+              unitsByDrinkKey={currentUnitsByDrinkKey}
+              drinkTypeFilter={drinkTypeFilter}
+            />
+          </View>
+        </ChartCard>
+
+        <ChartCard
+          title={translate('statistics.tabs.breakdown.multiples.title')}
+          subtitle={translate('statistics.tabs.breakdown.multiples.subtitle')}>
+          <PerTypeWeeklyMultiples
+            unitsByDrinkKeyAndWeek={unitsByDrinkKeyAndWeek}
             drinkTypeFilter={drinkTypeFilter}
+            rangeStart={range.start}
+            rangeEnd={range.end}
           />
-        </View>
-      </ChartCard>
+        </ChartCard>
 
-      <ChartCard
-        title={translate('statistics.tabs.breakdown.multiples.title')}
-        subtitle={translate('statistics.tabs.breakdown.multiples.subtitle')}>
-        <PerTypeWeeklyMultiples
-          unitsByDrinkKeyAndWeek={unitsByDrinkKeyAndWeek}
-          drinkTypeFilter={drinkTypeFilter}
-          rangeStart={range.start}
-          rangeEnd={range.end}
+        <TypeConcentrationSentence
+          currentUnitsByDrinkKey={currentUnitsByDrinkKey}
+          priorUnitsByDrinkKey={priorUnitsByDrinkKey}
+          preset={range.preset}
         />
-      </ChartCard>
-
-      <TypeConcentrationSentence
-        currentUnitsByDrinkKey={currentUnitsByDrinkKey}
-        priorUnitsByDrinkKey={priorUnitsByDrinkKey}
-        preset={range.preset}
-      />
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
 

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -1,8 +1,225 @@
-import React from 'react';
-import TabPlaceholder from './TabPlaceholder';
+import React, {useMemo} from 'react';
+import {View} from 'react-native';
+import ScrollView from '@components/ScrollView';
+import {CalendarHeatmap} from '@components/Charts/CalendarHeatmap';
+import {ChartCard} from '@components/Charts/ChartCard';
+import {KpiCard, KpiCardGroup} from '@components/Charts/KpiCard';
+import type {KpiCardProps} from '@components/Charts/KpiCard';
+import {MiniTrendLine} from '@components/Charts/MiniTrendLine';
+import Text from '@components/Text';
+import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {
+  selectAfDaysThisMonth,
+  selectHasEverLogged,
+  selectIsSparse,
+  selectThisMonthHeatmapCells,
+  selectTrendSeries,
+  selectWeeklyKpis,
+} from '@libs/Statistics/overviewSelectors';
+import type {TranslationPaths} from '@src/languages/types';
+
+type DeltaShape = NonNullable<KpiCardProps['delta']>;
+
+function makeDelta(
+  current: number,
+  previous: number,
+  label: string,
+): DeltaShape {
+  const diff = current - previous;
+  let direction: DeltaShape['direction'] = 'flat';
+  if (diff > 0) {
+    direction = 'up';
+  } else if (diff < 0) {
+    direction = 'down';
+  }
+  return {value: diff, direction, label};
+}
+
+function formatUnits(value: number): string {
+  // 1 decimal for partial units, else integer — matches existing chart formatting.
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
 
 function OverviewTab() {
-  return <TabPlaceholder copyKey="statistics.tabs.overview.placeholder" />;
+  const {translate} = useLocalize();
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {events, isLoading} = useDrinkEvents();
+
+  // Snapshot `now` once per mount so all selectors agree. Re-deriving on each
+  // render would let an animation frame land between two reads and disagree
+  // about today's date.
+  const now = useMemo(() => new Date(), []);
+
+  const afDays = useMemo(
+    () => selectAfDaysThisMonth(events, now),
+    [events, now],
+  );
+  const weekly = useMemo(() => selectWeeklyKpis(events, now), [events, now]);
+  const trend = useMemo(() => selectTrendSeries(events, now), [events, now]);
+  const cells = useMemo(
+    () => selectThisMonthHeatmapCells(events, now),
+    [events, now],
+  );
+
+  const hasEverLogged = selectHasEverLogged(events);
+  const isSparse = selectIsSparse(events, trend.weeksWithData);
+
+  // Don't paint anything in the brief Onyx-hydration window — the
+  // alternative is a flicker from "never logged" copy into the real screen.
+  if (isLoading) {
+    return <View style={styles.flex1} />;
+  }
+
+  if (!hasEverLogged) {
+    return (
+      <ScrollView
+        style={styles.flex1}
+        contentContainerStyle={[styles.p4, styles.alignItemsCenter]}>
+        <View style={[styles.p4, styles.alignItemsCenter]}>
+          <Text
+            style={[
+              styles.textHeadline,
+              styles.textAlignCenter,
+              {color: theme.successHover},
+            ]}>
+            {translate('statistics.tabs.overview.empty.neverLogged.title')}
+          </Text>
+          <Text style={[styles.textNormal, styles.textAlignCenter, styles.mt3]}>
+            {translate('statistics.tabs.overview.empty.neverLogged.body')}
+          </Text>
+        </View>
+      </ScrollView>
+    );
+  }
+
+  const sessionsDelta = makeDelta(
+    weekly.sessionsThisWeek,
+    weekly.sessionsLastWeek,
+    translate('statistics.tabs.overview.kpi.sessionsThisWeek.delta'),
+  );
+  const quietDelta = makeDelta(
+    weekly.quietDaysThisWeek,
+    weekly.quietDaysLastWeek,
+    translate('statistics.tabs.overview.kpi.quietDaysThisWeek.delta'),
+  );
+  const unitsDelta = makeDelta(
+    weekly.unitsThisWeek,
+    weekly.unitsLastWeek,
+    translate('statistics.tabs.overview.kpi.unitsThisWeek.delta'),
+  );
+
+  let trendChipKey: TranslationPaths =
+    'statistics.tabs.overview.trend.chip.none';
+  if (trend.mannKendall.trend === 'down') {
+    trendChipKey = 'statistics.tabs.overview.trend.chip.down';
+  } else if (trend.mannKendall.trend === 'up') {
+    trendChipKey = 'statistics.tabs.overview.trend.chip.up';
+  }
+
+  const kpiCards: KpiCardProps[] = [
+    {
+      label: translate('statistics.tabs.overview.kpi.sessionsThisWeek.label'),
+      value: weekly.sessionsThisWeek,
+      delta: sessionsDelta,
+      polarity: 'lower-is-supportive',
+    },
+    {
+      label: translate('statistics.tabs.overview.kpi.quietDaysThisWeek.label'),
+      value: weekly.quietDaysThisWeek,
+      delta: quietDelta,
+      polarity: 'higher-is-supportive',
+    },
+    {
+      label: translate('statistics.tabs.overview.kpi.unitsThisWeek.label'),
+      value: formatUnits(weekly.unitsThisWeek),
+      delta: {...unitsDelta, value: Number(unitsDelta.value.toFixed(1))},
+      polarity: 'lower-is-supportive',
+    },
+  ];
+
+  const heroA11y = translate('statistics.tabs.overview.hero.afDays.a11yLabel', {
+    value: afDays.value,
+    total: afDays.total,
+  });
+
+  return (
+    <ScrollView
+      style={styles.flex1}
+      contentContainerStyle={[styles.p4]}
+      showsVerticalScrollIndicator={false}>
+      <View style={styles.mb3}>
+        <KpiCard
+          label={translate('statistics.tabs.overview.hero.afDays.label')}
+          value={afDays.value}
+          unit={`/${afDays.total}`}
+          tone="celebratory"
+          polarity="higher-is-supportive"
+          accessibilityLabel={heroA11y}
+        />
+      </View>
+
+      <View style={styles.mb3}>
+        <KpiCardGroup cards={kpiCards} />
+      </View>
+
+      <ChartCard title={translate('statistics.charts.calendarHeatmap.title')}>
+        <CalendarHeatmap
+          cells={cells}
+          accessibilityLabel={translate(
+            'statistics.charts.calendarHeatmap.title',
+          )}
+        />
+      </ChartCard>
+
+      <ChartCard
+        title={translate('statistics.tabs.overview.trend.title')}
+        footer={
+          <Text style={[styles.textMicroSupporting]}>
+            {translate('statistics.tabs.overview.trend.bandCaption')}
+          </Text>
+        }>
+        <MiniTrendLine
+          points={trend.points}
+          band={trend.band}
+          ewma={trend.ewma}
+          height={120}
+          accessibilityLabel={translate(
+            'statistics.tabs.overview.trend.a11yLabel',
+          )}
+        />
+      </ChartCard>
+
+      <View style={[styles.mt2, styles.mb2]}>
+        <Text style={[styles.textLabelSupporting, styles.textAlignCenter]}>
+          {translate(trendChipKey)}
+        </Text>
+      </View>
+
+      {isSparse ? (
+        <View style={styles.mt2}>
+          {weekly.quietDaysThisWeek > 0 ? (
+            <Text
+              style={[
+                styles.textMicroSupporting,
+                styles.textAlignCenter,
+                styles.mb2,
+              ]}>
+              {translate('statistics.tabs.overview.empty.noDataInWindow', {
+                quietDays: weekly.quietDaysThisWeek,
+              })}
+            </Text>
+          ) : null}
+          <Text style={[styles.textMicroSupporting, styles.textAlignCenter]}>
+            {translate('statistics.tabs.overview.sparseFooter')}
+          </Text>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
 }
 
 OverviewTab.displayName = 'OverviewTab';

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -6,6 +6,7 @@ import {Histogram} from '@components/Charts/Histogram';
 import type {HistogramBin} from '@components/Charts/Histogram';
 import {HourPolar} from '@components/Charts/HourPolar';
 import {ChartCard} from '@components/Charts/ChartCard';
+import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useLocalize from '@hooks/useLocalize';
@@ -179,72 +180,79 @@ function PatternsTab() {
     durationSeries.length >= 4 ? percentile(durationSeries, 0.75) : null;
 
   return (
-    <ScrollView
-      style={[styles.scroll, {backgroundColor: undefined}]}
-      contentContainerStyle={styles.scrollContent}>
-      <ChartCard title={translate('statistics.charts.hourOfDay.title')}>
-        <HourPolar
-          buckets={hourBuckets}
-          accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
-          onSpokePress={() => {
-            // Drill-down handler — v2-K wires this to StatsDrillDownSheet.
-          }}
-        />
-      </ChartCard>
-      <ChartCard title={translate('statistics.charts.dowHour.title')}>
-        <DowHourHeatmap
-          buckets={dowHourBuckets}
-          weekStart={weekStart}
-          accessibilityLabel={translate('statistics.charts.dowHour.title')}
-        />
-      </ChartCard>
-      <View style={styles.histogramRow}>
-        <View style={styles.histogramCell}>
-          <ChartCard
-            title={translate('statistics.charts.drinksPerSession.title')}
-            footer={
-              drinkP75 !== null ? (
-                <Text style={[themeStyles.textMicroSupporting]}>
-                  {translate('statistics.charts.drinksPerSession.p75Copy', {
-                    value: Math.round(drinkP75),
-                  })}
-                </Text>
-              ) : null
-            }>
-            <Histogram
-              bins={drinkBins}
-              accessibilityLabel={translate(
-                'statistics.charts.drinksPerSession.title',
-              )}
-              emptyLabel={translate('statistics.charts.drinksPerSession.empty')}
-              height={160}
-            />
-          </ChartCard>
+    <View style={themeStyles.flex1}>
+      <StatsFilterToolbar />
+      <ScrollView
+        style={[styles.scroll, {backgroundColor: undefined}]}
+        contentContainerStyle={styles.scrollContent}>
+        <ChartCard title={translate('statistics.charts.hourOfDay.title')}>
+          <HourPolar
+            buckets={hourBuckets}
+            accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
+            onSpokePress={() => {
+              // Drill-down handler — v2-K wires this to StatsDrillDownSheet.
+            }}
+          />
+        </ChartCard>
+        <ChartCard title={translate('statistics.charts.dowHour.title')}>
+          <DowHourHeatmap
+            buckets={dowHourBuckets}
+            weekStart={weekStart}
+            accessibilityLabel={translate('statistics.charts.dowHour.title')}
+          />
+        </ChartCard>
+        <View style={styles.histogramRow}>
+          <View style={styles.histogramCell}>
+            <ChartCard
+              title={translate('statistics.charts.drinksPerSession.title')}
+              footer={
+                drinkP75 !== null ? (
+                  <Text style={[themeStyles.textMicroSupporting]}>
+                    {translate('statistics.charts.drinksPerSession.p75Copy', {
+                      value: Math.round(drinkP75),
+                    })}
+                  </Text>
+                ) : null
+              }>
+              <Histogram
+                bins={drinkBins}
+                accessibilityLabel={translate(
+                  'statistics.charts.drinksPerSession.title',
+                )}
+                emptyLabel={translate(
+                  'statistics.charts.drinksPerSession.empty',
+                )}
+                height={160}
+              />
+            </ChartCard>
+          </View>
+          <View style={styles.histogramCell}>
+            <ChartCard
+              title={translate('statistics.charts.sessionDuration.title')}
+              footer={
+                durationP75 !== null ? (
+                  <Text style={[themeStyles.textMicroSupporting]}>
+                    {translate('statistics.charts.sessionDuration.p75Copy', {
+                      value: formatDurationMin(durationP75),
+                    })}
+                  </Text>
+                ) : null
+              }>
+              <Histogram
+                bins={durationBins}
+                accessibilityLabel={translate(
+                  'statistics.charts.sessionDuration.title',
+                )}
+                emptyLabel={translate(
+                  'statistics.charts.sessionDuration.empty',
+                )}
+                height={160}
+              />
+            </ChartCard>
+          </View>
         </View>
-        <View style={styles.histogramCell}>
-          <ChartCard
-            title={translate('statistics.charts.sessionDuration.title')}
-            footer={
-              durationP75 !== null ? (
-                <Text style={[themeStyles.textMicroSupporting]}>
-                  {translate('statistics.charts.sessionDuration.p75Copy', {
-                    value: formatDurationMin(durationP75),
-                  })}
-                </Text>
-              ) : null
-            }>
-            <Histogram
-              bins={durationBins}
-              accessibilityLabel={translate(
-                'statistics.charts.sessionDuration.title',
-              )}
-              emptyLabel={translate('statistics.charts.sessionDuration.empty')}
-              height={160}
-            />
-          </ChartCard>
-        </View>
-      </View>
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
 

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -5,6 +5,7 @@ import {CumulativeLine} from '@components/Charts/CumulativeLine';
 import {StackedArea} from '@components/Charts/StackedArea';
 import {TrendLine} from '@components/Charts/TrendLine';
 import ScrollView from '@components/ScrollView';
+import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useTrendsTabData from '@hooks/useStatistics/useTrendsTabData';
@@ -33,10 +34,14 @@ function TrendsTab() {
 
   if (isLoading) {
     return (
-      <View style={[styles.container, themeStyles.justifyContentCenter]}>
-        <Text style={[themeStyles.textSupporting, themeStyles.textAlignCenter]}>
-          {translate('common.loading')}
-        </Text>
+      <View style={themeStyles.flex1}>
+        <StatsFilterToolbar />
+        <View style={[styles.container, themeStyles.justifyContentCenter]}>
+          <Text
+            style={[themeStyles.textSupporting, themeStyles.textAlignCenter]}>
+            {translate('common.loading')}
+          </Text>
+        </View>
       </View>
     );
   }
@@ -51,79 +56,82 @@ function TrendsTab() {
   );
 
   return (
-    <ScrollView
-      style={themeStyles.flex1}
-      contentContainerStyle={styles.container}>
-      <ChartCard
-        title={translate('statistics.tabs.trends.weeklyTrend.title')}
-        subtitle={heroSubtitle}
-        footer={
-          <Text style={themeStyles.textMicroSupporting}>
-            {heroComparisonShown
-              ? `${heroCaption} · ${comparisonLegend}`
-              : heroCaption}
-          </Text>
-        }>
-        <TrendLine
-          weeks={hero.weeks}
-          units={hero.units}
-          ewma={hero.ewma}
-          comparison={hero.comparison}
-          band={hero.band}
-          emptyLabel={translate(
-            'statistics.tabs.trends.weeklyTrend.emptyLabel',
-          )}
-          accessibilityLabel={heroCaption}
-        />
-      </ChartCard>
-
-      {afYtd.hidden ? null : (
+    <View style={themeStyles.flex1}>
+      <StatsFilterToolbar />
+      <ScrollView
+        style={themeStyles.flex1}
+        contentContainerStyle={styles.container}>
         <ChartCard
-          title={translate('statistics.tabs.trends.cumulativeAf.title')}
+          title={translate('statistics.tabs.trends.weeklyTrend.title')}
+          subtitle={heroSubtitle}
           footer={
-            afYtd.comparisonPoints ? (
+            <Text style={themeStyles.textMicroSupporting}>
+              {heroComparisonShown
+                ? `${heroCaption} · ${comparisonLegend}`
+                : heroCaption}
+            </Text>
+          }>
+          <TrendLine
+            weeks={hero.weeks}
+            units={hero.units}
+            ewma={hero.ewma}
+            comparison={hero.comparison}
+            band={hero.band}
+            emptyLabel={translate(
+              'statistics.tabs.trends.weeklyTrend.emptyLabel',
+            )}
+            accessibilityLabel={heroCaption}
+          />
+        </ChartCard>
+
+        {afYtd.hidden ? null : (
+          <ChartCard
+            title={translate('statistics.tabs.trends.cumulativeAf.title')}
+            footer={
+              afYtd.comparisonPoints ? (
+                <Text style={themeStyles.textMicroSupporting}>
+                  {comparisonLegend}
+                </Text>
+              ) : undefined
+            }>
+            <CumulativeLine
+              points={afYtd.points}
+              comparisonPoints={afYtd.comparisonPoints}
+              emptyLabel={translate(
+                'statistics.tabs.trends.cumulativeAf.emptyLabel',
+              )}
+              accessibilityLabel={translate(
+                'statistics.tabs.trends.cumulativeAf.title',
+              )}
+            />
+          </ChartCard>
+        )}
+
+        <ChartCard
+          title={translate('statistics.tabs.trends.drinkTypeStack.title')}
+          footer={
+            stack.comparisonTotal ? (
               <Text style={themeStyles.textMicroSupporting}>
                 {comparisonLegend}
               </Text>
             ) : undefined
           }>
-          <CumulativeLine
-            points={afYtd.points}
-            comparisonPoints={afYtd.comparisonPoints}
+          <StackedArea
+            weeks={stack.weeks}
+            byKey={stack.byKey}
+            trackedKeys={stack.trackedKeys}
+            palette={stack.palette}
+            comparisonTotal={stack.comparisonTotal}
             emptyLabel={translate(
-              'statistics.tabs.trends.cumulativeAf.emptyLabel',
+              'statistics.tabs.trends.drinkTypeStack.emptyLabel',
             )}
             accessibilityLabel={translate(
-              'statistics.tabs.trends.cumulativeAf.title',
+              'statistics.tabs.trends.drinkTypeStack.title',
             )}
           />
         </ChartCard>
-      )}
-
-      <ChartCard
-        title={translate('statistics.tabs.trends.drinkTypeStack.title')}
-        footer={
-          stack.comparisonTotal ? (
-            <Text style={themeStyles.textMicroSupporting}>
-              {comparisonLegend}
-            </Text>
-          ) : undefined
-        }>
-        <StackedArea
-          weeks={stack.weeks}
-          byKey={stack.byKey}
-          trackedKeys={stack.trackedKeys}
-          palette={stack.palette}
-          comparisonTotal={stack.comparisonTotal}
-          emptyLabel={translate(
-            'statistics.tabs.trends.drinkTypeStack.emptyLabel',
-          )}
-          accessibilityLabel={translate(
-            'statistics.tabs.trends.drinkTypeStack.title',
-          )}
-        />
-      </ChartCard>
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
 


### PR DESCRIPTION
## Summary

Fills the **Overview** tab — replacing the v2-F placeholder with its real "How are you doing?" content per `mockups/STATISTICS_V2.md` §6.1 and the design-doc fixes in `DIRECTION_REVIEW.md`.

- **Celebratory AF-days hero** — denominator clamped to `min(monthEnd, today)` per `DIRECTION_REVIEW §3` (so day 1 reads 1/1, never 1/31).
- **KPI row** — sessions / quiet days / units this week with Δ vs last week; uses the v2-F `polarity` prop so "quiet days" colors correctly as `higher-is-supportive`.
- **This-month calendar heatmap** — extended `HeatmapCell` with `isFuture?`; future days render transparently and announce as "upcoming" for screen readers (per `DIRECTION_REVIEW §6.2`).
- **8-week mini trend** — new `MiniTrendLine` primitive (BaseChart + Skia band rect + EWMA line) with caption "The shaded band is where most of your last 8 weeks landed."
- **"Inside your usual range" verb chip** — driven by `mannKendall().trend`; numeric `tau`/`p` never displayed.
- **Sparse-data footer** — appears when `events.length === 0` OR `weeksWithData < 4` per `DIRECTION_REVIEW §5.1`.
- **Empty-state rewrite** per `DIRECTION_REVIEW §4` — "never logged" (celebratory) vs "no data in window" (additive).
- **Toolbar moved per-tab** — Overview uses fixed "this month"/"this week" semantics regardless of the toolbar, so `<StatsFilterToolbar />` now mounts inside Trends/Patterns/Breakdown only.

All Overview state is composed from pure selectors in `src/libs/Statistics/overviewSelectors.ts`, which lean on the existing `aggregate` / `byDay` / `byIsoWeek` / `sumUnits` / `sumSdu` / `percentile` / `ewma` / `mannKendall` building blocks.

Closes #583.

## Test plan

- [x] `npx prettier --write <changed files>` — clean
- [x] `npx eslint --fix <changed files>` — clean after fixes
- [x] `npm run typecheck-tsgo` — clean
- [x] `npx jest overviewSelectors MiniTrendLine CalendarHeatmap` — 18/18 pass
- [x] Broader Statistics/Charts suite — only pre-existing `StatsContextProvider` failure on master (unrelated to v2-G)
- [ ] Manual UI on iOS sim + Android emulator (see plan §Verification):
  - [ ] Cold mount of Overview renders the four primary regions without flicker; no toolbar on Overview
  - [ ] Switching to Trends/Patterns/Breakdown shows the toolbar; back to Overview hides it
  - [ ] Dark theme — hero stays in `successHover`; deltas keep polarity-correct colors
  - [ ] Fixture: full month with data — heatmap colors through "today", future cells invisible
  - [ ] Fixture: sparse (<3 sessions, <4 weeks) — sparse footer appears, chip says "Your weeks vary as usual"
  - [ ] Fixture: never-logged — celebratory copy renders, no KPI/chart cards
  - [ ] Future days — advance device clock mid-month, confirm right half of heatmap is empty and AF-days denominator matches elapsed days
  - [ ] Tap heatmap cell — no-op (drill-down lands in v2-K)

🤖 Generated with [Claude Code](https://claude.com/claude-code)