### PR TITLE
feat(search): prefix matching + debounced live friend search

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -356,6 +356,9 @@ const CONST = {
 
   SEARCH: {
     RESULTS_PAGE_SIZE: 50,
+    // Minimum normalized-prefix length for a `nickname_to_id` range query.
+    // Shorter prefixes are rejected to avoid scanning most of the index.
+    MIN_NICKNAME_PREFIX_LENGTH: 2,
     DATA_TYPES: {
       SESSION: 'session',
     },

--- a/src/components/Social/SearchWindow.tsx
+++ b/src/components/Social/SearchWindow.tsx
@@ -1,5 +1,5 @@
 import {Keyboard, View} from 'react-native';
-import {useState, useEffect, useCallback} from 'react';
+import {useEffect, useCallback} from 'react';
 import type {Database} from 'firebase/database';
 import {useFirebase} from '@src/context/global/FirebaseContext';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -7,6 +7,7 @@ import Button from '@components/Button';
 import useThemeStyles from '@hooks/useThemeStyles';
 import TextInput from '@components/TextInput';
 import useLocalize from '@hooks/useLocalize';
+import useDebouncedState from '@hooks/useDebouncedState';
 
 type SearchWindowProps = {
   windowText: string;
@@ -24,7 +25,8 @@ function SearchWindow({
   const styles = useThemeStyles();
   const {db} = useFirebase();
   const {translate} = useLocalize();
-  const [searchText, setSearchText] = useState<string>('');
+  const [searchText, debouncedSearchText, setSearchText] =
+    useDebouncedState<string>('');
 
   const handleDoSearch = useCallback(
     (text: string) => {
@@ -46,10 +48,10 @@ function SearchWindow({
       return;
     }
 
-    handleDoSearch(searchText);
+    handleDoSearch(debouncedSearchText);
     // Including the handleDoSearch function causes an infinite loop
     // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-  }, [searchText, searchOnTextChange]);
+  }, [debouncedSearchText, searchOnTextChange]);
 
   // useImperativeHandle(parentRef, () => ({
   //   focus: () => {

--- a/src/libs/Search.ts
+++ b/src/libs/Search.ts
@@ -1,36 +1,60 @@
 import type {Database} from 'firebase/database';
+import {endAt, get, orderByKey, query, ref, startAt} from 'firebase/database';
 import type {
   UserIDToNicknameMapping,
   UserSearchResults,
 } from '@src/types/various/Search';
-import type {NicknameToId} from '@src/types/onyx';
-import {readDataOnce} from '@database/baseFunctions';
+import type {NicknameToIdList} from '@src/types/onyx';
+import CONST from '@src/CONST';
 import {cleanStringForFirebaseKey} from './StringUtilsKiroku';
 
 /**
- * Using a database object and a nickname to search,
- * fetch the user IDs that belong to that nickname.
- * Return this object if it exists, or an empty object
- * if not.
+ * Using a database object and a search prefix, fetch every `nickname_to_id`
+ * bucket whose normalized name-key starts with that prefix (e.g. "john"
+ * matches "john_doe", "johnny", ...). Returns the matching buckets keyed by
+ * name-key, or `null` when the prefix is too short or nothing matches.
+ *
+ * The prefix range query relies on the standard Firebase key-ordering idiom:
+ * keys in `[prefix, prefix + '\uf8ff']` are exactly those starting with
+ * `prefix`, since `\uf8ff` is a very high code point that sorts after any
+ * realistic key suffix.
  *
  * @param db Firebase Database object.
- * @param searchText The nickname to search for.
- * @returns The user IDs
- *  that belong to this nickname
+ * @param searchText The nickname prefix to search for.
+ * @returns The matching name-key buckets, or null.
  */
 async function searchDbByNickname(
   db: Database,
   searchText: string,
-): Promise<NicknameToId | null> {
-  const nicknameKey = cleanStringForFirebaseKey(searchText);
-  return readDataOnce<NicknameToId>(db, `nickname_to_id/${nicknameKey}`);
+): Promise<NicknameToIdList | null> {
+  const prefix = cleanStringForFirebaseKey(searchText);
+  // `cleanStringForFirebaseKey` collapses empty/invalid input to '_'. Guard
+  // both that sentinel and overly short prefixes to avoid scanning the table.
+  if (
+    prefix === '_' ||
+    prefix.length < CONST.SEARCH.MIN_NICKNAME_PREFIX_LENGTH
+  ) {
+    return null;
+  }
+  const nicknameQuery = query(
+    ref(db, 'nickname_to_id'),
+    orderByKey(),
+    startAt(prefix),
+    endAt(`${prefix}\uf8ff`),
+  );
+  const snapshot = await get(nicknameQuery);
+  if (snapshot.exists()) {
+    return snapshot.val() as NicknameToIdList;
+  }
+  return null;
 }
 
 /**
- * Searches the database for a given searchText and returns a string of IDs that match the search text.
+ * Searches the database for a given searchText and returns the deduplicated
+ * list of user IDs whose normalized display name starts with it.
  * @param db - The database object.
  * @param searchText - The text to search for.
- * @returns A Promise that resolves to a string of IDs that match the search text.
+ * @returns A Promise that resolves to the matching user IDs.
  */
 async function searchDatabaseForUsers(
   db: Database | undefined,
@@ -39,12 +63,16 @@ async function searchDatabaseForUsers(
   if (!searchText || !db) {
     return [];
   }
-  let searchResultData: UserSearchResults = [];
-  const newResults = await searchDbByNickname(db, searchText); // Nickname is cleaned in the function
-  if (newResults) {
-    searchResultData = Object.keys(newResults);
+  const buckets = await searchDbByNickname(db, searchText); // Prefix is cleaned in the function
+  if (!buckets) {
+    return [];
   }
-  return searchResultData;
+  // Each bucket is a {userID: nickname} map; flatten and dedupe across buckets.
+  const userIDs = new Set<string>();
+  Object.values(buckets).forEach(bucket => {
+    Object.keys(bucket).forEach(userID => userIDs.add(userID));
+  });
+  return Array.from(userIDs);
 }
 
 function searchItemIsRelevant(

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -70,8 +70,23 @@ function FriendSearchScreen() {
     [friendRequests, searchResultData],
   );
 
+  const resetSearch = useCallback((): void => {
+    // Reset all values displayed on screen
+    setSearching(false);
+    setSearchResultData([]);
+    setRequestStatuses({});
+    setDisplayData({});
+    setNoUsersFound(false);
+  }, []);
+
   const dbSearch = useCallback(
     async (searchText: string, database?: Database): Promise<void> => {
+      // An empty/whitespace query (e.g. on mount or after clearing) should
+      // clear the screen rather than render the "no users found" message.
+      if (!searchText.trim()) {
+        resetSearch();
+        return;
+      }
       try {
         setSearching(true);
         const newData: UserSearchResults = await searchDatabaseForUsers(
@@ -95,17 +110,8 @@ function FriendSearchScreen() {
         setSearching(false);
       }
     },
-    [db, updateRequestStatuses],
+    [db, updateRequestStatuses, resetSearch],
   );
-
-  const resetSearch = (): void => {
-    // Reset all values displayed on screen
-    setSearching(false);
-    setSearchResultData([]);
-    setRequestStatuses({});
-    setDisplayData({});
-    setNoUsersFound(false);
-  };
 
   useMemo(() => {
     if (!userData) {
@@ -135,6 +141,7 @@ function FriendSearchScreen() {
         windowText={translate('friendSearchScreen.searchWindow')}
         onSearch={dbSearch}
         onResetSearch={resetSearch}
+        searchOnTextChange
       />
       <ScrollView style={[styles.w100, styles.flex1]}>
         {searching ? (


### PR DESCRIPTION
### Details

**Phase 1 (read-side only)** of the friend-search upgrade. Friend search previously required typing a user's **entire** display name exactly — the #1 complaint. This converts the exact `nickname_to_id/{fullKey}` lookup into a **prefix range query** and makes search **live + debounced** as you type.

No change to how `nickname_to_id` is written/populated — that's Phase 2 (token indexing on the write side).

What changed:
- **`src/libs/Search.ts`** — `searchDbByNickname` now runs a Firebase RTDB prefix range query: `query(ref(db,'nickname_to_id'), orderByKey(), startAt(prefix), endAt(prefix + ''))` via `get()`. It returns multiple name-key buckets (`NicknameToIdList`); `searchDatabaseForUsers` flattens each bucket's `{userID: nickname}` map into a deduplicated user-ID list. Guards empty/invalid (`'_'`) and prefixes shorter than `CONST.SEARCH.MIN_NICKNAME_PREFIX_LENGTH` (=2) to avoid scanning the index.
- **`src/components/Social/SearchWindow.tsx`** — swapped `useState` for `useDebouncedState` (300ms, `CONST.TIMING.SEARCH_OPTION_LIST_DEBOUNCE_TIME`); the on-type effect fires on the debounced value while the input shows the immediate value. The button path still uses the immediate value.
- **`src/screens/Social/FriendSearchScreen.tsx`** — enabled `searchOnTextChange`; wrapped `resetSearch` in `useCallback`; `dbSearch` now early-returns to a clean state on empty/whitespace input (prevents a "no users found" flash on mount/after clearing).
- **`src/CONST.ts`** — added `SEARCH.MIN_NICKNAME_PREFIX_LENGTH`.

Notes for reviewers:
- `SearchWindow` is shared. `FriendListScreen` and `FriendsFriendsScreen` already used `searchOnTextChange` with **local** filtering, so they gain debouncing for free (verify their filtering still feels right).
- `Profile.fetchUserProfiles` left as-is: it already fetches in parallel via `Promise.all` (not a serial N+1), and RTDB has no efficient multi-path batch get short of reading the whole `users` table.
- **Risk:** `fetchDisplayDataForUsers` throws if any `users/{userID}/profile` is null. Prefix matching surfaces more buckets, so a single stale `nickname_to_id` entry pointing at a deleted user would now fail the whole search (caught → `SEARCH_FAILED`). Hardening that fetch to tolerate missing profiles is a candidate follow-up.

### Tests

1. Open Friend Search. Verify no "no users found" message appears on an empty box.
2. Type the **start** of a known user's display name (e.g. `joh` for "John Doe"). Verify matches appear **without** tapping a Search button, updating live as you type.
3. Verify a prefix shared by multiple users (e.g. `jo`) returns all of them, deduplicated (no repeated rows).
4. Type a single character. Verify it does not query the whole table (min prefix length is 2).
5. Verify diacritics/case are ignored (e.g. `cǎ` and `ca` behave the same after normalization).
6. Clear the input. Verify results reset and no "no users found" flash.
7. Verify friend-request status badges and the supporter badge still render correctly on results.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, open Friend Search, type a prefix. Verify it fails gracefully (no crash) since search needs a live RTDB read.
2. Reconnect and verify search works again.

### QA Steps

1. On staging, open Friend Search and type partial display names; verify prefix matches appear live.
2. Verify common prefixes return multiple deduplicated users.
3. Verify single-character input returns nothing (guarded).
- [ ] Verify that no errors appear in the JS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)