### PR TITLE
feat(stats): Trends tab — weekly line + EWMA, cumulative AF, stacked area (v2-H)

### DIFF
--- a/__tests__/unit/Statistics/trends/afYtd.test.ts
+++ b/__tests__/unit/Statistics/trends/afYtd.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+
+import buildAfYtdSeries from '@libs/Statistics/trends/afYtd';
+import type {DrinkEvent} from '@libs/Statistics';
+
+function event(localDay: string): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts: new Date(`${localDay}T12:00:00.000Z`).getTime(),
+    localDay,
+    localIsoWeek: '2026-W01',
+    localMonth: localDay.slice(0, 7),
+    localHour: 12,
+    localDow: 0,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    blackoutSession: false,
+  };
+}
+
+describe('buildAfYtdSeries', () => {
+  test('returns empty array when end is before start', () => {
+    const out = buildAfYtdSeries(
+      [],
+      new Date('2026-05-02'),
+      new Date('2026-05-01'),
+    );
+    expect(out).toEqual([]);
+  });
+
+  test('counts up by one for each day with no events', () => {
+    const out = buildAfYtdSeries(
+      [],
+      new Date('2026-05-01T00:00:00.000Z'),
+      new Date('2026-05-04T00:00:00.000Z'),
+    );
+    expect(out.map(p => p.count)).toEqual([1, 2, 3, 4]);
+    expect(out.map(p => p.date)).toEqual([
+      '2026-05-01',
+      '2026-05-02',
+      '2026-05-03',
+      '2026-05-04',
+    ]);
+  });
+
+  test('day with events does not increment the counter', () => {
+    const out = buildAfYtdSeries(
+      [event('2026-05-02')],
+      new Date('2026-05-01T00:00:00.000Z'),
+      new Date('2026-05-04T00:00:00.000Z'),
+    );
+    expect(out.map(p => p.count)).toEqual([1, 1, 2, 3]);
+  });
+
+  test('resets to zero on Jan 1', () => {
+    const out = buildAfYtdSeries(
+      [],
+      new Date('2025-12-30T00:00:00.000Z'),
+      new Date('2026-01-02T00:00:00.000Z'),
+    );
+    // 2025-12-30 -> 1, 2025-12-31 -> 2, 2026-01-01 -> reset then +1 -> 1,
+    // 2026-01-02 -> 2.
+    expect(out.map(p => p.count)).toEqual([1, 2, 1, 2]);
+  });
+});

--- a/__tests__/unit/Statistics/trends/percentileBand.test.ts
+++ b/__tests__/unit/Statistics/trends/percentileBand.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+
+import percentileBand from '@libs/Statistics/trends/percentileBand';
+
+describe('percentileBand', () => {
+  test('returns null below 4 elements', () => {
+    expect(percentileBand([])).toBeNull();
+    expect(percentileBand([1])).toBeNull();
+    expect(percentileBand([1, 2, 3])).toBeNull();
+  });
+
+  test('computes p25 / p75 over the whole series when window >= n', () => {
+    const band = percentileBand([1, 2, 3, 4]);
+    expect(band).not.toBeNull();
+    if (!band) return;
+    // numpy percentile([1,2,3,4], [25,75], linear) -> [1.75, 3.25]
+    expect(band.p25).toBeCloseTo(1.75, 6);
+    expect(band.p75).toBeCloseTo(3.25, 6);
+  });
+
+  test('uses only the last `window` entries', () => {
+    const series = [100, 100, 100, 100, 1, 2, 3, 4];
+    const band = percentileBand(series, 4);
+    expect(band).not.toBeNull();
+    if (!band) return;
+    expect(band.p25).toBeCloseTo(1.75, 6);
+    expect(band.p75).toBeCloseTo(3.25, 6);
+  });
+});

--- a/__tests__/unit/Statistics/trends/shiftRange.test.ts
+++ b/__tests__/unit/Statistics/trends/shiftRange.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+import shiftRange from '@libs/Statistics/trends/shiftRange';
+import type {Range} from '@components/StatsContextProvider/types';
+
+function makeRange(start: string, end: string): Range {
+  return {
+    start: new Date(start),
+    end: new Date(end),
+    preset: 'Custom',
+  };
+}
+
+describe('shiftRange', () => {
+  test('returns null for comparison=none', () => {
+    expect(
+      shiftRange(makeRange('2026-01-01', '2026-01-31'), 'none'),
+    ).toBeNull();
+  });
+
+  test('previous-period returns same-length window placed before start', () => {
+    const range = makeRange(
+      '2026-04-01T00:00:00.000Z',
+      '2026-04-30T23:59:59.999Z',
+    );
+    const shifted = shiftRange(range, 'previous-period');
+    expect(shifted).not.toBeNull();
+    if (!shifted) {
+      return;
+    }
+    const length = range.end.getTime() - range.start.getTime();
+    expect(shifted.end.getTime()).toBe(range.start.getTime() - 1);
+    expect(shifted.start.getTime()).toBe(range.start.getTime() - length - 1);
+  });
+
+  test('previous-year subtracts exactly one calendar year', () => {
+    const range = makeRange(
+      '2026-05-15T00:00:00.000Z',
+      '2026-06-15T00:00:00.000Z',
+    );
+    const shifted = shiftRange(range, 'previous-year');
+    expect(shifted?.start.toISOString()).toBe('2025-05-15T00:00:00.000Z');
+    expect(shifted?.end.toISOString()).toBe('2025-06-15T00:00:00.000Z');
+  });
+
+  test('previous-year on Feb 29 rolls back to Feb 28', () => {
+    const range = makeRange(
+      '2024-02-29T00:00:00.000Z',
+      '2024-02-29T23:59:59.999Z',
+    );
+    const shifted = shiftRange(range, 'previous-year');
+    expect(shifted?.start.getUTCFullYear()).toBe(2023);
+    expect(shifted?.start.getUTCMonth()).toBe(1); // February
+    expect(shifted?.start.getUTCDate()).toBe(28);
+  });
+});

--- a/__tests__/unit/Statistics/trends/weeklyStacked.test.ts
+++ b/__tests__/unit/Statistics/trends/weeklyStacked.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+import buildWeeklyStackedSeries from '@libs/Statistics/trends/weeklyStacked';
+import type {DrinkEvent} from '@libs/Statistics';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+const ALL_KEYS: readonly DrinkKey[] = [
+  'small_beer',
+  'beer',
+  'wine',
+  'cocktail',
+  'strong_shot',
+  'weak_shot',
+  'other',
+];
+
+function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts: new Date('2026-04-08T12:00:00.000Z').getTime(),
+    localDay: '2026-04-08',
+    localIsoWeek: '2026-W15',
+    localMonth: '2026-04',
+    localHour: 12,
+    localDow: 2,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    blackoutSession: false,
+    ...overrides,
+  };
+}
+
+describe('buildWeeklyStackedSeries', () => {
+  test('empty filter tracks all keys, zero-filled per week', () => {
+    const {weeks, trackedKeys} = buildWeeklyStackedSeries(
+      [],
+      new Date(2026, 3, 6, 12), // Mon Apr 6 2026, local noon → ISO W15
+      new Date(2026, 3, 12, 12), // Sun Apr 12 2026, local noon → ISO W15
+      new Set<DrinkKey>(),
+      ALL_KEYS,
+    );
+    expect(trackedKeys).toEqual(ALL_KEYS);
+    expect(weeks).toHaveLength(1);
+    for (const key of ALL_KEYS) {
+      expect(weeks[0].byKey[key]).toBe(0);
+    }
+  });
+
+  test('non-empty filter narrows tracked keys', () => {
+    const {trackedKeys} = buildWeeklyStackedSeries(
+      [],
+      new Date(2026, 3, 6, 12),
+      new Date(2026, 3, 12, 12),
+      new Set<DrinkKey>(['beer', 'wine']),
+      ALL_KEYS,
+    );
+    expect(trackedKeys).toEqual(['beer', 'wine']);
+  });
+
+  test('attributes units to the correct week + key', () => {
+    const events = [
+      event({localIsoWeek: '2026-W15', drinkKey: 'beer', units: 4}),
+      event({localIsoWeek: '2026-W15', drinkKey: 'wine', units: 2}),
+      event({
+        localIsoWeek: '2026-W16',
+        ts: new Date('2026-04-15T12:00:00.000Z').getTime(),
+        localDay: '2026-04-15',
+        drinkKey: 'beer',
+        units: 1,
+      }),
+    ];
+    const {weeks} = buildWeeklyStackedSeries(
+      events,
+      new Date(2026, 3, 6, 12),
+      new Date(2026, 3, 19, 12), // Sun Apr 19 → ISO W16
+      new Set<DrinkKey>(),
+      ALL_KEYS,
+    );
+    expect(weeks).toHaveLength(2);
+    expect(weeks[0].isoWeek).toBe('2026-W15');
+    expect(weeks[0].byKey.beer).toBe(4);
+    expect(weeks[0].byKey.wine).toBe(2);
+    expect(weeks[1].byKey.beer).toBe(1);
+    expect(weeks[1].byKey.wine).toBe(0);
+  });
+
+  test('filter excludes drink keys not in the active filter', () => {
+    const events = [
+      event({localIsoWeek: '2026-W15', drinkKey: 'beer', units: 4}),
+      event({localIsoWeek: '2026-W15', drinkKey: 'wine', units: 2}),
+    ];
+    const {weeks, trackedKeys} = buildWeeklyStackedSeries(
+      events,
+      new Date(2026, 3, 6, 12),
+      new Date(2026, 3, 12, 12),
+      new Set<DrinkKey>(['beer']),
+      ALL_KEYS,
+    );
+    expect(trackedKeys).toEqual(['beer']);
+    expect(weeks[0].byKey.beer).toBe(4);
+    expect((weeks[0].byKey as Record<string, number>).wine).toBeUndefined();
+  });
+});

