### PR TITLE
feat(profile): read-only day drill-down on friend profiles

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -24,8 +24,11 @@ function DrinkingSessionOverview({
   sessionId,
   session,
   isEditModeOn,
+  readOnly = false,
+  preferences: preferencesProp,
 }: DrinkingSessionOverviewProps) {
-  const {preferences} = useDatabaseData();
+  const {preferences: ownPreferences} = useDatabaseData();
+  const preferences = preferencesProp ?? ownPreferences;
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
@@ -73,32 +76,42 @@ function DrinkingSessionOverview({
     sessionColor = resolvePalette(preferences?.session_color_palette).black;
   }
 
+  const rowStyle = [
+    styles.flexRow,
+    styles.alignItemsCenter,
+    styles.justifyContentBetween,
+    styles.p4,
+    styles.mh1,
+    styles.mb2,
+    StyleUtils.getColorAccentRowStyle(sessionColor),
+    {minHeight: 84},
+  ];
+
+  const sessionDetails = (
+    <View style={[styles.flexColumn, styles.flex1]}>
+      <Text style={[styles.textNormal, styles.textStrong]}>
+        {translate('common.units')}: {totalUnits}
+      </Text>
+      {shouldDisplayTime && (
+        <Text style={[styles.textMicroSupporting, styles.mt1]}>
+          {translate('common.time')}: {timeString}
+        </Text>
+      )}
+    </View>
+  );
+
+  if (readOnly) {
+    return <View style={rowStyle}>{sessionDetails}</View>;
+  }
+
   return (
     <PressableWithFeedback
       accessibilityLabel={translate('dayOverviewScreen.sessionWindow', {
         sessionId,
       })}
-      style={[
-        styles.flexRow,
-        styles.alignItemsCenter,
-        styles.justifyContentBetween,
-        styles.p4,
-        styles.mh1,
-        styles.mb2,
-        StyleUtils.getColorAccentRowStyle(sessionColor),
-        {minHeight: 84},
-      ]}
+      style={rowStyle}
       onPress={() => onSessionButtonPress()}>
-      <View style={[styles.flexColumn, styles.flex1]}>
-        <Text style={[styles.textNormal, styles.textStrong]}>
-          {translate('common.units')}: {totalUnits}
-        </Text>
-        {shouldDisplayTime && (
-          <Text style={[styles.textMicroSupporting, styles.mt1]}>
-            {translate('common.time')}: {timeString}
-          </Text>
-        )}
-      </View>
+      {sessionDetails}
       {session?.ongoing ? (
         <Button
           danger

--- a/src/components/DrinkingSessionOverview/types.ts
+++ b/src/components/DrinkingSessionOverview/types.ts
@@ -1,9 +1,22 @@
-import type {DrinkingSession, DrinkingSessionId} from '@src/types/onyx';
+import type {
+  DrinkingSession,
+  DrinkingSessionId,
+  Preferences,
+} from '@src/types/onyx';
 
 type DrinkingSessionOverviewProps = {
   sessionId: DrinkingSessionId;
   session: DrinkingSession;
   isEditModeOn: boolean;
+
+  /** Render as a non-interactive tile: no navigation into the session summary,
+   *  no edit/ongoing buttons. Used for viewing a friend's sessions. */
+  readOnly?: boolean;
+
+  /** Preferences to use for color/unit computation. Falls back to the current
+   *  user's preferences when omitted — pass the viewed user's preferences when
+   *  rendering someone else's session. */
+  preferences?: Preferences;
 };
 
 export default DrinkingSessionOverviewProps;

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -41,6 +41,7 @@ function SessionsCalendar({
   drinkingSessionData,
   preferences,
   isFetchingOlderMonths,
+  onForeignDayPress,
   mode = 'compact',
   initialMonthYear,
   initialFirstWeekY,
@@ -150,14 +151,14 @@ function SessionsCalendar({
   const onDayPress = useCallback(
     (dateData: DateData) => {
       if (userID !== user?.uid) {
+        onForeignDayPress?.(dateData.dateString as DateString);
         return;
       }
       Navigation.navigate(
         ROUTES.DAY_OVERVIEW.getRoute(dateData.dateString as DateString),
       );
-      // TODO display other user's sessions too in a clever manner
     },
-    [userID, user?.uid],
+    [userID, user?.uid, onForeignDayPress],
   );
 
   if (isLoading) {

--- a/src/components/SessionsCalendar/types.ts
+++ b/src/components/SessionsCalendar/types.ts
@@ -1,5 +1,5 @@
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
-import type {UserID} from '@src/types/onyx/OnyxCommon';
+import type {DateString, UserID} from '@src/types/onyx/OnyxCommon';
 import type {DateData} from 'react-native-calendars';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {DayComponentProps, CalendarColors} from './DayComponent/types';
@@ -23,6 +23,11 @@ type SessionsCalendarProps = {
   /** Show an inline spinner next to the month header while older months are
    *  being fetched after a back-nav past the loaded window edge. */
   isFetchingOlderMonths?: boolean;
+
+  /** Fires when a day is tapped while viewing another user's calendar (the
+   *  self case navigates to the day overview instead). Lets the parent open a
+   *  read-only drill-down. Omit to keep foreign-day taps inert. */
+  onForeignDayPress?: (date: DateString) => void;
 
   /**
    * Rendering mode:

--- a/src/screens/Profile/FriendDayDrillDownSheet.tsx
+++ b/src/screens/Profile/FriendDayDrillDownSheet.tsx
@@ -1,0 +1,121 @@
+import {useMemo} from 'react';
+import {FlatList, View} from 'react-native';
+import {format} from 'date-fns';
+import Button from '@components/Button';
+import DrinkingSessionOverview from '@components/DrinkingSessionOverview';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import Icon from '@components/Icon';
+import Modal from '@components/Modal';
+import {PressableWithFeedback} from '@components/Pressable';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {dateStringToDate} from '@libs/DataHandling';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
+import CONST from '@src/CONST';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+
+type FriendDayDrillDownSheetProps = {
+  /** Whether the modal is visible */
+  isVisible: boolean;
+
+  /** Callback fired when the modal requests to close */
+  onClose: () => void;
+
+  /** The selected day, or null when no day is selected */
+  date: DateString | null;
+
+  /** The viewed friend's drinking session data */
+  drinkingSessionData: DrinkingSessionList | null | undefined;
+
+  /** The viewed friend's preferences, used for color/unit computation */
+  preferences: Preferences;
+};
+
+function FriendDayDrillDownSheet({
+  isVisible,
+  onClose,
+  date,
+  drinkingSessionData,
+  preferences,
+}: FriendDayDrillDownSheetProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+
+  const sessions = useMemo(() => {
+    if (!date) {
+      return [];
+    }
+    const relevantData = DSUtils.getSingleDayDrinkingSessions(
+      dateStringToDate(date),
+      drinkingSessionData ?? undefined,
+      false,
+    ) as DrinkingSessionList;
+    return Object.entries(relevantData).map(([sessionId, session]) => ({
+      sessionId,
+      session,
+    }));
+  }, [date, drinkingSessionData]);
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      onClose={onClose}
+      type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
+      <View style={[styles.pt3, styles.pb5, {minHeight: 240, maxHeight: 560}]}>
+        <View
+          style={[
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.justifyContentBetween,
+            styles.ph4,
+            styles.mb2,
+          ]}>
+          <Text style={[styles.textHeadline, styles.flex1, styles.mr2]}>
+            {date
+              ? format(dateStringToDate(date), CONST.DATE.SHORT_DATE_FORMAT)
+              : ''}
+          </Text>
+          <PressableWithFeedback
+            accessibilityLabel={translate('common.close')}
+            accessibilityRole="button"
+            onPress={onClose}
+            style={[styles.p2]}>
+            <Icon src={KirokuIcons.Close} fill={theme.icon} />
+          </PressableWithFeedback>
+        </View>
+        {sessions.length === 0 ? (
+          <View style={[styles.flex1, styles.justifyContentCenter, styles.p5]}>
+            <Text style={[styles.textSupporting, styles.textAlignCenter]}>
+              {translate('dayOverviewScreen.noDrinkingSessions')}
+            </Text>
+          </View>
+        ) : (
+          <FlatList
+            data={sessions}
+            keyExtractor={item => String(item.sessionId)}
+            renderItem={({item}) => (
+              <DrinkingSessionOverview
+                sessionId={item.sessionId}
+                session={item.session}
+                isEditModeOn={false}
+                readOnly
+                preferences={preferences}
+              />
+            )}
+          />
+        )}
+        <View style={[styles.ph4, styles.mt2]}>
+          <Button large text={translate('common.close')} onPress={onClose} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+FriendDayDrillDownSheet.displayName = 'FriendDayDrillDownSheet';
+
+export default FriendDayDrillDownSheet;

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -18,7 +18,7 @@ import {getCommonFriendsCount} from '@libs/FriendUtils';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {DrinkingSessionArray} from '@src/types/onyx';
-import type {UserList} from '@src/types/onyx/OnyxCommon';
+import type {DateString, UserList} from '@src/types/onyx/OnyxCommon';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
@@ -39,6 +39,7 @@ import ManageFriendPopover from '@components/ManageFriendPopover';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
+import FriendDayDrillDownSheet from './FriendDayDrillDownSheet';
 
 type ProfileScreenProps = StackScreenProps<
   ProfileNavigatorParamList,
@@ -76,6 +77,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const [unitsConsumed, setUnitsConsumed] = useState(0);
   const [manageFriendModalVisible, setManageFriendModalVisible] =
     useState(false);
+  const [drillDownDate, setDrillDownDate] = useState<DateString | null>(null);
   const userData = fetchedData?.userData;
   const preferences = fetchedData?.preferences;
   const profileData = userData?.profile;
@@ -233,6 +235,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
             drinkingSessionData={drinkingSessionData}
             preferences={preferences}
             isFetchingOlderMonths={isFetchingOlderMonths}
+            onForeignDayPress={setDrillDownDate}
           />
         </View>
         <View style={[styles.flexRow, styles.justifyContentEnd]}>
@@ -249,6 +252,13 @@ function ProfileScreen({route}: ProfileScreenProps) {
         isVisible={manageFriendModalVisible}
         onClose={() => setManageFriendModalVisible(false)}
         friendId={userID}
+      />
+      <FriendDayDrillDownSheet
+        isVisible={!!drillDownDate}
+        onClose={() => setDrillDownDate(null)}
+        date={drillDownDate}
+        drinkingSessionData={drinkingSessionData}
+        preferences={preferences}
       />
     </ScreenWrapper>
   );


### PR DESCRIPTION
### Details

Tapping a calendar day on a **friend's** profile previously did nothing — `SessionsCalendar.onDayPress` returned early for non-self users (with a `// TODO display other user's sessions too` note). On the **self** profile the same tap navigates to the day overview.

This mirrors the Statistics-screen drill-down (`StatsDrillDownSheet`): tapping a friend's day opens a **bottom-docked modal** listing that day's sessions as **read-only tiles** — no navigation into the session summary (which renders private notes), no edit mode, and no add-session button.

**What changed:**
- `DrinkingSessionOverview` — added `readOnly` + optional `preferences` props. In read-only mode it renders a plain non-pressable row (units/time only, using the viewed user's color palette) with no navigation, edit, or "ongoing" buttons, so private notes are never reachable.
- `SessionsCalendar` — the foreign-user early-return now calls a new optional `onForeignDayPress(date)` callback; the self navigation path is unchanged. Fullscreen usages that don't pass the prop keep today's inert behavior.
- `FriendDayDrillDownSheet` (new) — bottom-docked modal listing the day's sessions via `DSUtils.getSingleDayDrinkingSessions` on the friend's already-fetched data.
- `ProfileScreen` — added `drillDownDate` state, wired `onForeignDayPress`, and rendered the modal.

**Privacy:** inherited for free. The visibility gate (`hide_from_all` / `hidden_from`) is enforced server-side in `database.rules.json`, so when a friend hides their data the fetch returns empty and the modal naturally shows the empty state — no client-side check needed.

No new copy was added: the modal reuses the existing `dayOverviewScreen.noDrinkingSessions` and `common.close` translation keys, and the date title reuses `CONST.DATE.SHORT_DATE_FORMAT` (matching the self day-overview header).

### Tests

1. Open your **own** profile, tap a calendar day with sessions → still navigates to the Day Overview screen (edit mode and add-session intact). _No regression._
2. Open a **friend's** profile (with visible data), tap a day that has sessions → a bottom-docked modal opens listing read-only tiles (units, and time for live sessions), colored with the friend's palette. Verify the tiles are **not** pressable and there is no edit/add button.
3. On the friend's profile, tap a day with **no** sessions → modal shows the "no drinking sessions" empty state.
4. Open a friend's profile where the friend has **hidden** their data → calendar shows 0s; tapping a day opens the modal showing the empty state (data is empty server-side).
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, open a friend's profile that was already loaded, tap a day → modal renders from cached data; no crash.
- [ ] Verify that no errors appear in the JS console

### QA Steps

1. As user A, open user B's profile (B and A are friends, B has logged sessions visible to A).
2. Tap a calendar day with sessions → confirm the read-only drill-down modal lists that day's sessions and cannot navigate into a session summary.
3. Have B hide their drinking data from A (or from all); as A, reopen B's profile and tap a day → confirm the modal shows the empty state and no session data leaks.
4. Confirm A's own profile day-tile still opens the full Day Overview with edit/add.
- [ ] Verify that no errors appear in the JS console

> [!NOTE]
> Automated checks (prettier, eslint, tsgo) pass for the changed files. Manual on-device verification of the three friend-profile cases above has **not** yet been performed — please exercise them during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)