### PR TITLE
fix(sessions): prevent silent location drop on undefined GPS accuracy

### DIFF
--- a/src/libs/getCurrentLocation.ts
+++ b/src/libs/getCurrentLocation.ts
@@ -13,9 +13,12 @@ const LOCATION_TIMEOUT_MS = 5000;
  */
 async function getCurrentLocation(): Promise<DrinkLocation | null> {
   try {
+    // If the timeout wins the race, getCurrentPositionAsync keeps running and
+    // may reject later with no awaiter; swallow that to avoid an unhandled
+    // rejection. The catch returns null so the race still resolves cleanly.
     const positionPromise = Location.getCurrentPositionAsync({
       accuracy: Location.Accuracy.Balanced,
-    });
+    }).catch(() => null);
     const timeoutPromise = new Promise<null>(resolve => {
       setTimeout(() => resolve(null), LOCATION_TIMEOUT_MS);
     });
@@ -23,15 +26,18 @@ async function getCurrentLocation(): Promise<DrinkLocation | null> {
     if (!result) {
       return null;
     }
-    return {
+    const location: DrinkLocation = {
       latitude: result.coords.latitude,
       longitude: result.coords.longitude,
-      accuracy:
-        typeof result.coords.accuracy === 'number'
-          ? result.coords.accuracy
-          : undefined,
       capturedAt: result.timestamp ?? Date.now(),
     };
+    // Only attach accuracy when the OS actually reported a number. Realtime
+    // Database rejects writes containing `undefined`, so an undefined field
+    // here would silently drop the entire location on the Firebase write.
+    if (typeof result.coords.accuracy === 'number') {
+      location.accuracy = result.coords.accuracy;
+    }
+    return location;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Two follow-up fixes to the GPS location tagging feature from #566, both in `src/libs/getCurrentLocation.ts`:

- **Undefined accuracy silently dropped the whole write (the real bug).** `getCurrentLocation` set `accuracy: undefined` whenever the OS didn't report horizontal accuracy. Realtime Database rejects any write containing `undefined`, so `SessionLocations.captureForTimestamp`'s `update()` threw and was swallowed by its `try/catch` — meaning the entire location was lost (and Onyx/Firebase diverged, since the `Onyx.merge` ran first). Now `accuracy` is only attached when it's actually a number. More common on Android indoors / cold GPS.
- **Unhandled promise rejection.** If the 5s timeout wins the `Promise.race` and `getCurrentPositionAsync` rejects *afterwards*, the position promise had no awaiter and surfaced as a "Possible Unhandled Promise Rejection" on both platforms. Added a `.catch(() => null)` so a late rejection resolves cleanly.

Both surfaced in the review of #566.

## Test plan

- [ ] **Undefined accuracy:** on a device/condition where `coords.accuracy` is null (e.g. Android indoors, fresh cold start), log a drink during a live session with tracking on. Confirm a `{latitude, longitude, capturedAt}` node (no `accuracy` key) is written under `/user_session_locations/$uid/$sessionId/` — previously nothing was written.
- [ ] **Happy path unchanged:** with a normal GPS fix, confirm `accuracy` is still present and the node validates against the DB rules.
- [ ] **No console noise:** exercise a slow/failing GPS fix that exceeds the 5s timeout and confirm no unhandled-rejection warning appears in the JS console on iOS and Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)