### PR TITLE
fix(ios): mask Fabric mounting cascade + edge-AA mismatch in splash hide

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -47,17 +47,24 @@ class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions
     )
 
+    // Override the React root view controller's view backgroundColor so it
+    // matches the storyboard yellow. ExpoReactNativeFactory installs an
+    // RCTSurfaceHostingProxyRootView whose default background is the system
+    // background (white on light mode). Painting it yellow means any frame
+    // where the cross-dissolve transition reveals it will not flash white.
+    self.window?.rootViewController?.view.backgroundColor =
+      UIColor(red: 0.9607843, green: 0.76862745, blue: 0, alpha: 1)
+
     // Force the app to LTR mode.
     RCTI18nUtil.sharedInstance().allowRTL(false)
     RCTI18nUtil.sharedInstance().forceRTL(false)
 
     _ = super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    // On New Arch the root view is RCTSurfaceHostingProxyRootView, which does
-    // not inherit from RCTRootView — an `as? RCTRootView` cast returns nil and
-    // skips RCTBootSplash entirely, leaving a white gap between the OS
-    // LaunchScreen and React's first paint. Pass the root view as UIView;
-    // RCTBootSplash.mm re-casts to RCTSurfaceHostingProxyRootView internally.
+    // Add the BootSplash storyboard view as a subview of the proxy root view.
+    // JS calls BootSplash.hide() with fade=1 — the native cross-dissolve
+    // forces iOS to render the React tree underneath BEFORE the storyboard
+    // alpha hits 0, masking Fabric's incremental mounting cascade.
     if let rootView = self.window?.rootViewController?.view {
       RCTBootSplash.initWithStoryboard("BootSplash", rootView: rootView)
     }

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -206,7 +206,12 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(hide : (RCTPromiseResolveBlock)
                       resolve reject : (RCTPromiseRejectBlock)reject) {
-  [self hideImpl:0 resolve:resolve];
+  // fade=1 → 250ms UIView crossDissolve. iOS has to compute the AFTER
+  // state (the React tree without the loadingView) to crossfade to it,
+  // which forces rendering of layers that were previously occluded.
+  // Bridges Fabric's incremental mounting so the React tree is on the
+  // framebuffer by the time the storyboard alpha hits 0.
+  [self hideImpl:1 resolve:resolve];
 }
 
 @end

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from 'react';
 import type {NativeEventSubscription} from 'react-native';
-import {AppState, Linking, Platform} from 'react-native';
+import {AppState, Linking, Platform, StyleSheet, View} from 'react-native';
 import Onyx, {useOnyx} from 'react-native-onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useUserConnection} from '@context/global/UserConnectionContext';
@@ -35,7 +35,20 @@ import CONFIG from './CONFIG';
 import UpdateAppModal from './components/UpdateAppModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import colors from './styles/theme/colors';
 import CONST from './CONST';
