### PR TITLE
feat(location): enable location tagging — iOS handler fix + first-session soft-ask

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -21,6 +21,7 @@ setup_permissions([
   'Notifications',
   'PhotoLibrary',
   'PhotoLibraryAddOnly',
+  'LocationWhenInUse',
 ])
 
 # As per the official React Native Firebase documentation: https://rnfirebase.io/#altering-cocoapods-to-use-frameworks

--- a/src/components/LocationTaggingPrompt.tsx
+++ b/src/components/LocationTaggingPrompt.tsx
@@ -1,0 +1,85 @@
+import React, {useState} from 'react';
+import {Alert} from 'react-native';
+import {useFirebase} from '@context/global/FirebaseContext';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useLocalize from '@hooks/useLocalize';
+import * as Preferences from '@userActions/Preferences';
+import checkPermission from '@libs/Permissions/checkPermission';
+import requestPermission from '@libs/Permissions/requestPermission';
+import ConfirmModal from './ConfirmModal';
+
+/**
+ * One-time soft-ask shown at live-session start offering to enable location
+ * tagging. Appears at most once per account: once the user answers (either
+ * button), `location_prompt_seen` is persisted and the prompt never auto-shows
+ * again — the Settings → Privacy toggle remains the only way back in.
+ *
+ * Mounting this component IS the "live session" gate; it should only be
+ * rendered from the live-session screen.
+ */
+function LocationTaggingPrompt() {
+  const {translate} = useLocalize();
+  const {preferences} = useDatabaseData();
+  const {auth, db} = useFirebase();
+  const user = auth.currentUser;
+
+  const [dismissed, setDismissed] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Eligible only when the user has never been asked and tagging isn't already
+  // on (the latter covers a user who enabled it in Settings on another device).
+  const isEligible =
+    preferences?.location_prompt_seen !== true &&
+    preferences?.track_location_during_sessions !== true;
+  const isVisible = isEligible && !dismissed;
+
+  const onConfirm = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    // requestPermission alerts + deep-links to Settings itself on a hard denial.
+    // Never persist tagging as enabled without the OS grant, but always record
+    // that the prompt was answered so it won't reappear.
+    checkPermission('location')
+      .then(allowed => (allowed ? true : requestPermission('location')))
+      .then(isGranted =>
+        Preferences.updatePreferences(db, user, {
+          location_prompt_seen: true,
+          ...(isGranted ? {track_location_during_sessions: true} : {}),
+        }),
+      )
+      .then(() => setDismissed(true))
+      .catch(error => {
+        // Leave the modal open so the user can retry; mirror PrivacyScreen.
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('privacyScreen.error.save'), errorMessage);
+      })
+      .finally(() => setIsSubmitting(false));
+  };
+
+  const onCancel = () => {
+    setDismissed(true);
+    Preferences.updatePreferences(db, user, {location_prompt_seen: true}).catch(
+      () => {
+        // Best-effort: if persisting "seen" fails (e.g. offline write error),
+        // the prompt may reappear on a future live session, which is acceptable.
+      },
+    );
+  };
+
+  return (
+    <ConfirmModal
+      title={translate('locationPrompt.title')}
+      prompt={translate('locationPrompt.prompt')}
+      confirmText={translate('locationPrompt.enable')}
+      cancelText={translate('locationPrompt.notNow')}
+      isVisible={isVisible}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}
+
+LocationTaggingPrompt.displayName = 'LocationTaggingPrompt';
+export default LocationTaggingPrompt;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -525,6 +525,13 @@ export default {
       save: 'Nepodařilo se uložit vaše předvolby. Zkuste to prosím znovu.',
     },
   },
+  locationPrompt: {
+    title: 'Označovat, kde si zapisujete drinky?',
+    prompt:
+      'Kiroku může ke každému drinku zaznamenanému během živého sezení připojit vaši aktuální polohu, takže se později můžete podívat, kde které sezení proběhlo. Toto nastavení můžete kdykoli změnit v Nastavení → Soukromí.',
+    enable: 'Zapnout',
+    notNow: 'Teď ne',
+  },
   privacyScreen: {
     title: 'Soukromí',
     diagnosticsSection: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -527,6 +527,13 @@ export default {
       save: "We couldn't save your preferences. Please try again.",
     },
   },
