### PR TITLE
feat(privacy): let users hide their drinking data from friends

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -55,7 +55,7 @@
       ".write": "auth.token.admin === true",
       "$uid": {
         ".validate": "newData.val() === null || newData.hasChildren()",
-        ".read": "auth != null && (auth.uid === $uid || root.child('users').child(auth.uid).child('friends').child($uid).exists())",
+        ".read": "auth != null && (auth.uid === $uid || (root.child('users').child(auth.uid).child('friends').child($uid).exists() && root.child('user_data_visibility').child($uid).child('hide_from_all').val() !== true && !root.child('user_data_visibility').child($uid).child('hidden_from').child(auth.uid).exists()))",
         ".write": "auth != null && auth.uid === $uid",
         ".indexOn": ["start_time"]
       }
@@ -147,6 +147,24 @@
         ".validate": "newData.val() === true || newData.val() === null",
         ".read": "auth != null  && auth.uid === $uid",
         ".write": "auth != null && auth.uid === $uid"
+      }
+    },
+    "user_data_visibility": {
+      ".read": "auth.token.admin === true",
+      ".write": "auth.token.admin === true",
+      "$uid": {
+        ".validate": "newData.val() === null || newData.hasChildren()",
+        ".read": "auth != null && auth.uid === $uid",
+        ".write": "auth != null && auth.uid === $uid",
+        "hide_from_all": {
+          ".validate": "newData.isBoolean() || newData.val() === null"
+        },
+        "hidden_from": {
+          ".validate": "newData.val() === null || newData.hasChildren()",
+          "$viewer_uid": {
+            ".validate": "newData.val() === true || newData.val() === null"
+          }
+        }
       }
     },
     "users": {

--- a/src/DBPATHS.ts
+++ b/src/DBPATHS.ts
@@ -126,6 +126,21 @@ const DBPATHS = {
     route: '/user_unconfirmed_days/:user_id',
     getRoute: (user_id: UserID) => `user_unconfirmed_days/${user_id}` as const,
   },
+  USER_DATA_VISIBILITY: 'user_data_visibility',
+  USER_DATA_VISIBILITY_USER_ID: {
+    route: '/user_data_visibility/:user_id',
+    getRoute: (user_id: UserID) => `user_data_visibility/${user_id}` as const,
+  },
+  USER_DATA_VISIBILITY_USER_ID_HIDE_FROM_ALL: {
+    route: '/user_data_visibility/:user_id/hide_from_all',
+    getRoute: (user_id: UserID) =>
+      `user_data_visibility/${user_id}/hide_from_all` as const,
+  },
+  USER_DATA_VISIBILITY_USER_ID_HIDDEN_FROM_VIEWER: {
+    route: '/user_data_visibility/:user_id/hidden_from/:viewer_uid',
+    getRoute: (user_id: UserID, viewer_uid: UserID) =>
+      `user_data_visibility/${user_id}/hidden_from/${viewer_uid}` as const,
+  },
   USERS: 'users',
   USERS_USER_ID: {
     route: '/users/:user_id',

--- a/src/ERRORS.ts
+++ b/src/ERRORS.ts
@@ -72,6 +72,7 @@ const ERRORS = {
     FRIEND_REQUEST_ACCEPT_FAILED: 'user/friend-request-accept-failed',
     FRIEND_REQUEST_REJECT_FAILED: 'user/friend-request-reject-failed',
     NICKNAME_UPDATE_FAILED: 'user/nickname-update-failed',
+    PRIVACY_UPDATE_FAILED: 'user/privacy-update-failed',
     STATUS_UPDATE_FAILED: 'user/status-update-failed',
     THEME_UPDATE_FAILED: 'user/theme-update-failed',
     TIMEZONE_UPDATE_FAILED: 'user/timezone-update-failed',

--- a/src/components/ManageFriendPopover.tsx
+++ b/src/components/ManageFriendPopover.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useRef} from 'react';
+import React, {useRef} from 'react';
 import {View} from 'react-native';
 import {unfriend} from '@database/friends';
 import {setFriendDataHidden} from '@database/privacy';
@@ -51,27 +51,22 @@ function ManageFriendPopover({
     });
   };
 
-  const menuItems = useMemo(() => {
-    const baseMenuItems: PopoverMenuItem[] = [
-      {
-        text: isHidden
-          ? translate('profileScreen.showDataToFriend')
-          : translate('profileScreen.hideDataFromFriend'),
-        icon: isHidden ? KirokuIcons.Eye : KirokuIcons.EyeDisabled,
-        onSelected: handleToggleHidden,
+  const menuItems: PopoverMenuItem[] = [
+    {
+      text: isHidden
+        ? translate('profileScreen.showDataToFriend')
+        : translate('profileScreen.hideDataFromFriend'),
+      icon: isHidden ? KirokuIcons.Eye : KirokuIcons.EyeDisabled,
+      onSelected: handleToggleHidden,
+    },
+    {
+      text: translate('profileScreen.unfriend'),
+      icon: KirokuIcons.RemoveUser,
+      onSelected: () => {
+        setUnfriendModalVisible(true);
       },
-      {
-        text: translate('profileScreen.unfriend'),
-        icon: KirokuIcons.RemoveUser,
-        onSelected: () => {
-          setUnfriendModalVisible(true);
-        },
-      },
-    ];
-
-    return baseMenuItems;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [translate, isHidden]);
+    },
+  ];
 
   const handleUnfriend = () => {
     (async () => {

--- a/src/components/ManageFriendPopover.tsx
+++ b/src/components/ManageFriendPopover.tsx
@@ -1,7 +1,9 @@
 import React, {useMemo, useRef} from 'react';
 import {View} from 'react-native';
 import {unfriend} from '@database/friends';
+import {setFriendDataHidden} from '@database/privacy';
 import {useFirebase} from '@src/context/global/FirebaseContext';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
@@ -33,12 +35,31 @@ function ManageFriendPopover({
   const user = auth.currentUser;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  const {dataVisibility} = useDatabaseData();
   const fabRef = useRef<HTMLDivElement>(null);
   const {windowHeight} = useWindowDimensions();
   const [unfriendModalVisible, setUnfriendModalVisible] = React.useState(false);
 
+  const isHidden = dataVisibility?.hidden_from?.[friendId] === true;
+
+  const handleToggleHidden = () => {
+    if (!user) {
+      return;
+    }
+    setFriendDataHidden(db, user.uid, friendId, !isHidden).catch(error => {
+      ErrorUtils.raiseAppError(ERRORS.USER.PRIVACY_UPDATE_FAILED, error);
+    });
+  };
+
   const menuItems = useMemo(() => {
     const baseMenuItems: PopoverMenuItem[] = [
+      {
+        text: isHidden
+          ? translate('profileScreen.showDataToFriend')
+          : translate('profileScreen.hideDataFromFriend'),
+        icon: isHidden ? KirokuIcons.Eye : KirokuIcons.EyeDisabled,
+        onSelected: handleToggleHidden,
+      },
       {
         text: translate('profileScreen.unfriend'),
         icon: KirokuIcons.RemoveUser,
@@ -49,7 +70,8 @@ function ManageFriendPopover({
     ];
 
     return baseMenuItems;
-  }, [translate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [translate, isHidden]);
 
   const handleUnfriend = () => {
     (async () => {

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -4,6 +4,7 @@ import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import Onyx from 'react-native-onyx';
 import type {
   Config,
+  DataVisibility,
   DrinkingSessionList,
   Preferences,
   UnconfirmedDays,
@@ -23,6 +24,9 @@ type DatabaseDataContextType = {
   preferences?: Preferences;
   unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
+  /** Owner-controlled visibility of the current user's drinking data to
+   *  friends. Absent ⇒ fully visible (grandfathered default). */
+  dataVisibility?: DataVisibility;
   /** Global app configuration, including the terms re-consent signal. */
   config?: Config;
   /** True while a wider-window resubscribe for `drinkingSessionData` is in
@@ -60,6 +64,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
     'preferences',
     'unconfirmedDays',
     'userData',
+    'dataVisibility',
   ];
 
   const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
@@ -71,6 +76,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
       preferences: data.preferences,
       unconfirmedDays: data.unconfirmedDays,
       userData: data.userData,
+      dataVisibility: data.dataVisibility,
       config: data.config,
       isFetchingOlderMonths,
     }),

--- a/src/database/privacy.ts
+++ b/src/database/privacy.ts
@@ -1,0 +1,55 @@
+import type {Database} from 'firebase/database';
+import {ref, update} from 'firebase/database';
+import DBPATHS from '@src/DBPATHS';
+
+const hideFromAllRef = DBPATHS.USER_DATA_VISIBILITY_USER_ID_HIDE_FROM_ALL;
+const hiddenFromViewerRef =
+  DBPATHS.USER_DATA_VISIBILITY_USER_ID_HIDDEN_FROM_VIEWER;
+
+/**
+ * Toggle the master switch that hides the user's drinking data from all
+ * friends. Writing `null` when disabling keeps the tree clean so absence of
+ * the node means "fully visible".
+ *
+ * @param db Firebase Database object.
+ * @param uid ID of the user whose visibility is being changed.
+ * @param value Whether to hide drinking data from all friends.
+ * @returns An empty promise.
+ * @throws In case the database fails to save the data.
+ */
+async function setHideFromAllFriends(
+  db: Database,
+  uid: string,
+  value: boolean,
+): Promise<void> {
+  const updates: Record<string, boolean | null> = {};
+  updates[hideFromAllRef.getRoute(uid)] = value ? true : null;
+  await update(ref(db), updates);
+}
+
+/**
+ * Add or remove a single friend from the current user's blocklist. A blocked
+ * friend can no longer read the user's drinking sessions (enforced by the
+ * `user_drinking_sessions` security rule). Writing `null` removes the entry.
+ *
+ * @param db Firebase Database object.
+ * @param ownerUid ID of the user who owns the data being hidden.
+ * @param friendUid ID of the friend to hide from / reveal to.
+ * @param hidden Whether the friend should be blocked.
+ * @returns An empty promise.
+ * @throws In case the database fails to save the data.
+ */
+async function setFriendDataHidden(
+  db: Database,
+  ownerUid: string,
+  friendUid: string,
+  hidden: boolean,
+): Promise<void> {
+  const updates: Record<string, boolean | null> = {};
+  updates[hiddenFromViewerRef.getRoute(ownerUid, friendUid)] = hidden
+    ? true
+    : null;
+  await update(ref(db), updates);
+}
+
+export {setHideFromAllFriends, setFriendDataHidden};

--- a/src/hooks/useFetchData/types.ts
+++ b/src/hooks/useFetchData/types.ts
@@ -1,5 +1,6 @@
 import type {
   Config,
+  DataVisibility,
   DrinkingSessionList,
   Preferences,
   UnconfirmedDays,
@@ -18,6 +19,7 @@ type FetchData = {
   preferences?: Preferences;
   unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
+  dataVisibility?: DataVisibility;
 };
 
 type FetchDataKey = StringKeyOf<FetchData>;

--- a/src/hooks/useFetchData/utils.ts
+++ b/src/hooks/useFetchData/utils.ts
@@ -28,6 +28,9 @@ function fetchDataKeyToDbPath(key: FetchDataKey, userID?: UserID) {
     case 'userData':
       path = DBPATHS.USERS_USER_ID.getRoute(id);
       break;
+    case 'dataVisibility':
+      path = DBPATHS.USER_DATA_VISIBILITY_USER_ID.getRoute(id);
+      break;
     default:
       break;
   }

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -534,6 +534,15 @@ export default {
   },
   privacyScreen: {
     title: 'Soukromí',
+    friendsVisibilitySection: {
+      title: 'Přátelé',
+      description: 'Spravujte, kteří přátelé vidí vaše data o pití.',
+    },
+    hideFromAllFriends: {
+      label: 'Skrýt má data před všemi přáteli',
+      description:
+        'Když je zapnuto, žádný z vašich přátel neuvidí vaše relace pití. Chcete-li skrýt data jen před jedním přítelem, otevřete jeho profil a použijte Spravovat přítele.',
+    },
     diagnosticsSection: {
       title: 'Diagnostika',
       description:
@@ -915,6 +924,8 @@ export default {
     manageFriend: 'Spravovat přítele',
     unfriendPrompt: 'Opravdu chcete tohoto uživatele odebrat z přátel?',
     unfriend: 'Odebrat z přátel',
+    hideDataFromFriend: 'Skrýt má data před tímto přítelem',
+    showDataToFriend: 'Zobrazit má data tomuto příteli',
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
       `${hasCommonFriends ? 'Společní přátelé:' : 'Přátelé:'}`,
     profileImage: 'Profilový obrázek',
@@ -1632,6 +1643,11 @@ export default {
         title: 'Nepodařilo se aktualizovat přezdívku',
         message:
           'Při aktualizaci přezdívky došlo k chybě. Zkuste to prosím znovu.',
+      },
+      privacyUpdateFailed: {
+        title: 'Nepodařilo se aktualizovat soukromí',
+        message:
+          'Při aktualizaci nastavení soukromí došlo k chybě. Zkuste to prosím znovu.',
       },
       statusUpdateFailed: {
         title: 'Nepodařilo se aktualizovat stav',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -536,6 +536,15 @@ export default {
   },
   privacyScreen: {
     title: 'Privacy',
+    friendsVisibilitySection: {
+      title: 'Friends',
+      description: 'Control which friends can see your drinking data.',
+    },
+    hideFromAllFriends: {
+      label: 'Hide my data from all friends',
+      description:
+        'When on, none of your friends can see your drinking sessions. To hide your data from just one friend instead, open their profile and use Manage Friend.',
+    },
     diagnosticsSection: {
       title: 'Diagnostics',
       description:
@@ -925,6 +934,8 @@ export default {
     manageFriend: 'Manage Friend',
     unfriendPrompt: 'Do you really want to unfriend this user?',
     unfriend: 'Unfriend',
+    hideDataFromFriend: 'Hide my data from this friend',
+    showDataToFriend: 'Show my data to this friend',
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
       `${hasCommonFriends ? 'Common friends:' : 'Friends:'}`,
     profileImage: 'Profile Image',
@@ -1641,6 +1652,11 @@ export default {
       nicknameUpdateFailed: {
         title: 'Nickname Update Failed',
         message: 'There was an error updating your nickname. Please try again.',
+      },
+      privacyUpdateFailed: {
+        title: 'Privacy Update Failed',
+        message:
+          'There was an error updating your privacy settings. Please try again.',
       },
       statusUpdateFailed: {
         title: 'Status Update Failed',

--- a/src/libs/Errors/ERROR_MAPPING.ts
+++ b/src/libs/Errors/ERROR_MAPPING.ts
@@ -60,6 +60,7 @@ const ERROR_MAPPING: ErrorMapping = {
   [ERRORS.USER.FRIEND_REQUEST_REJECT_FAILED]:
     'errors.user.friendRequestRejectFailed',
   [ERRORS.USER.NICKNAME_UPDATE_FAILED]: 'errors.user.nicknameUpdateFailed',
+  [ERRORS.USER.PRIVACY_UPDATE_FAILED]: 'errors.user.privacyUpdateFailed',
   [ERRORS.USER.STATUS_UPDATE_FAILED]: 'errors.user.statusUpdateFailed',
   [ERRORS.USER.THEME_UPDATE_FAILED]: 'errors.user.themeUpdateFailed',
   [ERRORS.USER.TIMEZONE_UPDATE_FAILED]: 'errors.user.timezoneUpdateFailed',

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -15,13 +15,14 @@ import Button from '@components/Button';
 import ConfirmModal from '@components/ConfirmModal';
 import * as Preferences from '@userActions/Preferences';
 import * as SessionLocations from '@userActions/SessionLocations';
+import {setHideFromAllFriends} from '@database/privacy';
 import checkPermission from '@libs/Permissions/checkPermission';
 import requestPermission from '@libs/Permissions/requestPermission';
 
 function PrivacyScreen() {
   const {translate} = useLocalize();
   const styles = useThemeStyles();
-  const {preferences} = useDatabaseData();
+  const {preferences, dataVisibility} = useDatabaseData();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
 
@@ -43,8 +44,30 @@ function PrivacyScreen() {
   const [savingTrackLocation, setSavingTrackLocation] = useState(false);
   const displayTrackLocation = pendingTrackLocation ?? persistedTrackLocation;
 
+  const persistedHideFromAll = dataVisibility?.hide_from_all === true;
+  const [pendingHideFromAll, setPendingHideFromAll] = useState<boolean | null>(
+    null,
+  );
+  const [savingHideFromAll, setSavingHideFromAll] = useState(false);
+  const displayHideFromAll = pendingHideFromAll ?? persistedHideFromAll;
+
   const [showPurgeConfirmModal, setShowPurgeConfirmModal] = useState(false);
   const [isPurging, setIsPurging] = useState(false);
+
+  const onToggleHideFromAll = (next: boolean) => {
+    if (savingHideFromAll || next === displayHideFromAll || !user) {
+      return;
+    }
+    setPendingHideFromAll(next);
+    setSavingHideFromAll(true);
+    setHideFromAllFriends(db, user.uid, next)
+      .catch(error => {
+        setPendingHideFromAll(null);
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('privacyScreen.error.save'), errorMessage);
+      })
+      .finally(() => setSavingHideFromAll(false));
+  };
 
   const onToggleCrashReporting = (next: boolean) => {
     if (savingCrashReporting || next === displayCrashReporting) {
@@ -137,6 +160,41 @@ function PrivacyScreen() {
         onBackButtonPress={() => Navigation.goBack()}
       />
       <ScrollView contentContainerStyle={[styles.w100]}>
+        <Section
+          title={translate('privacyScreen.friendsVisibilitySection.title')}
+          titleStyles={styles.generalSectionTitle}
+          subtitle={translate(
+            'privacyScreen.friendsVisibilitySection.description',
+          )}
+          subtitleMuted
+          isCentralPane
+          childrenStyles={styles.pt3}>
+          <View style={styles.sectionMenuItemTopDescription}>
+            <View
+              style={[
+                styles.flexRow,
+                styles.alignItemsCenter,
+                styles.justifyContentBetween,
+                styles.mb4,
+              ]}>
+              <View style={[styles.flexColumn, styles.flex1, styles.mr3]}>
+                <Text style={[styles.textNormal, styles.textStrong]}>
+                  {translate('privacyScreen.hideFromAllFriends.label')}
+                </Text>
+                <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                  {translate('privacyScreen.hideFromAllFriends.description')}
+                </Text>
+              </View>
+              <Switch
+                accessibilityLabel={translate(
+                  'privacyScreen.hideFromAllFriends.label',
+                )}
+                isOn={displayHideFromAll}
+                onToggle={onToggleHideFromAll}
+              />
+            </View>
+          </View>
+        </Section>
         <Section
           title={translate('privacyScreen.diagnosticsSection.title')}
           titleStyles={styles.generalSectionTitle}

--- a/src/types/onyx/DataVisibility.ts
+++ b/src/types/onyx/DataVisibility.ts
@@ -1,0 +1,15 @@
+import type {UserList} from './OnyxCommon';
+
+/** Owner-controlled visibility of a user's drinking data to their friends.
+ *  Absence of this node (or absent fields) means fully visible — the
+ *  grandfathered default. */
+type DataVisibility = {
+  /** When true, no friend can see this user's drinking sessions. */
+  hide_from_all?: boolean;
+
+  /** Per-friend blocklist: friends whose UID maps to `true` cannot see this
+   *  user's drinking sessions. */
+  hidden_from?: UserList;
+};
+
+export default DataVisibility;

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -4,6 +4,7 @@ import type Config from './Config';
 import type {AppSettings, Maintenance} from './Config';
 import type {CapturedLogs, Log} from './Console';
 import type Credentials from './Credentials';
+import type DataVisibility from './DataVisibility';
 import type DatabaseProps from './DatabaseProps';
 import type Download from './Download';
 import type DrinkingSession from './DrinkingSession';
@@ -85,6 +86,7 @@ export type {
   Config,
   Credentials,
   DatabaseProps,
+  DataVisibility,
   Download,
   DrinkingSession,
   DrinkingSessionArray,


### PR DESCRIPTION
### Details

Gives users control over **who** among their friends can see their drinking data. Two controls:

- **Master switch** in Settings → Privacy → Friends: "Hide my data from all friends".
- **Per-friend toggle** in a friend's profile → Manage Friend: "Hide my data from this friend" / "Show my data to this friend".

**Why a new node + rule change (the important part):** friends read each other's sessions directly from the Realtime Database, so any client-side hiding would be cosmetic and trivially bypassed. Enforcement therefore lives in Firebase rules. The blocklist is stored in a **new owner-private** `user_data_visibility/{uid}` node (`.read`/`.write` = owner only, modeled on `user_session_locations`) — it can't go under `users/{uid}` or `user_preferences/{uid}` because both grant friend reads at their top node and RTDB read grants cascade to descendants. The `user_drinking_sessions/{uid}` read rule now additionally requires that the owner hasn't set `hide_from_all` and hasn't blocked the requester.

**Behavior is silent by design:** a blocked friend sees an empty calendar, indistinguishable from a friend who simply logged nothing. The existing `useDrinkingSessionsFetch` already degrades a permission-denied read to `undefined`, so no read-path changes were needed. `users`/`user_preferences` reads are intentionally left open (preferences are needed to render anything and leak almost nothing).

**Default / migration:** none. Absence of the node = fully visible, so all existing users are grandfathered with no migration.

Scope is deliberately **WHO-only**. Detail-level granularity (e.g. show *which days* but not *how much*, hide blackouts) is **deferred** — it requires server-side field redaction, which RTDB rules can't do, and is a separate larger effort that this WHO gate will compose with.

Key files: `database.rules.json`, `src/database/privacy.ts` (write actions), `src/types/onyx/DataVisibility.ts`, `src/context/global/DatabaseDataContext.tsx` (subscribes the owner's node for the current user only), `src/screens/Settings/Privacy/PrivacyScreen.tsx`, `src/components/ManageFriendPopover.tsx`.

> [!NOTE]
> Separate from this PR, I noticed a **pre-existing** leak: `users/{uid}/private_data` (birthdate, weight, gender) is already friend-readable because its owner-only `.read` is overridden by the cascading grant on the parent `users/{uid}` node. Left out of scope intentionally; worth a follow-up that moves `private_data` to its own top-level owner-only node.

### Tests

1. As user **A**, go to Settings → Privacy. Toggle **"Hide my data from all friends"** on; kill and reopen the app and verify the toggle persists.
2. As friend **B** (friends with A), open A's profile and sessions calendar — verify **no sessions appear** and no error UI shows.
3. As A, toggle the master switch back off; as B, reopen A's profile — verify sessions **reappear**.
4. As A, open friend B's profile → **Manage Friend** → "Hide my data from this friend". As B, open A's profile — verify A's sessions disappear while other friends still see them. Reopen Manage Friend and verify the row now reads "Show my data to this friend".
5. Verify A always sees their own sessions regardless of either setting.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Toggle the master switch while offline — the UI reflects the pending state optimistically; on reconnect the write flushes and the listener confirms the value.
2. Verify a previously-loaded friend's cached sessions behave per `useDrinkingSessionsFetch` cache rules when offline.

### QA Steps

Same as the Tests section above, run on staging across iOS and Android with two friended accounts.
- [ ] Verify that no errors appear in the JS console

### Author notes

- Prettier: clean. `typecheck-tsgo`: passes for all changed files (the only error is a pre-existing `glob` type issue in `scripts/utils/FileUtils.ts`, unrelated to this PR).
- `lint-changed` / React Compiler compliance / unit tests are left to CI — `lint-changed` only diffs committed commits and the React Compiler script is blocked locally by the same pre-existing `glob` error.
- All new copy is localized in `src/languages/en.ts` and `src/languages/cs_cz.ts`. Czech strings are machine-translated and should be reviewed by a native speaker.
- I have not run the app on a device/simulator; the manual test steps above are unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)