### PR TITLE
feat(supporter): SupporterBadge component (#370)

### DIFF
--- a/__tests__/unit/components/SupporterBadge/SupporterBadge.test.tsx
+++ b/__tests__/unit/components/SupporterBadge/SupporterBadge.test.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+import {render} from '@testing-library/react-native';
+import SupporterBadge from '@components/SupporterBadge';
+
+jest.mock('@hooks/useLocalize', () => ({
+  __esModule: true,
+  default: () => ({
+    translate: (key: string) =>
+      key === 'supporter.badgeAccessibilityLabel' ? 'Kiroku Supporter' : key,
+  }),
+}));
+
+describe('SupporterBadge', () => {
+  it('renders nothing when isSupporter is false', () => {
+    const tree = render(<SupporterBadge isSupporter={false} />).toJSON();
+    expect(tree).toBeNull();
+  });
+
+  it('renders the supporter emoji when isSupporter is true', () => {
+    const tree = render(<SupporterBadge isSupporter />).toJSON();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('🍺');
+  });
+
+  it('exposes the localized accessibility label and image role', () => {
+    const tree = render(<SupporterBadge isSupporter />).toJSON() as {
+      props: {accessibilityLabel?: string; accessibilityRole?: string};
+    };
+    expect(tree.props.accessibilityLabel).toBe('Kiroku Supporter');
+    expect(tree.props.accessibilityRole).toBe('image');
+  });
+
+  it('uses a smaller font size for the small variant', () => {
+    const small = render(
+      <SupporterBadge isSupporter size="small" />,
+    ).toJSON() as {props: {style: Array<{fontSize?: number}>}} | null;
+    const medium = render(
+      <SupporterBadge isSupporter size="medium" />,
+    ).toJSON() as {props: {style: Array<{fontSize?: number}>}} | null;
+
+    function findFontSize(
+      node: {props?: {style?: unknown}} | null,
+    ): number | undefined {
+      const styleProp = node?.props?.style;
+      const styles = Array.isArray(styleProp)
+        ? (styleProp as unknown[]).flat(Infinity)
+        : [styleProp];
+      for (const entry of styles) {
+        if (entry && typeof entry === 'object' && 'fontSize' in entry) {
+          return (entry as {fontSize: number}).fontSize;
+        }
+      }
+      return undefined;
+    }
+
+    const smallSize = findFontSize(small) ?? 0;
+    const mediumSize = findFontSize(medium) ?? 0;
+    expect(smallSize).toBeGreaterThan(0);
+    expect(mediumSize).toBeGreaterThan(0);
+    expect(smallSize).toBeLessThan(mediumSize);
+  });
+});

--- a/src/components/SupporterBadge.tsx
+++ b/src/components/SupporterBadge.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {useOnyx} from 'react-native-onyx';
+import useLocalize from '@hooks/useLocalize';
+import * as UserUtils from '@libs/UserUtils';
+import {useFirebase} from '@context/global/FirebaseContext';
+import variables from '@styles/variables';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+import Text from './Text';
+
+const SUPPORTER_BADGE_EMOJI = '🍺';
+
+type SupporterBadgeSize = 'small' | 'medium';
+
+const SIZE_TO_FONT_SIZE: Record<SupporterBadgeSize, number> = {
+  small: variables.fontSizeSmall,
+  medium: variables.fontSizeMedium,
+};
+
+type SupporterBadgeProps = {
+  /** Whether the user holds an active supporter entitlement. */
+  isSupporter: boolean;
+
+  /** Visual scale — `small` for friend lists, `medium` for profile views. */
+  size?: SupporterBadgeSize;
+};
+
+/**
+ * Purely presentational badge that renders the 🍺 marker when the target user
+ * is an active supporter. Renders `null` (not an empty wrapper) when not a
+ * supporter so layout siblings collapse around it.
+ */
+function SupporterBadge({isSupporter, size = 'medium'}: SupporterBadgeProps) {
+  const {translate} = useLocalize();
+
+  if (!isSupporter) {
+    return null;
+  }
+
+  const label = translate('supporter.badgeAccessibilityLabel');
+
+  return (
+    <Text
+      fontSize={SIZE_TO_FONT_SIZE[size]}
+      accessibilityLabel={label}
+      accessibilityRole="image">
+      {SUPPORTER_BADGE_EMOJI}
+    </Text>
+  );
+}
+
+SupporterBadge.displayName = 'SupporterBadge';
+
+type SupporterBadgeForUserProps = {
+  /** ID of the user whose supporter status we want to render. */
+  userID: UserID | undefined;
+
+  /** Visual scale — `small` for friend lists, `medium` for profile views. */
+  size?: SupporterBadgeSize;
+};
+
+/**
+ * Onyx-aware convenience wrapper that resolves `isSupporter` for any user ID
+ * (current user or a friend) and renders the base badge. Keeps the base
+ * component free of state coupling so it remains snapshot-friendly.
+ */
+function SupporterBadgeForUser({userID, size}: SupporterBadgeForUserProps) {
+  const {auth} = useFirebase();
+  const currentUserID = auth?.currentUser?.uid;
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
+  const [privateData] = useOnyx(ONYXKEYS.USER_PRIVATE_DATA);
+
+  const isSupporter = UserUtils.getUserIsSupporter(
+    userID,
+    userDataList,
+    currentUserID,
+    privateData,
+  );
+
+  return <SupporterBadge isSupporter={isSupporter} size={size} />;
+}
+
+SupporterBadgeForUser.displayName = 'SupporterBadgeForUser';
+
+export default SupporterBadge;
+export {SupporterBadgeForUser};
+export type {
+  SupporterBadgeSize,
+  SupporterBadgeProps,
+  SupporterBadgeForUserProps,
+};

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -655,6 +655,13 @@ export default {
     },
     error: {},
   },
