### PR TITLE
DO NOT MERGE: diagnostic — color-tag boot surfaces to identify residual splash flash

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -47,19 +47,13 @@ class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions
     )
 
-    // Override the React root view controller's view backgroundColor so it
-    // matches the storyboard yellow. ExpoReactNativeFactory installs an
-    // RCTSurfaceHostingProxyRootView whose default background is the system
-    // background (white on light mode), which sits between the yellow window
-    // and the native _loadingView. If anything reveals what's under the
-    // _loadingView before the JS SplashScreenHider has painted (e.g. a
-    // crossfade during hide, or a one-frame lag in Reanimated's first commit
-    // with the autolinked native module growth from RevenueCat + Skia), that
-    // white root view shows through and produces a visible flash. Painting
-    // the root view yellow makes the whole stack — window, root view,
-    // storyboard, JS overlay — a single continuous color.
+    // DIAGNOSTIC — DO NOT MERGE
+    // Color-tag this surface so a residual cold-start flash can identify
+    // its source. Cyan = RCTSurfaceHostingProxyRootView. See
+    // src/components/SafeArea/index.ios.tsx (magenta) and src/Kiroku.tsx
+    // (orange) for the other tagged surfaces.
     self.window?.rootViewController?.view.backgroundColor =
-      UIColor(red: 0.9607843, green: 0.76862745, blue: 0, alpha: 1)
+      UIColor(red: 0, green: 1, blue: 1, alpha: 1)
 
     // Force the app to LTR mode.
     RCTI18nUtil.sharedInstance().allowRTL(false)

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -47,6 +47,20 @@ class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions
     )
 
+    // Override the React root view controller's view backgroundColor so it
+    // matches the storyboard yellow. ExpoReactNativeFactory installs an
+    // RCTSurfaceHostingProxyRootView whose default background is the system
+    // background (white on light mode), which sits between the yellow window
+    // and the native _loadingView. If anything reveals what's under the
+    // _loadingView before the JS SplashScreenHider has painted (e.g. a
+    // crossfade during hide, or a one-frame lag in Reanimated's first commit
+    // with the autolinked native module growth from RevenueCat + Skia), that
+    // white root view shows through and produces a visible flash. Painting
+    // the root view yellow makes the whole stack — window, root view,
+    // storyboard, JS overlay — a single continuous color.
+    self.window?.rootViewController?.view.backgroundColor =
+      UIColor(red: 0.9607843, green: 0.76862745, blue: 0, alpha: 1)
+
     // Force the app to LTR mode.
     RCTI18nUtil.sharedInstance().allowRTL(false)
     RCTI18nUtil.sharedInstance().forceRTL(false)

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from 'react';
 import type {NativeEventSubscription} from 'react-native';
-import {AppState, Linking, Platform} from 'react-native';
+import {AppState, Linking, Platform, StyleSheet, View} from 'react-native';
 import Onyx, {useOnyx} from 'react-native-onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useUserConnection} from '@context/global/UserConnectionContext';
@@ -35,7 +35,17 @@ import CONFIG from './CONFIG';
 import UpdateAppModal from './components/UpdateAppModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import colors from './styles/theme/colors';
 import CONST from './CONST';
