### PR TITLE
refactor(privacy): unify Friends section wording with other sections

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -536,12 +536,10 @@ export default {
     title: 'Soukromí',
     friendsVisibilitySection: {
       title: 'Přátelé',
-      description: 'Spravujte, kteří přátelé vidí vaše data o pití.',
     },
     hideFromAllFriends: {
       label: 'Skrýt má data před všemi přáteli',
-      description:
-        'Když je zapnuto, žádný z vašich přátel neuvidí vaše relace pití. Chcete-li skrýt data jen před jedním přítelem, otevřete jeho profil a použijte Spravovat přítele.',
+      description: 'Když je zapnuto, žádný přítel neuvidí vaše relace pití.',
     },
     diagnosticsSection: {
       title: 'Diagnostika',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -538,12 +538,10 @@ export default {
     title: 'Privacy',
     friendsVisibilitySection: {
       title: 'Friends',
-      description: 'Control which friends can see your drinking data.',
     },
     hideFromAllFriends: {
       label: 'Hide my data from all friends',
-      description:
-        'When on, none of your friends can see your drinking sessions. To hide your data from just one friend instead, open their profile and use Manage Friend.',
+      description: 'When on, no friend can see your drinking sessions.',
     },
     diagnosticsSection: {
       title: 'Diagnostics',

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -163,10 +163,6 @@ function PrivacyScreen() {
         <Section
           title={translate('privacyScreen.friendsVisibilitySection.title')}
           titleStyles={styles.generalSectionTitle}
-          subtitle={translate(
-            'privacyScreen.friendsVisibilitySection.description',
-          )}
-          subtitleMuted
           isCentralPane
           childrenStyles={styles.pt3}>
           <View style={styles.sectionMenuItemTopDescription}>


### PR DESCRIPTION
### Details

The Privacy screen's Diagnostics and Location sections were already cleaned up to a consistent pattern: a `<Section>` with **only a title** (no subtitle), and each option rendered as a strong label plus **one concise supporting line**.

The Friends section was the lone holdout — it alone had a section-level subtitle (`friendsVisibilitySection.description`) *and* gave its single option a long, two-sentence description. This is both structurally inconsistent (extra subtitle) and redundant (subtitle and option description overlapped).

This PR unifies it:
- Removes the `subtitle`/`subtitleMuted` props from the Friends `<Section>` so it shows only the "Friends" title, like the other sections.
- Deletes the now-unused `friendsVisibilitySection.description` localization key.
- Trims `hideFromAllFriends.description` to a single concise line. The "Manage Friend" hint was intentionally dropped to match the one-liner style of the other options.
- Mirrors the localization changes in `en.ts` and `cs_cz.ts`.

No behavior changes — wording/layout only.

### Tests

1. Open Settings → Privacy.
2. Verify the **Friends** section shows only the "Friends" heading (no subtitle/description under it), matching the Diagnostics and Location sections.
3. Verify the single toggle reads "Hide my data from all friends" with the one-line description "When on, no friend can see your drinking sessions."
4. Switch the app language to Czech and verify the equivalent strings render correctly.

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A — static copy/layout change, no network behavior affected.

### QA Steps

1. Same as Tests above, performed on the staging build.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>