### PR TITLE
stats-v2: drill-down sheet — cross-tab session list (v2-K, closes #587)

### DIFF
--- a/__tests__/unit/bucketToFilter.test.ts
+++ b/__tests__/unit/bucketToFilter.test.ts
@@ -1,0 +1,156 @@
+import type {DrinkEvent} from '@libs/Statistics';
+import {
+  bucketToFilter,
+  bucketToSessionFilter,
+} from '@src/screens/Statistics/drilldown/bucketToFilter';
+
+function makeEvent(overrides: Partial<DrinkEvent>): DrinkEvent {
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts: 0,
+    localDay: '2025-06-12',
+    localIsoWeek: '2025-W24',
+    localMonth: '2025-06',
+    localHour: 12,
+    localDow: 3,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    sdu: undefined,
+    blackoutSession: false,
+    sessionDurationMin: undefined,
+    ...overrides,
+  };
+}
+
+describe('bucketToFilter', () => {
+  it('day matches by localDay', () => {
+    const f = bucketToFilter({kind: 'day', date: '2025-06-12'});
+    expect(f(makeEvent({localDay: '2025-06-12'}))).toBe(true);
+    expect(f(makeEvent({localDay: '2025-06-13'}))).toBe(false);
+  });
+
+  it('isoWeek matches by localIsoWeek', () => {
+    const f = bucketToFilter({kind: 'isoWeek', isoWeek: '2025-W24'});
+    expect(f(makeEvent({localIsoWeek: '2025-W24'}))).toBe(true);
+    expect(f(makeEvent({localIsoWeek: '2025-W25'}))).toBe(false);
+  });
+
+  it('month matches by localMonth', () => {
+    const f = bucketToFilter({kind: 'month', month: '2025-06'});
+    expect(f(makeEvent({localMonth: '2025-06'}))).toBe(true);
+    expect(f(makeEvent({localMonth: '2025-07'}))).toBe(false);
+  });
+
+  it('hour matches by localHour', () => {
+    const f = bucketToFilter({kind: 'hour', hour: 21});
+    expect(f(makeEvent({localHour: 21}))).toBe(true);
+    expect(f(makeEvent({localHour: 20}))).toBe(false);
+  });
+
+  it('dow matches by localDow', () => {
+    const f = bucketToFilter({kind: 'dow', dow: 5});
+    expect(f(makeEvent({localDow: 5}))).toBe(true);
+    expect(f(makeEvent({localDow: 4}))).toBe(false);
+  });
+
+  it('dowHour matches when both fields agree', () => {
+    const f = bucketToFilter({kind: 'dowHour', dow: 5, hour: 21});
+    expect(f(makeEvent({localDow: 5, localHour: 21}))).toBe(true);
+    expect(f(makeEvent({localDow: 5, localHour: 22}))).toBe(false);
+    expect(f(makeEvent({localDow: 4, localHour: 21}))).toBe(false);
+  });
+
+  it('drinkType matches by drinkKey', () => {
+    const f = bucketToFilter({kind: 'drinkType', drinkKey: 'wine'});
+    expect(f(makeEvent({drinkKey: 'wine'}))).toBe(true);
+    expect(f(makeEvent({drinkKey: 'beer'}))).toBe(false);
+  });
+
+  it('isoWeekDrinkType matches when both fields agree', () => {
+    const f = bucketToFilter({
+      kind: 'isoWeekDrinkType',
+      isoWeek: '2025-W24',
+      drinkKey: 'wine',
+    });
+    expect(f(makeEvent({localIsoWeek: '2025-W24', drinkKey: 'wine'}))).toBe(
+      true,
+    );
+    expect(f(makeEvent({localIsoWeek: '2025-W24', drinkKey: 'beer'}))).toBe(
+      false,
+    );
+    expect(f(makeEvent({localIsoWeek: '2025-W23', drinkKey: 'wine'}))).toBe(
+      false,
+    );
+  });
+
+  it('session-level bins pass every event at the event-filter layer', () => {
+    const drink = bucketToFilter({
+      kind: 'sessionDrinkCountBin',
+      minDrinks: 1,
+      maxDrinks: 2,
+    });
+    const duration = bucketToFilter({
+      kind: 'sessionDurationBin',
+      minMinutes: 0,
+      maxMinutes: 30,
+    });
+    expect(drink(makeEvent({}))).toBe(true);
+    expect(duration(makeEvent({}))).toBe(true);
+  });
+});
+
+describe('bucketToSessionFilter', () => {
+  it('event-level kinds pass every session', () => {
+    const f = bucketToSessionFilter({kind: 'day', date: '2025-06-12'});
+    expect(f({drinkCount: 999, durationMin: 999})).toBe(true);
+    expect(f({drinkCount: 0, durationMin: undefined})).toBe(true);
+  });
+
+  it('sessionDrinkCountBin honours half-open [min, max)', () => {
+    const f = bucketToSessionFilter({
+      kind: 'sessionDrinkCountBin',
+      minDrinks: 2,
+      maxDrinks: 4,
+    });
+    expect(f({drinkCount: 1, durationMin: undefined})).toBe(false);
+    expect(f({drinkCount: 2, durationMin: undefined})).toBe(true);
+    expect(f({drinkCount: 3, durationMin: undefined})).toBe(true);
+    expect(f({drinkCount: 4, durationMin: undefined})).toBe(false);
+  });
+
+  it('sessionDrinkCountBin with no max is open-ended (5+)', () => {
+    const f = bucketToSessionFilter({
+      kind: 'sessionDrinkCountBin',
+      minDrinks: 5,
+    });
+    expect(f({drinkCount: 4, durationMin: undefined})).toBe(false);
+    expect(f({drinkCount: 5, durationMin: undefined})).toBe(true);
+    expect(f({drinkCount: 99, durationMin: undefined})).toBe(true);
+  });
+
+  it('sessionDurationBin excludes sessions with unknown duration', () => {
+    const f = bucketToSessionFilter({
+      kind: 'sessionDurationBin',
+      minMinutes: 0,
+      maxMinutes: 30,
+    });
+    expect(f({drinkCount: 1, durationMin: undefined})).toBe(false);
+    expect(f({drinkCount: 1, durationMin: NaN})).toBe(false);
+    expect(f({drinkCount: 1, durationMin: 0})).toBe(true);
+    expect(f({drinkCount: 1, durationMin: 29.9})).toBe(true);
+    expect(f({drinkCount: 1, durationMin: 30})).toBe(false);
+  });
+
+  it('sessionDurationBin with no max is open-ended (4h+)', () => {
+    const f = bucketToSessionFilter({
+      kind: 'sessionDurationBin',
+      minMinutes: 240,
+    });
+    expect(f({drinkCount: 1, durationMin: 239.9})).toBe(false);
+    expect(f({drinkCount: 1, durationMin: 240})).toBe(true);
+    expect(f({drinkCount: 1, durationMin: 600})).toBe(true);
+  });
+});

