### PR TITLE
fix(home): align calendar skeleton with current grid shape

### DIFF
--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -71,44 +71,60 @@ function StatOverviewSkeleton() {
   );
 }
 
-const CALENDAR_WEEKS = [0, 1, 2, 3, 4] as const;
+// react-native-calendars renders 6 week rows for most months (some months span
+// 6 partial weeks). Matching 6 here keeps the skeleton from being shorter than
+// the calendar that swaps in, which would otherwise jolt the layout down.
+const CALENDAR_WEEKS = [0, 1, 2, 3, 4, 5] as const;
 const CALENDAR_DAYS = [0, 1, 2, 3, 4, 5, 6] as const;
 
 /** Placeholder for the sessions calendar matching react-native-calendars layout. */
 function SessionsCalendarSkeleton() {
   const styles = useThemeStyles();
+  const daySize = variables.sessionsCalendarDaySize;
+  const dayRadius = variables.componentBorderRadiusNormal;
   return (
-    <View style={[styles.sessionsCalendarContainer, styles.pv4]}>
-      {/* Month header: left arrow + month name + right arrow */}
+    <View style={styles.sessionsCalendarContainer}>
+      {/* Month header — matches the custom renderHeader in SessionsCalendarView
+       *  (single centered text, no nav arrows). */}
+      <View style={[styles.sessionsCalendarHeader, styles.pv3]}>
+        <Block width={100} height={18} />
+      </View>
+      {/* Day-name row — matches the library's `stylesheet.calendar.header`
+       *  spacing (marginTop:7 on the week, marginBottom:7 on each dayHeader). */}
       <View
         style={[
           styles.flexRow,
-          styles.alignItemsCenter,
-          styles.justifyContentBetween,
-          styles.mb3,
+          styles.justifyContentAround,
+          styles.mt2,
+          styles.mb2,
         ]}>
-        <Block width={24} height={24} radius={4} />
-        <Block width={100} height={18} />
-        <Block width={24} height={24} radius={4} />
-      </View>
-      {/* Day-name row (Mon Tue Wed …) */}
-      <View style={[styles.flexRow, styles.justifyContentBetween, styles.mb3]}>
         {CALENDAR_DAYS.map(day => (
-          <Block key={`name-${day}`} width={20} height={12} />
+          <View
+            key={`name-${day}`}
+            style={[styles.flex1, styles.alignItemsCenter]}>
+            <Block width={20} height={12} />
+          </View>
         ))}
       </View>
-      {/* Week rows — each cell mirrors DayComponent: day number + marking box */}
+      {/* Week rows — each cell mirrors the real DayComponent: a single
+       *  heatmap-tile square sized via variables.sessionsCalendarDaySize.
+       *  marginVertical:6 matches stylesheet.calendar.main.week in
+       *  getSessionsCalendarStyle, so swap-in lands at the same Y. */}
       {CALENDAR_WEEKS.map(week => (
         <View
           key={`week-${week}`}
-          style={[styles.flexRow, styles.justifyContentBetween, styles.mb3]}>
+          style={[
+            styles.flexRow,
+            styles.justifyContentAround,
+            {marginVertical: 6},
+          ]}>
           {CALENDAR_DAYS.map(day => (
-            <View
+            <Block
               key={`day-${week}-${day}`}
-              style={[styles.flexColumn, styles.alignItemsCenter]}>
-              <Block width={16} height={12} style={styles.mb1} />
-              <Block width={28} height={28} radius={4} />
-            </View>
+              width={daySize}
+              height={daySize}
+              radius={dayRadius}
+            />
           ))}
         </View>
       ))}


### PR DESCRIPTION
## Summary
- The home-screen calendar skeleton was drawn for the older "day number above marking" cell layout. The real `DayComponent` now renders a single `44×44` heatmap-tile square with an absolute-positioned corner number, so the skeleton's `28×28` stacked cells underdrew the grid by ~60% per tile and one full week row, producing a visible jolt when data swapped in.
- Update `SessionsCalendarSkeleton` to mirror the current shape:
  - One tile per cell sized via `variables.sessionsCalendarDaySize` (44) with `componentBorderRadiusNormal` (8).
  - 6 week rows (the real calendar usually renders 6 partial weeks).
  - `marginVertical: 6` to match `stylesheet.calendar.main.week` in `getSessionsCalendarStyle`.
  - Single centered text in the month header to match the custom `renderHeader` (no nav arrows).
  - Day-name row spaced via `justifyContentAround` with each name in a `flex: 1` column to line up with the tile columns.
  - Drop the outer `pv4` — the real container has no vertical padding.

## Test plan
- [ ] Launch the app cold and confirm the calendar swap-in no longer jolts the layout down.
- [ ] Toggle light/dark theme on the home screen while the skeleton is visible — tiles should still render with `theme.highlightBG`.
- [ ] Open the home screen on a month that natively renders 6 weeks (e.g. May 2026) and confirm the skeleton height matches the calendar that swaps in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)