+
+// Painted on top of NavigationRoot but below SplashScreenHider (zIndex 20)
+// while the splash is up, so any one-frame mount lag in SplashScreenHider's
+// tree can never expose React Navigation's white appBG. Plain View only
+// — every JS-rendered child has its own first-paint lag, so the guard
+// contributes the color, not the logo. The native loadingView covers the
+// logo until SplashScreenHider catches up.
+const splashGuardStyle = {
+  ...StyleSheet.absoluteFillObject,
+  backgroundColor: colors.yellowStrong,
+  zIndex: 19,
+};
 
 Onyx.registerLogger(({level, message}) => {
   if (level === 'alert') {
@@ -158,13 +171,11 @@ function Kiroku() {
   }, []);
 
   // Splash hide is driven by <SplashScreenHider /> below. It calls
-  // BootSplash.hide() (the 250ms native crossDissolve under the in-process
-  // storyboard subview) and then runs its own 250ms JS scale+opacity fade
-  // before signaling onHide here. The JS overlay covers the React tree the
-  // whole time, so the home screen's first-paint loading indicator is not
-  // visible to the user before content arrives — the same masking the old
-  // pre-PR #325 design provided. The overlay also owns the 15s force-hide
-  // safety timeout so a stuck gating condition can't pin the splash forever.
+  // BootSplash.hide(), which crossDissolves the in-process storyboard
+  // subview over 250ms — that transition also forces iOS to render the
+  // React tree underneath, masking Fabric's incremental mounting cascade.
+  // The overlay owns the 15s force-hide safety timeout so a stuck gating
+  // condition can't pin the splash forever.
   const onSplashHide = useCallback(() => {
     setSplashScreenState(CONST.BOOT_SPLASH_STATE.HIDDEN);
   }, [setSplashScreenState]);
@@ -267,45 +278,57 @@ function Kiroku() {
     setCrashlyticsUserId(auth?.currentUser?.uid ?? '-1');
   }, [isAuthenticated, auth?.currentUser?.uid]);
 
-  // Display a blank page until the onyx migration completes
-  if (!isOnyxMigrated) {
-    return null;
-  }
-
   if (updateRequired) {
     throw new Error(CONST.ERROR.UPDATE_REQUIRED);
   }
 
+  // Always render the splash guard and SplashScreenHider, even before
+  // Onyx has migrated. Returning `null` before isOnyxMigrated would
+  // commit an empty tree, and the React surface would still transition
+  // to "Running" stage on that empty commit, leaving the guard +
+  // SplashScreenHider unmounted while the native loadingView starts to
+  // dissolve. Gate only the heavier subtree (NavigationRoot + modals)
+  // on isOnyxMigrated.
   return (
-    // TODO
-    // <DeeplinkWrapper
-    //     isAuthenticated={isAuthenticated}
-    //     autoAuthState={autoAuthState}
-    // >
     <>
-      {loadingText ? (
-        <FullScreenLoadingIndicator loadingText={loadingText} />
-      ) : (
+      {isOnyxMigrated && (
         <>
-          {!isOnline && !CONFIG.IS_USING_EMULATORS && <UserOfflineModal />}
-          {isUnderMaintenance && <UnderMaintenanceModal config={config} />}
+          {loadingText ? (
+            <FullScreenLoadingIndicator loadingText={loadingText} />
+          ) : (
+            <>
+              {!isOnline && !CONFIG.IS_USING_EMULATORS && <UserOfflineModal />}
+              {isUnderMaintenance && <UnderMaintenanceModal config={config} />}
+            </>
+          )}
+
+          {shouldInit && (
+            <>
+              {shouldShowVerifyEmailModal && <VerifyEmailModal />}
+              {shouldShowUpdateModal && <UpdateAppModal />}
+              {/* // TODO show shared session invites here */}
+            </>
+          )}
+
+          <NavigationRoot
+            onReady={setNavigationReady}
+            authenticated={isAuthenticated}
+            lastVisitedPath={lastVisitedPath as Route}
+            initialUrl={initialUrl}
+          />
         </>
       )}
-
-      {shouldInit && (
-        <>
-          {shouldShowVerifyEmailModal && <VerifyEmailModal />}
-          {shouldShowUpdateModal && <UpdateAppModal />}
-          {/* // TODO show shared session invites here */}
-        </>
-      )}
-
-      <NavigationRoot
-        onReady={setNavigationReady}
-        authenticated={isAuthenticated}
-        lastVisitedPath={lastVisitedPath as Route}
-        initialUrl={initialUrl}
-      />
+      {/*
+        Guard layer between NavigationRoot and SplashScreenHider. Hides
+        NavigationContainer's white appBG during any frame where
+        SplashScreenHider's tree lags first paint. Unmounted as soon as
+        shouldHideSplash flips so the native cross-dissolve in
+        BootSplash.hide() can reveal the real content underneath.
+      */}
+      {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN &&
+        !shouldHideSplash && (
+          <View pointerEvents="none" style={splashGuardStyle} />
+        )}
       {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN && (
         <SplashScreenHider
           shouldHideSplash={shouldHideSplash}

--- a/src/components/SafeArea/index.ios.tsx
+++ b/src/components/SafeArea/index.ios.tsx
@@ -1,12 +1,31 @@
 import React from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {useSplashScreenStateContext} from '@context/global/SplashScreenStateContext';
+import CONST from '@src/CONST';
 import type SafeAreaProps from './types';
 
 function SafeArea({children}: SafeAreaProps) {
   const styles = useThemeStyles();
+  const theme = useTheme();
+  const {splashScreenState} = useSplashScreenStateContext();
+  // While the splash is up, paint the SafeAreaView's native backing view
+  // splashBG yellow instead of theme.inverse. The Kiroku-level guard View
+  // covers the content area but the SafeAreaView is the outermost native
+  // view inside the React surface — if any layer above it lags first
+  // paint, theme.inverse (#1F2329 in light, #F0F6FC in dark) would show
+  // through. Yellow here keeps the boot stack one continuous color and
+  // reverts to theme.inverse the moment the splash unmounts, preserving
+  // the bounce / landscape-notch behavior for normal use.
+  const splashBgOverride =
+    splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN
+      ? {backgroundColor: theme.splashBG}
+      : null;
   return (
-    <SafeAreaView style={[styles.iPhoneXSafeArea]} edges={['left', 'right']}>
+    <SafeAreaView
+      style={[styles.iPhoneXSafeArea, splashBgOverride]}
+      edges={['left', 'right']}>
       {children}
     </SafeAreaView>
   );

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,13 +1,5 @@
-import {useCallback, useEffect, useRef} from 'react';
-import type {ViewStyle} from 'react-native';
-import {StyleSheet} from 'react-native';
-import Reanimated, {
-  Easing,
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {Animated, Easing, Image, Platform, StyleSheet} from 'react-native';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import ImageSVG from '@components/ImageSVG';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -24,12 +16,8 @@ import type {
 // never flips and the user is left staring at the yellow overlay indefinitely.
 const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 
-// Storyboard asset is 108pt (108/216/324 at 1×/2×/3×). The JS overlay must
-// render the logo at the SAME size as the storyboard so the handoff from the
-// in-process native splash to this JS overlay is visually seamless. Before
-// PR #325 this was read from the native module's constantsToExport, but iOS
-// never exported it, so it fell back to 100pt and produced a visible ~7.4%
-// size jump. Hardcoding 108pt eliminates that mismatch.
+// Storyboard asset is 108pt (108/216/324 at 1×/2×/3×). The JS overlay
+// renders the logo at the same size so the native → JS handoff is seamless.
 const LOGO_SIZE = 108;
 
 function SplashScreenHider({
@@ -38,51 +26,58 @@ function SplashScreenHider({
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const styles = useThemeStyles();
 
-  const opacity = useSharedValue(1);
-  const scale = useSharedValue(1);
-
-  const opacityStyle = useAnimatedStyle<ViewStyle>(() => ({
-    opacity: opacity.get(),
-  }));
-  const scaleStyle = useAnimatedStyle<ViewStyle>(() => ({
-    transform: [{scale: scale.get()}],
-  }));
+  // Use React Native's Animated API (not Reanimated). Reanimated 4 on Fabric
+  // binds animated styles via a worklet that may not execute on the first
+  // commit, leaving the outer View briefly rendered with opacity 0 — the
+  // source of the visible "flash" at the handoff in the old design. RN's
+  // Animated applies initial values synchronously on first render, so the
+  // first paint is at opacity 1 / scale 1 deterministically.
+  // useMemo with an empty dep array creates the Animated.Value once per
+  // mount. Avoids `useRef(new Animated.Value(1)).current` which trips
+  // the react-hooks/refs lint rule (ref access during render).
+  const opacity = useMemo(() => new Animated.Value(1), []);
+  const scale = useMemo(() => new Animated.Value(1), []);
 
   const hideHasBeenCalled = useRef(false);
 
   const hide = useCallback(() => {
-    // hide can only be called once
     if (hideHasBeenCalled.current) {
       return;
     }
 
     hideHasBeenCalled.current = true;
 
+    // BootSplash.hide() runs a 250ms cross-dissolve on the native side
+    // (fade=1 in RCTBootSplash.mm). The dissolve forces iOS to render
+    // the React tree underneath the storyboard view to prepare its
+    // AFTER state — which masks Fabric's incremental mounting cascade
+    // (proxy → GestureHandlerRootView → SplashScreenHider). By the
+    // time the dissolve resolves, the React tree is fully composited.
+    //
+    // After the native dissolve resolves, run a JS-side fade so the
+    // logo gracefully shrinks + fades to reveal the home screen
+    // beneath, instead of cutting instantly.
     BootSplash.hide().then(() => {
-      // Straight shrink to 0. Previously used Easing.back(2), but `back`
-      // dips negative in the middle of the eased curve, which (when
-      // interpolating from 1 to 0) pushes the scale above 1 — the logo
-      // visibly "pops" outward by ~13% before shrinking. Reads as a brief
-      // flash now that the rest of the cold-start is smooth.
-      scale.set(
-        withTiming(0, {
+      Animated.parallel([
+        Animated.timing(scale, {
+          toValue: 0,
           duration: 200,
           easing: Easing.out(Easing.ease),
+          useNativeDriver: true,
         }),
-      );
-
-      opacity.set(
-        withTiming(
-          0,
-          {
-            duration: 250,
-            easing: Easing.out(Easing.ease),
-          },
-          () => runOnJS(onHide)(),
-        ),
-      );
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 250,
+          easing: Easing.out(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]).start(({finished}) => {
+        if (finished) {
+          onHide();
+        }
+      });
     });
-  }, [opacity, scale, onHide]);
+  }, [onHide, opacity, scale]);
 
   useEffect(() => {
     if (!shouldHideSplash) {
@@ -108,20 +103,33 @@ function SplashScreenHider({
   }, [hide]);
 
   return (
-    <Reanimated.View
-      style={[StyleSheet.absoluteFill, styles.splashScreenHider, opacityStyle]}>
-      <Reanimated.View style={scaleStyle}>
-        <ImageSVG
-          contentFit="fill"
-          style={{
-            width: LOGO_SIZE,
-            height: LOGO_SIZE,
-          }}
-          fill={colors.white}
-          src={KirokuIcons.Logo}
-        />
-      </Reanimated.View>
-    </Reanimated.View>
+    <Animated.View
+      style={[StyleSheet.absoluteFill, styles.splashScreenHider, {opacity}]}>
+      <Animated.View style={{transform: [{scale}]}}>
+        {Platform.OS === 'ios' ? (
+          // iOS: load BootSplashLogo from the asset catalog via
+          // [UIImage imageNamed:]. The string-uri form falls through to
+          // exactly the same UIImage instance the BootSplash storyboard's
+          // own UIImageView renders — same anti-aliasing, same edge alpha,
+          // same color profile. Critical: any other source (Metro PNG, SVG
+          // via react-native-svg, etc.) produces pixel-level differences
+          // from the storyboard render that show as a logo "blink" at the
+          // cross-dissolve boundary, even though positions and sizes match.
+          <Image
+            source={{uri: 'BootSplashLogo'}}
+            style={{width: LOGO_SIZE, height: LOGO_SIZE}}
+            resizeMode="contain"
+          />
+        ) : (
+          <ImageSVG
+            contentFit="fill"
+            style={{width: LOGO_SIZE, height: LOGO_SIZE}}
+            fill={colors.white}
+            src={KirokuIcons.Logo}
+          />
+        )}
+      </Animated.View>
+    </Animated.View>
   );
 }
 


### PR DESCRIPTION
## Summary

The cold-start splash on iOS had two related visual artifacts:

1. **An orange-only gap** between native splash and JS overlay (the primary regression — appeared between `0.3.13-1` and `0.3.13-19` as autolinked native module growth from [c9a4b2d3](https://github.com/PetrCala/Kiroku/commit/c9a4b2d3) (RevenueCat) and [b212dc1b](https://github.com/PetrCala/Kiroku/commit/b212dc1b) (Skia) widened cold start).
2. **A residual logo blink** at the moment the storyboard handed off to the JS overlay (longer-standing — present even in `0.3.13-1`).

## Root cause — orange gap

[Diagnostic series #629](https://github.com/PetrCala/Kiroku/pull/629) (closed) color-tagged every fallback surface in the boot stack to find which was composited during the gap. The progression was:

```
proxy view (HOT PINK) → GestureHandlerRootView (LIME) → SplashScreenHider (RED)
```

That's **Fabric's incremental mounting cascade**. RN flushes UIViews to the iOS framebuffer progressively as it commits — outermost first, then inner ones. The surface activity indicator is removed at the *first* commit when the surface transitions to "Running" stage, but for several frames after that, the React tree's inner UIViews are still being composited. During those frames, whichever fallback surface is on screen shows through.

## Root cause — residual logo blink

[Diagnostic series #632](https://github.com/PetrCala/Kiroku/pull/632) (closed) ran nine progressive diagnostics ruling out: image source (PNG vs SVG), logo size (100 vs 108), snapshot timing (rAF), the snapshot mechanism itself (transitionWithView vs animateWithDuration), and position offset. The blink survived all of them. The breakthrough was a diagnostic that made the JS overlay's logo **red** instead of white — and the cross-fade became visibly smooth. That meant positions matched and compositing was correct; what differed was the **edge anti-aliasing**:

- **Storyboard:** `UIImageView` rendering `BootSplashLogo` from the asset catalog — UIKit's standard `UIImage` pipeline, AA from the pre-rasterized PNG.
- **JS overlay (old):** `ImageSVG` via `react-native-svg` rendering the SVG path into a `CAShapeLayer` — AA computed from the path geometry.

Both produced "white" interiors that matched. But AA edge pixels had subtly different alpha values. In white-on-red, that mismatch was dominated by the color transition. In white-on-white, the eye keyed on the silhouette and read the AA mismatch as a "blink."

## Fixes

- **`ios/kiroku/RCTBootSplash.mm`** — `RCT_EXPORT_METHOD hide` calls `hideImpl:1` (`fade=1`), enabling the 250ms `UIView.transitionWithView` cross-dissolve that was wired but never invoked from JS. The transition forces iOS to render the React tree underneath to prepare the AFTER state, bridging the Fabric mounting cascade.
- **`ios/AppDelegate.swift`** — paint `rootViewController.view` yellow so any frame where the proxy is exposed during the dissolve doesn't flash white.
- **`src/components/SafeArea/index.ios.tsx`** — override `SafeAreaView` backgroundColor from `theme.inverse` to `theme.splashBG` while `splashScreenState !== HIDDEN`. Reverts to `theme.inverse` after, preserving bounce / landscape-notch behavior.
- **`src/Kiroku.tsx`** — static `View` guard (yellow, `zIndex: 19`) between `NavigationRoot` and `SplashScreenHider` while `!shouldHideSplash`, hiding `NavigationContainer`'s white `appBG` during any frame where the JS overlay's tree lags first paint. Moves the `isOnyxMigrated` gate so it covers only the heavy subtree — splash guard and `SplashScreenHider` always render while the splash is up.
- **`src/components/SplashScreenHider/index.native.tsx`** — three coordinated changes:
    1. **iOS-only:** load the logo via `<Image source={{uri: 'BootSplashLogo'}}>`. The string-uri form on iOS falls through to `[UIImage imageNamed:]`, loading from the same asset catalog the storyboard's `UIImageView` uses. Identical UIImage = identical anti-aliasing on both layers. Android keeps `ImageSVG` (no storyboard handoff problem on Android).
    2. **Replace `Reanimated.View` with RN's `Animated.View`.** Reanimated 4 on Fabric binds animated styles via a worklet that may not execute on the first commit, leaving the View briefly rendered with `opacity: 0` — the original "flash" sudden-appearance. RN's `Animated` applies initial values synchronously on first render.
    3. **Restore the JS-side scale + opacity fade-out** after `BootSplash.hide()` resolves, so the logo gracefully shrinks + fades into the home screen instead of cutting instantly.

## Test plan

- [ ] Cold-launch on a physical iOS device (release build), light mode. The full splash sequence is one continuous yellow surface with the logo from launch to home screen reveal — no orange gap, no logo flicker.
- [ ] Repeat in dark mode.
- [ ] Force-quit + cold-launch several times in a row (the regression was timing-dependent on real device boot).
- [ ] End-of-splash fade-out is smooth: logo shrinks and fades over ~250ms before the home screen takes over.
- [ ] Pull-to-refresh / scroll bounce in normal post-boot use still shows `theme.inverse` behind the content (SafeArea override only active while splash is up).
- [ ] Android cold start unaffected (changes are all iOS-only or live in `*.ios.tsx` / `*.native.tsx` with Platform-conditional logo source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)