### PR TITLE
fix(store): caption shot 03 as drink breakdown

### DIFF
--- a/scripts/store-screenshots.config.mjs
+++ b/scripts/store-screenshots.config.mjs
@@ -63,8 +63,8 @@ const shots = [
   {
     raw: '03-calendar.png',
     caption: {
-      'en-US': 'See your full history at a glance',
-      cs: 'Mějte celou historii na očích',
+      'en-US': 'See your drink breakdown',
+      cs: 'Rozklad podle typu nápoje',
     },
   },
   {


### PR DESCRIPTION
## Summary

Updates the default caption for screenshot slot `03-calendar.png` in `scripts/store-screenshots.config.mjs`. The recommended capture for that slot is the **Statistics → Breakdown** donut ("Units by drink type"), so the caption now reads **"See your drink breakdown"** (cs: "Rozklad podle typu nápoje") instead of the stale "See your full history at a glance" / calendar wording.

Came out of actually capturing the en-US App Store screenshot set with the `frame-app-store-screenshots` skill — the framed output now matches its caption.

## Test plan

- [x] `npm run frame-screenshots -- --locale en-US` renders all 6 shots; slot 03 shows the new caption over the breakdown screen
- [ ] Captions read correctly in the framed PNGs before uploading to ASC

🤖 Generated with [Claude Code](https://claude.com/claude-code)