### PR TITLE
chore(ios): accurate permission strings + gate test-tools gesture

### DIFF
--- a/ios/kiroku/Info.plist
+++ b/ios/kiroku/Info.plist
@@ -49,12 +49,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSCameraUsageDescription</key>
-	<string>We need access to your camera to capture videos.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>We need access to your photos to select images or videos.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>We need access to your photos to select images or videos.</string>
+	<string>Kiroku accesses your photos so you can choose a profile picture.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -172,7 +172,12 @@ function ScreenWrapper(
 
   const panResponder = useRef(
     PanResponder.create({
+      // Gate the gesture to dev only, matching where `<TestToolsModal />` is
+      // actually rendered (see `isDevelopment &&` below). Outside dev the modal
+      // never mounts, so capturing the multi-touch gesture would only fire a
+      // no-op toggle.
       onStartShouldSetPanResponderCapture: (_e, gestureState) =>
+        isDevelopment &&
         gestureState.numberActiveTouches === CONST.TEST_TOOL.NUMBER_OF_TAPS,
       onPanResponderRelease: toggleTestToolsModal,
     }),


### PR DESCRIPTION
## Summary

Two small App Store submission-readiness fixes from #648:

- **`ios/kiroku/Info.plist` — accurate permission strings.** The app's only image entry point is `src/components/UploadImage.tsx`, which calls `launchImageLibraryAsync` with `MediaTypeOptions.Images` for profile pictures — photo library only, images only, no camera, no library writes. So:
  - Reword `NSPhotoLibraryUsageDescription` to accurately describe profile-picture selection (was the inaccurate "select images or videos").
  - Remove `NSCameraUsageDescription` — the camera is never invoked (`launchCameraAsync` is never called). Removes the false "capture videos" string Apple would flag.
  - Remove `NSPhotoLibraryAddUsageDescription` — the app never writes to the photo library (images upload to Firebase).
- **`src/components/ScreenWrapper.tsx` — gate the test-tools gesture.** The multi-touch `PanResponder` that toggles the Test Tools modal had no environment gate, while `<TestToolsModal />` itself is already dev-only (`{isDevelopment && ...}`). Gated the gesture behind the same `isDevelopment` flag (already in scope from `useEnvironment()`) so it's consistent — outside dev the modal never mounts, so the gesture was only firing a no-op.

## Notes

- The Test Tools item was **not** actually a production blocker (the modal couldn't open outside dev); this is consistency hardening. The Info.plist reword is the genuine review item. Will update #648's framing accordingly.
- `plutil -lint` confirms the plist is well-formed after removing the two keys.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `./scripts/lint.sh` clean
- [x] `npx prettier` clean
- [x] `plutil -lint ios/kiroku/Info.plist` → OK
- [ ] iOS dev build: choosing a profile picture still prompts the (reworded) photo-library permission; app doesn't crash from the removed keys (safe — no camera/library-write code paths exist).
- [ ] Dev build: N-finger test-tools gesture still opens the modal; staging/prod build: gesture is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)