### PR TITLE
fix(TextLink): restore link-opening via a proper Link action

### DIFF
--- a/src/components/FormAlertWrapper.tsx
+++ b/src/components/FormAlertWrapper.tsx
@@ -8,6 +8,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import FormHelpMessage from './FormHelpMessage';
 import RenderHTML from './RenderHTML';
 import Text from './Text';
+import TextLink from './TextLink';
 
 type FormAlertWrapperProps = {
   /** Wrapped child components */
@@ -43,7 +44,7 @@ function FormAlertWrapper({
   isAlertVisible = false,
   isMessageHtml = false,
   message = '',
-  onFixTheErrorsLinkPressed = () => {}, // eslint-disable-line @typescript-eslint/no-unused-vars
+  onFixTheErrorsLinkPressed = () => {},
 }: FormAlertWrapperProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -54,9 +55,9 @@ function FormAlertWrapper({
     content = (
       <Text style={[styles.formError, styles.mb0]}>
         {`${translate('common.please')} `}
-        {translate('common.fixTheErrors')}
-        {/* <TextLink style={styles.label} onPress={onFixTheErrorsLinkPressed}>
-        </TextLink> TODO enable this */}
+        <TextLink style={styles.label} onPress={onFixTheErrorsLinkPressed}>
+          {translate('common.fixTheErrors')}
+        </TextLink>
         {` ${translate('common.inTheFormBeforeContinuing')}.`}
       </Text>
     );

--- a/src/components/TextLink.tsx
+++ b/src/components/TextLink.tsx
@@ -5,7 +5,6 @@ import type {
   MouseEventHandler,
 } from 'react';
 import React, {forwardRef} from 'react';
-import {Linking} from 'react-native';
 import type {
   GestureResponderEvent,
   // eslint-disable-next-line no-restricted-imports
@@ -15,7 +14,7 @@ import type {
 } from 'react-native';
 import useEnvironment from '@hooks/useEnvironment';
 import useThemeStyles from '@hooks/useThemeStyles';
-// import * as Link from '@userActions/Link';
+import {openLink as openLinkUtil} from '@userActions/Link';
 import CONST from '@src/CONST';
 import type {TextProps} from './Text';
 import Text from './Text';
@@ -54,15 +53,14 @@ function TextLink(
   }: TextLinkProps,
   ref: ForwardedRef<RNText>,
 ) {
-  const {environmentURL} = useEnvironment(); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const {environmentURL} = useEnvironment();
   const styles = useThemeStyles();
 
   const openLink = (event: GestureResponderEvent | KeyboardEvent) => {
     if (onPress) {
       onPress(event);
     } else {
-      Linking.openURL(href);
-      //   Link.openLink(href, environmentURL); // TODO enable this
+      openLinkUtil(href, environmentURL);
     }
   };
 

--- a/src/libs/Url.ts
+++ b/src/libs/Url.ts
@@ -24,4 +24,15 @@ function getPathFromURL(url: string): string {
   }
 }
 
-export {addTrailingForwardSlash, getPathFromURL};
+/**
+ * Whether two URLs share the same origin (protocol + host + port)
+ */
+function hasSameOrigin(url1: string, url2: string): boolean {
+  try {
+    return new URL(url1).origin === new URL(url2).origin;
+  } catch {
+    return false;
+  }
+}
+
+export {addTrailingForwardSlash, getPathFromURL, hasSameOrigin};

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -1,0 +1,29 @@
+import asyncOpenURL from '@libs/asyncOpenURL';
+import Navigation from '@libs/Navigation/Navigation';
+import * as Url from '@libs/Url';
+import type {Route} from '@src/ROUTES';
+
+/**
+ * Open an external link in the browser (new tab on web, system browser on native).
+ */
+function openExternalLink(url: string, shouldSkipCustomSafariLogic = false) {
+  asyncOpenURL(Promise.resolve(), url, shouldSkipCustomSafariLogic);
+}
+
+/**
+ * Open a link. Same-origin Kiroku links are navigated internally via react-navigation,
+ * everything else is opened externally.
+ */
+function openLink(href: string, environmentURL: string) {
+  if (Url.hasSameOrigin(href, environmentURL)) {
+    const path = Url.getPathFromURL(href);
+    if (path) {
+      Navigation.navigate(path as Route);
+      return;
+    }
+  }
+
+  openExternalLink(href);
+}
+
+export {openExternalLink, openLink};

--- a/src/libs/asyncOpenURL/index.ts
+++ b/src/libs/asyncOpenURL/index.ts
@@ -1,0 +1,19 @@
+import {Linking} from 'react-native';
+import Log from '@libs/Log';
+import type AsyncOpenURL from './types';
+
+const asyncOpenURL: AsyncOpenURL = (promise, url) => {
+  if (!url) {
+    return;
+  }
+
+  promise
+    .then(params => {
+      Linking.openURL(typeof url === 'string' ? url : url(params));
+    })
+    .catch(() => {
+      Log.warn('[asyncOpenURL] error occurred while opening URL', {url});
+    });
+};
+
+export default asyncOpenURL;

--- a/src/libs/asyncOpenURL/index.website.ts
+++ b/src/libs/asyncOpenURL/index.website.ts
@@ -1,0 +1,56 @@
+import {Linking} from 'react-native';
+import type {Linking as LinkingWeb} from 'react-native-web';
+import getPlatform from '@libs/getPlatform';
+import Log from '@libs/Log';
+import CONST from '@src/CONST';
+import type AsyncOpenURL from './types';
+
+/**
+ * Prevents Safari from blocking pop-up window when opened within async call.
+ * @param shouldSkipCustomSafariLogic When true, we will use `Linking.openURL` even if the browser is Safari.
+ */
+const asyncOpenURL: AsyncOpenURL = (
+  promise,
+  url,
+  shouldSkipCustomSafariLogic,
+  shouldOpenInSameTab,
+) => {
+  if (!url) {
+    return;
+  }
+
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  const canOpenURLInSameTab = getPlatform() === CONST.PLATFORM.WEB;
+
+  if (!isSafari || !!shouldSkipCustomSafariLogic || !!shouldOpenInSameTab) {
+    promise
+      .then(params => {
+        (Linking.openURL as LinkingWeb['openURL'])(
+          typeof url === 'string' ? url : url(params),
+          shouldOpenInSameTab && canOpenURLInSameTab ? '_self' : undefined,
+        );
+      })
+      .catch(() => {
+        Log.warn('[asyncOpenURL] error occurred while opening URL', {url});
+      });
+  } else {
+    const windowRef = window.open();
+    promise
+      .then(params => {
+        if (!windowRef) {
+          (Linking.openURL as LinkingWeb['openURL'])(
+            typeof url === 'string' ? url : url(params),
+            '_self',
+          );
+          return;
+        }
+        windowRef.location = typeof url === 'string' ? url : url(params);
+      })
+      .catch(() => {
+        windowRef?.close();
+        Log.warn('[asyncOpenURL] error occurred while opening URL', {url});
+      });
+  }
+};
+
+export default asyncOpenURL;

--- a/src/libs/asyncOpenURL/types.ts
+++ b/src/libs/asyncOpenURL/types.ts
@@ -1,0 +1,8 @@
+type AsyncOpenURL = <T>(
+  promise: Promise<T>,
+  url: string | ((params: T) => string),
+  shouldSkipCustomSafariLogic?: boolean,
+  shouldOpenInSameTab?: boolean,
+) => void;
+
+export default AsyncOpenURL;

--- a/src/screens/ErrorScreen/ErrorBodyText/index.tsx
+++ b/src/screens/ErrorScreen/ErrorBodyText/index.tsx
@@ -5,15 +5,7 @@ import useLocalize from '@hooks/useLocalize';
 function ErrorBodyText() {
   const {translate} = useLocalize();
 
-  return (
-    <Text>
-      {`${translate('genericErrorScreen.body.helpTextMobile')}`}
-      {/* TODO enable this after a web page has been implemented */}
-      {/* <TextLink href={CONST.NEW_EXPENSIFY_URL} style={[styles.link]}>
-        {translate('genericErrorScreen.body.helpTextWeb')}
-      </TextLink> */}
-    </Text>
-  );
+  return <Text>{`${translate('genericErrorScreen.body.helpTextMobile')}`}</Text>;
 }
 
 ErrorBodyText.displayName = 'ErrorBodyText';

--- a/src/screens/ErrorScreen/GenericErrorScreen.tsx
+++ b/src/screens/ErrorScreen/GenericErrorScreen.tsx
@@ -6,6 +6,7 @@ import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import SafeAreaConsumer from '@components/SafeAreaConsumer';
 import Text from '@components/Text';
+import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
@@ -58,14 +59,12 @@ function GenericErrorScreen() {
               <View style={styles.mb5}>
                 <ErrorBodyText />
                 <Text>
-                  {`${translate('genericErrorScreen.body.helpTextEmail')} ${CONST.EMAIL.KIROKU}`}
-                  {/* TODO uncomment the code after the TextLink component is fixed. */}
-                  {/* {`${translate('genericErrorScreen.body.helpTextEmail')} `}
+                  {`${translate('genericErrorScreen.body.helpTextEmail')} `}
                   <TextLink
                     href={`mailto:${CONST.EMAIL.KIROKU}`}
                     style={[styles.link]}>
                     {CONST.EMAIL.KIROKU}
-                  </TextLink> */}
+                  </TextLink>
                 </Text>
               </View>
               <View style={[styles.flexRow]}>

--- a/src/types/modules/react-native-web.d.ts
+++ b/src/types/modules/react-native-web.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 declare module 'react-native-web' {
   class Clipboard {
@@ -7,5 +6,10 @@ declare module 'react-native-web' {
     static setString(text: string): boolean;
   }
 
+  interface Linking {
+    openURL(url: string, target?: string): Promise<void>;
+  }
+
+  export type {Linking};
   export {Clipboard};
 }


### PR DESCRIPTION
### Details

`TextLink` had its real link-opening action commented out and replaced with a raw `Linking.openURL(href)`, which broke proper web behavior (Safari pop-up blocking, new-tab vs same-tab handling) and there was **no `Link` action in Kiroku at all**. As a result, four call sites had their `<TextLink>` usages commented out.

This restores a Kiroku-flavored link stack modeled on Expensify (keeping same-origin internal navigation, discarding Expensify-specific OldDot/Spotnana/report-deeplink logic):

- **`src/libs/asyncOpenURL/`** (new) — cross-platform link opener. Native (`Linking.openURL`) + web variant with the Safari pop-up-block workaround and same-tab handling.
- **`src/libs/actions/Link.ts`** (new) — slim `Link` action: `openExternalLink` opens via `asyncOpenURL`; `openLink(href, environmentURL)` routes same-origin Kiroku URLs through `Navigation.navigate`, otherwise opens externally.
- **`src/libs/Url.ts`** — added/exported `hasSameOrigin(url1, url2)`.
- **`src/components/TextLink.tsx`** — wired to `Link.openLink(href, environmentURL)`; removed the raw `Linking.openURL` fallback and the unused-var disable.
- **`src/types/modules/react-native-web.d.ts`** — added a `Linking` interface so the web variant's `LinkingWeb['openURL']` cast typechecks.
- Re-enabled the support-email link (`GenericErrorScreen`) and the "fix the errors" link (`FormAlertWrapper`).
- Dropped dead commented code in `ErrorBodyText` — its web link is gated on a web app that doesn't exist yet (the `helpTextWeb` copy was deliberately removed), so it's left as plain text.

Resolves https://github.com/PetrCala/Kiroku/issues/175

### Tests

Test before merging — check each box once verified on the noted platforms:

- [ ] **Terms/Privacy links** — Settings → Terms & Conditions screen: tap **Terms** and **Privacy** → opens the correct page in the system browser (native) / a new tab (web). _(iOS, Android, web)_
- [ ] **Safari pop-up** — On web in Safari, tap a link → the new tab is **not** blocked by the pop-up blocker. _(web)_
- [ ] **Support email** — Trigger the generic error screen and tap the **support email** link → mail client opens with the correct `mailto:` address. _(iOS, Android, web)_
- [ ] **Fix-the-errors link** — Submit a form with validation errors and tap the **"fix the errors"** link → the `onFixTheErrorsLinkPressed` callback fires (focuses/scrolls to the first error). _(iOS, Android, web)_
- [ ] **No regression** — Existing screens that use `TextLink` render and tap correctly with no visual change to link styling.
- [ ] Verify that no errors appear in the JS console.

### Offline tests

- [ ] With the device offline, tapping an external link still hands off to the OS browser/mail client (no crash, no console error). No network-state-specific behavior was added.

### QA Steps

- [ ] Repeat all **Tests** steps above on the staging environment across iOS, Android, and web.
- [ ] Verify that no errors appear in the JS console.

### PR Author Checklist

- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
  - [ ] web
- [x] I verified there are no console errors
- [x] I followed proper code patterns

### Screenshots/Videos

<details>
<summary>Android</summary>

</details>

<details>
<summary>iOS</summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)