### PR TITLE
fix(navigation): single back to Home from new-session create flow

### DIFF
--- a/src/screens/DrinkingSession/EditSessionScreen.tsx
+++ b/src/screens/DrinkingSession/EditSessionScreen.tsx
@@ -13,6 +13,7 @@ import UserOfflineModal from '@components/UserOfflineModal';
 import useLocalize from '@hooks/useLocalize';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
 import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 
 type EditSessionScreenProps = StackScreenProps<
@@ -30,7 +31,14 @@ function EditSessionScreen({route}: EditSessionScreenProps) {
     action: DeepValueOf<typeof CONST.NAVIGATION.SESSION_ACTION>,
   ) => {
     if (backTo) {
-      Navigation.navigate(backTo as Route);
+      if (backTo === ROUTES.HOME) {
+        // The create flow stacks the date-pick and edit screens in the same
+        // modal, so dismiss the whole modal in one slide instead of navigating
+        // to a bottom-tab route (which forward-pushes and bounces).
+        Navigation.dismissModal();
+      } else {
+        Navigation.goBack(backTo as Route);
+      }
       return;
     }
     const previousScreenName = Navigation.getLastScreenName(true);

--- a/src/screens/DrinkingSession/SessionDateScreen.tsx
+++ b/src/screens/DrinkingSession/SessionDateScreen.tsx
@@ -50,7 +50,14 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
         await DS.setIsCreatingNewSession(false);
       }
       if (backTo) {
-        Navigation.navigate(backTo as Route);
+        if (backTo === ROUTES.HOME) {
+          // Cancelling the create flow: dismiss the whole modal in one slide
+          // rather than navigating to a bottom-tab route, which forward-pushes
+          // and bounces.
+          Navigation.dismissModal();
+        } else {
+          Navigation.goBack(backTo as Route);
+        }
         return;
       }
       Navigation.goBack();


### PR DESCRIPTION
### Details

Stacked on top of #679 (`claude/hopeful-varahamihira-4a78aa`). #679 fixes the **ongoing/live** session back-nav; this PR fixes the sibling bug in the **new-session create / edit** flow.

> ⚠️ Note: #679 is still an interim fix and will need revision. This PR is intentionally self-contained — it only touches `EditSessionScreen.tsx` and `SessionDateScreen.tsx` (files #679 does not modify), so it stands regardless of how #679 evolves. It also deliberately diverges from #679's `goBack(backTo)` pattern where that would be wrong here (see below).

**Bug:** Creating a session (Home → start-session → **session date pick** → **edit screen**) and then pressing **Back** bounces — the screen slides back, forth, and sometimes again before landing on Home, instead of a single slide-right revealing Home.

**Root cause:** The create flow tags the date/edit routes with `backTo = ROUTES.HOME`, and both `EditSessionScreen.onNavigateBack` and `SessionDateScreen.onGoBack` exited via `Navigation.navigate(ROUTES.HOME)`. `ROUTES.HOME` is a **bottom-tab route**, so `linkTo` dispatches a bottom-tab navigate **plus** a `POP_TO_TOP` while the modal stack is still open — two animations = the bounce. (Same forward-push class of bug #679 identified for the live screen.)

**Why not `goBack(backTo)` like #679?** The live-from-DayOverview stack keeps Live in its own modal entry next to Day Overview, so `goBack` pops cleanly. But the create flow stacks `[SessionDate, Edit]` in the **same** DrinkingSession navigator, so `goBack(HOME)` would pop to the date screen, not Home. For `backTo === HOME` the correct primitive is `Navigation.dismissModal()`, which pops the whole modal in one slide → Home (matching the existing "avoid double animation" comment already in these files). Non-HOME `backTo` targets now use `goBack` instead of `navigate` to avoid the same duplicate-screen push.

### Changes

- `EditSessionScreen.tsx` — `onNavigateBack`: `backTo === HOME` → `dismissModal()`, else `goBack(backTo)`.
- `SessionDateScreen.tsx` — `onGoBack`: same treatment (covers cancelling the date pick during creation, and returning to the edit screen when changing an existing session's date).
- `eslint.seatbelt.tsv` — drops the stale `LiveSessionScreen` `no-unnecessary-type-assertion` entry left behind by #679 (its `as Route` cast was removed there).

### Tests

1. **Reported bug:** Home → start-session "+" → pick a day → confirm → edit screen → press **Back** → expect a single slide-right to **Home**, no flashing.
2. **Create save:** same path, tap **Save** → single slide to **Home** (no bounce).
3. **Cancel at date pick:** Home → "+" → on the date-pick screen press **Back** → single slide to **Home**.
4. **Regression — edit from Day Overview (no backTo):** Home → tap a day → Day Overview → edit mode → edit icon → **Back** → returns to **Day Overview** (unchanged); second Back closes to Home.
5. **Regression — change existing session's date:** open an existing session in edit → tap the **Date** row → Back/confirm → returns to the **edit screen**, not Home.

- [ ] Verify no errors appear in the JS console

### Offline tests

Navigation is local-only; no network behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)