+  locationPrompt: {
+    title: 'Tag where you log drinks?',
+    prompt:
+      'Kiroku can tag each drink you log during a live session with your current location, so you can look back and see where each session happened. You can change this anytime in Settings → Privacy.',
+    enable: 'Enable',
+    notNow: 'Not now',
+  },
   privacyScreen: {
     title: 'Privacy',
     diagnosticsSection: {

--- a/src/screens/DrinkingSession/LiveSessionScreen.tsx
+++ b/src/screens/DrinkingSession/LiveSessionScreen.tsx
@@ -11,6 +11,7 @@ import type SCREENS from '@src/SCREENS';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import DrinkingSessionWindow from '@components/DrinkingSessionWindow';
+import LocationTaggingPrompt from '@components/LocationTaggingPrompt';
 import useBatchedUpdates from '@hooks/useBatchedUpdates';
 import ScreenWrapper from '@components/ScreenWrapper';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
@@ -121,6 +122,7 @@ function LiveSessionScreen({route}: LiveSessionScreenProps) {
         onyxKey={ONYXKEYS.ONGOING_SESSION_DATA}
         type={CONST.SESSION.TYPES.LIVE}
       />
+      <LocationTaggingPrompt />
     </ScreenWrapper>
   );
 }

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -72,6 +72,11 @@ type Preferences = {
    *  explicit opt-out. Only ever takes effect when the build flag
    *  CONFIG.SEND_CRASH_REPORTS is also true. */
   crash_reporting_enabled?: boolean;
+
+  /** True once the user has answered the one-time location-tagging soft-ask
+   *  shown at live-session start. Gates that prompt so it appears at most once
+   *  per account; undefined means it has not been shown yet. */
+  location_prompt_seen?: boolean;
 };
 
 /** A collection of preferences of multiple users */


### PR DESCRIPTION
## Summary
Makes the "tag drinks with location" feature actually usable end-to-end:

1. **iOS permission handler fix.** Add `LocationWhenInUse` to `setup_permissions([...])` in `ios/Podfile`. Without it, enabling location tagging on iOS crashed with `No "ios.permission.LOCATION_WHEN_IN_USE" permission handler detected` (`RNPermissions.mm:259`) — `react-native-permissions` v5 only compiles a handler when it's listed there.

2. **First-session soft-ask.** Previously the feature was only reachable by deliberately toggling it in Settings → Privacy, so almost no one enabled it. A new one-time prompt now appears the first time a user opens a **live** session, offering to enable tagging in context. Declining (or simply answering) records the decision and it **never auto-asks again** — the Settings toggle stays as the only way back.

## Changes
- `ios/Podfile` — register the `LocationWhenInUse` handler.
- `src/types/onyx/Preferences.ts` — new synced `location_prompt_seen` flag gating the prompt to once per account.
- `src/components/LocationTaggingPrompt.tsx` — new `ConfirmModal`-based prompt; reuses the existing `checkPermission`/`requestPermission` + `updatePreferences` flow. Enable path mirrors `PrivacyScreen`: never persists "enabled" without the OS grant.
- `src/screens/DrinkingSession/LiveSessionScreen.tsx` — mounts the prompt (mounting on this screen *is* the live-session gate).
- `src/languages/{en,cs_cz}.ts` — `locationPrompt` copy.

## ⚠️ Required before this works on a build
Authored in a worktree without `node_modules` / a UTF-8 locale, so pods and the native build could not run here:
1. `cd ios && pod install` — regenerates `Podfile.lock` (commit it; not included here).
2. Clean rebuild (clear Xcode DerivedData, then `npm run ios`). A JS reload will not pick up the new native handler.

## Validation done locally
- `tsgo --noEmit` typecheck: clean.
- Prettier: clean.
- ESLint (incl. `react-compiler` rule) on changed files: clean; only pre-existing grandfathered findings remain.

## Test plan
- [ ] `pod install` + clean iOS rebuild.
- [ ] First live session → soft-ask appears once.
- [ ] **Enable** → OS prompt → grant → `track_location_during_sessions` and `location_prompt_seen` both `true` under `user_preferences/<uid>/`; logging a drink writes to `user_session_locations/<uid>/<sessionId>/<timestamp>` (set a simulator location first).
- [ ] **Not now** → `location_prompt_seen` set, tagging off; starting another live session does **not** re-show the prompt.
- [ ] User who already enabled tagging in Settings never sees the prompt.
- [ ] Deny at OS prompt → "open Settings" alert; preference stays off, prompt still won't re-ask.
- [ ] Regression: Camera / Notifications / Photo Library permission flows still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)