### PR TITLE
fix(search): stack friend-search results tightly via FlatList

### DIFF
--- a/src/components/Search/SendFriendRequestButton/index.tsx
+++ b/src/components/Search/SendFriendRequestButton/index.tsx
@@ -90,14 +90,7 @@ function SendFriendRequestButton({
   };
 
   return (
-    <View
-      style={[
-        styles.flexShrink1,
-        styles.justifyContentCenter,
-        styles.alignItemsCenter,
-        styles.h100,
-        // max height 100
-      ]}>
+    <View style={[styles.flexRow, styles.alignItemsCenter]}>
       {renderContents()}
     </View>
   );

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -1,4 +1,4 @@
-import {View} from 'react-native';
+import type {ListRenderItemInfo} from 'react-native';
 import React, {useCallback, useMemo, useState} from 'react';
 import type {
   FriendRequestList,
@@ -23,7 +23,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
-import ScrollView from '@components/ScrollView';
+import FlatList from '@components/FlatList';
 import ERRORS from '@src/ERRORS';
 
 function FriendSearchScreen() {
@@ -126,6 +126,21 @@ function FriendSearchScreen() {
     // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
   }, [friendRequests]); // When updated in the database, not locally
 
+  const renderItem = useCallback(
+    ({item: userID}: ListRenderItemInfo<string>) => (
+      <SearchResult
+        userID={userID}
+        userDisplayData={displayData[userID]}
+        db={db}
+        storage={storage}
+        userFrom={user?.uid ?? ''}
+        requestStatus={requestStatuses[userID]}
+        alreadyAFriend={friends ? friends[userID] : false}
+      />
+    ),
+    [displayData, db, storage, user?.uid, requestStatuses, friends],
+  );
+
   if (!user) {
     return;
   }
@@ -143,32 +158,25 @@ function FriendSearchScreen() {
         onResetSearch={resetSearch}
         searchOnTextChange
       />
-      <ScrollView style={[styles.w100, styles.flex1]}>
-        {searching ? (
-          <FlexibleLoadingIndicator style={styles.pt4} />
-        ) : (
-          <View>
-            {noUsersFound ? (
+      {searching ? (
+        <FlexibleLoadingIndicator style={styles.pt4} />
+      ) : (
+        <FlatList
+          style={[styles.w100, styles.flex1]}
+          contentContainerStyle={[styles.pt1]}
+          keyboardShouldPersistTaps="always"
+          data={searchResultData}
+          renderItem={renderItem}
+          keyExtractor={userID => `${userID}-container`}
+          ListEmptyComponent={
+            noUsersFound ? (
               <Text style={styles.noResultsText}>
                 {translate('friendSearchScreen.noUsersFound')}
               </Text>
-            ) : (
-              searchResultData.map(userID => (
-                <SearchResult
-                  key={`${userID}-container`}
-                  userID={userID}
-                  userDisplayData={displayData[userID]}
-                  db={db}
-                  storage={storage}
-                  userFrom={user.uid}
-                  requestStatus={requestStatuses[userID]}
-                  alreadyAFriend={friends ? friends[userID] : false}
-                />
-              ))
-            )}
-          </View>
-        )}
-      </ScrollView>
+            ) : undefined
+          }
+        />
+      )}
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- Friend **search** results rendered with huge vertical gaps — rows spread down the whole screen instead of stacking at the top. The friend **list** (visually identical rows) renders correctly because it uses a real `FlatList`.
- Root cause: `FriendSearchScreen` hand-rolled the list as a `ScrollView` wrapping a plain `<View>` + `searchResultData.map(...)`. The shared row style `userOverviewLeftContent` has `height: 100%`; inside a `FlatList` cell that's bounded, but inside an unbounded `View` the rows stretch/distribute down the full height.
- Fix: render results through `@components/FlatList` (same component the friend list's `UserListComponent` uses) with `contentContainerStyle={[styles.pt1]}` and `keyboardShouldPersistTaps="always"`, using the existing `SearchResult` as `renderItem`. Loading state (`searching` → spinner) and empty state (`noUsersFound` → message via `ListEmptyComponent`) preserved; all `SearchResult` props unchanged. No search-logic or shared-style changes.

## Test plan
- [ ] Open "Search For New Friends", type a 2+ char prefix returning multiple users → rows stack tightly at the top (like Friend List), no large gaps.
- [ ] Loading spinner still shows while searching.
- [ ] "No users found" message still renders for no matches.
- [ ] Friend List screen and other `UserOverview`/`userOverviewContainer` consumers unchanged.

> Note: on-device visual verification was not performed in this session (Simulator control unavailable); please confirm the above on a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)