--- a/__tests__/unit/Statistics/trends/weeklyUnits.test.ts
+++ b/__tests__/unit/Statistics/trends/weeklyUnits.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+import buildWeeklyUnits from '@libs/Statistics/trends/weeklyUnits';
+import type {DrinkEvent} from '@libs/Statistics';
+
+function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts: 0,
+    localDay: '2026-04-08',
+    localIsoWeek: '2026-W15',
+    localMonth: '2026-04',
+    localHour: 12,
+    localDow: 2,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    blackoutSession: false,
+    ...overrides,
+  };
+}
+
+describe('buildWeeklyUnits', () => {
+  test('zero-fills weeks with no events', () => {
+    // 2026-04-06 is Monday of ISO week 15; range covers 3 ISO weeks.
+    const out = buildWeeklyUnits(
+      [],
+      new Date('2026-04-06T00:00:00.000Z'),
+      new Date('2026-04-26T00:00:00.000Z'),
+    );
+    expect(out.map(p => p.units)).toEqual([0, 0, 0]);
+    expect(out[0].isoWeek).toBe('2026-W15');
+  });
+
+  test('sums units within the event week', () => {
+    const events = [
+      event({
+        ts: new Date('2026-04-08T12:00:00.000Z').getTime(),
+        localIsoWeek: '2026-W15',
+        units: 2,
+      }),
+      event({
+        ts: new Date('2026-04-09T12:00:00.000Z').getTime(),
+        localIsoWeek: '2026-W15',
+        units: 3,
+      }),
+      event({
+        ts: new Date('2026-04-15T12:00:00.000Z').getTime(),
+        localIsoWeek: '2026-W16',
+        units: 1,
+      }),
+    ];
+    const out = buildWeeklyUnits(
+      events,
+      new Date('2026-04-06T00:00:00.000Z'),
+      new Date('2026-04-26T00:00:00.000Z'),
+    );
+    expect(out.map(p => p.units)).toEqual([5, 1, 0]);
+  });
+
+  test('excludes events outside the range via the dateRange filter', () => {
+    const events = [
+      event({
+        ts: new Date('2026-04-04T12:00:00.000Z').getTime(),
+        localIsoWeek: '2026-W14',
+        units: 10,
+      }),
+    ];
+    const out = buildWeeklyUnits(
+      events,
+      new Date('2026-04-06T00:00:00.000Z'),
+      new Date('2026-04-19T00:00:00.000Z'),
+    );
+    expect(out.every(p => p.units === 0)).toBe(true);
+  });
+});

--- a/src/components/Charts/BaseChart/BaseChart.tsx
+++ b/src/components/Charts/BaseChart/BaseChart.tsx
@@ -3,30 +3,36 @@ import {CartesianChart} from 'victory-native';
 import Text from '@components/Text';
 import useThemeStyles from '@hooks/useThemeStyles';
 import A11yOverlay from './A11yOverlay';
-import type {BaseChartProps} from './types';
+import type {BaseChartProps, ChartRenderCtx} from './types';
 import useChartTheme from './useChartTheme';
 
 const DEFAULT_HEIGHT = 200;
+const DEFAULT_Y_KEYS = ['y'] as const;
 
 /**
  * Theme-aware wrapper around `victory-native`'s `CartesianChart`. The only
  * file in the chart layer that imports `victory-native` — concrete charts
- * (WeeklyBars, future TrendLine) consume this primitive through its
+ * (WeeklyBars, TrendLine, StackedArea) consume this primitive through its
  * render-prop and never touch Victory directly.
+ *
+ * `yKeys` defaults to `['y']` (the canonical `ChartDatum` shape). Multi-
+ * series charts pass a wider tuple, and `data` rows must include numeric
+ * fields for every key (zero-fill the gaps upstream).
  *
  * When `data` is empty and `emptyLabel` is provided, BaseChart short-circuits
  * to a reassuring text state. Otherwise it renders the chart canvas wrapped
  * in an `A11yOverlay` so VoiceOver / TalkBack can announce it (Skia draws to
  * canvas with no native a11y nodes — the overlay is the only handhold).
  */
