### PR TITLE
fix(lint): unblock master — disable no-console on Skia warning suppressor

### DIFF
--- a/src/setup/suppressSkiaPathDeprecationWarnings.ts
+++ b/src/setup/suppressSkiaPathDeprecationWarnings.ts
@@ -37,7 +37,9 @@ export default function suppressSkiaPathDeprecationWarnings(): void {
     return;
   }
 
+  // eslint-disable-next-line no-console
   const originalWarn = console.warn.bind(console);
+  // eslint-disable-next-line no-console
   console.warn = (...args: unknown[]) => {
     if (isSkiaPathDeprecationWarning(args)) {
       return;


### PR DESCRIPTION
## Summary
- The `Process new code merged to master` workflow has been **failing on the lint job** since commit effc13fe. `src/setup/suppressSkiaPathDeprecationWarnings.ts` overrides `console.warn`, which the `no-console` rule rejects (only `debug`/`error` are allowed) — 2 errors, lint exits 1.
- This adds `// eslint-disable-next-line no-console` on the two intentional `console.warn` lines (the override is the whole point of the dev-only filter). Verified clean with `npx eslint` on the file.

## Context
While investigating I also ran the requested `ios:pod:reset` in this worktree. It produced **nothing meaningful to commit**: the `project.pbxproj` diff was 100% random-UUID churn (zero semantic change; xUnique didn't normalize it this run), and `Podfile.lock` only shifted 3 codegen-pod checksums (`ReactCodegen`/`RNReanimated`/`RNWorklets`, which are non-deterministic). Those artifacts were discarded — `Podfile.lock` was already regenerated in daad16d9.

## Test plan
- [x] `npx eslint src/setup/suppressSkiaPathDeprecationWarnings.ts` passes
- [ ] `lint` job green on this PR