### PR TITLE
fix(ios): render BootSplash logo at its native 108pt size

### DIFF
--- a/ios/kiroku/BootSplash.storyboard
+++ b/ios/kiroku/BootSplash.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="BootSplashLogo" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
-                                <rect key="frame" x="137.5" y="283.5" width="100" height="100"/>
+                                <rect key="frame" x="133.5" y="279.5" width="108" height="108"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
                                 </accessibility>
@@ -40,6 +40,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="BootSplashLogo" width="100" height="100"/>
+        <image name="BootSplashLogo" width="108" height="108"/>
     </resources>
 </document>


### PR DESCRIPTION
## Summary

The storyboard's `ImageView` frame was `100×100`, but the `BootSplashLogo` asset ships at 108pt natively (108/216/324 PNGs at 1×/2×/3×). With `contentMode=scaleAspectFit`, iOS was scaling the 108pt asset down to 100pt for display — slightly softer edges and a smaller logo than intended.

The JS `SplashScreenHider` already renders at 108pt (`LOGO_SIZE`), so this aligns the storyboard with both the asset's native dimensions and the JS overlay.

No behavioral change beyond rendering the logo crisper and at the size it was designed for. The cross-dissolve handoff fix in [#616](https://github.com/PetrCala/Kiroku/pull/616) was unaffected by this mismatch (a diagnostic in that investigation explicitly tested 108pt storyboard alone and the blink remained — proving size wasn't the culprit), but this restores [PR #325](https://github.com/PetrCala/Kiroku/commit/78389a1f)'s original intent of *"OS → native → JS chain is one continuous logo"* at the size the asset was designed for.

## Test plan

- [ ] Cold-launch on a physical iOS device. The logo on the boot splash should look identical in position but slightly larger (~8% in each dimension) and sharper-edged than before.
- [ ] No regressions in the splash handoff sequence from #616 (no orange gap, no logo blink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)