### PR TITLE
feat(session): color active drink tile with the user's palette

### DIFF
--- a/src/components/Buttons/SessionDrinksInputWindow.tsx
+++ b/src/components/Buttons/SessionDrinksInputWindow.tsx
@@ -5,7 +5,14 @@ import * as DSUtils from '@src/libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import type {DrinkingSessionId, DrinkKey, DrinksList} from '@src/types/onyx';
 import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useResolvedPalette from '@hooks/useResolvedPalette';
+import {
+  DEFAULT_PALETTE_ID,
+  getPaletteIdFromColors,
+  isLightHex,
+} from '@libs/SessionColorPalettes';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import Log from '@libs/Log';
@@ -28,8 +35,16 @@ function SessionDrinksInputWindow({
   sessionId,
 }: SessionDrinksInputWindowProps) {
   const styles = useThemeStyles();
+  const theme = useTheme();
   const {translate} = useLocalize();
   const {preferences} = useDatabaseData();
+  const palette = useResolvedPalette(preferences);
+  const isClassicPalette =
+    getPaletteIdFromColors(palette) === DEFAULT_PALETTE_ID;
+  const activeColor = isClassicPalette ? theme.appColor : palette.yellow;
+  const highlightTextStyle = isLightHex(activeColor)
+    ? styles.textBlack
+    : styles.textWhite;
   const [shouldHighlight, setShouldHighlight] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>(
     sumDrinksOfSingleType(drinks, drinkKey).toString(),
@@ -157,7 +172,9 @@ function SessionDrinksInputWindow({
       <PressableWithoutFeedback
         accessibilityLabel="button"
         onPress={handleContainerPress}
-        style={styles.sessionDrinksInputContainer(shouldHighlight)}>
+        style={styles.sessionDrinksInputContainer(
+          shouldHighlight ? activeColor : null,
+        )}>
         <TextInput
           accessibilityLabel={translate('common.textInputField')}
           ref={inputRef}
@@ -165,7 +182,7 @@ function SessionDrinksInputWindow({
             styles.textLarge,
             styles.textAlignCenter,
             styles.textBold,
-            shouldHighlight ? styles.textBlack : styles.textPlainColor,
+            shouldHighlight ? highlightTextStyle : styles.textPlainColor,
           ]}
           value={inputValue}
           onKeyPress={handleKeyPress}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1953,9 +1953,9 @@ const styles = (theme: ThemeColors) =>
           direction === CONST.DIRECTION.LEFT ? 'flex-start' : 'flex-end',
       }) satisfies ViewStyle,
 
-    sessionDrinksInputContainer: (shouldHighlight: boolean) =>
+    sessionDrinksInputContainer: (activeBackground: string | null) =>
       ({
-        backgroundColor: shouldHighlight ? theme.appColor : theme.cardBG,
+        backgroundColor: activeBackground ?? theme.cardBG,
         alignItems: 'center',
         justifyContent: 'center',
         borderRadius: variables.borderRadiusSmall,


### PR DESCRIPTION
### Details

On the drinking session screen each drink-type tile (`SessionDrinksInputWindow`) turned a flat brand gold (`theme.appColor` = `#F5C400`) the moment its count went non-zero. This ignored the user-selectable **session color palette** that already colors the calendar tiles and session summary, so users on a non-default palette (e.g. `ocean`, `pink`) saw an out-of-place gold tile.

This change makes the active-tile highlight cohere with the chosen palette:

- **Default preserved:** users on the `classic` palette — and users who never picked one, which resolves to `classic` — keep the current brand gold. No visual change for them.
- **Other palettes:** the active tile uses that palette's `yellow` swatch. `yellow` is the brand-color slot (the `brand` palette's `yellow` is literally `#F5C400`), so it's the closest analog to today's color.
- **Contrast-aware text:** the tile number was hardcoded black, unreadable on dark swatches (`ocean`, `mono`). It now picks black/white via the existing `isLightHex` helper.

Implementation reuses existing utilities: `useResolvedPalette`, and `getPaletteIdFromColors` / `DEFAULT_PALETTE_ID` / `isLightHex` from `SessionColorPalettes`. The `styles.sessionDrinksInputContainer` signature changed from a boolean to the active background color (`string | null`); it has a single caller.

Files:
- `src/components/Buttons/SessionDrinksInputWindow.tsx`
- `src/styles/index.ts`

### Tests

1. Set the color palette to `classic` (or leave it unset) in Settings → Preferences → Color Palette.
2. Open a drinking session and increment a drink type. Verify the tile turns the same brand gold as before and the number is black.
3. Set the count back to 0 and verify the tile returns to the card background.
4. Switch the palette to `ocean` (dark swatches), return to a session, increment a drink. Verify the tile uses the palette's yellow swatch and the number is **white** (readable).
5. Switch the palette to `pink`, repeat, and verify the tile matches that palette and the number stays readable.
6. Confirm the session-screen tile color is consistent with the calendar tiles for the same palette.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Palette selection and session drink logging are local/optimistic; no network dependency for this change. Repeat the tests above while offline and verify identical behavior.

### QA Steps

1. On staging, go to Settings → Preferences → Color Palette and pick a non-classic palette (e.g. `ocean`).
2. Start or open a drinking session and add drinks; verify active tiles adopt the palette color with readable numbers.
3. Switch back to `classic` and verify the tile is the original brand gold.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)