### PR TITLE
DO NOT MERGE: diagnostic v9 — same iOS asset catalog image for both splash layers

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -47,17 +47,24 @@ class AppDelegate: ExpoAppDelegate {
       launchOptions: launchOptions
     )
 
+    // Override the React root view controller's view backgroundColor so it
+    // matches the storyboard yellow. ExpoReactNativeFactory installs an
+    // RCTSurfaceHostingProxyRootView whose default background is the system
+    // background (white on light mode). Painting it yellow means any frame
+    // where the cross-dissolve transition reveals it will not flash white.
+    self.window?.rootViewController?.view.backgroundColor =
+      UIColor(red: 0.9607843, green: 0.76862745, blue: 0, alpha: 1)
+
     // Force the app to LTR mode.
     RCTI18nUtil.sharedInstance().allowRTL(false)
     RCTI18nUtil.sharedInstance().forceRTL(false)
 
     _ = super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    // On New Arch the root view is RCTSurfaceHostingProxyRootView, which does
-    // not inherit from RCTRootView — an `as? RCTRootView` cast returns nil and
-    // skips RCTBootSplash entirely, leaving a white gap between the OS
-    // LaunchScreen and React's first paint. Pass the root view as UIView;
-    // RCTBootSplash.mm re-casts to RCTSurfaceHostingProxyRootView internally.
+    // Add the BootSplash storyboard view as a subview of the proxy root view.
+    // JS calls BootSplash.hide() with fade=1 — the native cross-dissolve
+    // forces iOS to render the React tree underneath BEFORE the storyboard
+    // alpha hits 0, masking Fabric's incremental mounting cascade.
     if let rootView = self.window?.rootViewController?.view {
       RCTBootSplash.initWithStoryboard("BootSplash", rootView: rootView)
     }

--- a/ios/kiroku/BootSplash.storyboard
+++ b/ios/kiroku/BootSplash.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="BootSplashLogo" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
-                                <rect key="frame" x="137.5" y="283.5" width="100" height="100"/>
+                                <rect key="frame" x="133.5" y="279.5" width="108" height="108"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
                                 </accessibility>
@@ -40,6 +40,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="BootSplashLogo" width="100" height="100"/>
+        <image name="BootSplashLogo" width="108" height="108"/>
     </resources>
 </document>

--- a/ios/kiroku/BootSplash.storyboard
+++ b/ios/kiroku/BootSplash.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="BootSplashLogo" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
-                                <rect key="frame" x="133.5" y="279.5" width="108" height="108"/>
+                                <rect key="frame" x="137.5" y="283.5" width="100" height="100"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
                                 </accessibility>
@@ -40,6 +40,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="BootSplashLogo" width="108" height="108"/>
+        <image name="BootSplashLogo" width="100" height="100"/>
     </resources>
 </document>

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -136,21 +136,6 @@ RCT_EXPORT_MODULE();
                                     CGRectGetMidY(initialFrame)};
     _loadingView.hidden = NO;
 
-    // DIAGNOSTIC — DO NOT MERGE.
-    // Tag _loadingView's background BLUE (overriding the yellow from
-    // the storyboard) so the iOS-LaunchScreen → RCTBootSplash handoff
-    // is visually distinguishable. iOS shows its own LaunchScreen
-    // (yellow + logo) from the same storyboard, then ~350ms after
-    // didFinishLaunchingWithOptions returns it dismisses LaunchScreen,
-    // and the _loadingView beneath becomes visible.
-    //
-    //   • Blink coincides with the yellow→blue color change
-    //     → iOS LaunchScreen → RCTBootSplash handoff is the cause.
-    //   • Blink happens before / after the color change
-    //     → handoff isn't the cause; localize from when the blink
-    //       happens relative to the color transition.
-    _loadingView.backgroundColor = [UIColor blueColor];
-
     [_rootView addSubview:_loadingView];
 
     // Intentionally do NOT call -disableActivityIndicatorAutoHide: or

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -206,7 +206,12 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(hide : (RCTPromiseResolveBlock)
                       resolve reject : (RCTPromiseRejectBlock)reject) {
-  [self hideImpl:0 resolve:resolve];
+  // fade=1 → 250ms UIView crossDissolve. iOS has to compute the AFTER
+  // state (the React tree without the loadingView) to crossfade to it,
+  // which forces rendering of layers that were previously occluded.
+  // Bridges Fabric's incremental mounting so the React tree is on the
+  // framebuffer by the time the storyboard alpha hits 0.
+  [self hideImpl:1 resolve:resolve];
 }
 
 @end

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -56,12 +56,8 @@ RCT_EXPORT_MODULE();
 
   if (_fade) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      // DIAGNOSTIC — DO NOT MERGE.
