### PR TITLE
chore(onboarding): pin removal TODO on isLegacyGrandfatheredUser

### DIFF
--- a/src/libs/OnboardingSelectors.ts
+++ b/src/libs/OnboardingSelectors.ts
@@ -43,6 +43,16 @@ function hasAcceptedCurrentTerms(userData: UserData | undefined): boolean {
  * (`username_chosen !== false`). Users mid-signup whose username step is
  * still pending always go through the new flow, even if `agreed_to_terms_at`
  * happens to be set.
+ *
+ * TODO (pinned at 0.3.13-35): remove this selector and rely solely on
+ * `hasCompletedOnboarding`. The #358 backfill already stamped existing users
+ * with `onboarding.completed_at`; this selector now only protects accounts
+ * created through pre-rebuild builds (oldest in the wild: Android beta 0.3.10)
+ * whose signup doesn't write `completed_at`. Safe to remove once the
+ * minimum-supported version is bumped above those builds (at app launch, or
+ * with the next Android beta ship that force-updates off 0.3.10). Tracked in
+ * https://github.com/PetrCala/Kiroku/issues/645 — see it for the full removal
+ * procedure.
  */
 function isLegacyGrandfatheredUser(userData: UserData | undefined): boolean {
   if (!userData) {


### PR DESCRIPTION
## Summary

- Adds a removal TODO (pinned at `0.3.13-35`) to `isLegacyGrandfatheredUser` in `src/libs/OnboardingSelectors.ts`, pointing at the tracking issue #645.
- Comment-only change. No behavior change.

## Why

The #358 onboarding backfill has run in production, stamping existing users with `onboarding.completed_at`, so `hasCompletedOnboarding` already covers them. The grandfathering selector now only protects accounts created through pre-rebuild builds (oldest in the wild: Android beta `0.3.10`) whose signup flow doesn't write `completed_at`. It's safe to delete once the minimum-supported version is bumped above those builds — at app launch, or with the next Android beta ship that force-updates off `0.3.10`. Capturing that context at the code site so it isn't lost.

Full removal procedure lives in #645.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `./scripts/lint.sh` clean
- [x] `npx prettier` clean
- [x] Comment-only — no runtime behavior to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)