--- a/__tests__/unit/components/Charts/CalendarHeatmap.test.tsx
+++ b/__tests__/unit/components/Charts/CalendarHeatmap.test.tsx
@@ -11,6 +11,13 @@ jest.mock('@shopify/react-native-skia', () => ({
   RoundedRect: () => null,
 }));
 
+// react-native-haptic-feedback registers a TurboModule at import time that
+// jest can't resolve; PressableWithoutFeedback pulls it in transitively.
+jest.mock('react-native-haptic-feedback', () => ({
+  __esModule: true,
+  default: {trigger: jest.fn()},
+}));
+
 jest.mock('@components/Charts/BaseChart', () => ({
   __esModule: true,
   useChartTheme: () => ({

--- a/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -2,12 +2,13 @@ import {useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {Canvas, RoundedRect} from '@shopify/react-native-skia';
 import {useChartTheme} from '@components/Charts/BaseChart';
+import {PressableWithoutFeedback} from '@components/Pressable';
 import type {HeatmapCell} from '@libs/Statistics';
 
 type CalendarHeatmapProps = {
   cells: HeatmapCell[];
   accessibilityLabel: string;
-  /** v1 wires the prop; no-op until Tier 3 drill-down lands. */
+  /** Fired when a (non-future) cell is tapped. */
   onDayPress?: (cell: HeatmapCell) => void;
   /** Pixel gap between cells. Default 2. */
   gap?: number;
@@ -23,7 +24,6 @@ type CalendarHeatmapProps = {
 function CalendarHeatmap({
   cells,
   accessibilityLabel,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- v2 hook
   onDayPress,
   gap = 2,
 }: CalendarHeatmapProps) {
@@ -81,12 +81,32 @@ function CalendarHeatmap({
             const a11yLabel = cell.isFuture
               ? `${cell.dateKey}, upcoming`
               : `${cell.dateKey}, ${cell.totalSdu} units`;
+            // Future cells stay as static a11y nodes; only past/present days
+            // are tappable so drill-down can't land on an empty future bucket.
+            if (cell.isFuture || !onDayPress) {
+              return (
+                <View
+                  key={`a11y-${cell.dateKey}`}
+                  accessible
+                  accessibilityLabel={a11yLabel}
+                  accessibilityRole="text"
+                  style={{
+                    position: 'absolute',
+                    left: col * cellSize,
+                    top: row * cellSize,
+                    width: cellSize,
+                    height: cellSize,
+                  }}
+                />
+              );
+            }
             return (
-              <View
+              <PressableWithoutFeedback
                 key={`a11y-${cell.dateKey}`}
                 accessible
                 accessibilityLabel={a11yLabel}
-                accessibilityRole="text"
+                accessibilityRole="button"
+                onPress={() => onDayPress(cell)}
                 style={{
                   position: 'absolute',
                   left: col * cellSize,

--- a/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
+++ b/src/components/Charts/CalendarHeatmap/CalendarHeatmap.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {Canvas, RoundedRect} from '@shopify/react-native-skia';
 import {useChartTheme} from '@components/Charts/BaseChart';
-import {PressableWithoutFeedback} from '@components/Pressable';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import type {HeatmapCell} from '@libs/Statistics';
 
 type CalendarHeatmapProps = {

--- a/src/components/Charts/TrendLine/TrendLine.tsx
+++ b/src/components/Charts/TrendLine/TrendLine.tsx
@@ -1,6 +1,8 @@
 import {useMemo} from 'react';
+import {View} from 'react-native';
 import {DashPathEffect, Rect} from '@shopify/react-native-skia';
 import {BaseChart, Line} from '@components/Charts/BaseChart';
+import {PressableWithoutFeedback} from '@components/Pressable';
 
 type TrendLineProps = {
   /** ISO-week labels, one per data point. Drives the chart's x-axis order. */
@@ -16,6 +18,8 @@ type TrendLineProps = {
   accessibilityLabel: string;
   emptyLabel?: string;
   height?: number;
+  /** Fired with the ISO-week label of the tapped point (drill-down hook). */
+  onWeekPress?: (isoWeek: string) => void;
 };
 
 type TrendRow = {
@@ -38,6 +42,8 @@ const COMPARISON_DASH: number[] = [4, 4];
  * missing series upstream (in `useTrendsTabData`) so the underlying chart
  * doesn't ingest NaN.
  */
+const MIN_TAP_TARGET = 44;
+
 function TrendLine({
   weeks,
   units,
@@ -47,6 +53,7 @@ function TrendLine({
   accessibilityLabel,
   emptyLabel,
   height,
+  onWeekPress,
 }: TrendLineProps) {
   const showEwma = !!ewma && ewma.length === weeks.length;
   const showComparison =
@@ -81,7 +88,9 @@ function TrendLine({
     return max;
   }, [data, band, showEwma, showComparison]);
 
-  return (
+  const hasTapTargets = !!onWeekPress && weeks.length > 0;
+
+  const chart = (
     <BaseChart
       data={data}
       yKeys={yKeys}
@@ -141,6 +150,36 @@ function TrendLine({
         );
       }}
     </BaseChart>
+  );
+
+  if (!hasTapTargets) {
+    return chart;
+  }
+
+  return (
+    <View>
+      {chart}
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          flexDirection: 'row',
+        }}>
+        {weeks.map(week => (
+          <PressableWithoutFeedback
+            key={week}
+            accessibilityRole="button"
+            accessibilityLabel={week}
+            onPress={() => onWeekPress?.(week)}
+            style={{flex: 1, minWidth: MIN_TAP_TARGET}}
+          />
+        ))}
+      </View>
+    </View>
   );
 }
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -22,6 +22,7 @@ import type {
   SessionStartTimeParams,
   SessionWindowIdParams,
   StatsAfDaysParams,
+  StatsDrillDownTitleParams,
   StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,
@@ -953,6 +954,25 @@ export default {
         empty: 'Klidné období — žádné relace k změření.',
         p75Copy: ({value}: {value: string}) =>
           `75 % tvých relací je kratších než ${value}.`,
+      },
+    },
+    drilldown: {
+      empty: 'V tomto výběru žádné relace.',
+      close: 'Zavřít',
+      title: {
+        day: ({label}: StatsDrillDownTitleParams) => `Relace dne ${label}`,
+        isoWeek: ({label}: StatsDrillDownTitleParams) => `Týden ${label}`,
+        month: ({label}: StatsDrillDownTitleParams) =>
+          `Relace v měsíci ${label}`,
+        hour: ({label}: StatsDrillDownTitleParams) => `Relace kolem ${label}`,
+        dow: ({label}: StatsDrillDownTitleParams) => `Relace — ${label}`,
+        dowHour: ({label}: StatsDrillDownTitleParams) => label,
+        drinkType: ({label}: StatsDrillDownTitleParams) => `Relace — ${label}`,
+        isoWeekDrinkType: ({label}: StatsDrillDownTitleParams) => label,
+        sessionDrinkCountBin: ({label}: StatsDrillDownTitleParams) =>
+          `Relace s ${label}`,
+        sessionDurationBin: ({label}: StatsDrillDownTitleParams) =>
+          `Relace trvající ${label}`,
       },
     },
     filters: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -23,6 +23,7 @@ import type {
   SessionStartTimeParams,
   SessionWindowIdParams,
   StatsAfDaysParams,
+  StatsDrillDownTitleParams,
   StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,
@@ -964,6 +965,25 @@ export default {
         empty: 'A quiet range — no sessions to measure.',
         p75Copy: ({value}: {value: string}) =>
           `75% of your sessions are ${value} or shorter.`,
+      },
+    },
+    drilldown: {
+      empty: 'No sessions match this view.',
+      close: 'Close',
+      title: {
+        day: ({label}: StatsDrillDownTitleParams) => `Sessions on ${label}`,
+        isoWeek: ({label}: StatsDrillDownTitleParams) => `Week ${label}`,
+        month: ({label}: StatsDrillDownTitleParams) => `Sessions in ${label}`,
+        hour: ({label}: StatsDrillDownTitleParams) =>
+          `Sessions around ${label}`,
+        dow: ({label}: StatsDrillDownTitleParams) => `${label} sessions`,
+        dowHour: ({label}: StatsDrillDownTitleParams) => label,
+        drinkType: ({label}: StatsDrillDownTitleParams) => `${label} sessions`,
+        isoWeekDrinkType: ({label}: StatsDrillDownTitleParams) => label,
+        sessionDrinkCountBin: ({label}: StatsDrillDownTitleParams) =>
+          `Sessions with ${label}`,
+        sessionDurationBin: ({label}: StatsDrillDownTitleParams) =>
+          `Sessions lasting ${label}`,
       },
     },
     filters: {

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -55,6 +55,10 @@ type StatsQuietDaysParams = {
   quietDays: number;
 };
 
+type StatsDrillDownTitleParams = {
+  label: string;
+};
+
 type UnitCountParams = {
   unitCount: number;
 };
@@ -107,6 +111,7 @@ export type {
   SessionStartTimeParams,
   SessionWindowIdParams,
   StatsAfDaysParams,
+  StatsDrillDownTitleParams,
   StatsQuietDaysParams,
   UnitCountParams,
   UpdateEmailSentEmailParams,

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -4,6 +4,8 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import StatsContextProvider from '@components/StatsContextProvider';
 import useLocalize from '@hooks/useLocalize';
 import Navigation from '@libs/Navigation/Navigation';
+import DrillDownProvider from './drilldown/DrillDownContext';
+import StatsDrillDownSheet from './StatsDrillDownSheet';
 import StatisticsTabs from './StatisticsTabs';
 
 function StatisticsScreen() {
@@ -16,9 +18,12 @@ function StatisticsScreen() {
         onBackButtonPress={Navigation.goBack}
       />
       <StatsContextProvider>
-        {/* The filter toolbar lives per-tab (Trends/Patterns/Breakdown);
-            Overview uses fixed this-month/this-week semantics. */}
-        <StatisticsTabs />
+        <DrillDownProvider>
+          {/* The filter toolbar lives per-tab (Trends/Patterns/Breakdown);
+              Overview uses fixed this-month/this-week semantics. */}
+          <StatisticsTabs />
+          <StatsDrillDownSheet />
+        </DrillDownProvider>
       </StatsContextProvider>
     </ScreenWrapper>
   );

--- a/src/screens/Statistics/StatsDrillDownSheet.tsx
+++ b/src/screens/Statistics/StatsDrillDownSheet.tsx
@@ -1,0 +1,193 @@
+import {useMemo} from 'react';
+import {FlatList, View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import Button from '@components/Button';
+import DrinkingSessionOverview from '@components/DrinkingSessionOverview';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import Modal from '@components/Modal';
+import {PressableWithFeedback} from '@components/Pressable';
+import Icon from '@components/Icon';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useStatsContext from '@hooks/useStatsContext';
+import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {
+  composeFilters,
+  dateRange,
+  drinkTypeSubset,
+  forUsers,
+} from '@libs/Statistics';
+import type {DrinkEvent} from '@libs/Statistics';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {DrinkingSession, DrinkingSessionId} from '@src/types/onyx';
+import {
+  bucketToFilter,
+  bucketToSessionFilter,
+} from './drilldown/bucketToFilter';
+import bucketToTitle from './drilldown/bucketToTitle';
+import {useStatsDrillDown} from './drilldown/DrillDownContext';
+
+type SessionEntry = {
+  sessionId: DrinkingSessionId;
+  session: DrinkingSession;
+  /** Newest event timestamp in the session — used to sort newest-first. */
+  maxTs: number;
+};
+
+/**
+ * Groups filtered events back into sessions, looks each up in the cached
+ * session map, and returns them newest-first. Sessions that don't resolve
+ * against the cache (e.g. evicted, foreign user) are dropped silently.
+ */
+function groupEventsIntoSessions(
+  events: DrinkEvent[],
+  sessionsByUser: Record<string, Record<string, DrinkingSession>> | undefined,
+): SessionEntry[] {
+  if (!sessionsByUser) {
+    return [];
+  }
+  type Pending = {userId: string; eventCount: number; maxTs: number};
+  const sessionPending = new Map<string, Pending>();
+  for (const event of events) {
+    const existing = sessionPending.get(event.sessionId);
+    if (existing) {
+      existing.eventCount += 1;
+      if (event.ts > existing.maxTs) {
+        existing.maxTs = event.ts;
+      }
+    } else {
+      sessionPending.set(event.sessionId, {
+        userId: event.userId,
+        eventCount: 1,
+        maxTs: event.ts,
+      });
+    }
+  }
+  const out: SessionEntry[] = [];
+  for (const [sessionId, pending] of sessionPending) {
+    const session = sessionsByUser[pending.userId]?.[sessionId];
+    if (!session) {
+      continue;
+    }
+    out.push({
+      sessionId,
+      session,
+      maxTs: pending.maxTs,
+    });
+  }
+  out.sort((a, b) => b.maxTs - a.maxTs);
+  return out;
+}
+
+function StatsDrillDownSheet() {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const {activeBucket, closeDrillDown} = useStatsDrillDown();
+  const {range, drinkTypeFilter, userIds} = useStatsContext();
+  const {events} = useDrinkEvents(
+    userIds.length > 0 ? [...userIds] : undefined,
+  );
+  // CACHED_DRINKING_SESSIONS is already subscribed by `useDrinkEvents` — this
+  // is a second consumer of the same key, not a new fetch.
+  const [sessionsByUser] = useOnyx(ONYXKEYS.CACHED_DRINKING_SESSIONS);
+
+  const isVisible = activeBucket !== null;
+
+  const sessions = useMemo<SessionEntry[]>(() => {
+    if (!activeBucket) {
+      return [];
+    }
+    const eventFilter = composeFilters(
+      dateRange(range.start.getTime(), range.end.getTime()),
+      drinkTypeFilter.size > 0 ? drinkTypeSubset(drinkTypeFilter) : undefined,
+      userIds.length > 0 ? forUsers([...userIds]) : undefined,
+      bucketToFilter(activeBucket),
+    );
+    const filteredEvents =
+      eventFilter === undefined ? events : events.filter(eventFilter);
+    const grouped = groupEventsIntoSessions(filteredEvents, sessionsByUser);
+    const sessionFilter = bucketToSessionFilter(activeBucket);
+    return grouped.filter(({sessionId, session}) => {
+      const drinkCount = filteredEvents.reduce(
+        (acc, e) => (e.sessionId === sessionId ? acc + e.count : acc),
+        0,
+      );
+      const endTime = session.end_time;
+      const durationMin =
+        endTime !== undefined &&
+        Number.isFinite(session.start_time) &&
+        Number.isFinite(endTime)
+          ? (endTime - session.start_time) / 60000
+          : undefined;
+      return sessionFilter({drinkCount, durationMin});
+    });
+  }, [activeBucket, events, range, drinkTypeFilter, userIds, sessionsByUser]);
+
+  const title = useMemo(
+    () => (activeBucket ? bucketToTitle(activeBucket, translate) : ''),
+    [activeBucket, translate],
+  );
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      onClose={closeDrillDown}
+      type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
+      <View style={[styles.pt3, styles.pb5, {minHeight: 240, maxHeight: 560}]}>
+        <View
+          style={[
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.justifyContentBetween,
+            styles.ph4,
+            styles.mb2,
+          ]}>
+          <Text style={[styles.textHeadline, styles.flex1, styles.mr2]}>
+            {title}
+          </Text>
+          <PressableWithFeedback
+            accessibilityLabel={translate('statistics.drilldown.close')}
+            accessibilityRole="button"
+            onPress={closeDrillDown}
+            style={[styles.p2]}>
+            <Icon src={KirokuIcons.Close} fill={theme.icon} />
+          </PressableWithFeedback>
+        </View>
+        {sessions.length === 0 ? (
+          <View style={[styles.flex1, styles.justifyContentCenter, styles.p5]}>
+            <Text style={[styles.textSupporting, styles.textAlignCenter]}>
+              {translate('statistics.drilldown.empty')}
+            </Text>
+          </View>
+        ) : (
+          <FlatList
+            data={sessions}
+            keyExtractor={item => String(item.sessionId)}
+            renderItem={({item}) => (
+              <DrinkingSessionOverview
+                sessionId={item.sessionId}
+                session={item.session}
+                isEditModeOn={false}
+              />
+            )}
+          />
+        )}
+        <View style={[styles.ph4, styles.mt2]}>
+          <Button
+            large
+            text={translate('common.close')}
+            onPress={closeDrillDown}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+StatsDrillDownSheet.displayName = 'StatsDrillDownSheet';
+
+export default StatsDrillDownSheet;

--- a/src/screens/Statistics/drilldown/DrillDownContext.tsx
+++ b/src/screens/Statistics/drilldown/DrillDownContext.tsx
@@ -1,0 +1,65 @@
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+import type {ReactNode} from 'react';
+import type {BucketDescriptor} from './types';
+
+type DrillDownState = {
+  activeBucket: BucketDescriptor | null;
+};
+
+type DrillDownActions = {
+  openDrillDown: (bucket: BucketDescriptor) => void;
+  closeDrillDown: () => void;
+};
+
+const DrillDownStateContext = createContext<DrillDownState | null>(null);
+const DrillDownActionsContext = createContext<DrillDownActions | null>(null);
+
+type DrillDownProviderProps = {
+  children: ReactNode;
+};
+
+function DrillDownProvider({children}: DrillDownProviderProps) {
+  const [activeBucket, setActiveBucket] = useState<BucketDescriptor | null>(
+    null,
+  );
+
+  const openDrillDown = useCallback((bucket: BucketDescriptor) => {
+    setActiveBucket(bucket);
+  }, []);
+
+  const closeDrillDown = useCallback(() => {
+    setActiveBucket(null);
+  }, []);
+
+  const state = useMemo<DrillDownState>(() => ({activeBucket}), [activeBucket]);
+
+  const actions = useMemo<DrillDownActions>(
+    () => ({openDrillDown, closeDrillDown}),
+    [openDrillDown, closeDrillDown],
+  );
+
+  return (
+    <DrillDownActionsContext.Provider value={actions}>
+      <DrillDownStateContext.Provider value={state}>
+        {children}
+      </DrillDownStateContext.Provider>
+    </DrillDownActionsContext.Provider>
+  );
+}
+
+type UseStatsDrillDownResult = DrillDownState & DrillDownActions;
+
+function useStatsDrillDown(): UseStatsDrillDownResult {
+  const state = useContext(DrillDownStateContext);
+  const actions = useContext(DrillDownActionsContext);
+  if (!state || !actions) {
+    throw new Error(
+      'useStatsDrillDown must be used inside a <DrillDownProvider>',
+    );
+  }
+  return useMemo(() => ({...state, ...actions}), [state, actions]);
+}
+
+export default DrillDownProvider;
+export {useStatsDrillDown};
+export type {DrillDownActions, DrillDownProviderProps, DrillDownState};

--- a/src/screens/Statistics/drilldown/bucketToFilter.ts
+++ b/src/screens/Statistics/drilldown/bucketToFilter.ts
@@ -1,0 +1,97 @@
+import type {DrinkEvent, EventFilter} from '@libs/Statistics';
+import type {BucketDescriptor} from './types';
+
+type SessionStats = {
+  drinkCount: number;
+  durationMin: number | undefined;
+};
+
+type SessionFilter = (stats: SessionStats) => boolean;
+
+const ALWAYS_TRUE: EventFilter = () => true;
+const ALWAYS_TRUE_SESSION: SessionFilter = () => true;
+
+/**
+ * Predicate over individual `DrinkEvent`s. Returns `ALWAYS_TRUE` for the two
+ * session-level bin kinds — those are handled by {@link bucketToSessionFilter}
+ * after events have been grouped into sessions.
+ */
+function bucketToFilter(bucket: BucketDescriptor): EventFilter {
+  switch (bucket.kind) {
+    case 'day':
+      return (e: DrinkEvent) => e.localDay === bucket.date;
+    case 'isoWeek':
+      return (e: DrinkEvent) => e.localIsoWeek === bucket.isoWeek;
+    case 'month':
+      return (e: DrinkEvent) => e.localMonth === bucket.month;
+    case 'hour':
+      return (e: DrinkEvent) => e.localHour === bucket.hour;
+    case 'dow':
+      return (e: DrinkEvent) => e.localDow === bucket.dow;
+    case 'dowHour':
+      return (e: DrinkEvent) =>
+        e.localDow === bucket.dow && e.localHour === bucket.hour;
+    case 'drinkType':
+      return (e: DrinkEvent) => e.drinkKey === bucket.drinkKey;
+    case 'isoWeekDrinkType':
+      return (e: DrinkEvent) =>
+        e.localIsoWeek === bucket.isoWeek && e.drinkKey === bucket.drinkKey;
+    case 'sessionDrinkCountBin':
+    case 'sessionDurationBin':
+    default:
+      return ALWAYS_TRUE;
+  }
+}
+
+/**
+ * Predicate over session-level summary stats. Returns `ALWAYS_TRUE_SESSION`
+ * for event-level buckets — those are handled by {@link bucketToFilter}.
+ *
+ * For `sessionDurationBin`, sessions whose duration is unknown (`undefined`,
+ * e.g. ongoing or never-ended) are excluded from any duration bucket: the user
+ * tapped "0–30m" expecting to see actual short sessions, not unknowns.
+ */
+function bucketToSessionFilter(bucket: BucketDescriptor): SessionFilter {
+  switch (bucket.kind) {
+    case 'sessionDrinkCountBin': {
+      const {minDrinks, maxDrinks} = bucket;
+      return ({drinkCount}) => {
+        if (drinkCount < minDrinks) {
+          return false;
+        }
+        if (maxDrinks !== undefined && drinkCount >= maxDrinks) {
+          return false;
+        }
+        return true;
+      };
+    }
+    case 'sessionDurationBin': {
+      const {minMinutes, maxMinutes} = bucket;
+      return ({durationMin}) => {
+        if (durationMin === undefined || !Number.isFinite(durationMin)) {
+          return false;
+        }
+        if (durationMin < minMinutes) {
+          return false;
+        }
+        if (maxMinutes !== undefined && durationMin >= maxMinutes) {
+          return false;
+        }
+        return true;
+      };
+    }
+    case 'day':
+    case 'isoWeek':
+    case 'month':
+    case 'hour':
+    case 'dow':
+    case 'dowHour':
+    case 'drinkType':
+    case 'isoWeekDrinkType':
+    default:
+      return ALWAYS_TRUE_SESSION;
+  }
+}
+
+export {bucketToFilter, bucketToSessionFilter};
+export type {SessionFilter, SessionStats};

--- a/src/screens/Statistics/drilldown/bucketToTitle.ts
+++ b/src/screens/Statistics/drilldown/bucketToTitle.ts
@@ -1,0 +1,130 @@
+import {format, parseISO} from 'date-fns';
+import type useLocalize from '@hooks/useLocalize';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import type {TranslationPaths} from '@src/languages/types';
+import type {BucketDescriptor} from './types';
+
+type Translate = ReturnType<typeof useLocalize>['translate'];
+
+const DRINK_LABEL_KEY: Readonly<Record<DrinkKey, TranslationPaths>> = {
+  small_beer: 'drinks.smallBeer',
+  beer: 'drinks.beer',
+  wine: 'drinks.wine',
+  weak_shot: 'drinks.weakShot',
+  strong_shot: 'drinks.strongShot',
+  cocktail: 'drinks.cocktail',
+  other: 'drinks.other',
+};
+
+function formatHour(hour: number): string {
+  if (hour === 0) {
+    return '12 AM';
+  }
+  if (hour === 12) {
+    return '12 PM';
+  }
+  if (hour < 12) {
+    return `${hour} AM`;
+  }
+  return `${hour - 12} PM`;
+}
+
+function formatDay(dateKey: string): string {
+  try {
+    return format(parseISO(dateKey), 'PP');
+  } catch {
+    return dateKey;
+  }
+}
+
+function formatMonth(monthKey: string): string {
+  try {
+    return format(parseISO(`${monthKey}-01`), 'MMMM yyyy');
+  } catch {
+    return monthKey;
+  }
+}
+
+function formatSessionDrinkCountBin(
+  min: number,
+  max: number | undefined,
+): string {
+  if (max === undefined) {
+    return `${min}+ drinks`;
+  }
+  // Bins are half-open [min, max) so 1..2 means exactly 1.
+  if (max - min === 1) {
+    return `${min} drink${min === 1 ? '' : 's'}`;
+  }
+  return `${min}–${max - 1} drinks`;
+}
+
+function formatSessionDurationBin(
+  minMin: number,
+  maxMin: number | undefined,
+): string {
+  const fmt = (m: number) =>
+    m < 60 ? `${Math.round(m)}m` : `${Math.round((m / 60) * 10) / 10}h`;
+  if (maxMin === undefined) {
+    return `${fmt(minMin)}+`;
+  }
+  return `${fmt(minMin)}–${fmt(maxMin)}`;
+}
+
+/**
+ * Produces the human-readable title for a drill-down sheet's bucket. Pure —
+ * depends only on its inputs. The `translate` argument is the bound function
+ * from `useLocalize()` so the sheet can stay in JSX-land and the helper stays
+ * trivial to test.
+ */
+function bucketToTitle(bucket: BucketDescriptor, translate: Translate): string {
+  switch (bucket.kind) {
+    case 'day':
+      return translate('statistics.drilldown.title.day', {
+        label: formatDay(bucket.date),
+      });
+    case 'isoWeek':
+      return translate('statistics.drilldown.title.isoWeek', {
+        label: bucket.isoWeek,
+      });
+    case 'month':
+      return translate('statistics.drilldown.title.month', {
+        label: formatMonth(bucket.month),
+      });
+    case 'hour':
+      return translate('statistics.drilldown.title.hour', {
+        label: formatHour(bucket.hour),
+      });
+    case 'dow':
+      // dow/dowHour kinds aren't wired in v2-K. Rotated 0..6 needs the
+      // user's week-start to render as a weekday name — defer until a chart
+      // actually emits this bucket.
+      return translate('statistics.drilldown.title.dow', {
+        label: `Day ${bucket.dow + 1}`,
+      });
+    case 'dowHour':
+      return translate('statistics.drilldown.title.dowHour', {
+        label: `Day ${bucket.dow + 1} at ${formatHour(bucket.hour)}`,
+      });
+    case 'drinkType':
+      return translate('statistics.drilldown.title.drinkType', {
+        label: translate(DRINK_LABEL_KEY[bucket.drinkKey]),
+      });
+    case 'isoWeekDrinkType':
+      return translate('statistics.drilldown.title.isoWeekDrinkType', {
+        label: `${translate(DRINK_LABEL_KEY[bucket.drinkKey])} — ${bucket.isoWeek}`,
+      });
+    case 'sessionDrinkCountBin':
+      return translate('statistics.drilldown.title.sessionDrinkCountBin', {
+        label: formatSessionDrinkCountBin(bucket.minDrinks, bucket.maxDrinks),
+      });
+    case 'sessionDurationBin':
+      return translate('statistics.drilldown.title.sessionDurationBin', {
+        label: formatSessionDurationBin(bucket.minMinutes, bucket.maxMinutes),
+      });
+    default:
+      return '';
+  }
+}
+
+export default bucketToTitle;

--- a/src/screens/Statistics/drilldown/types.ts
+++ b/src/screens/Statistics/drilldown/types.ts
@@ -1,0 +1,27 @@
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+
+/**
+ * A tap on any Statistics chart describes one bucket of the underlying
+ * `DrinkEvent` stream. The drill-down sheet filters events to the events
+ * (and sessions) that fall in that bucket.
+ *
+ * Most kinds are event-level — they map to a `DrinkEvent` predicate via
+ * {@link bucketToFilter}. The two `session*Bin` kinds are session-level:
+ * they're evaluated after events have been grouped into sessions, because
+ * "drinks per session" and "session duration" aren't event attributes.
+ */
+type BucketDescriptor =
+  | {kind: 'day'; date: string}
+  | {kind: 'isoWeek'; isoWeek: string}
+  | {kind: 'month'; month: string}
+  | {kind: 'hour'; hour: number}
+  | {kind: 'dow'; dow: number}
+  | {kind: 'dowHour'; dow: number; hour: number}
+  | {kind: 'drinkType'; drinkKey: DrinkKey}
+  | {kind: 'isoWeekDrinkType'; isoWeek: string; drinkKey: DrinkKey}
+  | {kind: 'sessionDrinkCountBin'; minDrinks: number; maxDrinks?: number}
+  | {kind: 'sessionDurationBin'; minMinutes: number; maxMinutes?: number};
+
+type BucketKind = BucketDescriptor['kind'];
+
+export type {BucketDescriptor, BucketKind};

--- a/src/screens/Statistics/tabs/BreakdownTab.tsx
+++ b/src/screens/Statistics/tabs/BreakdownTab.tsx
@@ -15,6 +15,7 @@ import {
   sumUnits,
 } from '@libs/Statistics';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
+import {useStatsDrillDown} from '@src/screens/Statistics/drilldown/DrillDownContext';
 import DrinkTypeDonut from './breakdown/DrinkTypeDonut';
 import PerTypeWeeklyMultiples from './breakdown/PerTypeWeeklyMultiples';
 import TypeConcentrationSentence from './breakdown/TypeConcentrationSentence';
@@ -25,6 +26,7 @@ function BreakdownTab() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const {range, drinkTypeFilter, userIds} = useStatsContext();
+  const {openDrillDown} = useStatsDrillDown();
   const {events} = useDrinkEvents(
     userIds.length > 0 ? [...userIds] : undefined,
   );
@@ -73,6 +75,9 @@ function BreakdownTab() {
             <DrinkTypeDonut
               unitsByDrinkKey={currentUnitsByDrinkKey}
               drinkTypeFilter={drinkTypeFilter}
+              onSlicePress={drinkKey =>
+                openDrillDown({kind: 'drinkType', drinkKey})
+              }
             />
           </View>
         </ChartCard>

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -20,6 +20,7 @@ import {
   selectWeeklyKpis,
 } from '@libs/Statistics/overviewSelectors';
 import type {TranslationPaths} from '@src/languages/types';
+import {useStatsDrillDown} from '@src/screens/Statistics/drilldown/DrillDownContext';
 
 type DeltaShape = NonNullable<KpiCardProps['delta']>;
 
@@ -48,6 +49,7 @@ function OverviewTab() {
   const styles = useThemeStyles();
   const theme = useTheme();
   const {events, isLoading} = useDrinkEvents();
+  const {openDrillDown} = useStatsDrillDown();
 
   // Snapshot `now` once per mount so all selectors agree. Re-deriving on each
   // render would let an animation frame land between two reads and disagree
@@ -172,6 +174,7 @@ function OverviewTab() {
           accessibilityLabel={translate(
             'statistics.charts.calendarHeatmap.title',
           )}
+          onDayPress={cell => openDrillDown({kind: 'day', date: cell.dateKey})}
         />
       </ChartCard>
 

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -27,6 +27,7 @@ import {
   sumUnits,
 } from '@libs/Statistics';
 import type {WeekStart} from '@libs/Statistics';
+import {useStatsDrillDown} from '@src/screens/Statistics/drilldown/DrillDownContext';
 
 const styles = StyleSheet.create({
   scroll: {
@@ -123,6 +124,7 @@ function PatternsTab() {
   );
   const {translate} = useLocalize();
   const themeStyles = useThemeStyles();
+  const {openDrillDown} = useStatsDrillDown();
 
   const weekStart = resolveWeekStart(preferences?.first_day_of_week);
 
@@ -190,9 +192,7 @@ function PatternsTab() {
             buckets={hourBuckets}
             accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
             emptyLabel={translate('statistics.charts.hourOfDay.empty')}
-            onSpokePress={() => {
-              // Drill-down handler — v2-K wires this to StatsDrillDownSheet.
-            }}
+            onSpokePress={hour => openDrillDown({kind: 'hour', hour})}
           />
         </ChartCard>
         <ChartCard title={translate('statistics.charts.dowHour.title')}>

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -11,6 +11,7 @@ import useLocalize from '@hooks/useLocalize';
 import useTrendsTabData from '@hooks/useStatistics/useTrendsTabData';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {TranslationPaths} from '@src/languages/types';
+import {useStatsDrillDown} from '@src/screens/Statistics/drilldown/DrillDownContext';
 
 const styles = StyleSheet.create({
   container: {
@@ -31,6 +32,7 @@ function TrendsTab() {
   const {translate} = useLocalize();
   const themeStyles = useThemeStyles();
   const {hero, afYtd, stack, isLoading} = useTrendsTabData();
+  const {openDrillDown} = useStatsDrillDown();
 
   if (isLoading) {
     return (
@@ -81,6 +83,7 @@ function TrendsTab() {
               'statistics.tabs.trends.weeklyTrend.emptyLabel',
             )}
             accessibilityLabel={heroCaption}
+            onWeekPress={isoWeek => openDrillDown({kind: 'isoWeek', isoWeek})}
           />
         </ChartCard>
 

--- a/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
+++ b/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
@@ -38,6 +38,8 @@ type DrinkTypeDonutProps = {
   /** Set of keys the user has chip-filtered to. Empty Set = all keys. */
   drinkTypeFilter: ReadonlySet<DrinkKey>;
   size?: number;
+  /** Fired alongside the internal selection when a slice is hit (drill-down hook). */
+  onSlicePress?: (drinkKey: DrinkKey) => void;
 };
 
 function buildSlices(
@@ -141,6 +143,7 @@ function DrinkTypeDonut({
   unitsByDrinkKey,
   drinkTypeFilter,
   size = DEFAULT_SIZE,
+  onSlicePress,
 }: DrinkTypeDonutProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -160,9 +163,7 @@ function DrinkTypeDonut({
   const isEmpty = slices.length === 0;
   const selected = selectedIdx >= 0 ? slices[selectedIdx] : undefined;
 
-  const handlePress = (
-    event?: GestureResponderEvent | KeyboardEvent,
-  ): void => {
+  const handlePress = (event?: GestureResponderEvent | KeyboardEvent): void => {
     if (isEmpty || !event || !('nativeEvent' in event)) {
       return;
     }
@@ -177,6 +178,9 @@ function DrinkTypeDonut({
       locationY,
     );
     setSelectedIdx(prev => (prev === idx ? -1 : idx));
+    if (idx >= 0) {
+      onSlicePress?.(slices[idx].key);
+    }
   };
 
   const a11yLabel = translate('statistics.tabs.breakdown.donut.a11y');


### PR DESCRIPTION
## Summary
- New bottom-docked `StatsDrillDownSheet` that every Statistics chart tap opens, derived from the existing `useDrinkEvents()` stream plus the active `StatsContext` filters. Renders `DrinkingSessionOverview` rows so tapping a session opens the existing summary screen.
- `BucketDescriptor` union + pure `bucketToFilter` / `bucketToSessionFilter` mappings cover every existing and near-future tap-target across tabs G/H/I/J. Unit-tested in `__tests__/unit/bucketToFilter.test.ts` (14 assertions).
- Wires the four canonical tap-targets per the acceptance criteria on [#587](https://github.com/PetrCala/Kiroku/issues/587): Overview `CalendarHeatmap` day, Trends `TrendLine` week, Patterns `HourPolar` hour, Breakdown `DrinkTypeDonut` slice. `TrendLine` gains per-week tap overlays; `DrinkTypeDonut` gains `onSlicePress` alongside its existing internal selection; `CalendarHeatmap` activates its previously no-op `onDayPress`.
- `DrillDownProvider` is a sibling of `StatisticsTabs` inside `StatisticsScreen` (so any tab can open it) and splits state/actions contexts per `rulesdir/context-provider-split-values`.

## Decision: bottom-docked modal (not pushed screen)
Followed `STATISTICS_V2.md §13.4`'s open question. Chose `<Modal type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>` (the convention used by `AppShareScreen`) — pushing a new RHP on top of the Statistics RHP would lose chart context, and `react-native-modal` already provides swipe-down + backdrop dismiss. No new dependency.

## Out of scope (deferred follow-ups)
The descriptor union, mapping, and context already cover these; they need only an `onPress` prop wired (plus a gesture surface where missing):
- Trends `StackedArea` → `isoWeekDrinkType`
- Trends `CumulativeLine` → `day`
- Patterns `DowHourHeatmap` → `dowHour`
- Patterns `Histogram` (×2) → `sessionDrinkCountBin` / `sessionDurationBin`
- Breakdown `PerTypeWeeklyMultiples` → `isoWeekDrinkType`
- Overview `KpiCard` Tier-2 routes
- Final tone audit on title/empty copy (v2-M)
- Pretty weekday-name formatting for `dow` / `dowHour` titles (deferred until a chart actually emits these — needs `WeekStart` rotation)

## Test plan
- [x] `npx prettier --write` on changed files
- [x] `./scripts/lint.sh <changed files>` clean
- [x] `npm run typecheck-tsgo` clean
- [x] `npm run test -- bucketToFilter` — 14/14 passing
- [ ] iOS visual: tap heatmap day with sessions, with no sessions, future day; tap a TrendLine week; tap an HourPolar spoke; tap a donut slice; swipe sheet down; tap backdrop; tap close button; re-open
- [ ] Android visual: same matrix
- [ ] Dark theme visual on both
- [ ] Sheet results respect drink-type chip + range filters
- [ ] Tap a session row → navigates to `DRINKING_SESSION_SUMMARY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)