### PR TITLE
fix(privacy): purge all user-scoped nodes on account deletion

### DIFF
--- a/src/DBPATHS.ts
+++ b/src/DBPATHS.ts
@@ -95,6 +95,11 @@ const DBPATHS = {
     getRoute: (user_id: UserID) =>
       `user_preferences/${user_id}/crash_reporting_enabled` as const,
   },
+  USER_SESSION_LOCATIONS: 'user_session_locations',
+  USER_SESSION_LOCATIONS_USER_ID: {
+    route: '/user_session_locations/:user_id',
+    getRoute: (user_id: UserID) => `user_session_locations/${user_id}` as const,
+  },
   USER_SESSION_PLACEHOLDER: 'user_session_placeholder',
   USER_SESSION_PLACEHOLDER_USER_ID: {
     route: '/user_session_placeholder/:user_id',

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -170,6 +170,7 @@ async function deleteUserData(
   const userRef = DBPATHS.USERS_USER_ID;
   const drinkingSessionsRef = DBPATHS.USER_DRINKING_SESSIONS_USER_ID;
   const unconfirmedDaysRef = DBPATHS.USER_UNCONFIRMED_DAYS_USER_ID;
+  const dataVisibilityRef = DBPATHS.USER_DATA_VISIBILITY_USER_ID;
   const friendsRef = DBPATHS.USERS_USER_ID_FRIENDS_FRIEND_ID;
   const friendRequestsRef = DBPATHS.USERS_USER_ID_FRIEND_REQUESTS_REQUEST_ID;
   const reasonForLeavingRef = DBPATHS.REASONS_FOR_LEAVING_REASON_ID;
@@ -183,6 +184,7 @@ async function deleteUserData(
   updates[userRef.getRoute(userID)] = null;
   updates[drinkingSessionsRef.getRoute(userID)] = null;
   updates[unconfirmedDaysRef.getRoute(userID)] = null;
+  updates[dataVisibilityRef.getRoute(userID)] = null;
 
   if (reasonForLeaving) {
     const reasonID: ReasonForLeavingId = getReasonForLeavingID(userID);

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -171,6 +171,8 @@ async function deleteUserData(
   const drinkingSessionsRef = DBPATHS.USER_DRINKING_SESSIONS_USER_ID;
   const unconfirmedDaysRef = DBPATHS.USER_UNCONFIRMED_DAYS_USER_ID;
   const dataVisibilityRef = DBPATHS.USER_DATA_VISIBILITY_USER_ID;
+  const sessionLocationsRef = DBPATHS.USER_SESSION_LOCATIONS_USER_ID;
+  const sessionPlaceholderRef = DBPATHS.USER_SESSION_PLACEHOLDER_USER_ID;
   const friendsRef = DBPATHS.USERS_USER_ID_FRIENDS_FRIEND_ID;
   const friendRequestsRef = DBPATHS.USERS_USER_ID_FRIEND_REQUESTS_REQUEST_ID;
   const reasonForLeavingRef = DBPATHS.REASONS_FOR_LEAVING_REASON_ID;
@@ -185,6 +187,8 @@ async function deleteUserData(
   updates[drinkingSessionsRef.getRoute(userID)] = null;
   updates[unconfirmedDaysRef.getRoute(userID)] = null;
   updates[dataVisibilityRef.getRoute(userID)] = null;
+  updates[sessionLocationsRef.getRoute(userID)] = null;
+  updates[sessionPlaceholderRef.getRoute(userID)] = null;
 
   if (reasonForLeaving) {
     const reasonID: ReasonForLeavingId = getReasonForLeavingID(userID);


### PR DESCRIPTION
### Details

Follow-up to the privacy feature ([#689](https://github.com/PetrCala/Kiroku/pull/689)). `deleteUserData()` in `src/libs/actions/User.ts` purges a hardcoded list of the user's RTDB nodes on account close. An audit of every user-scoped (`/{uid}`) node found three that were never deleted, leaving orphaned data:

- **`user_data_visibility/{uid}`** — the new privacy settings (`hide_from_all`, `hidden_from`).
- **`user_session_locations/{uid}`** — captured GPS fixes per drink. This is the most privacy-sensitive leftover; there's a `SessionLocations.purgeAll` for the in-app "clear location history" action, but account deletion never invoked equivalent cleanup.
- **`user_session_placeholder/{uid}`** — transient live-session state.

All three are now added to the multi-path delete. A `USER_SESSION_LOCATIONS_USER_ID` path constant was added to `DBPATHS.ts` to keep `deleteUserData` uniform (it previously had no constant; the path was built inline in `SessionLocations.ts`).

#### Full audit — every user-scoped node

| Node | Deleted on account close? |
|---|---|
| `users/{uid}` (+ `friends`/`friend_requests` cross-refs) | ✅ already |
| `user_drinking_sessions/{uid}` | ✅ already |
| `user_preferences/{uid}` | ✅ already |
| `user_status/{uid}` | ✅ already |
| `user_unconfirmed_days/{uid}` | ✅ already |
| `nickname_to_id/{key}/{uid}` | ✅ already |
| `user_data_visibility/{uid}` | ✅ **this PR** |
| `user_session_locations/{uid}` | ✅ **this PR** |
| `user_session_placeholder/{uid}` | ✅ **this PR** |
| `account_creations/{deviceId}/{uid}` | ⏸️ intentionally retained — abuse/rate-limit tracking; deleting it would let delete-then-recreate bypass account-creation limits |
| `bugs/{bugId}`, `feedback/{feedbackId}` (contain a `user_id` field) | ⏸️ retained — keyed by their own IDs, no reverse index to find a user's submissions client-side; treated like support tickets. Flag for a future GDPR-erasure pass if full PII removal is required |

**Cross-user references not cleaned (intentional):** entries in *other* users' `user_data_visibility/{otherUid}/hidden_from/{deletedUid}`. That node is owner-only-writable (unlike the permissive `friends` rule), so the deleting client can't touch a friend's node. The leftover is inert — a deleted Firebase Auth UID is never reissued, so a stray `true` never matches a real viewer.

### Tests

1. As a user, generate data in each node: log sessions, set a privacy preference (Settings → Privacy), enable location tagging and log a drink during a live session (creates `user_session_locations`), start a live session (creates the placeholder).
2. Confirm those nodes exist under your `{uid}` in the Realtime Database.
3. Close the account (account deletion flow).
4. Verify `user_data_visibility/{uid}`, `user_session_locations/{uid}`, `user_session_placeholder/{uid}` — and the previously-handled nodes — are all gone.
- [ ] Verify that no errors appear in the JS console

### Offline tests

- Account deletion already requires connectivity (reauthenticate + multi-path write); no offline behavior changes.

### QA Steps

Same as Tests, on staging.
- [ ] Verify that no errors appear in the JS console

### Author notes

- Additions to the existing multi-path delete plus one new path constant; prettier + `typecheck-tsgo` clean for changed files.
- I have not run the account-deletion flow on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)