### PR TITLE
fix(avatar): show loading spinner on the profile-screen avatar

### DIFF
--- a/src/components/Buttons/EnlargableImage.tsx
+++ b/src/components/Buttons/EnlargableImage.tsx
@@ -6,7 +6,6 @@ import type {
   ImageStyle,
 } from 'react-native';
 import {Animated} from 'react-native';
-import Image from '@src/components/Image';
 import FullScreenModal from '@components/Modals/FullScreenModal';
 import type ImageLayout from '@src/types/various/ImageLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -17,9 +16,15 @@ import useWindowDimensions from '@hooks/useWindowDimensions';
 type EnlargableImageProps = {
   imageSource: ImageSourcePropType;
   imageStyle: StyleProp<ImageStyle>;
+  /** The thumbnail trigger that opens the fullscreen view when pressed. */
+  children: React.ReactNode;
 };
 
-function EnlargableImage({imageSource, imageStyle}: EnlargableImageProps) {
+function EnlargableImage({
+  imageSource,
+  imageStyle,
+  children,
+}: EnlargableImageProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const [modalVisible, setModalVisible] = useState(false);
@@ -110,7 +115,7 @@ function EnlargableImage({imageSource, imageStyle}: EnlargableImageProps) {
         accessibilityLabel={translate('profileScreen.profileImage')}
         onPress={handlePress}
         onLayout={handleOnLayout}>
-        <Image source={imageSource} style={imageStyle} />
+        {children}
       </PressableWithFeedback>
       <FullScreenModal
         visible={modalVisible}

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -158,19 +158,7 @@ function ProfileImage({
       downloadPath.includes(CONST.FIREBASE_STORAGE_URL));
   const iconTint = imageUrl ? undefined : theme.icon;
 
-  if (enlargable) {
-    const imageSource: ImageSourcePropType = imageUrl
-      ? {uri: imageUrl}
-      : KirokuIcons.UserIcon;
-    return (
-      <EnlargableImage
-        imageSource={imageSource}
-        imageStyle={[style, {tintColor: iconTint}]}
-      />
-    );
-  }
-
-  return (
+  const avatar = (
     <AvatarImage
       uri={imageUrl ?? null}
       isResolving={imageUrl === undefined}
@@ -179,6 +167,21 @@ function ProfileImage({
       style={style}
     />
   );
+
+  if (enlargable) {
+    const imageSource: ImageSourcePropType = imageUrl
+      ? {uri: imageUrl}
+      : KirokuIcons.UserIcon;
+    return (
+      <EnlargableImage
+        imageSource={imageSource}
+        imageStyle={[style, {tintColor: iconTint}]}>
+        {avatar}
+      </EnlargableImage>
+    );
+  }
+
+  return avatar;
 }
 
 export default ProfileImage;


### PR DESCRIPTION
### Details

The profile-screen avatar renders through `ProfileImage`'s `enlargable` path, which returned `EnlargableImage` directly and never touched the `AvatarImage` sub-component. `AvatarImage` is where the recent avatar work landed (loading spinner + `expo-image` `cachePolicy="memory-disk"`, see commits `ac16b002e`, `a2c9204ae`, `51e7684f4`), so the profile avatar missed all of it — it kept showing the "no photo" silhouette during load while every friends-list avatar (default path) looked correct.

`EnlargableImage` is only used by `ProfileImage`, so its API was changed freely:

- `EnlargableImage` now takes a `children` thumbnail trigger and renders it inside the pressable, keeping `imageSource`/`imageStyle` only for the fullscreen `Animated.Image` zoom view (unchanged).
- `ProfileImage` builds the `AvatarImage` element once and wraps it in `EnlargableImage` when `enlargable`, deduping the two former branches.

Net effect: the profile thumbnail now renders identically to the friends-list avatars (spinner during load, shared expo-image cache, no silhouette flash) while tap-to-zoom fullscreen is preserved.

No changes to `ProfileOverview` / `ProfileScreen` — the `enlargable` prop stays.

### Tests

1. Open the Profile screen for a user **with** a profile photo on a cold cache.
2. Verify a loading spinner shows immediately and then swaps to the photo — no "no photo" silhouette flash. Matches the friends-list avatar behavior.
3. Tap the avatar and verify it animates into the fullscreen zoom modal; close it and verify it returns.
4. Open the Profile screen for a user **without** a photo and verify the tinted silhouette shows (no spinner), as before.
5. Re-upload a profile picture and verify the new image appears (new Firebase download token = expo-image cache miss).

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline with a previously-loaded profile photo and verify the cached avatar still renders on the Profile screen.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. On staging, open your own Profile screen and confirm the avatar loads via spinner then image (no silhouette flash).
2. Tap the avatar to enlarge, then dismiss.
3. Confirm friends-list avatars are unchanged.

- [ ] Verify that no errors appear in the JS console

### Reviewer notes

`ProfileImage` is a shared component; this PR changes the `EnlargableImage` prop contract (`imageSource` thumbnail → `children`). The only caller is `ProfileImage` itself, updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)