-      // 1500ms cross-dissolve (6× slower than production 250ms) so the
-      // user can visually pinpoint when the logo blinks during the
-      // transition. Production duration is 0.250.
       [UIView transitionWithView:_rootView
-          duration:1.500
+          duration:0.250
           options:UIViewAnimationOptionTransitionCrossDissolve
           animations:^{
             _loadingView.hidden = YES;
@@ -133,6 +129,21 @@ RCT_EXPORT_MODULE();
     _loadingView.center = (CGPoint){CGRectGetMidX(initialFrame),
                                     CGRectGetMidY(initialFrame)};
     _loadingView.hidden = NO;
+
+    // DIAGNOSTIC — DO NOT MERGE.
+    // Tag _loadingView's background BLUE (overriding the yellow from
+    // the storyboard) so the iOS-LaunchScreen → RCTBootSplash handoff
+    // is visually distinguishable. iOS shows its own LaunchScreen
+    // (yellow + logo) from the same storyboard, then ~350ms after
+    // didFinishLaunchingWithOptions returns it dismisses LaunchScreen,
+    // and the _loadingView beneath becomes visible.
+    //
+    //   • Blink coincides with the yellow→blue color change
+    //     → iOS LaunchScreen → RCTBootSplash handoff is the cause.
+    //   • Blink happens before / after the color change
+    //     → handoff isn't the cause; localize from when the blink
+    //       happens relative to the color transition.
+    _loadingView.backgroundColor = [UIColor blueColor];
 
     [_rootView addSubview:_loadingView];
 

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -56,11 +56,17 @@ RCT_EXPORT_MODULE();
 
   if (_fade) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [UIView transitionWithView:_rootView
-          duration:0.250
-          options:UIViewAnimationOptionTransitionCrossDissolve
+      // DIAGNOSTIC v6 — DO NOT MERGE.
+      // Replace transitionWithView (snapshot-based) with a direct alpha
+      // animation. transitionWithView captures BEFORE and AFTER snapshots
+      // and crossfades them; at the end of the duration, iOS swaps the
+      // snapshot for the live view, and any mismatch between the cached
+      // AFTER snapshot and the actual live view at that moment shows as
+      // a one-frame discontinuity. Direct alpha animation interpolates
+      // the live view's alpha — no snapshots, no swap discontinuity.
+      [UIView animateWithDuration:0.250
           animations:^{
-            _loadingView.hidden = YES;
+            _loadingView.alpha = 0;
           }
           completion:^(__unused BOOL finished) {
             [_loadingView removeFromSuperview];

--- a/ios/kiroku/RCTBootSplash.mm
+++ b/ios/kiroku/RCTBootSplash.mm
@@ -56,8 +56,12 @@ RCT_EXPORT_MODULE();
 
   if (_fade) {
     dispatch_async(dispatch_get_main_queue(), ^{
+      // DIAGNOSTIC — DO NOT MERGE.
+      // 1500ms cross-dissolve (6× slower than production 250ms) so the
+      // user can visually pinpoint when the logo blinks during the
+      // transition. Production duration is 0.250.
       [UIView transitionWithView:_rootView
-          duration:0.250
+          duration:1.500
           options:UIViewAnimationOptionTransitionCrossDissolve
           animations:^{
             _loadingView.hidden = YES;

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from 'react';
 import type {NativeEventSubscription} from 'react-native';
-import {AppState, Linking, Platform} from 'react-native';
+import {AppState, Linking, Platform, StyleSheet, View} from 'react-native';
 import Onyx, {useOnyx} from 'react-native-onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useUserConnection} from '@context/global/UserConnectionContext';
@@ -35,7 +35,20 @@ import CONFIG from './CONFIG';
 import UpdateAppModal from './components/UpdateAppModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import colors from './styles/theme/colors';
 import CONST from './CONST';
+
+// Painted on top of NavigationRoot but below SplashScreenHider (zIndex 20)
+// while the splash is up, so any one-frame mount lag in SplashScreenHider's
+// tree can never expose React Navigation's white appBG. Plain View only
+// — every JS-rendered child has its own first-paint lag, so the guard
+// contributes the color, not the logo. The native loadingView covers the
+// logo until SplashScreenHider catches up.
+const splashGuardStyle = {
+  ...StyleSheet.absoluteFillObject,
+  backgroundColor: colors.yellowStrong,
+  zIndex: 19,
+};
 
 Onyx.registerLogger(({level, message}) => {
   if (level === 'alert') {
@@ -158,13 +171,11 @@ function Kiroku() {
   }, []);
 
   // Splash hide is driven by <SplashScreenHider /> below. It calls
-  // BootSplash.hide() (the 250ms native crossDissolve under the in-process
-  // storyboard subview) and then runs its own 250ms JS scale+opacity fade
-  // before signaling onHide here. The JS overlay covers the React tree the
-  // whole time, so the home screen's first-paint loading indicator is not
-  // visible to the user before content arrives — the same masking the old
-  // pre-PR #325 design provided. The overlay also owns the 15s force-hide
-  // safety timeout so a stuck gating condition can't pin the splash forever.
+  // BootSplash.hide(), which crossDissolves the in-process storyboard
+  // subview over 250ms — that transition also forces iOS to render the
+  // React tree underneath, masking Fabric's incremental mounting cascade.
+  // The overlay owns the 15s force-hide safety timeout so a stuck gating
+  // condition can't pin the splash forever.
   const onSplashHide = useCallback(() => {
     setSplashScreenState(CONST.BOOT_SPLASH_STATE.HIDDEN);
   }, [setSplashScreenState]);
@@ -267,45 +278,57 @@ function Kiroku() {
     setCrashlyticsUserId(auth?.currentUser?.uid ?? '-1');
   }, [isAuthenticated, auth?.currentUser?.uid]);
 
-  // Display a blank page until the onyx migration completes
-  if (!isOnyxMigrated) {
-    return null;
-  }
-
   if (updateRequired) {
     throw new Error(CONST.ERROR.UPDATE_REQUIRED);
   }
 
+  // Always render the splash guard and SplashScreenHider, even before
+  // Onyx has migrated. Returning `null` before isOnyxMigrated would
+  // commit an empty tree, and the React surface would still transition
+  // to "Running" stage on that empty commit, leaving the guard +
+  // SplashScreenHider unmounted while the native loadingView starts to
+  // dissolve. Gate only the heavier subtree (NavigationRoot + modals)
+  // on isOnyxMigrated.
   return (
-    // TODO
-    // <DeeplinkWrapper
-    //     isAuthenticated={isAuthenticated}
-    //     autoAuthState={autoAuthState}
-    // >
     <>
-      {loadingText ? (
-        <FullScreenLoadingIndicator loadingText={loadingText} />
-      ) : (
+      {isOnyxMigrated && (
         <>
-          {!isOnline && !CONFIG.IS_USING_EMULATORS && <UserOfflineModal />}
-          {isUnderMaintenance && <UnderMaintenanceModal config={config} />}
+          {loadingText ? (
+            <FullScreenLoadingIndicator loadingText={loadingText} />
+          ) : (
+            <>
+              {!isOnline && !CONFIG.IS_USING_EMULATORS && <UserOfflineModal />}
+              {isUnderMaintenance && <UnderMaintenanceModal config={config} />}
+            </>
+          )}
+
+          {shouldInit && (
+            <>
+              {shouldShowVerifyEmailModal && <VerifyEmailModal />}
+              {shouldShowUpdateModal && <UpdateAppModal />}
+              {/* // TODO show shared session invites here */}
+            </>
+          )}
+
+          <NavigationRoot
+            onReady={setNavigationReady}
+            authenticated={isAuthenticated}
+            lastVisitedPath={lastVisitedPath as Route}
+            initialUrl={initialUrl}
+          />
         </>
       )}
-
-      {shouldInit && (
-        <>
-          {shouldShowVerifyEmailModal && <VerifyEmailModal />}
-          {shouldShowUpdateModal && <UpdateAppModal />}
-          {/* // TODO show shared session invites here */}
-        </>
-      )}
-
-      <NavigationRoot
-        onReady={setNavigationReady}
-        authenticated={isAuthenticated}
-        lastVisitedPath={lastVisitedPath as Route}
-        initialUrl={initialUrl}
-      />
+      {/*
+        Guard layer between NavigationRoot and SplashScreenHider. Hides
+        NavigationContainer's white appBG during any frame where
+        SplashScreenHider's tree lags first paint. Unmounted as soon as
+        shouldHideSplash flips so the native cross-dissolve in
+        BootSplash.hide() can reveal the real content underneath.
+      */}
+      {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN &&
+        !shouldHideSplash && (
+          <View pointerEvents="none" style={splashGuardStyle} />
+        )}
       {splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN && (
         <SplashScreenHider
           shouldHideSplash={shouldHideSplash}

--- a/src/components/SafeArea/index.ios.tsx
+++ b/src/components/SafeArea/index.ios.tsx
@@ -1,12 +1,31 @@
 import React from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {useSplashScreenStateContext} from '@context/global/SplashScreenStateContext';
+import CONST from '@src/CONST';
 import type SafeAreaProps from './types';
 
 function SafeArea({children}: SafeAreaProps) {
   const styles = useThemeStyles();
+  const theme = useTheme();
+  const {splashScreenState} = useSplashScreenStateContext();
+  // While the splash is up, paint the SafeAreaView's native backing view
+  // splashBG yellow instead of theme.inverse. The Kiroku-level guard View
+  // covers the content area but the SafeAreaView is the outermost native
+  // view inside the React surface — if any layer above it lags first
+  // paint, theme.inverse (#1F2329 in light, #F0F6FC in dark) would show
+  // through. Yellow here keeps the boot stack one continuous color and
+  // reverts to theme.inverse the moment the splash unmounts, preserving
+  // the bounce / landscape-notch behavior for normal use.
+  const splashBgOverride =
+    splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN
+      ? {backgroundColor: theme.splashBG}
+      : null;
   return (
-    <SafeAreaView style={[styles.iPhoneXSafeArea]} edges={['left', 'right']}>
+    <SafeAreaView
+      style={[styles.iPhoneXSafeArea, splashBgOverride]}
+      edges={['left', 'right']}>
       {children}
     </SafeAreaView>
   );

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,8 +1,11 @@
 import {useCallback, useEffect, useRef} from 'react';
-import {Image, StyleSheet, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import ImageSVG from '@components/ImageSVG';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
 import Log from '@libs/Log';
+import colors from '@src/styles/theme/colors';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
@@ -20,9 +23,6 @@ const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 // never exported it, so it fell back to 100pt and produced a visible ~7.4%
 // size jump. Hardcoding 108pt eliminates that mismatch.
 const LOGO_SIZE = 108;
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const LOGO_PNG = require('@assets/images/app-logo.png');
 
 function SplashScreenHider({
   onHide = () => {},
@@ -57,7 +57,17 @@ function SplashScreenHider({
     if (!shouldHideSplash) {
       return;
     }
-    hide();
+    // DIAGNOSTIC — DO NOT MERGE.
+    // Defer BootSplash.hide() by one vsync via requestAnimationFrame.
+    // iOS's UIView.transitionWithView snapshots the AFTER state at the
+    // start of the transition; if the JS overlay's logo hasn't been
+    // pushed to the framebuffer yet at that moment, the snapshot has
+    // the bg but no logo, and the cross-dissolve crossfades to a
+    // logo-less AFTER state. rAF runs after the next vsync, by which
+    // point the previous React commit's pixels (including the logo)
+    // are on screen — so any snapshot iOS takes will include the logo.
+    const handle = requestAnimationFrame(() => hide());
+    return () => cancelAnimationFrame(handle);
   }, [shouldHideSplash, hide]);
 
   useEffect(() => {
@@ -76,22 +86,25 @@ function SplashScreenHider({
     return () => clearTimeout(timeoutId);
   }, [hide]);
 
-  // DIAGNOSTIC — DO NOT MERGE.
-  // Swap ImageSVG (react-native-svg) for a plain RN <Image> using the
-  // existing app-logo.png. react-native-svg constructs a CAShapeLayer
-  // with path data which has its own first-draw cost; UIImage is a
-  // precomputed bitmap that paints in the same frame as its parent.
-  // If the residual logo flicker disappears with this change, the SVG
-  // first-paint lag was the cause and the production fix is to use the
-  // PNG here.
+  // Plain View (not Reanimated.View). Reanimated 4 on Fabric binds
+  // animated styles via a worklet that may not execute on the first
+  // commit, leaving the View briefly rendered with opacity 0 — the
+  // source of the visible "flash" at the handoff before this refactor.
+  // Background and logo are static; the native cross-dissolve in
+  // BootSplash.hide() provides the only fade.
   return (
     <View style={[StyleSheet.absoluteFill, styles.splashScreenHider]}>
-      <Image
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        source={LOGO_PNG}
-        style={{width: LOGO_SIZE, height: LOGO_SIZE}}
-        resizeMode="contain"
-      />
+      <View>
+        <ImageSVG
+          contentFit="fill"
+          style={{
+            width: LOGO_SIZE,
+            height: LOGO_SIZE,
+          }}
+          fill={colors.white}
+          src={KirokuIcons.Logo}
+        />
+      </View>
     </View>
   );
 }

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -57,17 +57,7 @@ function SplashScreenHider({
     if (!shouldHideSplash) {
       return;
     }
-    // DIAGNOSTIC — DO NOT MERGE.
-    // Defer BootSplash.hide() by one vsync via requestAnimationFrame.
-    // iOS's UIView.transitionWithView snapshots the AFTER state at the
-    // start of the transition; if the JS overlay's logo hasn't been
-    // pushed to the framebuffer yet at that moment, the snapshot has
-    // the bg but no logo, and the cross-dissolve crossfades to a
-    // logo-less AFTER state. rAF runs after the next vsync, by which
-    // point the previous React commit's pixels (including the logo)
-    // are on screen — so any snapshot iOS takes will include the logo.
-    const handle = requestAnimationFrame(() => hide());
-    return () => cancelAnimationFrame(handle);
+    hide();
   }, [shouldHideSplash, hide]);
 
   useEffect(() => {

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,11 +1,8 @@
 import {useCallback, useEffect, useRef} from 'react';
-import {StyleSheet, View} from 'react-native';
-import * as KirokuIcons from '@components/Icon/KirokuIcons';
-import ImageSVG from '@components/ImageSVG';
+import {Image, StyleSheet, View} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
 import Log from '@libs/Log';
-import colors from '@src/styles/theme/colors';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
@@ -23,6 +20,9 @@ const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 // never exported it, so it fell back to 100pt and produced a visible ~7.4%
 // size jump. Hardcoding 108pt eliminates that mismatch.
 const LOGO_SIZE = 108;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const LOGO_PNG = require('@assets/images/app-logo.png');
 
 function SplashScreenHider({
   onHide = () => {},
@@ -76,25 +76,22 @@ function SplashScreenHider({
     return () => clearTimeout(timeoutId);
   }, [hide]);
 
-  // Plain View (not Reanimated.View). Reanimated 4 on Fabric binds
-  // animated styles via a worklet that may not execute on the first
-  // commit, leaving the View briefly rendered with opacity 0 — the
-  // source of the visible "flash" at the handoff before this refactor.
-  // Background and logo are static; the native cross-dissolve in
-  // BootSplash.hide() provides the only fade.
+  // DIAGNOSTIC — DO NOT MERGE.
+  // Swap ImageSVG (react-native-svg) for a plain RN <Image> using the
+  // existing app-logo.png. react-native-svg constructs a CAShapeLayer
+  // with path data which has its own first-draw cost; UIImage is a
+  // precomputed bitmap that paints in the same frame as its parent.
+  // If the residual logo flicker disappears with this change, the SVG
+  // first-paint lag was the cause and the production fix is to use the
+  // PNG here.
   return (
     <View style={[StyleSheet.absoluteFill, styles.splashScreenHider]}>
-      <View>
-        <ImageSVG
-          contentFit="fill"
-          style={{
-            width: LOGO_SIZE,
-            height: LOGO_SIZE,
-          }}
-          fill={colors.white}
-          src={KirokuIcons.Logo}
-        />
-      </View>
+      <Image
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        source={LOGO_PNG}
+        style={{width: LOGO_SIZE, height: LOGO_SIZE}}
+        resizeMode="contain"
+      />
     </View>
   );
 }

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,13 +1,5 @@
 import {useCallback, useEffect, useRef} from 'react';
-import type {ViewStyle} from 'react-native';
-import {StyleSheet} from 'react-native';
-import Reanimated, {
-  Easing,
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import {StyleSheet, View} from 'react-native';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import ImageSVG from '@components/ImageSVG';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -38,51 +30,28 @@ function SplashScreenHider({
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const styles = useThemeStyles();
 
-  const opacity = useSharedValue(1);
-  const scale = useSharedValue(1);
-
-  const opacityStyle = useAnimatedStyle<ViewStyle>(() => ({
-    opacity: opacity.get(),
-  }));
-  const scaleStyle = useAnimatedStyle<ViewStyle>(() => ({
-    transform: [{scale: scale.get()}],
-  }));
-
   const hideHasBeenCalled = useRef(false);
 
   const hide = useCallback(() => {
-    // hide can only be called once
     if (hideHasBeenCalled.current) {
       return;
     }
 
     hideHasBeenCalled.current = true;
 
+    // BootSplash.hide() runs a 250ms cross-dissolve on the native side
+    // (fade=1 in RCTBootSplash.mm). The dissolve forces iOS to render
+    // the React tree underneath the storyboard view to prepare its
+    // AFTER state — which masks Fabric's incremental mounting cascade
+    // (proxy → GestureHandlerRootView → SplashScreenHider). By the
+    // time the dissolve resolves, the React tree is fully composited.
+    // No JS-side fade animation is needed; this component just owns
+    // the safety timeout and unmounts when the native dissolve
+    // resolves.
     BootSplash.hide().then(() => {
-      // Straight shrink to 0. Previously used Easing.back(2), but `back`
-      // dips negative in the middle of the eased curve, which (when
-      // interpolating from 1 to 0) pushes the scale above 1 — the logo
-      // visibly "pops" outward by ~13% before shrinking. Reads as a brief
-      // flash now that the rest of the cold-start is smooth.
-      scale.set(
-        withTiming(0, {
-          duration: 200,
-          easing: Easing.out(Easing.ease),
-        }),
-      );
-
-      opacity.set(
-        withTiming(
-          0,
-          {
-            duration: 250,
-            easing: Easing.out(Easing.ease),
-          },
-          () => runOnJS(onHide)(),
-        ),
-      );
+      onHide();
     });
-  }, [opacity, scale, onHide]);
+  }, [onHide]);
 
   useEffect(() => {
     if (!shouldHideSplash) {
@@ -107,10 +76,15 @@ function SplashScreenHider({
     return () => clearTimeout(timeoutId);
   }, [hide]);
 
+  // Plain View (not Reanimated.View). Reanimated 4 on Fabric binds
+  // animated styles via a worklet that may not execute on the first
+  // commit, leaving the View briefly rendered with opacity 0 — the
+  // source of the visible "flash" at the handoff before this refactor.
+  // Background and logo are static; the native cross-dissolve in
+  // BootSplash.hide() provides the only fade.
   return (
-    <Reanimated.View
-      style={[StyleSheet.absoluteFill, styles.splashScreenHider, opacityStyle]}>
-      <Reanimated.View style={scaleStyle}>
+    <View style={[StyleSheet.absoluteFill, styles.splashScreenHider]}>
+      <View>
         <ImageSVG
           contentFit="fill"
           style={{
@@ -120,8 +94,8 @@ function SplashScreenHider({
           fill={colors.white}
           src={KirokuIcons.Logo}
         />
-      </Reanimated.View>
-    </Reanimated.View>
+      </View>
+    </View>
   );
 }
 

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -91,7 +91,7 @@ function SplashScreenHider({
             width: LOGO_SIZE,
             height: LOGO_SIZE,
           }}
-          fill={colors.white}
+          fill="red"
           src={KirokuIcons.Logo}
         />
       </View>

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,11 +1,8 @@
 import {useCallback, useEffect, useRef} from 'react';
-import {StyleSheet, View} from 'react-native';
-import * as KirokuIcons from '@components/Icon/KirokuIcons';
-import ImageSVG from '@components/ImageSVG';
+import {Image, StyleSheet, View} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
 import Log from '@libs/Log';
-import colors from '@src/styles/theme/colors';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
@@ -82,19 +79,21 @@ function SplashScreenHider({
   // source of the visible "flash" at the handoff before this refactor.
   // Background and logo are static; the native cross-dissolve in
   // BootSplash.hide() provides the only fade.
+  // DIAGNOSTIC v9 — DO NOT MERGE.
+  // Use the iOS asset catalog image directly via `source={{uri: ...}}`.
+  // The string URI form falls through to [UIImage imageNamed:] internally,
+  // which loads BootSplashLogo from the same asset catalog the storyboard's
+  // UIImageView uses. Both layers should now render identical pixels —
+  // including identical anti-aliasing on the logo's edges. If the blink
+  // disappears with this change, edge anti-aliasing mismatch between SVG
+  // path rendering and UIImage rendering was the cause.
   return (
     <View style={[StyleSheet.absoluteFill, styles.splashScreenHider]}>
-      <View>
-        <ImageSVG
-          contentFit="fill"
-          style={{
-            width: LOGO_SIZE,
-            height: LOGO_SIZE,
-          }}
-          fill="red"
-          src={KirokuIcons.Logo}
-        />
-      </View>
+      <Image
+        source={{uri: 'BootSplashLogo'}}
+        style={{width: LOGO_SIZE, height: LOGO_SIZE}}
+        resizeMode="contain"
+      />
     </View>
   );
 }


### PR DESCRIPTION
**⚠️ DIAGNOSTIC — DO NOT MERGE ⚠️**

## What v8 confirmed

User observation with red JS logo:
> Very smooth white → red color transition at the same position, as far as I can tell.

That's a big result:
- **Positions match exactly** — if they didn't, two distinct logos would appear at offset positions during the fade.
- **Compositing math works correctly** — the cross-dissolve produces clean intermediate states (white → pink → red).

But here's the puzzle: my alpha math says white-on-white should *also* produce a smooth result. `white * (1-t) + white * t = white` throughout. And yet v7 (white-on-white) had a visible blink, while v8 (white-on-red) is smooth.

## What's left

If positions match and compositing works, the difference must be in the **pixel-level rendering of the logo's anti-aliased edges**:

- **Storyboard:** `UIImageView` → UIKit's `UIImage` rendering of the `BootSplashLogo` asset catalog image. Edge anti-aliasing comes from the pre-rasterized PNG.
- **JS overlay:** `ImageSVG` (`react-native-svg`) → renders the SVG path geometry into a `CAShapeLayer`. Edge anti-aliasing is computed from the path math.

Both produce white interiors that match. But the edge pixels likely have subtly different alpha values. In white-on-red, that edge mismatch is dominated visually by the dramatic color transition. In white-on-white, there's no color signal — the eye keys on the logo's silhouette and the subtle anti-aliasing mismatch reads as a "blink."

## What v9 changes

Swap `<ImageSVG ...>` for `<Image source={{uri: 'BootSplashLogo'}} ...>`. The string `uri` form on iOS falls through to `[UIImage imageNamed:]`, which loads from the **iOS asset catalog** — the exact same source the storyboard's `UIImageView` uses. Both layers now render identical `UIImage` instances with identical anti-aliasing.

(This is different from v1's PNG diagnostic — v1 used `require('@assets/images/app-logo.png')` which loads a Metro-bundled PNG. v9 uses `{uri: 'BootSplashLogo'}` which loads from `ios/kiroku/Images.xcassets/BootSplashLogo.imageset` directly.)

## How to interpret

| What you see | Conclusion | Real fix |
| --- | --- | --- |
| **Blink disappears, logo holds continuously** | Edge anti-aliasing mismatch between SVG path drawing and UIImage rendering was the cause. | Use `<Image source={{uri: 'BootSplashLogo'}}>` in production `SplashScreenHider`. |
| **Same blink** | Rendering paths produce identical pixels too. The "blink" is likely perceptual or inherent to the cross-dissolve architecture; pursuing it further may not pay off. | Accept the residual blink as the limit of this approach; the fix in #616 is the main win. |

JS-only change — Metro reset or `bun run ios` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)