-function BaseChart({
+function BaseChart<TYKey extends string = 'y'>({
   data,
+  yKeys,
   accessibilityLabel,
   emptyLabel,
   height = DEFAULT_HEIGHT,
   hideAxes = false,
   children,
-}: BaseChartProps) {
+}: BaseChartProps<TYKey>) {
   const styles = useThemeStyles();
   const theme = useChartTheme();
   const isEmpty = data.length === 0;
@@ -55,16 +61,32 @@ function BaseChart({
     ? 0
     : {left: 24, right: 24, top: 16, bottom: 0};
 
+  const resolvedYKeys =
+    yKeys ?? (DEFAULT_Y_KEYS as unknown as readonly TYKey[]);
+
+  // Victory's CartesianChart binds `data` shape to `xKey` and `yKeys` at the
+  // type level, but BaseChart accepts a generic record-shaped row so concrete
+  // charts can pass arbitrary series. The runtime contract is identical
+  // (every row has `x` plus a numeric field for each key); the cast just
+  // bridges the structural typing.
+  type CastedRow = Record<string, string | number> & {x: string | number};
+  const castedData = data as CastedRow[];
+  const castedYKeys = resolvedYKeys as ReadonlyArray<
+    Extract<keyof CastedRow, string>
+  >;
+
   return (
     <A11yOverlay accessibilityLabel={accessibilityLabel}>
       <View style={{height}}>
         <CartesianChart
-          data={data}
+          data={castedData}
           xKey="x"
-          yKeys={['y']}
+          yKeys={castedYKeys as never}
           axisOptions={axisOptions}
           domainPadding={domainPadding}>
-          {ctx => children?.({...ctx, theme})}
+          {ctx =>
+            children?.({...ctx, theme} as unknown as ChartRenderCtx<TYKey>)
+          }
         </CartesianChart>
       </View>
     </A11yOverlay>

--- a/src/components/Charts/BaseChart/index.ts
+++ b/src/components/Charts/BaseChart/index.ts
@@ -4,5 +4,10 @@ export {default as useChartTheme} from './useChartTheme';
 // Re-export Victory mark primitives so concrete chart components can draw
 // without importing `victory-native` directly (per design doc §6).
 export {Area, Bar, Line} from 'victory-native';
-export type {BaseChartProps, ChartRenderCtx, ChartTheme} from './types';
+export type {
+  BaseChartDatum,
+  BaseChartProps,
+  ChartRenderCtx,
+  ChartTheme,
+} from './types';
 export type {A11yOverlayProps} from './A11yOverlay';

--- a/src/components/Charts/BaseChart/types.ts
+++ b/src/components/Charts/BaseChart/types.ts
@@ -20,8 +20,16 @@ type ChartTheme = {
   primaryStroke: string;
   /** Translucent fill for the "band of normal" overlay. */
   bandFill: string;
+  /** Stroke color for muted comparison ("vs previous period") lines. */
+  comparisonStroke: string;
   /** Five-stop intensity ramp for the heatmap, indices 0..4. */
   intensityRamp: [string, string, string, string, string];
+  /**
+   * Seven-stop yellow→orange ramp keyed to the canonical DrinkKey order
+   * (`small_beer`, `beer`, `wine`, `cocktail`, `strong_shot`, `weak_shot`,
+   * `other`). No red, no black — see STATISTICS_V2.md §3.
+   */
+  drinkTypeRamp: [string, string, string, string, string, string, string];
 };
 
 /**
@@ -29,15 +37,23 @@ type ChartTheme = {
  * own context with our theme colors so concrete charts don't have to
  * re-derive theming.
  */
-type ChartRenderCtx<TYKey extends string = 'y'> = {
+type ChartRenderCtx<TYKey extends string = string> = {
   points: Record<TYKey, PointsArray>;
   chartBounds: ChartBounds;
   theme: ChartTheme;
 };
 
-type BaseChartProps = {
-  data: ChartDatum[];
+type BaseChartDatum = ChartDatum | Record<string, string | number>;
+
+type BaseChartProps<TYKey extends string = 'y'> = {
+  data: BaseChartDatum[];
   range: ChartRange;
+  /**
+   * Y-axis keys to project. Defaults to `['y']`, matching the canonical
+   * `ChartDatum` shape used by `WeeklyBars` and `Sparkline`. Charts with
+   * multiple series (TrendLine + EWMA, StackedArea) pass extra keys.
+   */
+  yKeys?: readonly TYKey[];
   /** Required — Skia draws to a canvas with no native a11y nodes. */
   accessibilityLabel: string;
   /** Shown in place of the chart when `data` is empty. */
@@ -46,7 +62,7 @@ type BaseChartProps = {
   height?: number;
   /** Suppresses axis labels, ticks, and padding. Use for inline sparklines. */
   hideAxes?: boolean;
-  children?: (ctx: ChartRenderCtx) => ReactNode;
+  children?: (ctx: ChartRenderCtx<TYKey>) => ReactNode;
 };
 
-export type {BaseChartProps, ChartRenderCtx, ChartTheme};
+export type {BaseChartDatum, BaseChartProps, ChartRenderCtx, ChartTheme};

--- a/src/components/Charts/BaseChart/useChartTheme.ts
+++ b/src/components/Charts/BaseChart/useChartTheme.ts
@@ -25,11 +25,28 @@ function useChartTheme(): ChartTheme {
       primaryStroke: appColor,
       // ~20% alpha suffix on the theme accent for the band-of-normal stripe.
       bandFill: `${appColor}33`,
+      // Muted ~67% alpha on the supporting text color for dashed
+      // "vs previous period" overlays — visible but never competes with
+      // the primary series.
+      comparisonStroke: `${textSupporting}AA`,
       intensityRamp: [
         borderLighter,
         `${warning}55`,
         `${warning}AA`,
         warning,
+        add,
+      ],
+      // Seven stops along the yellow → orange spectrum, keyed positionally
+      // to `CONST.DRINKS.KEYS` order at the call site. Walks from a low-
+      // alpha warning yellow up to the warmer `add` orange — no red, no
+      // black, per STATISTICS_V2.md §3.
+      drinkTypeRamp: [
+        `${warning}55`,
+        `${warning}88`,
+        `${warning}BB`,
+        warning,
+        `${add}CC`,
+        `${add}EE`,
         add,
       ],
     }),

--- a/src/components/Charts/CumulativeLine/CumulativeLine.tsx
+++ b/src/components/Charts/CumulativeLine/CumulativeLine.tsx
@@ -1,0 +1,82 @@
+import {useMemo} from 'react';
+import {DashPathEffect} from '@shopify/react-native-skia';
+import {BaseChart, Line} from '@components/Charts/BaseChart';
+
+type CumulativeLinePoint = {date: string; count: number};
+
+type CumulativeLineProps = {
+  points: CumulativeLinePoint[];
+  /** Parallel-indexed comparison series; omit to hide. */
+  comparisonPoints?: CumulativeLinePoint[];
+  accessibilityLabel: string;
+  emptyLabel?: string;
+  height?: number;
+};
+
+type CumulativeRow = {x: string; y: number; cmp: number};
+
+const COMPARISON_DASH: number[] = [4, 4];
+
+/**
+ * Cumulative AF-days line. Resets are handled upstream by
+ * `buildAfYtdSeries` (returns 0 on Jan 1), so the chart just plots whatever
+ * it's handed — including the reset, which surfaces as a downward step.
+ * That step is the only time the line goes down; within a calendar year it
+ * is monotonically non-decreasing.
+ */
+function CumulativeLine({
+  points,
+  comparisonPoints,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+}: CumulativeLineProps) {
+  const showComparison =
+    !!comparisonPoints && comparisonPoints.length === points.length;
+
+  const data = useMemo<CumulativeRow[]>(
+    () =>
+      points.map((p, i) => ({
+        x: p.date,
+        y: p.count,
+        cmp: showComparison ? comparisonPoints?.[i]?.count ?? 0 : 0,
+      })),
+    [points, comparisonPoints, showComparison],
+  );
+
+  const yKeys = useMemo<ReadonlyArray<'y' | 'cmp'>>(
+    () => (showComparison ? ['y', 'cmp'] : ['y']),
+    [showComparison],
+  );
+
+  return (
+    <BaseChart
+      data={data}
+      yKeys={yKeys}
+      range="allTime"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}>
+      {({points: linePoints, theme}) => (
+        <>
+          <Line
+            points={linePoints.y}
+            color={theme.primaryStroke}
+            strokeWidth={2}
+          />
+          {showComparison ? (
+            <Line
+              points={linePoints.cmp}
+              color={theme.comparisonStroke}
+              strokeWidth={1.5}>
+              <DashPathEffect intervals={COMPARISON_DASH} />
+            </Line>
+          ) : null}
+        </>
+      )}
+    </BaseChart>
+  );
+}
+
+export default CumulativeLine;
+export type {CumulativeLinePoint, CumulativeLineProps};

--- a/src/components/Charts/CumulativeLine/index.ts
+++ b/src/components/Charts/CumulativeLine/index.ts
@@ -1,0 +1,2 @@
+export {default as CumulativeLine} from './CumulativeLine';
+export type {CumulativeLinePoint, CumulativeLineProps} from './CumulativeLine';

--- a/src/components/Charts/StackedArea/StackedArea.tsx
+++ b/src/components/Charts/StackedArea/StackedArea.tsx
@@ -1,0 +1,117 @@
+import {useMemo} from 'react';
+import {DashPathEffect} from '@shopify/react-native-skia';
+import {Area, BaseChart, Line} from '@components/Charts/BaseChart';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+type StackedAreaProps = {
+  /** ISO-week labels, one per row, index-aligned with `byKey` arrays. */
+  weeks: string[];
+  /** Per-key weekly totals; arrays length === weeks.length. */
+  byKey: Partial<Record<DrinkKey, number[]>>;
+  /** Order in which keys are stacked (innermost first → outermost last). */
+  trackedKeys: readonly DrinkKey[];
+  /** Per-key fill color. */
+  palette: Partial<Record<DrinkKey, string>>;
+  /** Optional comparison series — drawn as a single dashed total line. */
+  comparisonTotal?: number[];
+  accessibilityLabel: string;
+  emptyLabel?: string;
+  height?: number;
+};
+
+const COMPARISON_DASH: number[] = [4, 4];
+const COMPARISON_KEY = '__cmpTotal__';
+
+/**
+ * Weekly drink-type stacked area. Each tracked key contributes one Skia
+ * `<Area>` layer; layers are pre-stacked at the data level (each row's
+ * value for key Kn is the cumulative sum of K0..Kn). Layers render back-to-
+ * front so the smallest cumulative sits on top — the visible thickness of
+ * each layer corresponds to its underlying weekly total.
+ *
+ * Comparison mode adds a single dashed muted line tracing the previous
+ * period's grand total (sum across keys). Seven dashed cumulative lines
+ * would be visual mud; one total line carries the "vs last period"
+ * comparison without competing with the stack itself.
+ */
+function StackedArea({
+  weeks,
+  byKey,
+  trackedKeys,
+  palette,
+  comparisonTotal,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+}: StackedAreaProps) {
+  const showComparison =
+    !!comparisonTotal && comparisonTotal.length === weeks.length;
+
+  const data = useMemo(
+    () =>
+      weeks.map((week, i) => {
+        const row: Record<string, string | number> = {x: week};
+        let running = 0;
+        for (const key of trackedKeys) {
+          running += byKey[key]?.[i] ?? 0;
+          row[key] = running;
+        }
+        if (showComparison) {
+          row[COMPARISON_KEY] = comparisonTotal?.[i] ?? 0;
+        }
+        return row;
+      }),
+    [weeks, byKey, trackedKeys, comparisonTotal, showComparison],
+  );
+
+  const yKeys = useMemo<readonly string[]>(
+    () =>
+      showComparison ? [...trackedKeys, COMPARISON_KEY] : [...trackedKeys],
+    [trackedKeys, showComparison],
+  );
+
+  return (
+    <BaseChart
+      data={data}
+      yKeys={yKeys}
+      range="rolling8w"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}>
+      {({points, chartBounds, theme}) => {
+        const baseline = chartBounds.bottom;
+        // Render back-to-front: highest cumulative first (drawn behind),
+        // smallest cumulative last (drawn on top).
+        const reversedKeys = [...trackedKeys].reverse();
+        return (
+          <>
+            {reversedKeys.map(key => {
+              const layerPoints = points[key];
+              if (!layerPoints) return null;
+              return (
+                <Area
+                  key={key}
+                  points={layerPoints}
+                  y0={baseline}
+                  color={palette[key] ?? theme.primaryFill}
+                  animate={{type: 'timing', duration: 200}}
+                />
+              );
+            })}
+            {showComparison ? (
+              <Line
+                points={points[COMPARISON_KEY]}
+                color={theme.comparisonStroke}
+                strokeWidth={1.5}>
+                <DashPathEffect intervals={COMPARISON_DASH} />
+              </Line>
+            ) : null}
+          </>
+        );
+      }}
+    </BaseChart>
+  );
+}
+
+export default StackedArea;
+export type {StackedAreaProps};

--- a/src/components/Charts/StackedArea/index.ts
+++ b/src/components/Charts/StackedArea/index.ts
@@ -1,0 +1,2 @@
+export {default as StackedArea} from './StackedArea';
+export type {StackedAreaProps} from './StackedArea';

--- a/src/components/Charts/TrendLine/TrendLine.tsx
+++ b/src/components/Charts/TrendLine/TrendLine.tsx
@@ -1,0 +1,148 @@
+import {useMemo} from 'react';
+import {DashPathEffect, Rect} from '@shopify/react-native-skia';
+import {BaseChart, Line} from '@components/Charts/BaseChart';
+
+type TrendLineProps = {
+  /** ISO-week labels, one per data point. Drives the chart's x-axis order. */
+  weeks: string[];
+  /** Raw weekly units, length === weeks.length. */
+  units: number[];
+  /** Smoothed EWMA series; omit to hide the overlay (sparse data). */
+  ewma?: number[];
+  /** Comparison-period units, parallel-indexed; omit to hide. */
+  comparison?: number[];
+  /** P25 / P75 band; null when the underlying series is too short. */
+  band?: {p25: number; p75: number} | null;
+  accessibilityLabel: string;
+  emptyLabel?: string;
+  height?: number;
+};
+
+type TrendRow = {
+  x: string;
+  y: number;
+  ewma: number;
+  cmp: number;
+};
+
+const COMPARISON_DASH: number[] = [4, 4];
+
+/**
+ * Hero chart for the Trends tab. Composes:
+ *   1. translucent P25–P75 "band of normal" stripe (Skia <Rect>),
+ *   2. solid weekly-units line in the brand color,
+ *   3. thinner EWMA line above (hidden when < 4 weeks),
+ *   4. dashed muted-color comparison line (hidden when not requested).
+ *
+ * Every yKey present on `data` rows must be a real number; callers zero-fill
+ * missing series upstream (in `useTrendsTabData`) so the underlying chart
+ * doesn't ingest NaN.
+ */
+function TrendLine({
+  weeks,
+  units,
+  ewma,
+  comparison,
+  band,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+}: TrendLineProps) {
+  const showEwma = !!ewma && ewma.length === weeks.length;
+  const showComparison =
+    !!comparison && comparison.length === weeks.length && weeks.length > 0;
+
+  const data = useMemo<TrendRow[]>(
+    () =>
+      weeks.map((w, i) => ({
+        x: w,
+        y: units[i] ?? 0,
+        ewma: showEwma ? ewma?.[i] ?? 0 : 0,
+        cmp: showComparison ? comparison?.[i] ?? 0 : 0,
+      })),
+    [weeks, units, ewma, comparison, showEwma, showComparison],
+  );
+
+  const yKeys = useMemo<ReadonlyArray<'y' | 'ewma' | 'cmp'>>(() => {
+    const keys: Array<'y' | 'ewma' | 'cmp'> = ['y'];
+    if (showEwma) keys.push('ewma');
+    if (showComparison) keys.push('cmp');
+    return keys;
+  }, [showEwma, showComparison]);
+
+  const maxY = useMemo(() => {
+    let max = 1;
+    for (const row of data) {
+      if (row.y > max) max = row.y;
+      if (showEwma && row.ewma > max) max = row.ewma;
+      if (showComparison && row.cmp > max) max = row.cmp;
+    }
+    if (band && band.p75 > max) max = band.p75;
+    return max;
+  }, [data, band, showEwma, showComparison]);
+
+  return (
+    <BaseChart
+      data={data}
+      yKeys={yKeys}
+      range="rolling8w"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}>
+      {({points, chartBounds, theme}) => {
+        const top = chartBounds.top;
+        const bottom = chartBounds.bottom;
+        const yFor = (value: number) =>
+          top + (1 - value / maxY) * (bottom - top);
+
+        let bandRect = null;
+        if (band) {
+          const bandTopY = yFor(band.p75);
+          const bandBottomY = yFor(band.p25);
+          const bandHeight = Math.max(0, bandBottomY - bandTopY);
+          if (bandHeight > 0) {
+            bandRect = (
+              <Rect
+                x={chartBounds.left}
+                y={bandTopY}
+                width={chartBounds.right - chartBounds.left}
+                height={bandHeight}
+                color={theme.bandFill}
+              />
+            );
+          }
+        }
+
+        return (
+          <>
+            {bandRect}
+            <Line
+              points={points.y}
+              color={theme.primaryStroke}
+              strokeWidth={2}
+            />
+            {showEwma ? (
+              <Line
+                points={points.ewma}
+                color={theme.primaryStroke}
+                strokeWidth={1.5}
+                opacity={0.6}
+              />
+            ) : null}
+            {showComparison ? (
+              <Line
+                points={points.cmp}
+                color={theme.comparisonStroke}
+                strokeWidth={1.5}>
+                <DashPathEffect intervals={COMPARISON_DASH} />
+              </Line>
+            ) : null}
+          </>
+        );
+      }}
+    </BaseChart>
+  );
+}
+
+export default TrendLine;
+export type {TrendLineProps};

--- a/src/components/Charts/TrendLine/index.ts
+++ b/src/components/Charts/TrendLine/index.ts
@@ -1,0 +1,2 @@
+export {default as TrendLine} from './TrendLine';
+export type {TrendLineProps} from './TrendLine';

--- a/src/hooks/useStatistics/useTrendsTabData.ts
+++ b/src/hooks/useStatistics/useTrendsTabData.ts
@@ -1,0 +1,235 @@
+import {useMemo} from 'react';
+import {useChartTheme} from '@components/Charts/BaseChart';
+import {ewma, mannKendall} from '@libs/Statistics/stats';
+import {
+  buildAfYtdSeries,
+  buildWeeklyStackedSeries,
+  buildWeeklyUnits,
+  percentileBand,
+  shiftRange,
+} from '@libs/Statistics/trends';
+import type {AfYtdPoint} from '@libs/Statistics/trends';
+import useStatsContext from '@hooks/useStatsContext';
+import CONST from '@src/CONST';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import useDrinkEvents from './useDrinkEvents';
+
+type CaptionKey = 'trendingUp' | 'trendingDown' | 'neutral' | 'notEnoughData';
+
+type Hero = {
+  weeks: string[];
+  units: number[];
+  ewma?: number[];
+  comparison?: number[];
+  band: {p25: number; p75: number} | null;
+  captionKey: CaptionKey;
+};
+
+type Stack = {
+  weeks: string[];
+  byKey: Partial<Record<DrinkKey, number[]>>;
+  trackedKeys: readonly DrinkKey[];
+  palette: Partial<Record<DrinkKey, string>>;
+  comparisonTotal?: number[];
+};
+
+type TrendsTabData = {
+  hero: Hero;
+  afYtd: {
+    points: AfYtdPoint[];
+    comparisonPoints?: AfYtdPoint[];
+    hidden: boolean;
+  };
+  stack: Stack;
+  isLoading: boolean;
+};
+
+const MIN_TREND_N = 8;
+const MIN_EWMA_N = 4;
+
+const ALL_DRINK_KEYS: readonly DrinkKey[] = Object.values(CONST.DRINKS.KEYS);
+
+/**
+ * Single composed data hook backing the Trends tab. Reads the event stream
+ * once, then derives:
+ *
+ *   - Hero weekly-units series (raw + EWMA + band + Mann–Kendall caption).
+ *   - Cumulative AF-days YTD series (and its comparison twin when enabled).
+ *   - Per-DrinkKey weekly stack (respecting the active `drinkTypeFilter`).
+ *
+ * All series are zero-filled and index-aligned with their comparison
+ * counterparts so the chart layer can read row-by-row without bounds checks.
+ */
+function useTrendsTabData(): TrendsTabData {
+  const {events, isLoading} = useDrinkEvents();
+  const {range, comparison, drinkTypeFilter} = useStatsContext();
+  const theme = useChartTheme();
+
+  const comparisonRange = useMemo(
+    () => shiftRange(range, comparison),
+    [range, comparison],
+  );
+
+  // Hero — weekly units.
+  const hero = useMemo<Hero>(() => {
+    const weekly = buildWeeklyUnits(events, range.start, range.end);
+    const weeks = weekly.map(p => p.isoWeek);
+    const units = weekly.map(p => p.units);
+
+    const ewmaSeries =
+      units.length >= MIN_EWMA_N ? ewma(units, 0.3) : undefined;
+    const band = percentileBand(units);
+
+    const comparisonUnits = comparisonRange
+      ? buildWeeklyUnits(
+          events,
+          comparisonRange.start,
+          comparisonRange.end,
+        ).map(p => p.units)
+      : undefined;
+
+    // Pad / trim comparison to match weeks.length so the chart can index by
+    // position. We rely on shiftRange producing same-length windows; clamp
+    // defensively.
+    let comparisonAligned: number[] | undefined;
+    if (comparisonUnits) {
+      if (comparisonUnits.length === weeks.length) {
+        comparisonAligned = comparisonUnits;
+      } else if (comparisonUnits.length > weeks.length) {
+        comparisonAligned = comparisonUnits.slice(
+          comparisonUnits.length - weeks.length,
+        );
+      } else {
+        const padding = new Array<number>(
+          weeks.length - comparisonUnits.length,
+        ).fill(0);
+        comparisonAligned = [...padding, ...comparisonUnits];
+      }
+    }
+
+    let captionKey: CaptionKey = 'notEnoughData';
+    if (units.length >= MIN_TREND_N) {
+      const mk = mannKendall(units);
+      if (mk.trend === 'up') captionKey = 'trendingUp';
+      else if (mk.trend === 'down') captionKey = 'trendingDown';
+      else captionKey = 'neutral';
+    }
+
+    return {
+      weeks,
+      units,
+      ewma: ewmaSeries,
+      comparison: comparisonAligned,
+      band,
+      captionKey,
+    };
+  }, [events, range.start, range.end, comparisonRange]);
+
+  // AF-days YTD.
+  const afYtd = useMemo(() => {
+    const hidden = range.preset === 'W';
+    if (hidden) {
+      return {points: [] as AfYtdPoint[], hidden};
+    }
+    const points = buildAfYtdSeries(events, range.start, range.end);
+    let comparisonPoints: AfYtdPoint[] | undefined;
+    if (comparisonRange) {
+      const raw = buildAfYtdSeries(
+        events,
+        comparisonRange.start,
+        comparisonRange.end,
+      );
+      // Pad to match `points.length` so the chart layer can index in lock-
+      // step. Drop oldest or pad with the leading count, mirroring the hero
+      // alignment policy.
+      if (raw.length === points.length) {
+        comparisonPoints = raw;
+      } else if (raw.length > points.length) {
+        comparisonPoints = raw.slice(raw.length - points.length);
+      } else if (raw.length > 0) {
+        const padCount = points.length - raw.length;
+        const head = raw[0];
+        const pad: AfYtdPoint[] = Array.from({length: padCount}, () => head);
+        comparisonPoints = [...pad, ...raw];
+      }
+    }
+    return {points, comparisonPoints, hidden};
+  }, [events, range.start, range.end, range.preset, comparisonRange]);
+
+  // Drink-type stacked area.
+  const stack = useMemo<Stack>(() => {
+    const {weeks, trackedKeys} = buildWeeklyStackedSeries(
+      events,
+      range.start,
+      range.end,
+      drinkTypeFilter,
+      ALL_DRINK_KEYS,
+    );
+    // Pivot the per-week row data into per-key arrays for the StackedArea
+    // component, which prefers column-major input.
+    const weekLabels = weeks.map(w => w.isoWeek);
+    const byKey: Partial<Record<DrinkKey, number[]>> = {};
+    for (const key of trackedKeys) {
+      byKey[key] = weeks.map(w => w.byKey[key] ?? 0);
+    }
+
+    // Per-key palette: walk trackedKeys in ALL_DRINK_KEYS order, zipping
+    // against `theme.drinkTypeRamp` positionally so colors stay stable when
+    // the user toggles drink-type chips.
+    const palette: Partial<Record<DrinkKey, string>> = {};
+    ALL_DRINK_KEYS.forEach((key, i) => {
+      if (trackedKeys.includes(key)) {
+        palette[key] = theme.drinkTypeRamp[i] ?? theme.primaryFill;
+      }
+    });
+
+    let comparisonTotal: number[] | undefined;
+    if (comparisonRange) {
+      const cmp = buildWeeklyStackedSeries(
+        events,
+        comparisonRange.start,
+        comparisonRange.end,
+        drinkTypeFilter,
+        ALL_DRINK_KEYS,
+      );
+      const totals = cmp.weeks.map(w => {
+        let sum = 0;
+        for (const k of cmp.trackedKeys) {
+          sum += w.byKey[k] ?? 0;
+        }
+        return sum;
+      });
+      if (totals.length === weekLabels.length) {
+        comparisonTotal = totals;
+      } else if (totals.length > weekLabels.length) {
+        comparisonTotal = totals.slice(totals.length - weekLabels.length);
+      } else {
+        comparisonTotal = [
+          ...new Array<number>(weekLabels.length - totals.length).fill(0),
+          ...totals,
+        ];
+      }
+    }
+
+    return {
+      weeks: weekLabels,
+      byKey,
+      trackedKeys,
+      palette,
+      comparisonTotal,
+    };
+  }, [
+    events,
+    range.start,
+    range.end,
+    drinkTypeFilter,
+    comparisonRange,
+    theme.drinkTypeRamp,
+    theme.primaryFill,
+  ]);
+
+  return {hero, afYtd, stack, isLoading};
+}
+
+export default useTrendsTabData;
+export type {CaptionKey, Hero, Stack, TrendsTabData};

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -812,8 +812,30 @@ export default {
       },
       trends: {
         label: 'Trendy',
-        placeholder:
-          'Týdenní trend a pásmo normálu se tu objeví, jak budou přibývat data.',
+        weeklyTrend: {
+          title: 'Týdenní jednotky',
+          emptyLabel: 'Zaznamenej pár týdnů a uvidíš svůj trend.',
+          bandCaption:
+            'Stínované pásmo ukazuje, kde se pohybovala většina posledních týdnů.',
+          captions: {
+            trendingDown: 'Tvé týdenní jednotky mají sestupný trend.',
+            trendingUp: 'Tvé týdenní jednotky mají vzestupný trend.',
+            neutral: 'Tvé týdny se mění obvyklým způsobem.',
+            notEnoughData:
+              'Pokračuj v zaznamenávání — trend se ukáže, až bude víc dat.',
+          },
+        },
+        cumulativeAf: {
+          title: 'Dny bez alkoholu letos',
+          emptyLabel: 'Letos zatím žádné dny bez alkoholu.',
+        },
+        drinkTypeStack: {
+          title: 'Mix nápojů v čase',
+          emptyLabel: 'Zaznamenej pár setkání a uvidíš svůj mix.',
+        },
+        comparison: {
+          legend: 'Předchozí období',
+        },
       },
       patterns: {
         label: 'Vzorce',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -823,8 +823,30 @@ export default {
       },
       trends: {
         label: 'Trends',
-        placeholder:
-          'Your weekly trend and band-of-normal will surface here as data builds.',
+        weeklyTrend: {
+          title: 'Weekly units',
+          emptyLabel: 'Log a few weeks to see your trend.',
+          bandCaption:
+            'The shaded band is where most of your recent weeks landed.',
+          captions: {
+            trendingDown: 'Your weekly units are trending down.',
+            trendingUp: 'Your weekly units are trending up.',
+            neutral: 'Your weeks vary as usual.',
+            notEnoughData:
+              'Keep logging — your trend will surface as data builds.',
+          },
+        },
+        cumulativeAf: {
+          title: 'Alcohol-free days this year',
+          emptyLabel: 'No alcohol-free days logged yet this year.',
+        },
+        drinkTypeStack: {
+          title: 'Drink mix over time',
+          emptyLabel: 'Log a few sessions to see your mix.',
+        },
+        comparison: {
+          legend: 'Previous period',
+        },
       },
       patterns: {
         label: 'Patterns',

--- a/src/libs/Statistics/trends/afYtd.ts
+++ b/src/libs/Statistics/trends/afYtd.ts
@@ -1,0 +1,57 @@
+import {addDays, format, startOfDay} from 'date-fns';
+import type {DrinkEvent} from '@libs/Statistics/types';
+
+type AfYtdPoint = {
+  date: string;
+  count: number;
+};
+
+/**
+ * Cumulative alcohol-free-days series over the inclusive window
+ * `[start, end]`, resetting to 0 at each Jan 1. One point per day:
+ *
+ *   - on Jan 1 the counter resets to 0 before evaluating that day.
+ *   - if a day has no drink events in `events`, the counter increments and
+ *     the new value is emitted.
+ *   - if a day has any drink events, the counter is unchanged.
+ *
+ * Both branches emit a point so the resulting series is dense and
+ * monotonically non-decreasing within each calendar year — the chart's
+ * "only-up line" visual. Reads `localDay` directly to avoid re-deriving the
+ * session timezone here.
+ */
+function buildAfYtdSeries(
+  events: DrinkEvent[],
+  start: Date,
+  end: Date,
+): AfYtdPoint[] {
+  const startDay = startOfDay(start);
+  const endDay = startOfDay(end);
+  if (endDay.getTime() < startDay.getTime()) {
+    return [];
+  }
+
+  const eventDays = new Set<string>();
+  for (const event of events) {
+    eventDays.add(event.localDay);
+  }
+
+  const out: AfYtdPoint[] = [];
+  let counter = 0;
+  let cursor = startDay;
+  while (cursor.getTime() <= endDay.getTime()) {
+    const key = format(cursor, 'yyyy-MM-dd');
+    if (key.endsWith('-01-01')) {
+      counter = 0;
+    }
+    if (!eventDays.has(key)) {
+      counter += 1;
+    }
+    out.push({date: key, count: counter});
+    cursor = addDays(cursor, 1);
+  }
+  return out;
+}
+
+export default buildAfYtdSeries;
+export type {AfYtdPoint};

--- a/src/libs/Statistics/trends/index.ts
+++ b/src/libs/Statistics/trends/index.ts
@@ -1,0 +1,11 @@
+export {default as buildAfYtdSeries} from './afYtd';
+export type {AfYtdPoint} from './afYtd';
+export {default as buildWeeklyUnits} from './weeklyUnits';
+export type {WeeklyUnitsPoint} from './weeklyUnits';
+export {default as buildWeeklyStackedSeries} from './weeklyStacked';
+export type {StackedWeek} from './weeklyStacked';
+export {default as percentileBand} from './percentileBand';
+export type {Band} from './percentileBand';
+export {default as shiftRange} from './shiftRange';
+export type {ShiftedRange} from './shiftRange';
+export {formatIsoWeek, weekKeysInRange} from './weeks';

--- a/src/libs/Statistics/trends/percentileBand.ts
+++ b/src/libs/Statistics/trends/percentileBand.ts
@@ -1,0 +1,21 @@
+import percentile from '@libs/Statistics/stats/percentile';
+
+type Band = {p25: number; p75: number};
+
+/**
+ * "Band of normal" — P25/P75 over the last `window` (default 12) entries.
+ * Returns `null` for `series.length < 4` since the percentile would be
+ * mostly noise; callers (TrendLine) interpret null as "do not render".
+ */
+function percentileBand(series: number[], window = 12): Band | null {
+  if (series.length < 4) {
+    return null;
+  }
+  const slice = series.slice(-Math.min(window, series.length));
+  const p25 = percentile(slice, 0.25);
+  const p75 = percentile(slice, 0.75);
+  return {p25, p75};
+}
+
+export default percentileBand;
+export type {Band};

--- a/src/libs/Statistics/trends/shiftRange.ts
+++ b/src/libs/Statistics/trends/shiftRange.ts
@@ -1,0 +1,40 @@
+import {subYears} from 'date-fns';
+import type {Comparison, Range} from '@components/StatsContextProvider/types';
+
+type ShiftedRange = {start: Date; end: Date};
+
+/**
+ * Derive the comparison window for a given `range` and `comparison` mode.
+ *
+ *   - `'none'`              → null (no comparison series rendered)
+ *   - `'previous-period'`   → window of equal length placed immediately
+ *                              before `range.start`. The comparison's `end`
+ *                              is `range.start - 1ms` so the two windows
+ *                              are disjoint.
+ *   - `'previous-year'`     → both endpoints shifted back by one calendar
+ *                              year via date-fns `subYears`. Leap day handling
+ *                              follows date-fns: Feb 29 shifts to Feb 28.
+ *
+ * `'All'` ranges are valid input — callers (the toolbar) typically gate the
+ * comparison toggle to non-`All` presets, but this helper does not enforce it
+ * and will happily return a previous window for `All` too.
+ */
+function shiftRange(range: Range, comparison: Comparison): ShiftedRange | null {
+  if (comparison === 'none') {
+    return null;
+  }
+  if (comparison === 'previous-year') {
+    return {
+      start: subYears(range.start, 1),
+      end: subYears(range.end, 1),
+    };
+  }
+  const length = range.end.getTime() - range.start.getTime();
+  return {
+    start: new Date(range.start.getTime() - length - 1),
+    end: new Date(range.start.getTime() - 1),
+  };
+}
+
+export default shiftRange;
+export type {ShiftedRange};

--- a/src/libs/Statistics/trends/weeklyStacked.ts
+++ b/src/libs/Statistics/trends/weeklyStacked.ts
@@ -1,0 +1,90 @@
+import aggregate from '@libs/Statistics/aggregate';
+import {
+  byDrinkKey,
+  byIsoWeek,
+  composeBuckets,
+  COMPOSITE_KEY_SEP,
+} from '@libs/Statistics/bucketers';
+import {sumUnits} from '@libs/Statistics/reducers';
+import {dateRange, drinkTypeSubset} from '@libs/Statistics/filters';
+import type {DrinkEvent} from '@libs/Statistics/types';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import {weekKeysInRange} from './weeks';
+
+type StackedWeek = {
+  isoWeek: string;
+  byKey: Record<DrinkKey, number>;
+};
+
+/**
+ * Weekly drink-type breakdown for the inclusive window `[start, end]`.
+ *
+ *   - `drinkTypeFilter` empty Set ⇒ all keys in `allKeys` are tracked.
+ *   - Otherwise only keys in the filter are tracked.
+ *   - Weeks with zero events for a tracked key get `0` for that key.
+ *
+ * The returned array is index-aligned with {@link weekKeysInRange}, so the
+ * chart layer can iterate by row index and read each stacked layer by name.
+ */
+function buildWeeklyStackedSeries(
+  events: DrinkEvent[],
+  start: Date,
+  end: Date,
+  drinkTypeFilter: ReadonlySet<DrinkKey>,
+  allKeys: readonly DrinkKey[],
+): {weeks: StackedWeek[]; trackedKeys: readonly DrinkKey[]} {
+  const trackedKeys =
+    drinkTypeFilter.size === 0
+      ? allKeys
+      : allKeys.filter(k => drinkTypeFilter.has(k));
+
+  const labels = weekKeysInRange(start, end);
+
+  const baseFilter = dateRange(start.getTime(), end.getTime());
+  const filter =
+    drinkTypeFilter.size === 0
+      ? baseFilter
+      : (event: DrinkEvent) =>
+          baseFilter(event) && drinkTypeSubset(drinkTypeFilter)(event);
+
+  const composite = aggregate(
+    events,
+    composeBuckets(byIsoWeek, byDrinkKey),
+    sumUnits,
+    filter,
+  );
+
+  // Zero-fill skeleton.
+  const byWeek = new Map<string, Record<DrinkKey, number>>();
+  for (const week of labels) {
+    const row = {} as Record<DrinkKey, number>;
+    for (const key of trackedKeys) {
+      row[key] = 0;
+    }
+    byWeek.set(week, row);
+  }
+
+  composite.forEach((units, compositeKey) => {
+    const idx = compositeKey.indexOf(COMPOSITE_KEY_SEP);
+    if (idx === -1) {
+      return;
+    }
+    const week = compositeKey.slice(0, idx);
+    const key = compositeKey.slice(idx + 1) as DrinkKey;
+    const row = byWeek.get(week);
+    if (!row || !(key in row)) {
+      return;
+    }
+    row[key] = units;
+  });
+
+  const weeks: StackedWeek[] = labels.map(isoWeek => ({
+    isoWeek,
+    byKey: byWeek.get(isoWeek) ?? ({} as Record<DrinkKey, number>),
+  }));
+
+  return {weeks, trackedKeys};
+}
+
+export default buildWeeklyStackedSeries;
+export type {StackedWeek};

--- a/src/libs/Statistics/trends/weeklyUnits.ts
+++ b/src/libs/Statistics/trends/weeklyUnits.ts
@@ -1,0 +1,39 @@
+import aggregate from '@libs/Statistics/aggregate';
+import {byIsoWeek} from '@libs/Statistics/bucketers';
+import {sumUnits} from '@libs/Statistics/reducers';
+import {dateRange} from '@libs/Statistics/filters';
+import type {DrinkEvent} from '@libs/Statistics/types';
+import {weekKeysInRange} from './weeks';
+
+type WeeklyUnitsPoint = {
+  isoWeek: string;
+  units: number;
+};
+
+/**
+ * Gap-filled weekly-units series for the inclusive window `[start, end]`.
+ * Every ISO week the window touches is represented exactly once — weeks with
+ * no events contribute `0`. The returned array is index-aligned with
+ * {@link weekKeysInRange}, which is what makes the "vs previous period"
+ * comparison series stack neatly underneath the current series.
+ */
+function buildWeeklyUnits(
+  events: DrinkEvent[],
+  start: Date,
+  end: Date,
+): WeeklyUnitsPoint[] {
+  const labels = weekKeysInRange(start, end);
+  const byWeek = aggregate(
+    events,
+    byIsoWeek,
+    sumUnits,
+    dateRange(start.getTime(), end.getTime()),
+  );
+  return labels.map(isoWeek => ({
+    isoWeek,
+    units: byWeek.get(isoWeek) ?? 0,
+  }));
+}
+
+export default buildWeeklyUnits;
+export type {WeeklyUnitsPoint};

--- a/src/libs/Statistics/trends/weeks.ts
+++ b/src/libs/Statistics/trends/weeks.ts
@@ -1,0 +1,29 @@
+import {addWeeks, format, startOfISOWeek} from 'date-fns';
+
+/**
+ * Canonical ISO-8601 week label, matching the `localIsoWeek` field on
+ * `DrinkEvent` (`RRRR-'W'II`). Use this when keying chart data by week so
+ * `aggregate(events, byIsoWeek, …)` and the chart's x-axis labels line up.
+ */
+function formatIsoWeek(date: Date): string {
+  return format(date, "RRRR-'W'II");
+}
+
+/**
+ * Ordered ISO-week labels covering the inclusive `[start, end]` window. The
+ * cursor always lives on `startOfISOWeek(start)` so a range that straddles a
+ * week boundary still emits both weeks.
+ */
+function weekKeysInRange(start: Date, end: Date): string[] {
+  const cursor = startOfISOWeek(start);
+  const last = startOfISOWeek(end);
+  const labels: string[] = [];
+  let current = cursor;
+  while (current.getTime() <= last.getTime()) {
+    labels.push(formatIsoWeek(current));
+    current = addWeeks(current, 1);
+  }
+  return labels;
+}
+
+export {formatIsoWeek, weekKeysInRange};

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -1,8 +1,130 @@
 import React from 'react';
-import TabPlaceholder from './TabPlaceholder';
+import {StyleSheet, View} from 'react-native';
+import {ChartCard} from '@components/Charts/ChartCard';
+import {CumulativeLine} from '@components/Charts/CumulativeLine';
+import {StackedArea} from '@components/Charts/StackedArea';
+import {TrendLine} from '@components/Charts/TrendLine';
+import ScrollView from '@components/ScrollView';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useTrendsTabData from '@hooks/useStatistics/useTrendsTabData';
+import useThemeStyles from '@hooks/useThemeStyles';
+import type {TranslationPaths} from '@src/languages/types';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 12,
+    paddingBottom: 24,
+  },
+});
+
+const CAPTION_KEYS: Record<string, TranslationPaths> = {
+  trendingUp: 'statistics.tabs.trends.weeklyTrend.captions.trendingUp',
+  trendingDown: 'statistics.tabs.trends.weeklyTrend.captions.trendingDown',
+  neutral: 'statistics.tabs.trends.weeklyTrend.captions.neutral',
+  notEnoughData: 'statistics.tabs.trends.weeklyTrend.captions.notEnoughData',
+};
 
 function TrendsTab() {
-  return <TabPlaceholder copyKey="statistics.tabs.trends.placeholder" />;
+  const {translate} = useLocalize();
+  const themeStyles = useThemeStyles();
+  const {hero, afYtd, stack, isLoading} = useTrendsTabData();
+
+  if (isLoading) {
+    return (
+      <View style={[styles.container, themeStyles.justifyContentCenter]}>
+        <Text style={[themeStyles.textSupporting, themeStyles.textAlignCenter]}>
+          {translate('common.loading')}
+        </Text>
+      </View>
+    );
+  }
+
+  const heroComparisonShown = !!hero.comparison;
+  const heroSubtitle = hero.band
+    ? translate('statistics.tabs.trends.weeklyTrend.bandCaption')
+    : undefined;
+  const heroCaption = translate(CAPTION_KEYS[hero.captionKey]);
+  const comparisonLegend = translate(
+    'statistics.tabs.trends.comparison.legend',
+  );
+
+  return (
+    <ScrollView
+      style={themeStyles.flex1}
+      contentContainerStyle={styles.container}>
+      <ChartCard
+        title={translate('statistics.tabs.trends.weeklyTrend.title')}
+        subtitle={heroSubtitle}
+        footer={
+          <Text style={themeStyles.textMicroSupporting}>
+            {heroComparisonShown
+              ? `${heroCaption} · ${comparisonLegend}`
+              : heroCaption}
+          </Text>
+        }>
+        <TrendLine
+          weeks={hero.weeks}
+          units={hero.units}
+          ewma={hero.ewma}
+          comparison={hero.comparison}
+          band={hero.band}
+          emptyLabel={translate(
+            'statistics.tabs.trends.weeklyTrend.emptyLabel',
+          )}
+          accessibilityLabel={heroCaption}
+        />
+      </ChartCard>
+
+      {afYtd.hidden ? null : (
+        <ChartCard
+          title={translate('statistics.tabs.trends.cumulativeAf.title')}
+          footer={
+            afYtd.comparisonPoints ? (
+              <Text style={themeStyles.textMicroSupporting}>
+                {comparisonLegend}
+              </Text>
+            ) : undefined
+          }>
+          <CumulativeLine
+            points={afYtd.points}
+            comparisonPoints={afYtd.comparisonPoints}
+            emptyLabel={translate(
+              'statistics.tabs.trends.cumulativeAf.emptyLabel',
+            )}
+            accessibilityLabel={translate(
+              'statistics.tabs.trends.cumulativeAf.title',
+            )}
+          />
+        </ChartCard>
+      )}
+
+      <ChartCard
+        title={translate('statistics.tabs.trends.drinkTypeStack.title')}
+        footer={
+          stack.comparisonTotal ? (
+            <Text style={themeStyles.textMicroSupporting}>
+              {comparisonLegend}
+            </Text>
+          ) : undefined
+        }>
+        <StackedArea
+          weeks={stack.weeks}
+          byKey={stack.byKey}
+          trackedKeys={stack.trackedKeys}
+          palette={stack.palette}
+          comparisonTotal={stack.comparisonTotal}
+          emptyLabel={translate(
+            'statistics.tabs.trends.drinkTypeStack.emptyLabel',
+          )}
+          accessibilityLabel={translate(
+            'statistics.tabs.trends.drinkTypeStack.title',
+          )}
+        />
+      </ChartCard>
+    </ScrollView>
+  );
 }
 
 TrendsTab.displayName = 'TrendsTab';


### PR DESCRIPTION
### Details

Replaces the Trends tab placeholder with the three charts spec'd in [STATISTICS_V2.md §6.2](https://github.com/PetrCala/Kiroku/blob/claude/elegant-darwin-ad9da8/mockups/STATISTICS_V2.md#62-trends--how-is-this-changing):

1. **Hero weekly-units trend** — raw line in brand color, EWMA overlay (λ = 0.3), translucent P25–P75 band-of-normal, Mann–Kendall caption gated per §8 (`p < 0.05` AND `n >= 8`, otherwise neutral copy; `tau` and `p` never displayed). EWMA + band auto-hide below 4 weeks of data.
2. **Cumulative alcohol-free days YTD** — only-up step line, resets at Jan 1. Hidden on `range='W'` (a 7-day slice didn't earn its row).
3. **Weekly drink-type stacked area** — one Skia `<Area>` per `DrinkKey`, colors from a new theme `drinkTypeRamp` (7-stop yellow → orange, no red, no black). Respects the active drink-type filter (empty = all keys).

All three charts re-aggregate from the visible `range`. When `comparison !== 'none'`, each chart gains a dashed muted-color series for the shifted window — `previous-period` shifts by window length, `previous-year` by `subYears(_, 1)`. The stacked area's comparison is a single dashed *total* line (7 per-key cumulative lines would be visual mud).

Plan: [reflective-waddling-pebble.md](/Users/petr/.claude/plans/reflective-waddling-pebble.md). Issue: https://github.com/PetrCala/Kiroku/issues/584.

**Surface added:**
- Pure helpers in `src/libs/Statistics/trends/` (`shiftRange`, `weeklyUnits`, `afYtd`, `weeklyStacked`, `percentileBand`, `weeks`), all composing the v2-C `aggregate` / `dateRange` / `drinkTypeSubset` plumbing.
- Three new chart primitives — `TrendLine`, `CumulativeLine`, `StackedArea` — each composes `BaseChart`. `BaseChart` extended with an optional `yKeys` prop (default `['y']`) so multi-series charts stay within the design invariant that `BaseChart` is the only file importing `victory-native`. `WeeklyBars` and `Sparkline` are source-compatible.
- `useTrendsTabData` hook composes the event stream once and derives all three series + their comparison twins, with length-aligned padding so the chart layer can index row-by-row without bounds checks.
- `theme.comparisonStroke` (muted) and `theme.drinkTypeRamp` (7-stop) added to the chart theme.
- New `statistics.tabs.trends.{weeklyTrend,cumulativeAf,drinkTypeStack,comparison}` keys in `en` + `cs_cz`; the old `placeholder` key removed.

### Tests

**Automated:** 18 new unit tests under `__tests__/unit/Statistics/trends/` covering: year-boundary AF reset, sparse vs dense AF, gap-fill weekly units, range-filter exclusion, comparison-window shift incl. Feb 29 leap-day fallback, percentile-band window clipping, drink-type filter narrowing, stacked-area zero-fill.

```
PASS __tests__/unit/Statistics/trends/percentileBand.test.ts
PASS __tests__/unit/Statistics/trends/weeklyUnits.test.ts
PASS __tests__/unit/Statistics/trends/afYtd.test.ts
PASS __tests__/unit/Statistics/trends/shiftRange.test.ts
PASS __tests__/unit/Statistics/trends/weeklyStacked.test.ts
Tests:       18 passed, 18 total
```

`typecheck-tsgo` clean. `lint.sh` over all touched files clean. (Full-repo lint avoided per repo convention — CI's `lint.yml` is the gate.)

**Manual** (not yet run by me — needs device walk-through):

1. Open **Statistics → Trends**. Confirm three cards render: weekly-units line, cumulative AF, drink-type stack.
2. Cycle the range toolbar through `W`, `M`, `6M`, `Y`, `All`, `Custom`. Each chart updates; the AF card disappears on `W` and reappears on every other preset.
3. Toggle the comparison toolbar to **`vs last period`**, then **`vs last year`**. A dashed muted-color second series appears on the hero + AF charts; a single dashed total line appears on the stacked area.
4. Toggle drink-type chips. The stacked area's tracked layers change; hero and AF charts are unaffected.
5. With < 4 weeks of data, the hero shows the raw line only (no EWMA, no band), and the caption reads "Keep logging — your trend will surface as data builds."
6. With ≥ 8 weeks of data and a real trend, the caption reads "Your weekly units are trending up/down."
7. Toggle to **dark theme**. Band translucency and dashed comparison contrast read cleanly.
8. With sessions spanning Dec → Feb, scroll the AF chart and confirm the line resets at Jan 1 (the only point at which it goes down).
9. Switch app language to **CS**; confirm captions and titles render in Czech.

### Offline tests

- [x] Trends derives entirely from cached Onyx sessions (`useDrinkEvents`); no new network calls.
- [x] Charts render the cached data with no spinner once Onyx has hydrated.

### QA Steps

1. Log a handful of sessions across a week, open Statistics → Trends, and verify the three charts render.
2. Step through every range preset and confirm chart updates.
3. Toggle comparison on and confirm dashed second series.
4. Log sessions across a year boundary and confirm the cumulative AF chart resets on Jan 1.
5. With drink-type filter active, confirm the stacked area shows only the selected types.
6. Verify dark-theme contrast on all three charts.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I added unit tests under `__tests__/unit/Statistics/trends/`
- [x] Verified copy is localized (`en.ts` + `cs_cz.ts`)
- [x] `typecheck-tsgo` clean, `lint.sh` clean on touched files
- [ ] Device walk-through on iOS + Android (open, surfacing for reviewer)

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- pending device walk-through -->

</details>

<details>
<summary>iOS</summary>

<!-- pending device walk-through -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)