### PR TITLE
chore(stats): v2-M i18n + tone audit close-out

### DIFF
--- a/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
+++ b/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
@@ -23,6 +23,8 @@ type DowHourHeatmapProps = {
   accessibilityLabel: string;
   /** Pixel gap between cells. Default 1 (denser than CalendarHeatmap's 2). */
   gap?: number;
+  /** Overlay copy when every bucket is zero. When omitted, no overlay renders. */
+  emptyLabel?: string;
 };
 
 const HOURS = 24;
@@ -81,6 +83,7 @@ function DowHourHeatmap({
   weekStart,
   accessibilityLabel,
   gap = 1,
+  emptyLabel,
 }: DowHourHeatmapProps) {
   const [width, setWidth] = useState(0);
   const theme = useChartTheme();
@@ -201,7 +204,7 @@ function DowHourHeatmap({
               </Text>
             </View>
           ))}
-          {!hasData ? (
+          {!hasData && emptyLabel ? (
             <View
               pointerEvents="none"
               style={[
@@ -216,7 +219,7 @@ function DowHourHeatmap({
                 },
               ]}>
               <Text style={[styles.textSupporting, styles.textAlignCenter]}>
-                No drinks recorded in this range.
+                {emptyLabel}
               </Text>
             </View>
           ) : null}

--- a/src/components/Charts/HourPolar/HourPolar.tsx
+++ b/src/components/Charts/HourPolar/HourPolar.tsx
@@ -16,6 +16,8 @@ type HourPolarProps = {
   onSpokePress?: (hour: number) => void;
   /** Square canvas size in dp; defaults to the parent width. */
   size?: number;
+  /** Overlay copy when every bucket is zero. When omitted, no overlay renders. */
+  emptyLabel?: string;
 };
 
 const TAU = Math.PI * 2;
@@ -71,6 +73,7 @@ function HourPolar({
   labelForHour = defaultLabelForHour,
   onSpokePress,
   size,
+  emptyLabel,
 }: HourPolarProps) {
   const [measuredWidth, setMeasuredWidth] = useState(0);
   const theme = useChartTheme();
@@ -214,7 +217,7 @@ function HourPolar({
               />
             );
           })}
-          {!hasData ? (
+          {!hasData && emptyLabel ? (
             <View
               pointerEvents="none"
               style={[
@@ -229,7 +232,7 @@ function HourPolar({
                 },
               ]}>
               <Text style={[styles.textSupporting, styles.textAlignCenter]}>
-                No drinks recorded in this range.
+                {emptyLabel}
               </Text>
             </View>
           ) : null}

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -841,8 +841,8 @@ export default {
           bandCaption:
             'Stínovaný pás je tam, kde se odehrála většina tvých posledních 8 týdnů.',
           chip: {
-            down: 'Trend dolů — méně jednotek týden po týdnu.',
-            up: 'Trend nahoru — více jednotek týden po týdnu.',
+            down: 'Trend dolů — tvé týdenní jednotky postupně klesají.',
+            up: 'Trend nahoru — tvé týdenní jednotky postupně rostou.',
             none: 'Tvé týdny se proměňují jako obvykle.',
           },
           a11yLabel: 'Posledních 8 týdnů týdenních jednotek, vyhlazeno',
@@ -862,7 +862,7 @@ export default {
         label: 'Trendy',
         weeklyTrend: {
           title: 'Týdenní jednotky',
-          emptyLabel: 'Zaznamenej pár týdnů a uvidíš svůj trend.',
+          emptyLabel: 'Tvůj trend se ukáže, jak budou přibývat data.',
           bandCaption:
             'Stínované pásmo ukazuje, kde se pohybovala většina posledních týdnů.',
           captions: {
@@ -875,11 +875,11 @@ export default {
         },
         cumulativeAf: {
           title: 'Dny bez alkoholu letos',
-          emptyLabel: 'Letos zatím žádné dny bez alkoholu.',
+          emptyLabel: 'Každý letošní klidný den se počítá.',
         },
         drinkTypeStack: {
           title: 'Mix nápojů v čase',
-          emptyLabel: 'Zaznamenej pár setkání a uvidíš svůj mix.',
+          emptyLabel: 'Tvůj mix nápojů se ukáže, jak budeš přidávat data.',
         },
         comparison: {
           legend: 'Předchozí období',
@@ -896,7 +896,7 @@ export default {
           subtitle: 'Složení za aktuální období.',
           centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
           centerCaption: 'jednotek',
-          empty: 'V tomto období žádné záznamy.',
+          empty: 'Klidné období — zatím není co rozdělit.',
           sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
             `${label}: ${units} jednotek (${share} %)`,
           a11y: 'Koláč složení podle druhu pití',
@@ -936,21 +936,21 @@ export default {
       },
       hourOfDay: {
         title: 'Hodina dne',
-        empty: 'V tomto období žádné pití.',
+        empty: 'Klidné období — zatím není co zobrazit.',
       },
       dowHour: {
         title: 'Den v týdnu × hodina',
-        empty: 'V tomto období žádné pití.',
+        empty: 'Klidné období — zatím není co zobrazit.',
       },
       drinksPerSession: {
         title: 'Nápojů na relaci',
-        empty: 'V tomto období žádné relace.',
+        empty: 'Klidné období — žádné relace k započtení.',
         p75Copy: ({value}: {value: number}) =>
           `75 % tvých relací má ${value} nápojů nebo méně.`,
       },
       sessionDuration: {
         title: 'Délka relace',
-        empty: 'V tomto období žádné relace.',
+        empty: 'Klidné období — žádné relace k změření.',
         p75Copy: ({value}: {value: string}) =>
           `75 % tvých relací je kratších než ${value}.`,
       },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -851,8 +851,8 @@ export default {
           bandCaption:
             'The shaded band is where most of your last 8 weeks landed.',
           chip: {
-            down: 'Trending down — fewer units week over week.',
-            up: 'Trending up — more units week over week.',
+            down: 'Trending down — your weekly units have been easing.',
+            up: 'Trending up — your weekly units have been rising.',
             none: 'Your weeks vary as usual.',
           },
           a11yLabel: 'Last 8 weeks of weekly units, smoothed',
@@ -872,7 +872,7 @@ export default {
         label: 'Trends',
         weeklyTrend: {
           title: 'Weekly units',
-          emptyLabel: 'Log a few weeks to see your trend.',
+          emptyLabel: 'Your trend will show as data builds.',
           bandCaption:
             'The shaded band is where most of your recent weeks landed.',
           captions: {
@@ -885,11 +885,11 @@ export default {
         },
         cumulativeAf: {
           title: 'Alcohol-free days this year',
-          emptyLabel: 'No alcohol-free days logged yet this year.',
+          emptyLabel: 'Every quiet day this year adds up.',
         },
         drinkTypeStack: {
           title: 'Drink mix over time',
-          emptyLabel: 'Log a few sessions to see your mix.',
+          emptyLabel: 'Your drink mix will appear as you log more.',
         },
         comparison: {
           legend: 'Previous period',
@@ -907,7 +907,7 @@ export default {
           subtitle: 'Composition over the current range.',
           centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
           centerCaption: 'units',
-          empty: 'No drinks logged in this range.',
+          empty: 'A quiet range — nothing to break down yet.',
           sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
             `${label}: ${units} units (${share}%)`,
           a11y: 'Drink-type composition donut',
@@ -947,21 +947,21 @@ export default {
       },
       hourOfDay: {
         title: 'Hour of day',
-        empty: 'No drinks recorded in this range.',
+        empty: 'A quiet range — nothing to plot here.',
       },
       dowHour: {
         title: 'Day of week × hour',
-        empty: 'No drinks recorded in this range.',
+        empty: 'A quiet range — nothing to plot here.',
       },
       drinksPerSession: {
         title: 'Drinks per session',
-        empty: 'No sessions in this range.',
+        empty: 'A quiet range — no sessions to count.',
         p75Copy: ({value}: {value: number}) =>
           `75% of your sessions are ${value} drinks or fewer.`,
       },
       sessionDuration: {
         title: 'Session length',
-        empty: 'No sessions in this range.',
+        empty: 'A quiet range — no sessions to measure.',
         p75Copy: ({value}: {value: string}) =>
           `75% of your sessions are ${value} or shorter.`,
       },

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -189,6 +189,7 @@ function PatternsTab() {
           <HourPolar
             buckets={hourBuckets}
             accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
+            emptyLabel={translate('statistics.charts.hourOfDay.empty')}
             onSpokePress={() => {
               // Drill-down handler — v2-K wires this to StatsDrillDownSheet.
             }}
@@ -199,6 +200,7 @@ function PatternsTab() {
             buckets={dowHourBuckets}
             weekStart={weekStart}
             accessibilityLabel={translate('statistics.charts.dowHour.title')}
+            emptyLabel={translate('statistics.charts.dowHour.empty')}
           />
         </ChartCard>
         <View style={styles.histogramRow}>


### PR DESCRIPTION
## Summary

Closes the Statistics v2 epic ([#576](https://github.com/PetrCala/Kiroku/issues/576)) per [#589](https://github.com/PetrCala/Kiroku/issues/589). Pure copy + i18n pass — no new features, no logic changes.

- **Tone retone** of eight empty/sparse strings to match [STATISTICS.md §3](contributingGuides/STATISTICS.md) "additive framing, no 'no data' register":
  - `tabs.trends.weeklyTrend.emptyLabel`, `tabs.trends.cumulativeAf.emptyLabel`, `tabs.trends.drinkTypeStack.emptyLabel`
  - `tabs.breakdown.donut.empty`
  - `charts.hourOfDay.empty`, `charts.dowHour.empty`, `charts.drinksPerSession.empty`, `charts.sessionDuration.empty`
- **Voice alignment** of `tabs.overview.trend.chip.{up,down}` with the Trends tab's Mann–Kendall gated captions (per `STATISTICS_V2.md` §8).
- **Hardcoded-string fixes**: `HourPolar` and `DowHourHeatmap` now take an `emptyLabel?` prop wired through `translate()` in `PatternsTab`, removing the last English literals in the v2 chart layer.
- **Czech parity**: every string mirrored in `cs_cz.ts` with tone preserved (warm "klidné období" / "klidný den" register).

The §4 two-state empty split (`neverLogged` vs `noDataInWindow`) was already implemented in `OverviewTab.tsx` during v2-G — no code change needed there. Tone of the existing copy reviewed and confirmed compliant.

Pre-existing Czech-parity nits surfaced but intentionally **out of scope** (separate follow-ups): inconsistent *relace* vs *setkání* for "session," and ungrammatical period interpolation in `concentration.aboutTheSame` ("minulý 6 měsíců").

Diff: 5 files, +32 / -24.

## Test plan

- [ ] `npx prettier --check` on touched files — passes
- [ ] `./scripts/lint.sh` on touched files — passes
- [ ] `npm run typecheck-tsgo` — passes
- [ ] Open Statistics → Patterns with a date range that yields zero events; confirm the overlay reads "A quiet range — nothing to plot here." (en) and "Klidné období — zatím není co zobrazit." (cs_cz) on both Hour-of-day and Day×Hour charts
- [ ] Open Statistics → Trends in the same empty state; confirm rewritten copy on `weeklyTrend`, `cumulativeAf`, `drinkTypeStack` empty labels
- [ ] Open Statistics → Breakdown in the same empty state; confirm `donut.empty` copy
- [ ] `grep -rn "No drinks recorded in this range\|Log a few weeks to see\|No alcohol-free days logged yet" src/` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)