### PR TITLE
feat(terms): drive T&C re-consent off a server timestamp

### DIFF
--- a/__tests__/unit/OnboardingSelectors.test.ts
+++ b/__tests__/unit/OnboardingSelectors.test.ts
@@ -2,14 +2,13 @@
  * @jest-environment node
  */
 
-import CONST from '@src/CONST';
 import {
   getOnboardingLastVisitedPath,
   hasAcceptedCurrentTerms,
   hasCompletedOnboarding,
   isLegacyGrandfatheredUser,
 } from '@src/libs/OnboardingSelectors';
-import type {UserData} from '@src/types/onyx';
+import type {Config, UserData} from '@src/types/onyx';
 
 function makeUserData(overrides: Partial<UserData> = {}): UserData {
   return {
@@ -18,6 +17,14 @@ function makeUserData(overrides: Partial<UserData> = {}): UserData {
       photo_url: '',
     },
     role: 'open_beta_user',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    app_settings: {},
+    maintenance: {maintenance_mode: false},
     ...overrides,
   };
 }
@@ -61,33 +68,49 @@ describe('OnboardingSelectors', () => {
   });
 
   describe('hasAcceptedCurrentTerms', () => {
+    const PUBLISHED_AT = 1_700_000_000_000;
+
     test('returns false for undefined userData', () => {
-      expect(hasAcceptedCurrentTerms(undefined)).toBe(false);
+      expect(hasAcceptedCurrentTerms(undefined, makeConfig())).toBe(false);
     });
 
-    test('returns true when version matches CURRENT_TERMS_VERSION', () => {
-      const userData = makeUserData({
-        agreed_to_terms_version: CONST.CURRENT_TERMS_VERSION,
-      });
-      expect(hasAcceptedCurrentTerms(userData)).toBe(true);
+    test('returns false when the user has never accepted (new account)', () => {
+      // Independent of config so the onboarding terms step always shows.
+      expect(hasAcceptedCurrentTerms(makeUserData(), undefined)).toBe(false);
+      expect(
+        hasAcceptedCurrentTerms(
+          makeUserData(),
+          makeConfig({terms_last_updated: PUBLISHED_AT}),
+        ),
+      ).toBe(false);
     });
 
-    test('returns false when version field is missing', () => {
-      expect(hasAcceptedCurrentTerms(makeUserData())).toBe(false);
+    test('fails open (true) once accepted when config is not loaded', () => {
+      const userData = makeUserData({agreed_to_terms_at: PUBLISHED_AT});
+      expect(hasAcceptedCurrentTerms(userData, undefined)).toBe(true);
     });
 
-    test('returns false for an older version', () => {
-      const userData = makeUserData({
-        agreed_to_terms_version: CONST.CURRENT_TERMS_VERSION - 1,
-      });
-      expect(hasAcceptedCurrentTerms(userData)).toBe(false);
+    test('fails open (true) once accepted when terms_last_updated is unset', () => {
+      const userData = makeUserData({agreed_to_terms_at: PUBLISHED_AT});
+      expect(hasAcceptedCurrentTerms(userData, makeConfig())).toBe(true);
     });
 
-    test('returns false for a newer version (defensive)', () => {
-      const userData = makeUserData({
-        agreed_to_terms_version: CONST.CURRENT_TERMS_VERSION + 1,
-      });
-      expect(hasAcceptedCurrentTerms(userData)).toBe(false);
+    test('returns true when accepted after terms were published', () => {
+      const userData = makeUserData({agreed_to_terms_at: PUBLISHED_AT + 1});
+      const config = makeConfig({terms_last_updated: PUBLISHED_AT});
+      expect(hasAcceptedCurrentTerms(userData, config)).toBe(true);
+    });
+
+    test('returns true when accepted exactly at publish time', () => {
+      const userData = makeUserData({agreed_to_terms_at: PUBLISHED_AT});
+      const config = makeConfig({terms_last_updated: PUBLISHED_AT});
+      expect(hasAcceptedCurrentTerms(userData, config)).toBe(true);
+    });
+
+    test('returns false when accepted before terms were published (re-consent)', () => {
+      const userData = makeUserData({agreed_to_terms_at: PUBLISHED_AT - 1});
+      const config = makeConfig({terms_last_updated: PUBLISHED_AT});
+      expect(hasAcceptedCurrentTerms(userData, config)).toBe(false);
     });
   });
 

--- a/__tests__/unit/useOnboardingFlow.test.ts
+++ b/__tests__/unit/useOnboardingFlow.test.ts
@@ -4,7 +4,7 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import useOnboardingFlow from '@hooks/useOnboardingFlow';
 import CONFIG from '@src/CONFIG';
 import ROUTES from '@src/ROUTES';
-import type {UserData} from '@src/types/onyx';
+import type {Config, UserData} from '@src/types/onyx';
 
 jest.mock('@context/global/FirebaseContext', () => ({
   useFirebase: jest.fn(),
@@ -25,9 +25,10 @@ function setAuth(uid: string | undefined): void {
   } as unknown as ReturnType<typeof useFirebase>);
 }
 
-function setUserData(userData: UserData | undefined): void {
+function setUserData(userData: UserData | undefined, config?: Config): void {
   mockedUseDatabaseData.mockReturnValue({
     userData,
+    config,
   } as unknown as ReturnType<typeof useDatabaseData>);
 }
 
@@ -144,7 +145,7 @@ describe('useOnboardingFlow', () => {
     setAuth(TEST_UID);
     setUserData(
       makeUserData({
-        agreed_to_terms_version: 1,
+        agreed_to_terms_at: 1_700_000_000_000,
         profile: {
           display_name: 'foo@example.com',
           photo_url: '',
@@ -184,7 +185,7 @@ describe('useOnboardingFlow', () => {
     setAuth(TEST_UID);
     setUserData(
       makeUserData({
-        agreed_to_terms_version: 1,
+        agreed_to_terms_at: 1_700_000_000_000,
         onboarding: {last_visited_path: ROUTES.ONBOARDING_DISPLAY_NAME},
         profile: {
           display_name: 'foo@example.com',

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -3,6 +3,7 @@ import type {ReactNode} from 'react';
 import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import Onyx from 'react-native-onyx';
 import type {
+  Config,
   DrinkingSessionList,
   Preferences,
   UnconfirmedDays,
@@ -21,6 +22,8 @@ type DatabaseDataContextType = {
   preferences?: Preferences;
   unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
+  /** Global app configuration, including the terms re-consent signal. */
+  config?: Config;
   /** True while a wider-window resubscribe for `drinkingSessionData` is in
    *  flight (calendar scrolled past the loaded edge). */
   isFetchingOlderMonths: boolean;
@@ -50,6 +53,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const userID = user ? user.uid : '';
 
   const dataTypes: FetchDataKeys = [
+    'config',
     'userStatusData',
     'drinkingSessionData',
     'preferences',
@@ -66,6 +70,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
       preferences: data.preferences,
       unconfirmedDays: data.unconfirmedDays,
       userData: data.userData,
+      config: data.config,
       isFetchingOlderMonths,
     }),
     [data, isFetchingOlderMonths],

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -31,7 +31,7 @@ type OnboardingFlowState = {
 function useOnboardingFlow(): OnboardingFlowState {
   const {auth} = useFirebase();
   const userID = auth?.currentUser?.uid;
-  const {userData} = useDatabaseData();
+  const {userData, config} = useDatabaseData();
 
   return useMemo<OnboardingFlowState>(() => {
     const skipOnboarding = CONFIG.SKIP_ONBOARDING;
@@ -70,7 +70,7 @@ function useOnboardingFlow(): OnboardingFlowState {
     }
 
     let currentOnboardingRoute: Route;
-    if (!hasAcceptedCurrentTerms(userData)) {
+    if (!hasAcceptedCurrentTerms(userData, config)) {
       currentOnboardingRoute = ROUTES.ONBOARDING_TERMS;
     } else if (userData?.profile?.username_chosen === false) {
       currentOnboardingRoute = ROUTES.ONBOARDING_DISPLAY_NAME;
@@ -85,7 +85,7 @@ function useOnboardingFlow(): OnboardingFlowState {
       lastVisitedPath: getOnboardingLastVisitedPath(userData),
       skipOnboarding,
     };
-  }, [userID, userData]);
+  }, [userID, userData, config]);
 }
 
 export default useOnboardingFlow;

--- a/src/libs/Navigation/guards/TermsReConsentGuard.tsx
+++ b/src/libs/Navigation/guards/TermsReConsentGuard.tsx
@@ -22,7 +22,7 @@ import {View} from 'react-native';
 function TermsReConsentGuard() {
   const {auth, db} = useFirebase();
   const {translate} = useLocalize();
-  const {userData} = useDatabaseData();
+  const {userData, config} = useDatabaseData();
 
   const shouldPrompt = useMemo(() => {
     if (!auth?.currentUser) {
@@ -34,8 +34,8 @@ function TermsReConsentGuard() {
     if (!hasCompletedOnboarding(userData)) {
       return false;
     }
-    return !hasAcceptedCurrentTerms(userData);
-  }, [auth?.currentUser, userData]);
+    return !hasAcceptedCurrentTerms(userData, config);
+  }, [auth?.currentUser, userData, config]);
 
   const handleAccept = useCallback(async () => {
     await Onboarding.acceptTerms(db, auth.currentUser);

--- a/src/libs/OnboardingSelectors.ts
+++ b/src/libs/OnboardingSelectors.ts
@@ -1,5 +1,4 @@
-import CONST from '@src/CONST';
-import type {UserData} from '@src/types/onyx';
+import type {Config, UserData} from '@src/types/onyx';
 
 /**
  * Returns whether the user has completed the onboarding flow.
@@ -27,11 +26,35 @@ function hasCompletedOnboarding(userData: UserData | undefined): boolean {
 }
 
 /**
- * Returns whether the user's accepted Terms & Conditions version matches the
- * current shipping version.
+ * Returns whether the user's Terms & Conditions acceptance is current with the
+ * server-published terms.
+ *
+ * The "current terms" signal is the server value `config.terms_last_updated`
+ * (a timestamp), not a build-time constant — so re-consent fires when the terms
+ * actually change, regardless of the installed app version. The user re-accepts
+ * by writing a fresh `agreed_to_terms_at`, so acceptance is current whenever
+ * they accepted at or after the terms were last published.
+ *
+ * A user who has never accepted (`agreed_to_terms_at === undefined`) always
+ * returns `false` so the onboarding terms step still shows, independent of
+ * whether `config` has loaded. Fail-open (`true`) only applies once they have
+ * accepted at least once and no server signal is available, so a missing or
+ * not-yet-loaded `config` never locks an existing user behind the re-consent
+ * modal.
  */
-function hasAcceptedCurrentTerms(userData: UserData | undefined): boolean {
-  return userData?.agreed_to_terms_version === CONST.CURRENT_TERMS_VERSION;
+function hasAcceptedCurrentTerms(
+  userData: UserData | undefined,
+  config: Config | undefined,
+): boolean {
+  const acceptedAt = userData?.agreed_to_terms_at;
+  if (acceptedAt === undefined) {
+    return false;
+  }
+  const publishedAt = config?.terms_last_updated;
+  if (!publishedAt) {
+    return true;
+  }
+  return acceptedAt >= publishedAt;
 }
 
 /**


### PR DESCRIPTION
## Summary

Re-consent for updated Terms & Conditions / Privacy Policy was gated on `CONST.CURRENT_TERMS_VERSION` — a **build-time constant**. A user who never updated the app kept reporting the old version forever and was never re-prompted, even after the terms changed. Re-consent was effectively tied to *app updates* rather than *terms changes*.

This wires re-consent to a server value instead:

- Surface the already-live-listened `config` node through `DatabaseDataContext` (the `config` fetch key existed but wasn't subscribed by the provider).
- Compare the user's `agreed_to_terms_at` against the server timestamp `config.terms_last_updated` (a field already declared in the `Config` type) instead of the baked-in version constant.
- Bumping `config/terms_last_updated` in the Firebase RTDB now re-prompts every client on next sync, regardless of installed app version. The legal text is already server-hosted (WebView → `kiroku.cz/terms`), so old apps always show current text.

### Behaviour

- **Never accepted** (`agreed_to_terms_at` undefined) → always `false`, so the onboarding terms step still shows even if `config` hasn't loaded. No risk of silently skipping consent.
- **Accepted, config not loaded / `terms_last_updated` unset** → fail open (`true`); never locks an existing user behind the modal.
- **Accepted before terms published** → `false` → re-consent modal fires.
- **Accepted at/after publish** → `true`.

The existing `agreed_to_terms_version` write and `CONST.CURRENT_TERMS_VERSION` are left in place (now vestigial but harmless) to keep the diff scoped.

## Out of scope (external)

- Triggering a re-prompt is an ops action: set `config/terms_last_updated = Date.now()` in the RTDB.
- Confirm RTDB rules keep `terms_last_updated` admin-write-only / client-readable.
- kiroku-api / kiroku-cli config seeding should include `terms_last_updated`.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `eslint` clean on changed files (0 errors)
- [x] Jest: `OnboardingSelectors`, `useOnboardingFlow`, `OnboardingGuard` (38 passed)
- [ ] End-to-end: set `config/terms_last_updated` newer than a previously-onboarded account's `agreed_to_terms_at`, launch, confirm the re-consent modal fires; accept and confirm it clears and does not re-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)