### PR TITLE
Move Support Kiroku button to bottom of general settings

### DIFF
--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -133,15 +133,6 @@ function SettingsScreen() {
           icon: KirokuIcons.Gear,
           routeName: ROUTES.SETTINGS_PREFERENCES,
         },
-        ...(shouldShowSupporterMenu
-          ? [
-              {
-                translationKey: 'supporter.menuEntry',
-                icon: KirokuIcons.Star,
-                routeName: ROUTES.SETTINGS_SUPPORT,
-              } as MenuData,
-            ]
-          : []),
         ...(shouldShowManageSubscription
           ? [
               {
@@ -160,11 +151,7 @@ function SettingsScreen() {
     };
 
     return defaultMenu;
-  }, [
-    styles.accountSettingsSectionContainer,
-    shouldShowSupporterMenu,
-    shouldShowManageSubscription,
-  ]);
+  }, [styles.accountSettingsSectionContainer, shouldShowManageSubscription]);
 
   /**
    * Retuns a list of menu items data for general section
@@ -195,9 +182,18 @@ function SettingsScreen() {
           icon: KirokuIcons.Info,
           routeName: ROUTES.SETTINGS_ABOUT,
         },
+        ...(shouldShowSupporterMenu
+          ? [
+              {
+                translationKey: 'supporter.menuEntry',
+                icon: KirokuIcons.Star,
+                routeName: ROUTES.SETTINGS_SUPPORT,
+              } as MenuData,
+            ]
+          : []),
       ],
     };
-  }, [styles.generalSettingsSectionContainer]);
+  }, [styles.generalSettingsSectionContainer, shouldShowSupporterMenu]);
 
   /**
    * Retuns a list of menu items data for authentication section


### PR DESCRIPTION
## Summary
- Moved the **Support Kiroku** menu entry out of the Account section and into the General section, positioned directly below **About**.
- The entry remains gated on `shouldShowSupporterMenu`.

## Test plan
- [ ] Open Settings as a user where the supporter menu should show — verify "Support Kiroku 🍺" appears at the bottom of the General section, below "About".
- [ ] Verify it no longer appears in the Account section.
- [ ] Verify tapping it still navigates to the support screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)