### PR TITLE
feat(supporter): gate visibility behind production env flag

### DIFF
--- a/__tests__/unit/SupporterUtils.test.ts
+++ b/__tests__/unit/SupporterUtils.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+
+import SupporterUtils from '@libs/SupporterUtils';
+import CONFIG from '@src/CONFIG';
+
+jest.mock('@src/CONFIG', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- ES module interop flag required for default-export mocks.
+  __esModule: true,
+  default: {IS_IN_PRODUCTION: false},
+}));
+
+const mockedCONFIG = CONFIG as unknown as {IS_IN_PRODUCTION: boolean};
+
+describe('libs/SupporterUtils.isSupporterTierVisible', () => {
+  afterEach(() => {
+    mockedCONFIG.IS_IN_PRODUCTION = false;
+  });
+
+  it('returns true outside production (dev / staging / adhoc)', () => {
+    mockedCONFIG.IS_IN_PRODUCTION = false;
+    expect(SupporterUtils.isSupporterTierVisible()).toBe(true);
+  });
+
+  it('returns false in production builds', () => {
+    mockedCONFIG.IS_IN_PRODUCTION = true;
+    expect(SupporterUtils.isSupporterTierVisible()).toBe(false);
+  });
+});

--- a/src/components/SupporterBadge.tsx
+++ b/src/components/SupporterBadge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useOnyx} from 'react-native-onyx';
 import useLocalize from '@hooks/useLocalize';
+import SupporterUtils from '@libs/SupporterUtils';
 import * as UserUtils from '@libs/UserUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
 import variables from '@styles/variables';