+  supporter: {
+    tierName: 'Kiroku Supporter',
+    badgeAccessibilityLabel: 'Kiroku Supporter',
+    benefit: 'Odznak podporovatele na profilu',
+    description:
+      'Podpořte Kiroku a získejte odznak podporovatele 🍺 na svém profilu.',
+  },
   accountScreen: {
     title: 'Detaily profilu',
     generalOptions: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -658,6 +658,13 @@ export default {
     },
     error: {},
   },
+  supporter: {
+    tierName: 'Kiroku Supporter',
+    badgeAccessibilityLabel: 'Kiroku Supporter',
+    benefit: 'Supporter badge on your profile',
+    description:
+      'Support Kiroku and get the 🍺 supporter badge on your profile.',
+  },
   accountScreen: {
     title: 'Profile Details',
     generalOptions: {


### PR DESCRIPTION
## Summary

Part of the Supporter subscription tier epic (issues #364–#373).

- New `SupporterBadge` component in `src/components/` — purely presentational, renders the 🍺 marker or `null`.
- `SupporterBadgeForUser` wrapper that reads supporter status from Onyx via the selector in `UserUtils.getUserIsSupporter` (landed in #366), so call sites only need a `userID`.
- Two sizes: `small` (friend list) maps to `fontSizeSmall`; `medium` (profile, default) maps to `fontSizeMedium`.
- Accessibility label `Kiroku Supporter` (matches the store-facing tier name) with `accessibilityRole="image"`.
- Translation keys added under `supporter.*` in both `en.ts` and `cs_cz.ts` (English brand kept for Czech locale — see epic decisions).
- Render tests covering the four contract points: null-when-false, emoji-when-true, accessibility props, size mapping.

## Checklist from issue #370

- [x] New `SupporterBadge` component in `src/components/`
- [x] Props: `isSupporter: boolean`, optional `size` (small for friend list, medium for profile)
- [x] Renders nothing when `isSupporter` is false
- [x] Visual: small 🍺 with localized accessibility label
- [x] Accessibility label + `accessibilityRole="image"`
- [x] Convenience wrapper that takes a `userID` and reads from Onyx via the selector
- [x] Basic render test (null/emoji/a11y/size)

## Notes

- Base component is purely presentational — no Onyx imports, no state coupling. Only `SupporterBadgeForUser` reads from Onyx.
- No tooltip / press behavior in v1 per the epic decision to keep the badge minimal; screen integration in #371 will pair it with affordances where needed.
- Czech brand uses `Kiroku Supporter` (locked decision; Czech users are heavily acclimated to English subscription tier names).

## Test plan

- [x] `npx jest __tests__/unit/components/SupporterBadge/` — 4/4 passing.
- [x] `./scripts/lint.sh` on touched files — clean.
- [x] `npm run typecheck-tsgo` — clean.
- [ ] Visual check in app once integrated by #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)