### PR TITLE
feat(privacy): crash-reporting opt-out toggle (GDPR)

### DIFF
--- a/src/DBPATHS.ts
+++ b/src/DBPATHS.ts
@@ -90,6 +90,11 @@ const DBPATHS = {
     getRoute: (user_id: UserID) =>
       `user_preferences/${user_id}/track_location_during_sessions` as const,
   },
+  USER_PREFERENCES_USER_ID_CRASH_REPORTING_ENABLED: {
+    route: '/user_preferences/:user_id/crash_reporting_enabled',
+    getRoute: (user_id: UserID) =>
+      `user_preferences/${user_id}/crash_reporting_enabled` as const,
+  },
   USER_SESSION_PLACEHOLDER: 'user_session_placeholder',
   USER_SESSION_PLACEHOLDER_USER_ID: {
     route: '/user_session_placeholder/:user_id',

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@src/types/onyx';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import useListenToData from '@hooks/useListenToData';
+import setCrashReportingCollectionEnabled from '@libs/setCrashReportingCollectionEnabled';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
 import {useFirebase} from './FirebaseContext';
@@ -80,6 +81,13 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
     const theme = data.preferences?.theme ?? CONST.THEME.DEFAULT;
     // eslint-disable-next-line rulesdir/prefer-actions-set-data
     Onyx.set(ONYXKEYS.PREFERRED_THEME, theme);
+    // Apply the crash-reporting opt-out from Firebase (source of truth, so it
+    // survives reinstall) to the native collectors. Absent ⇒ enabled (the
+    // legitimate-interest opt-out default); gating against the build flag and
+    // the web no-op live in the util. Crashlytics persists this across restarts.
+    setCrashReportingCollectionEnabled(
+      data.preferences?.crash_reporting_enabled !== false,
+    );
   }, [data.preferences]);
 
   // Monitor local data for changes - TODO rewrite this later

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -527,8 +527,21 @@ export default {
   },
   privacyScreen: {
     title: 'Soukromí',
-    description:
-      'Spravujte, jak Kiroku pracuje s polohou spojenou s vašimi živými sezeními.',
+    diagnosticsSection: {
+      title: 'Diagnostika',
+      description:
+        'Spravujte, zda Kiroku shromažďuje diagnostiku pádů a výkonu.',
+    },
+    crashReporting: {
+      label: 'Odesílat hlášení o pádech',
+      description:
+        'Když je zapnuto, Kiroku používá Firebase Crashlytics a Performance Monitoring k odesílání diagnostiky pádů a výkonu spojené s vaším účtem, což nám pomáhá rychleji opravovat chyby. Vypnutím se odhlásíte.',
+    },
+    locationSection: {
+      title: 'Poloha',
+      description:
+        'Spravujte, jak Kiroku pracuje s polohou spojenou s vašimi živými sezeními.',
+    },
     trackLocationDuringSessions: {
       label: 'Označovat drinky polohou',
       description:

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -529,8 +529,21 @@ export default {
   },
   privacyScreen: {
     title: 'Privacy',
-    description:
-      'Control how Kiroku handles location data tied to your live sessions.',
+    diagnosticsSection: {
+      title: 'Diagnostics',
+      description:
+        'Control whether Kiroku collects crash and performance diagnostics.',
+    },
+    crashReporting: {
+      label: 'Send crash reports',
+      description:
+        'When on, Kiroku uses Firebase Crashlytics and Performance Monitoring to send crash and performance diagnostics linked to your account, helping us fix issues faster. Turn off to opt out.',
+    },
+    locationSection: {
+      title: 'Location',
+      description:
+        'Control how Kiroku handles location data tied to your live sessions.',
+    },
     trackLocationDuringSessions: {
       label: 'Tag drinks with location',
       description:

--- a/src/libs/setCrashReportingCollectionEnabled/index.native.ts
+++ b/src/libs/setCrashReportingCollectionEnabled/index.native.ts
@@ -1,0 +1,17 @@
+import {
+  getCrashlytics,
+  setCrashlyticsCollectionEnabled,
+} from '@react-native-firebase/crashlytics';
+import {getPerformance} from '@react-native-firebase/perf';
+import CONFIG from '@src/CONFIG';
+
+/** Apply the user's crash-reporting preference to Crashlytics and Performance.
+ *  Effective collection is gated by the build flag — we never enable
+ *  collection in a build that opted out at compile time. */
+const setCrashReportingCollectionEnabled = (userPrefEnabled: boolean) => {
+  const effective = CONFIG.SEND_CRASH_REPORTS && userPrefEnabled;
+  setCrashlyticsCollectionEnabled(getCrashlytics(), effective);
+  getPerformance().dataCollectionEnabled = effective;
+};
+
+export default setCrashReportingCollectionEnabled;

--- a/src/libs/setCrashReportingCollectionEnabled/index.ts
+++ b/src/libs/setCrashReportingCollectionEnabled/index.ts
@@ -1,0 +1,4 @@
+// Crashlytics is native-only; no-op on web.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const setCrashReportingCollectionEnabled = (_: boolean) => {};
+export default setCrashReportingCollectionEnabled;

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -25,6 +25,16 @@ function PrivacyScreen() {
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
 
+  // Absent ⇒ enabled (legitimate-interest opt-out default).
+  const persistedCrashReporting =
+    preferences?.crash_reporting_enabled !== false;
+  const [pendingCrashReporting, setPendingCrashReporting] = useState<
+    boolean | null
+  >(null);
+  const [savingCrashReporting, setSavingCrashReporting] = useState(false);
+  const displayCrashReporting =
+    pendingCrashReporting ?? persistedCrashReporting;
+
   const persistedTrackLocation =
     preferences?.track_location_during_sessions === true;
   const [pendingTrackLocation, setPendingTrackLocation] = useState<
@@ -35,6 +45,23 @@ function PrivacyScreen() {
 
   const [showPurgeConfirmModal, setShowPurgeConfirmModal] = useState(false);
   const [isPurging, setIsPurging] = useState(false);
+
+  const onToggleCrashReporting = (next: boolean) => {
+    if (savingCrashReporting || next === displayCrashReporting) {
+      return;
+    }
+    setPendingCrashReporting(next);
+    setSavingCrashReporting(true);
+    Preferences.updatePreferences(db, user, {
+      crash_reporting_enabled: next,
+    })
+      .catch(error => {
+        setPendingCrashReporting(null);
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('privacyScreen.error.save'), errorMessage);
+      })
+      .finally(() => setSavingCrashReporting(false));
+  };
 
   const onToggleTrackLocation = (next: boolean) => {
     if (savingTrackLocation || next === displayTrackLocation) {
@@ -111,9 +138,42 @@ function PrivacyScreen() {
       />
       <ScrollView contentContainerStyle={[styles.w100]}>
         <Section
-          title={translate('privacyScreen.title')}
+          title={translate('privacyScreen.diagnosticsSection.title')}
           titleStyles={styles.generalSectionTitle}
-          subtitle={translate('privacyScreen.description')}
+          subtitle={translate('privacyScreen.diagnosticsSection.description')}
+          subtitleMuted
+          isCentralPane
+          childrenStyles={styles.pt3}>
+          <View style={styles.sectionMenuItemTopDescription}>
+            <View
+              style={[
+                styles.flexRow,
+                styles.alignItemsCenter,
+                styles.justifyContentBetween,
+                styles.mb4,
+              ]}>
+              <View style={[styles.flexColumn, styles.flex1, styles.mr3]}>
+                <Text style={[styles.textNormal, styles.textStrong]}>
+                  {translate('privacyScreen.crashReporting.label')}
+                </Text>
+                <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                  {translate('privacyScreen.crashReporting.description')}
+                </Text>
+              </View>
+              <Switch
+                accessibilityLabel={translate(
+                  'privacyScreen.crashReporting.label',
+                )}
+                isOn={displayCrashReporting}
+                onToggle={onToggleCrashReporting}
+              />
+            </View>
+          </View>
+        </Section>
+        <Section
+          title={translate('privacyScreen.locationSection.title')}
+          titleStyles={styles.generalSectionTitle}
+          subtitle={translate('privacyScreen.locationSection.description')}
           subtitleMuted
           isCentralPane
           childrenStyles={styles.pt3}>

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -66,6 +66,12 @@ type Preferences = {
    *  added to a LIVE session is tagged with the user's current GPS location.
    *  Off by default. Edit-session adds never capture location regardless. */
   track_location_during_sessions?: boolean;
+
+  /** Whether the user permits Crashlytics/Performance diagnostic collection.
+   *  Undefined/true means enabled (legitimate-interest default); false is an
+   *  explicit opt-out. Only ever takes effect when the build flag
+   *  CONFIG.SEND_CRASH_REPORTS is also true. */
+  crash_reporting_enabled?: boolean;
 };
 
 /** A collection of preferences of multiple users */


### PR DESCRIPTION
### Details

Resolves https://github.com/PetrCala/Kiroku/issues/651

Kiroku ships Firebase **Crashlytics** in production (decision in #648). Crash data is linked to the account ID, so for EU users it's personal data under GDPR and needs a lawful basis. The standard route for diagnostics is **legitimate interest + a user-facing opt-out** — this PR lands that opt-out.

Today Crashlytics is enabled/disabled only **once at startup** from the build flag. This adds a persisted, runtime crash-reporting toggle to the existing Privacy screen.

**What changed**
- **Privacy screen reorganized into titled divisions** (`src/screens/Settings/Privacy/PrivacyScreen.tsx`): a new **Diagnostics** section hosting the crash-reporting toggle, and the existing **Location** controls moved under their own section. Structured so future privacy controls (e.g. friend-data visibility) slot in as additional sections.
- **New `crash_reporting_enabled` preference** (`src/types/onyx/Preferences.ts`, `src/DBPATHS.ts`) persisted in the `user_preferences` DB node so it survives reinstall. Default **enabled** (opt-out, legitimate-interest basis).
- **Runtime application** via a platform-split util `src/libs/setCrashReportingCollectionEnabled/` — native applies to Crashlytics + Performance Monitoring, web is a no-op. Effective collection state is always `CONFIG.SEND_CRASH_REPORTS && userPref`, so collection is **never enabled against the build flag**.
- `src/context/global/DatabaseDataContext.tsx` applies the preference whenever preferences load (handles cold start + reinstall hydration; Firebase is the source of truth). Crashlytics itself persists the collection flag across restarts.
- i18n strings (en + cs_cz) for the new sections; the toggle description names Crashlytics.

**Reviewer notes**
- Design deviation from the linked issue's proposed scope: the issue suggested an Onyx key + startup read in `platformSetup`. That path required `Onyx.connect`, which the `rulesdir/no-onyx-connect` lint rule forbids for new code, and is redundant because `setCrashlyticsCollectionEnabled` persists natively across restarts. The implemented approach (Firebase source of truth + apply on preferences load) achieves identical behavior more simply, with no Onyx layer.
- Web is unaffected (Crashlytics is native-only; the util's web stub is a no-op).

### Tests

1. On a production-flag native build, go to Settings → Privacy → **Diagnostics**.
2. Toggle **Send crash reports** off → verify crash/diagnostic collection stops at runtime (Firebase console / `isCrashlyticsCollectionEnabled`).
3. Kill and relaunch the app → verify the toggle stays off and collection stays off.
4. Toggle back on → verify collection resumes.
5. Verify the **Location** division (tag drinks with location, clear location history) still works unchanged.
6. On a dev build (`SEND_CRASH_REPORTS=false`): toggling has no runtime effect (collection stays off regardless).

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, toggle the crash-reporting switch → the optimistic UI updates immediately and the preference is queued.
2. Go back online → verify the preference write reaches Firebase and the toggle state is consistent.

### QA Steps

1. Sign in on the staging build, open Settings → Privacy → Diagnostics.
2. Toggle crash reporting off, force-quit, relaunch → verify it remains off.
3. Reinstall the app and sign back in with the opted-out account → verify the preference hydrates from Firebase and collection stays off.

- [ ] Verify that no errors appear in the JS console

> Note: I was unable to run a native build in this environment, so the on-device behavior above is **not yet manually verified** — it needs validation on Android/iOS. Typecheck (`typecheck-tsgo`) and ESLint on changed files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)