### PR TITLE
fix(about): replace expired Discord invite with non-expiring link

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -77,7 +77,7 @@ const CONST = {
   },
   KIROKU_URL,
   GITHUB_URL: 'https://github.com/PetrCala/Kiroku',
-  DISCORD_INVITE_URL: 'https://discord.gg/YYR5bQhS',
+  DISCORD_INVITE_URL: 'https://discord.gg/PjvUFkuwMv',
   TERMS_URL: `${KIROKU_URL}/terms`,
   PRIVACY_URL: `${KIROKU_URL}/privacy`,
   SUBSCRIPTION_TERMS_URL: `${KIROKU_URL}/subscription-terms`,


### PR DESCRIPTION
## Summary
- The `Join our Discord server` link in the About screen pointed at an expired invite (`discord.gg/YYR5bQhS`), which returns `Unknown Invite` from the Discord API.
- Replaced it with a non-expiring invite (`discord.gg/PjvUFkuwMv`) for the Kiroku server. Verified via the Discord invite API: valid, `expires_at: null`.

## Test plan
- [ ] Settings → About → tap "Join our Discord server" and confirm it opens the Kiroku server invite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)