@@ -29,9 +30,18 @@ type SupporterBadgeProps = {
  * Purely presentational badge that renders the 🍺 marker when the target user
  * is an active supporter. Renders `null` (not an empty wrapper) when not a
  * supporter so layout siblings collapse around it.
+ *
+ * Also renders `null` when the supporter tier is hidden for this build
+ * (production until v1.1 launch — see `SupporterUtils.isSupporterTierVisible`).
+ * Gating here protects every render site automatically, including any
+ * future ones.
  */
 function SupporterBadge({isSupporter, size = 'medium'}: SupporterBadgeProps) {
   const {translate} = useLocalize();
+
+  if (!SupporterUtils.isSupporterTierVisible()) {
+    return null;
+  }
 
   if (!isSupporter) {
     return null;
@@ -63,8 +73,23 @@ type SupporterBadgeForUserProps = {
  * Onyx-aware convenience wrapper that resolves `isSupporter` for any user ID
  * (current user or a friend) and renders the base badge. Keeps the base
  * component free of state coupling so it remains snapshot-friendly.
+ *
+ * Short-circuits to `null` when the supporter tier is hidden for this build,
+ * before touching Onyx — saves the listener subscription on production
+ * builds where the badge can never render.
  */
 function SupporterBadgeForUser({userID, size}: SupporterBadgeForUserProps) {
+  if (!SupporterUtils.isSupporterTierVisible()) {
+    return null;
+  }
+
+  return <SupporterBadgeForUserInner userID={userID} size={size} />;
+}
+
+function SupporterBadgeForUserInner({
+  userID,
+  size,
+}: SupporterBadgeForUserProps) {
   const {auth} = useFirebase();
   const currentUserID = auth?.currentUser?.uid;
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);

--- a/src/libs/SupporterUtils.ts
+++ b/src/libs/SupporterUtils.ts
@@ -1,0 +1,21 @@
+import CONFIG from '@src/CONFIG';
+
+/**
+ * Whether Supporter-tier UI should be rendered in this build.
+ *
+ * Hidden in production until v1.1 launch — Apple's first-subscription gate
+ * requires an App Store version submission that attaches `supporter_monthly`
+ * before the IAP activates, and that submission will ride with the v1.1 cut.
+ * Until then, production builds bundle the supporter code paths (RevenueCat
+ * SDK, Onyx selectors, webhook handling, screen registrations) but never
+ * render any visual surface. Flip this on for v1.1 by adjusting the gate or
+ * by introducing a dedicated env flag — see the helper body.
+ *
+ * Dev/staging/adhoc builds always show the UI so the feature stays
+ * exercisable end-to-end during development.
+ */
+function isSupporterTierVisible(): boolean {
+  return !CONFIG.IS_IN_PRODUCTION;
+}
+
+export default {isSupporterTierVisible};

--- a/src/screens/Settings/ManageSubscriptionScreen.tsx
+++ b/src/screens/Settings/ManageSubscriptionScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Linking, Platform, View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
@@ -11,6 +11,7 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {restoreSupporterPurchases} from '@libs/actions/Subscriptions';
 import Navigation from '@libs/Navigation/Navigation';
+import SupporterUtils from '@libs/SupporterUtils';
 import * as UserUtils from '@libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -42,6 +43,16 @@ function ManageSubscriptionScreen() {
   const supporter = UserUtils.getCurrentUserSupporterStatus(privateData);
   const [isRestoring, setIsRestoring] = useState(false);
   const [restoreMessage, setRestoreMessage] = useState<string | null>(null);
+
+  // Defense-in-depth: even though the Settings menu entry is removed in
+  // production builds (see `SupporterUtils.isSupporterTierVisible`), bounce
+  // back if the screen is reached via deep link or stale navigation state.
+  const isVisible = SupporterUtils.isSupporterTierVisible();
+  useEffect(() => {
+    if (!isVisible) {
+      Navigation.goBack(ROUTES.SETTINGS);
+    }
+  }, [isVisible]);
 
   const status: SupporterStatus | null = supporter.supporter_status ?? null;
   const expiresDate = formatDate(supporter.supporter_expires_at);
@@ -124,6 +135,10 @@ function ManageSubscriptionScreen() {
     Platform.OS === 'ios'
       ? translate('supporter.manageSubscription.manageInAppStore')
       : translate('supporter.manageSubscription.manageInGooglePlay');
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <ScreenWrapper testID={ManageSubscriptionScreen.displayName}>

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -30,6 +30,7 @@ import useSingleExecution from '@hooks/useSingleExecution';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWaitForNavigation from '@hooks/useWaitForNavigation';
 import Navigation from '@libs/Navigation/Navigation';
+import SupporterUtils from '@libs/SupporterUtils';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import type {Route} from '@src/ROUTES';
@@ -79,11 +80,15 @@ function SettingsScreen() {
   const userIsAdmin = userData && userData.role === 'admin';
   const [privateData] = useOnyx(ONYXKEYS.USER_PRIVATE_DATA);
   const supporter = UserUtils.getCurrentUserSupporterStatus(privateData);
+  // Hidden entirely in production builds until v1.1 launch clears Apple's
+  // first-subscription gate (see `SupporterUtils.isSupporterTierVisible`).
+  const shouldShowSupporterMenu = SupporterUtils.isSupporterTierVisible();
   // Surface "Manage Subscription" only once the user has interacted with the
   // supporter tier — never-subscribed users should keep seeing just the
   // "Support Kiroku" entry point.
   const shouldShowManageSubscription =
-    !!supporter.is_supporter || !!supporter.supporter_status;
+    shouldShowSupporterMenu &&
+    (!!supporter.is_supporter || !!supporter.supporter_status);
 
   const [shouldShowSignoutConfirmModal, setShouldShowSignoutConfirmModal] =
     useState(false);
@@ -128,11 +133,15 @@ function SettingsScreen() {
           icon: KirokuIcons.Gear,
           routeName: ROUTES.SETTINGS_PREFERENCES,
         },
-        {
-          translationKey: 'supporter.menuEntry',
-          icon: KirokuIcons.Star,
-          routeName: ROUTES.SETTINGS_SUPPORT,
-        },
+        ...(shouldShowSupporterMenu
+          ? [
+              {
+                translationKey: 'supporter.menuEntry',
+                icon: KirokuIcons.Star,
+                routeName: ROUTES.SETTINGS_SUPPORT,
+              } as MenuData,
+            ]
+          : []),
         ...(shouldShowManageSubscription
           ? [
               {
@@ -146,7 +155,11 @@ function SettingsScreen() {
     };
 
     return defaultMenu;
-  }, [styles.accountSettingsSectionContainer, shouldShowManageSubscription]);
+  }, [
+    styles.accountSettingsSectionContainer,
+    shouldShowSupporterMenu,
+    shouldShowManageSubscription,
+  ]);
 
   /**
    * Retuns a list of menu items data for general section

--- a/src/screens/Settings/SupportKirokuScreen.tsx
+++ b/src/screens/Settings/SupportKirokuScreen.tsx
@@ -18,6 +18,7 @@ import {
   restoreSupporterPurchases,
 } from '@libs/actions/Subscriptions';
 import Navigation from '@libs/Navigation/Navigation';
+import SupporterUtils from '@libs/SupporterUtils';
 import * as UserUtils from '@libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -40,8 +41,19 @@ function SupportKirokuScreen() {
   const [isPurchasing, setIsPurchasing] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
 
+  // Defense-in-depth: even though the Settings menu entry is removed in
+  // production builds (see `SupporterUtils.isSupporterTierVisible`), bounce
+  // back if the screen is reached via deep link, stale navigation state, or a
+  // future entry point that forgets the gate.
+  const isVisible = SupporterUtils.isSupporterTierVisible();
+  useEffect(() => {
+    if (!isVisible) {
+      Navigation.goBack(ROUTES.SETTINGS);
+    }
+  }, [isVisible]);
+
   // Already-supporter UIs don't load offerings — there's nothing to sell.
-  const shouldLoadOfferings = !supporter.is_supporter;
+  const shouldLoadOfferings = isVisible && !supporter.is_supporter;
 
   const loadOffering = useCallback(async () => {
     const offering = await fetchCurrentOffering();
@@ -264,6 +276,10 @@ function SupportKirokuScreen() {
       </Section>
     );
   };
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <ScreenWrapper testID={SupportKirokuScreen.displayName}>


### PR DESCRIPTION
## Summary

- Hide the Supporter tier UI (badge, paywall, Manage Subscription) in production builds. Dev/staging/adhoc keep showing it.
- New `SupporterUtils.isSupporterTierVisible()` helper returning `!CONFIG.IS_IN_PRODUCTION`. No new env var — visibility is tied directly to the existing environment-detection constant.
- Gating is layered: badge component returns `null`, Settings menu omits both entries, and the two screens add a redirect guard for deep-link / stale-nav scenarios.
- Only **rendering** is gated. RevenueCat SDK init, Onyx selectors, webhook handling, screen registrations, and translations stay bundled so the feature remains exercisable end-to-end in non-production builds and can be lit up by adjusting the gate.

## Why

Issue #373 — end-to-end testing on iOS — is blocked by Apple's **first-subscription gate**: the first IAP must be attached to an App Store version submission before it activates in sandbox. Kiroku's v1.0 plan is Firebase-first with App Store later, so forcing an early App Store submission to unblock supporter-only sandbox testing inverts the roadmap (Supporter is explicitly v1.1, not blocking v1).

This change lets v1.0 ship to App Store / Play without surfacing untested IAP UI to end users, while keeping the supporter code paths fully bundled. v1.1 flips visibility on alongside the App Store submission that attaches `supporter_monthly`.

## Files

- `src/libs/SupporterUtils.ts` *(new)* — the helper, single default export of `{isSupporterTierVisible}`.
- `src/components/SupporterBadge.tsx` — both `SupporterBadge` (base) and `SupporterBadgeForUser` (wrapper) return `null` when hidden. Wrapper short-circuits before touching Onyx so production skips the subscription entirely.
- `src/screens/Settings/SettingsScreen.tsx` — both menu entries (Support Kiroku, Manage Subscription) gated by `shouldShowSupporterMenu`.
- `src/screens/Settings/SupportKirokuScreen.tsx` — `useEffect` redirect to Settings + early `null` return when hidden.
- `src/screens/Settings/ManageSubscriptionScreen.tsx` — same redirect guard.
- `__tests__/unit/SupporterUtils.test.ts` *(new)* — covers both branches of the helper.

## Rollback

This change is non-destructive. Revert the PR and supporter UI re-renders everywhere immediately; user data on the public/private nodes is untouched.

## Lighting it up for v1.1

When v1.1 ships:
1. Submit the v1.0 App Store version (no supporter UI visible). Apple's first-subscription gate stays in place but doesn't block v1.0.
2. For v1.1: either replace `!CONFIG.IS_IN_PRODUCTION` in the helper with a dedicated env flag (cleaner if other production-only features ride on `IS_IN_PRODUCTION`), or just keep the current gate semantics and adjust as needed.
3. Submit a v1.1 App Store version attaching `supporter_monthly`. Sandbox lights up. Run iOS test matrix from #373.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `npm run lint-changed` clean
- [x] `npx jest __tests__/unit/SupporterUtils.test.ts` — both cases pass
- [x] `npx prettier --check` on all modified files
- [ ] Manual dev build: confirm Settings shows "Support Kiroku" entry; badge renders for users with `is_supporter=true`.
- [ ] Manual production build locally: confirm Settings does not show either supporter entry; badge does not render even when `is_supporter=true` is set in Onyx; deep-linking to `/settings/support` or `/settings/manage-subscription` bounces back via `goBack()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)