+
+// Painted on top of NavigationRoot but below SplashScreenHider (zIndex 20)
+// while the splash is up, so a one-frame mount lag in SplashScreenHider's
+// Reanimated tree can never expose React Navigation's white appBG.
+const splashGuardStyle = {
+  ...StyleSheet.absoluteFillObject,
+  backgroundColor: colors.yellowStrong,
+  zIndex: 19,
+};
 
 Onyx.registerLogger(({level, message}) => {
   if (level === 'alert') {
@@ -306,6 +316,16 @@ function Kiroku() {
         lastVisitedPath={lastVisitedPath as Route}
         initialUrl={initialUrl}
       />
+      {/*
+        The guard sits between NavigationRoot and SplashScreenHider while the
+        splash is at full opacity. It is unmounted the moment shouldHideSplash
+        flips so SplashScreenHider's opacity fade can reveal real content
+        instead of cross-fading against a yellow backdrop.
+      */}
+      {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN &&
+        !shouldHideSplash && (
+          <View pointerEvents="none" style={splashGuardStyle} />
+        )}
       {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN && (
         <SplashScreenHider
           shouldHideSplash={shouldHideSplash}

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -35,15 +35,15 @@ import CONFIG from './CONFIG';
 import UpdateAppModal from './components/UpdateAppModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
-import colors from './styles/theme/colors';
 import CONST from './CONST';
 
-// Painted on top of NavigationRoot but below SplashScreenHider (zIndex 20)
-// while the splash is up, so a one-frame mount lag in SplashScreenHider's
-// Reanimated tree can never expose React Navigation's white appBG.
+// DIAGNOSTIC — DO NOT MERGE
+// Color-tag the splash guard layer so a residual cold-start flash can
+// identify its source. Orange = guard. SplashScreenHider stays yellow,
+// SafeAreaView is magenta, RCTSurfaceHostingProxyRootView is cyan.
 const splashGuardStyle = {
   ...StyleSheet.absoluteFillObject,
-  backgroundColor: colors.yellowStrong,
+  backgroundColor: '#FF6600',
   zIndex: 19,
 };
 

--- a/src/components/SafeArea/index.ios.tsx
+++ b/src/components/SafeArea/index.ios.tsx
@@ -5,8 +5,13 @@ import type SafeAreaProps from './types';
 
 function SafeArea({children}: SafeAreaProps) {
   const styles = useThemeStyles();
+  // DIAGNOSTIC — DO NOT MERGE
+  // Color-tag iPhoneXSafeArea (normally theme.inverse) so a residual
+  // cold-start flash can identify its source. Magenta = SafeAreaView.
   return (
-    <SafeAreaView style={[styles.iPhoneXSafeArea]} edges={['left', 'right']}>
+    <SafeAreaView
+      style={[styles.iPhoneXSafeArea, {backgroundColor: '#FF00FF'}]}
+      edges={['left', 'right']}>
       {children}
     </SafeAreaView>
   );


### PR DESCRIPTION
**⚠️ DIAGNOSTIC — DO NOT MERGE ⚠️**

Built on top of [#616](https://github.com/PetrCala/Kiroku/pull/616). The fix in #616 turned the boot flash from white into a theme-independent **mid-gray full-screen** flash of the same duration. That's a different surface than #616 targeted. This patch color-tags every candidate so the flash identifies its own source on a single cold-launch.

## Color key

| Color | RGB | Surface |
| --- | --- | --- |
| **Cyan** | `#00FFFF` | `RCTSurfaceHostingProxyRootView` (`window.rootViewController.view`) — set in [ios/AppDelegate.swift](ios/AppDelegate.swift) |
| **Magenta** | `#FF00FF` | `iPhoneXSafeArea` (`SafeAreaView` from `react-native-safe-area-context`) — set in [src/components/SafeArea/index.ios.tsx](src/components/SafeArea/index.ios.tsx) |
| **Orange** | `#FF6600` | `splashGuardStyle` View (z-index 19, between `NavigationRoot` and `SplashScreenHider`) — set in [src/Kiroku.tsx](src/Kiroku.tsx) |
| **Yellow** | `#F5C400` | `SplashScreenHider` (unchanged) |

## How to use

1. Cold-launch a build of this branch on a physical iOS device (release build is closest to real boot timing — Metro dev builds artificially extend the splash window).
2. Watch the native-splash → JS-splash handoff.
3. The residual flash's color identifies its source:
    - **Cyan** → proxy view; the AppDelegate `backgroundColor` assignment isn't taking effect (something is overriding it after `factory.startReactNative`).
    - **Magenta** → `SafeAreaView`'s background (`theme.inverse`) is being exposed during boot. Fix is to swap that bg for `theme.splashBG` (or gate it on splash state).
    - **Orange** → splash guard layer is in the tree but has a render/paint problem (first commit isn't reaching the screen before the handoff).
    - **Anything else** (white, gray, a color not in the table) → the flash is **not in our React tree or our root view**. It's iOS-level (LaunchScreen dismissal, app snapshot, system fade) or comes from a library autolinked into the boot path (Skia, Purchases, Expo). Next investigation would target those.
4. Report back with the color you see. Then we revert this PR and apply the fix the diagnostic points to.

## Cleanup

Once we have the answer, this branch gets deleted — no merge to master. The vivid colors are intentionally hideous so there's no temptation to ship them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)