### PR TITLE
fix(modal): replace react-native-modal with a Reanimated modal (iOS backdrop flicker)

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -645,6 +645,14 @@ const CONST = {
       DELETE: 'delete',
       PRESERVE: 'preserve',
     },
+    ANIMATION_TIMING: {
+      DEFAULT_IN: 300,
+      DEFAULT_OUT: 200,
+      DEFAULT_RIGHT_DOCKED_IOS_IN: 500,
+      DEFAULT_RIGHT_DOCKED_IOS_OUT: 400,
+      FAB_IN: 350,
+      FAB_OUT: 200,
+    },
   },
   MONTHS: [
     'January',
@@ -933,6 +941,12 @@ const CONST = {
     DISABLED: 'disabled',
   },
   SELECTION_SCRAPER_HIDDEN_ELEMENT: 'selection-scrapper-hidden-element',
+  SWIPE_DIRECTION: {
+    DOWN: 'down',
+    LEFT: 'left',
+    RIGHT: 'right',
+    UP: 'up',
+  },
   SESSION_EXPIRY: 60 * 60 * 1000 * 12, // 12 hours
   SESSION: {
     TYPES: SESSION_TYPES,

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -7,9 +7,8 @@ import React, {
   useRef,
 } from 'react';
 import {View} from 'react-native';
-import ReactNativeModal from 'react-native-modal';
+import Animated from 'react-native-reanimated';
 import ColorSchemeWrapper from '@components/ColorSchemeWrapper';
-import FocusTrapForModal from '@components/FocusTrap/FocusTrapForModal';
 import useKeyboardState from '@hooks/useKeyboardState';
 import usePrevious from '@hooks/usePrevious';
 import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
@@ -19,14 +18,54 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import ComposerFocusManager from '@libs/ComposerFocusManager';
 import Overlay from '@libs/Navigation/AppNavigator/Navigators/Overlay';
-import useNativeDriver from '@libs/useNativeDriver';
 import variables from '@styles/variables';
 import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import ModalContent from './ModalContent';
 import ModalContext from './ModalContext';
+import ReanimatedModal from './ReanimatedModal';
+import type {AnimationIn, AnimationOut} from './ReanimatedModal/types';
 import type BaseModalProps from './types';
+
+const SUPPORTED_ANIMATIONS_IN: AnimationIn[] = [
+  'fadeIn',
+  'slideInUp',
+  'slideInRight',
+];
+const SUPPORTED_ANIMATIONS_OUT: AnimationOut[] = [
+  'fadeOut',
+  'slideOutDown',
+  'slideOutRight',
+];
+
+/**
+ * Coerce the broad `react-native-modal` animation value (which may also be a
+ * custom animation object, e.g. for RIGHT_DOCKED modals) into one of the
+ * keyframe animations supported by ReanimatedModal.
+ */
+function resolveAnimationIn(
+  animation: BaseModalProps['animationIn'],
+): AnimationIn {
+  if (
+    typeof animation === 'string' &&
+    SUPPORTED_ANIMATIONS_IN.includes(animation as AnimationIn)
+  ) {
+    return animation as AnimationIn;
+  }
+  return 'slideInRight';
+}
+
+function resolveAnimationOut(
+  animation: BaseModalProps['animationOut'],
+): AnimationOut {
+  if (
+    typeof animation === 'string' &&
+    SUPPORTED_ANIMATIONS_OUT.includes(animation as AnimationOut)
+  ) {
+    return animation as AnimationOut;
+  }
+  return 'slideOutRight';
+}
 
 function BaseModal(
   {
@@ -39,12 +78,9 @@ function BaseModal(
     innerContainerStyle = {},
     outerStyle,
     onModalShow = () => {},
-    propagateSwipe,
     fullscreen = true,
     animationIn,
     animationOut,
-    useNativeDriver: useNativeDriverProp,
-    useNativeDriverForBackdrop,
     hideModalContentWhileAnimating = false,
     animationInTiming,
     animationOutTiming,
@@ -249,7 +285,7 @@ function BaseModal(
         // position absolute is needed to prevent the view from interfering with flex layout
         collapsable={false}
         style={[styles.pAbsolute, {zIndex: 1}]}>
-        <ReactNativeModal
+        <ReanimatedModal
           // Prevent the parent element to capture a click. This is useful when the modal component is put inside a pressable.
           onClick={e => e.stopPropagation()}
           onBackdropPress={handleBackdropPress}
@@ -257,9 +293,15 @@ function BaseModal(
           // eslint-disable-next-line react/jsx-props-no-multi-spaces
           onBackButtonPress={Modal.closeTop}
           onModalShow={handleShowModal}
-          propagateSwipe={propagateSwipe}
           onModalHide={hideModal}
           onModalWillShow={saveFocusState}
+          onModalWillHide={() => {
+            // Reset willAlertModalBecomeVisible when modal is about to hide
+            // This ensures it's cleared before any other components check its value
+            if (Modal.areAllModalsHidden()) {
+              Modal.willAlertModalBecomeVisible(false);
+            }
+          }}
           onDismiss={handleDismissModal}
           onSwipeComplete={() => onClose?.()}
           swipeDirection={swipeDirection}
@@ -276,14 +318,10 @@ function BaseModal(
           style={modalStyle}
           deviceHeight={windowHeight}
           deviceWidth={windowWidth}
-          animationIn={animationIn ?? modalStyleAnimationIn}
-          animationOut={animationOut ?? modalStyleAnimationOut}
-          // eslint-disable-next-line react-compiler/react-compiler
-          useNativeDriver={useNativeDriverProp && useNativeDriver}
-          useNativeDriverForBackdrop={
-            // eslint-disable-next-line react-compiler/react-compiler
-            useNativeDriverForBackdrop && useNativeDriver
-          }
+          animationIn={resolveAnimationIn(animationIn ?? modalStyleAnimationIn)}
+          animationOut={resolveAnimationOut(
+            animationOut ?? modalStyleAnimationOut,
+          )}
           hideModalContentWhileAnimating={hideModalContentWhileAnimating}
           animationInTiming={animationInTiming}
           animationOutTiming={animationOutTiming}
@@ -294,26 +332,22 @@ function BaseModal(
             shouldUseCustomBackdrop ? (
               <Overlay onPress={handleBackdropPress} />
             ) : undefined
-          }>
-          <ModalContent
-            onModalWillShow={saveFocusState}
-            onDismiss={handleDismissModal}>
+          }
+          type={type}
+          initialFocus={initialFocus}
+          shouldEnableNewFocusManagement={shouldEnableNewFocusManagement}>
+          <Animated.View
+            style={[
+              styles.defaultModalContainer,
+              modalContainerStyle,
+              modalPaddingStyles,
+              !isVisible && styles.pointerEventsNone,
+            ]}
+            ref={ref}>
+            <ColorSchemeWrapper>{children}</ColorSchemeWrapper>
             <PortalHost name="modal" />
-            {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-            <FocusTrapForModal active={isVisible} initialFocus={initialFocus}>
-              <View
-                style={[
-                  styles.defaultModalContainer,
-                  modalPaddingStyles,
-                  modalContainerStyle,
-                  !isVisible && styles.pointerEventsNone,
-                ]}
-                ref={ref}>
-                <ColorSchemeWrapper>{children}</ColorSchemeWrapper>
-              </View>
-            </FocusTrapForModal>
-          </ModalContent>
-        </ReactNativeModal>
+          </Animated.View>
+        </ReanimatedModal>
       </View>
     </ModalContext.Provider>
   );

--- a/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Animated, {Keyframe} from 'react-native-reanimated';
+import type {BackdropProps} from '@components/Modal/ReanimatedModal/types';
+import {
+  getModalInAnimation,
+  getModalOutAnimation,
+} from '@components/Modal/ReanimatedModal/utils';
+import {PressableWithoutFeedback} from '@components/Pressable';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+
+function Backdrop({
+  style,
+  customBackdrop,
+  onBackdropPress,
+  animationInTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_IN,
+  animationOutTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_OUT,
+  backdropOpacity = variables.overlayOpacity,
+}: BackdropProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  const Entering = new Keyframe(getModalInAnimation('fadeIn')).duration(
+    animationInTiming,
+  );
+  const Exiting = new Keyframe(getModalOutAnimation('fadeOut')).duration(
+    animationOutTiming,
+  );
+
+  const BackdropOverlay = (
+    <Animated.View
+      entering={Entering}
+      exiting={Exiting}
+      style={[styles.modalBackdrop, {opacity: backdropOpacity}, style]}>
+      {!!customBackdrop && customBackdrop}
+    </Animated.View>
+  );
+
+  if (!customBackdrop) {
+    return (
+      <PressableWithoutFeedback
+        accessible
+        accessibilityLabel={translate('modal.backdropLabel')}
+        onPressIn={onBackdropPress}>
+        {BackdropOverlay}
+      </PressableWithoutFeedback>
+    );
+  }
+
+  return BackdropOverlay;
+}
+
+export default Backdrop;

--- a/src/components/Modal/ReanimatedModal/Backdrop/index.web.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.web.tsx
@@ -1,0 +1,86 @@
+import React, {useMemo} from 'react';
+import {View} from 'react-native';
+import Animated, {Keyframe, ReduceMotion} from 'react-native-reanimated';
+import type {BackdropProps} from '@components/Modal/ReanimatedModal/types';
+import {
+  getModalInAnimation,
+  getModalOutAnimation,
+} from '@components/Modal/ReanimatedModal/utils';
+import {PressableWithoutFeedback} from '@components/Pressable';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+
+function Backdrop({
+  style,
+  customBackdrop,
+  onBackdropPress,
+  animationInTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_IN,
+  animationOutTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_OUT,
+  isBackdropVisible,
+  backdropOpacity = variables.overlayOpacity,
+}: BackdropProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  const Entering = useMemo(() => {
+    if (!backdropOpacity) {
+      return;
+    }
+    const FadeIn = new Keyframe(getModalInAnimation('fadeIn'));
+    return FadeIn.duration(animationInTiming).reduceMotion(ReduceMotion.Never);
+  }, [animationInTiming, backdropOpacity]);
+
+  const Exiting = useMemo(() => {
+    if (!backdropOpacity) {
+      return;
+    }
+    const FadeOut = new Keyframe(getModalOutAnimation('fadeOut'));
+    return FadeOut.duration(animationOutTiming).reduceMotion(
+      ReduceMotion.Never,
+    );
+  }, [animationOutTiming, backdropOpacity]);
+
+  const backdropStyle = useMemo(
+    () => ({
+      opacity: backdropOpacity,
+    }),
+    [backdropOpacity],
+  );
+
+  if (!customBackdrop) {
+    return (
+      <PressableWithoutFeedback
+        accessible
+        accessibilityLabel={translate('modal.backdropLabel')}
+        onPress={onBackdropPress}
+        style={[styles.userSelectNone, styles.cursorAuto]}
+        dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}>
+        {isBackdropVisible && (
+          <Animated.View
+            style={[styles.modalBackdrop, backdropStyle, style]}
+            entering={Entering}
+            exiting={Exiting}
+          />
+        )}
+      </PressableWithoutFeedback>
+    );
+  }
+  return (
+    isBackdropVisible && (
+      <View
+        style={[styles.userSelectNone]}
+        dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}>
+        <Animated.View
+          entering={Entering}
+          exiting={Exiting}
+          style={[styles.modalBackdrop, backdropStyle, style]}>
+          {!!customBackdrop && customBackdrop}
+        </Animated.View>
+      </View>
+    )
+  );
+}
+
+export default Backdrop;

--- a/src/components/Modal/ReanimatedModal/Container/GestureHandler.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/GestureHandler.tsx
@@ -1,0 +1,101 @@
+import type {PropsWithChildren} from 'react';
+import React, {useMemo} from 'react';
+import type {
+  GestureStateChangeEvent,
+  GestureType,
+  PanGestureHandlerEventPayload,
+} from 'react-native-gesture-handler';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {useSharedValue} from 'react-native-reanimated';
+import {scheduleOnRN} from 'react-native-worklets';
+import type {
+  GestureHandlerProps,
+  SwipeDirection,
+} from '@components/Modal/ReanimatedModal/types';
+import CONST from '@src/CONST';
+
+function hasSwipeEnded(
+  e: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
+  initialPosition: {x: number; y: number},
+  swipeThreshold: number,
+  swipeDirection?: SwipeDirection | SwipeDirection[],
+  onSwipeComplete?: () => void,
+) {
+  'worklet';
+
+  if (!swipeDirection || !swipeDirection?.length || !onSwipeComplete) {
+    return;
+  }
+  const directions = Array.isArray(swipeDirection)
+    ? swipeDirection
+    : [swipeDirection];
+
+  for (const direction of directions) {
+    switch (direction) {
+      case CONST.SWIPE_DIRECTION.RIGHT:
+        if (e.translationX - initialPosition.x > swipeThreshold) {
+          scheduleOnRN(onSwipeComplete);
+        }
+        break;
+      case CONST.SWIPE_DIRECTION.LEFT:
+        if (initialPosition.x - e.translationX > swipeThreshold) {
+          scheduleOnRN(onSwipeComplete);
+        }
+        break;
+      case CONST.SWIPE_DIRECTION.UP:
+        if (initialPosition.y - e.translationY > swipeThreshold) {
+          scheduleOnRN(onSwipeComplete);
+        }
+        break;
+      case CONST.SWIPE_DIRECTION.DOWN:
+        if (e.translationY - initialPosition.y > swipeThreshold) {
+          scheduleOnRN(onSwipeComplete);
+        }
+        break;
+      default:
+        throw new Error('Unknown swipe direction');
+    }
+  }
+}
+
+function GestureHandler({
+  swipeDirection,
+  onSwipeComplete,
+  swipeThreshold = 100,
+  children,
+}: PropsWithChildren<GestureHandlerProps>) {
+  const initialTranslationX = useSharedValue(0);
+  const initialTranslationY = useSharedValue(0);
+  const panGesture: GestureType = useMemo(
+    () =>
+      Gesture.Pan()
+        .onStart(e => {
+          initialTranslationX.set(e.translationX);
+          initialTranslationY.set(e.translationY);
+        })
+        .onEnd(e => {
+          hasSwipeEnded(
+            e,
+            {x: initialTranslationX.get(), y: initialTranslationY.get()},
+            swipeThreshold,
+            swipeDirection,
+            onSwipeComplete,
+          );
+        }),
+    [
+      initialTranslationX,
+      initialTranslationY,
+      onSwipeComplete,
+      swipeDirection,
+      swipeThreshold,
+    ],
+  );
+
+  if (!swipeDirection || !swipeDirection?.length || !onSwipeComplete) {
+    return children;
+  }
+
+  return <GestureDetector gesture={panGesture}>{children}</GestureDetector>;
+}
+
+export default GestureHandler;

--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -50,7 +50,12 @@ function Container({
 
   return (
     <View
-      style={style}
+      // `flex1` fills the RN Modal's content area so each modal type's own
+      // `justifyContent`/`alignItems` (from `style`) can position the sheet —
+      // e.g. BOTTOM_DOCKED's `flex-end` docks it to the bottom. react-native-modal
+      // provided this implicit fill before the migration. `style` is spread after
+      // so a type that sets its own size still wins.
+      style={[styles.flex1, style]}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}>
       <GestureHandler

--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -1,0 +1,74 @@
+import React, {useMemo} from 'react';
+import {View} from 'react-native';
+import Animated, {Keyframe} from 'react-native-reanimated';
+import {scheduleOnRN} from 'react-native-worklets';
+import type ReanimatedModalProps from '@components/Modal/ReanimatedModal/types';
+import type {ContainerProps} from '@components/Modal/ReanimatedModal/types';
+import {
+  getModalInAnimation,
+  getModalOutAnimation,
+} from '@components/Modal/ReanimatedModal/utils';
+import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
+import GestureHandler from './GestureHandler';
+
+function Container({
+  style,
+  animationInTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_IN,
+  animationOutTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_OUT,
+  onCloseCallBack,
+  onOpenCallBack,
+  animationIn,
+  animationOut,
+  type,
+  onSwipeComplete,
+  swipeDirection,
+  swipeThreshold = 100,
+  ...props
+}: Partial<ReanimatedModalProps> & ContainerProps) {
+  const styles = useThemeStyles();
+
+  const Entering = useMemo(() => {
+    const AnimationIn = new Keyframe(getModalInAnimation(animationIn));
+
+    return AnimationIn.duration(animationInTiming).withCallback(() => {
+      'worklet';
+
+      scheduleOnRN(onOpenCallBack);
+    });
+  }, [animationIn, animationInTiming, onOpenCallBack]);
+
+  const Exiting = useMemo(() => {
+    const AnimationOut = new Keyframe(getModalOutAnimation(animationOut));
+
+    return AnimationOut.duration(animationOutTiming).withCallback(() => {
+      'worklet';
+
+      scheduleOnRN(onCloseCallBack);
+    });
+  }, [animationOutTiming, onCloseCallBack, animationOut]);
+
+  return (
+    <View
+      style={style}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}>
+      <GestureHandler
+        swipeThreshold={swipeThreshold}
+        swipeDirection={swipeDirection}
+        onSwipeComplete={onSwipeComplete}>
+        <Animated.View
+          style={[
+            styles.modalAnimatedContainer,
+            type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED && styles.flex1,
+          ]}
+          entering={Entering}
+          exiting={Exiting}>
+          {props.children}
+        </Animated.View>
+      </GestureHandler>
+    </View>
+  );
+}
+
+export default Container;

--- a/src/components/Modal/ReanimatedModal/Container/index.web.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.web.tsx
@@ -71,6 +71,10 @@ function Container({
   return (
     <Animated.View
       style={[
+        // Fill the modal area so each type's own justifyContent/alignItems
+        // (from `style`) can position the sheet, matching the implicit flex
+        // react-native-modal applied before the migration.
+        styles.flex1,
         style,
         type !== CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED &&
           type !== CONST.MODAL.MODAL_TYPE.POPOVER &&

--- a/src/components/Modal/ReanimatedModal/Container/index.web.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.web.tsx
@@ -1,0 +1,89 @@
+import React, {useEffect, useMemo} from 'react';
+import Animated, {
+  Keyframe,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import type ReanimatedModalProps from '@components/Modal/ReanimatedModal/types';
+import type {ContainerProps} from '@components/Modal/ReanimatedModal/types';
+import {
+  easing,
+  getModalInAnimationStyle,
+  getModalOutAnimation,
+} from '@components/Modal/ReanimatedModal/utils';
+import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
+
+function Container({
+  style,
+  animationIn,
+  animationOut,
+  animationInTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_IN,
+  animationOutTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_OUT,
+  onOpenCallBack,
+  onCloseCallBack,
+  type,
+  ...props
+}: ReanimatedModalProps & ContainerProps) {
+  const styles = useThemeStyles();
+  const initProgress = useSharedValue(0);
+  const isInitiated = useSharedValue(false);
+
+  useEffect(() => {
+    if (isInitiated.get()) {
+      return;
+    }
+    isInitiated.set(true);
+    initProgress.set(
+      withTiming(
+        1,
+        {
+          duration: animationInTiming,
+          easing,
+          // on web the callbacks are not called when animations are disabled with the reduced motion setting on
+          // we enable the animations to make sure they are called
+          reduceMotion: ReduceMotion.Never,
+        },
+        onOpenCallBack,
+      ),
+    );
+  }, [animationInTiming, onOpenCallBack, initProgress, isInitiated]);
+
+  // instead of an entering transition since keyframe animations break keyboard on mWeb Chrome (#62799)
+  const animatedStyles = useAnimatedStyle(
+    () => getModalInAnimationStyle(animationIn)(initProgress.get()),
+    [initProgress],
+  );
+
+  const Exiting = useMemo(
+    () =>
+      new Keyframe(getModalOutAnimation(animationOut))
+        .duration(animationOutTiming)
+        .withCallback(() => onCloseCallBack())
+        // on web the callbacks are not called when animations are disabled with the reduced motion setting on
+        // we enable the animations to make sure they are called
+        .reduceMotion(ReduceMotion.Never),
+    [animationOutTiming, animationOut, onCloseCallBack],
+  );
+
+  return (
+    <Animated.View
+      style={[
+        style,
+        type !== CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED &&
+          type !== CONST.MODAL.MODAL_TYPE.POPOVER &&
+          styles.modalAnimatedContainer,
+        animatedStyles,
+        {zIndex: 1},
+      ]}
+      exiting={Exiting}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}>
+      {props.children}
+    </Animated.View>
+  );
+}
+
+export default Container;

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -1,0 +1,275 @@
+import noop from 'lodash/noop';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import type {NativeEventSubscription, ViewStyle} from 'react-native';
+// eslint-disable-next-line no-restricted-imports
+import {
+  BackHandler,
+  InteractionManager,
+  Modal,
+  StyleSheet,
+  View,
+} from 'react-native';
+import {LayoutAnimationConfig} from 'react-native-reanimated';
+import FocusTrapForModal from '@components/FocusTrap/FocusTrapForModal';
+import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
+import blurActiveElement from '@libs/Accessibility/blurActiveElement';
+import getPlatform from '@libs/getPlatform';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+import Backdrop from './Backdrop';
+import Container from './Container';
+import type ReanimatedModalProps from './types';
+
+function ReanimatedModal({
+  testID,
+  animationInDelay,
+  animationInTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_IN,
+  animationOutTiming = CONST.MODAL.ANIMATION_TIMING.DEFAULT_OUT,
+  animationIn = 'fadeIn',
+  animationOut = 'fadeOut',
+  avoidKeyboard = false,
+  coverScreen = true,
+  children,
+  hasBackdrop = true,
+  backdropColor = 'black',
+  backdropOpacity = variables.overlayOpacity,
+  customBackdrop = null,
+  isVisible = false,
+  onModalWillShow = noop,
+  onModalShow = noop,
+  onModalWillHide = noop,
+  onModalHide = noop,
+  onDismiss,
+  onBackdropPress = noop,
+  onBackButtonPress = noop,
+  style,
+  type,
+  statusBarTranslucent = false,
+  onSwipeComplete,
+  swipeDirection,
+  swipeThreshold,
+  shouldPreventScrollOnFocus,
+  initialFocus,
+  shouldIgnoreBackHandlerDuringTransition = false,
+  shouldEnableNewFocusManagement,
+  shouldReturnFocus,
+  ...props
+}: ReanimatedModalProps) {
+  const [isVisibleState, setIsVisibleState] = useState(isVisible);
+  const [isContainerOpen, setIsContainerOpen] = useState(false);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const {windowWidth, windowHeight} = useWindowDimensions();
+
+  const backHandlerListener = useRef<NativeEventSubscription | null>(null);
+  const handleRef = useRef<number | undefined>(undefined);
+
+  const styles = useThemeStyles();
+
+  const onBackButtonPressHandler = useCallback(() => {
+    if (shouldIgnoreBackHandlerDuringTransition && isTransitioning) {
+      return false;
+    }
+    if (isVisibleState) {
+      onBackButtonPress();
+      return true;
+    }
+    return false;
+  }, [
+    isVisibleState,
+    onBackButtonPress,
+    isTransitioning,
+    shouldIgnoreBackHandlerDuringTransition,
+  ]);
+
+  const handleEscape = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || onBackButtonPressHandler() !== true) {
+        return;
+      }
+      e.stopImmediatePropagation();
+    },
+    [onBackButtonPressHandler],
+  );
+
+  useEffect(() => {
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      document.body.addEventListener('keyup', handleEscape, {capture: true});
+    } else {
+      backHandlerListener.current = BackHandler.addEventListener(
+        'hardwareBackPress',
+        onBackButtonPressHandler,
+      );
+    }
+
+    return () => {
+      if (getPlatform() === CONST.PLATFORM.WEB) {
+        document.body.removeEventListener('keyup', handleEscape, {
+          capture: true,
+        });
+      } else {
+        backHandlerListener.current?.remove();
+      }
+    };
+  }, [handleEscape, onBackButtonPressHandler]);
+
+  useEffect(
+    () => () => {
+      if (handleRef.current) {
+        InteractionManager.clearInteractionHandle(handleRef.current);
+      }
+
+      setIsVisibleState(false);
+      setIsContainerOpen(false);
+    },
+
+    [],
+  );
+
+  useEffect(() => {
+    if (isVisible && !isContainerOpen && !isTransitioning) {
+      handleRef.current = InteractionManager.createInteractionHandle();
+      onModalWillShow();
+
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsVisibleState(true);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsTransitioning(true);
+    } else if (!isVisible && isContainerOpen && !isTransitioning) {
+      handleRef.current = InteractionManager.createInteractionHandle();
+      onModalWillHide();
+
+      blurActiveElement();
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsVisibleState(false);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsTransitioning(true);
+    }
+    // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+  }, [isVisible, isContainerOpen, isTransitioning]);
+
+  const backdropStyle: ViewStyle = useMemo(
+    () => ({
+      width: windowWidth,
+      height: windowHeight,
+      backgroundColor: backdropColor,
+    }),
+    [windowWidth, windowHeight, backdropColor],
+  );
+
+  const onOpenCallBack = useCallback(() => {
+    setIsTransitioning(false);
+    setIsContainerOpen(true);
+    if (handleRef.current) {
+      InteractionManager.clearInteractionHandle(handleRef.current);
+    }
+    onModalShow();
+  }, [onModalShow]);
+
+  const onCloseCallBack = useCallback(() => {
+    setIsTransitioning(false);
+    setIsContainerOpen(false);
+    if (handleRef.current) {
+      InteractionManager.clearInteractionHandle(handleRef.current);
+    }
+
+    // Because on Android, the Modal's onDismiss callback does not work reliably. There's a reported issue at:
+    // https://stackoverflow.com/questions/58937956/react-native-modal-ondismiss-not-invoked
+    // Therefore, we manually call onModalHide() here for Android.
+    if (getPlatform() === CONST.PLATFORM.ANDROID) {
+      onModalHide();
+    }
+  }, [onModalHide]);
+
+  const modalStyle = useMemo(
+    () => ({zIndex: StyleSheet.flatten(style)?.zIndex}),
+    [style],
+  );
+
+  const containerView = (
+    <Container
+      pointerEvents="box-none"
+      animationInTiming={animationInTiming}
+      animationOutTiming={animationOutTiming}
+      animationInDelay={animationInDelay}
+      onOpenCallBack={onOpenCallBack}
+      onCloseCallBack={onCloseCallBack}
+      animationIn={animationIn}
+      animationOut={animationOut}
+      style={style}
+      type={type}
+      onSwipeComplete={onSwipeComplete}
+      swipeDirection={swipeDirection}>
+      {children}
+    </Container>
+  );
+
+  const backdropView = (
+    <Backdrop
+      isBackdropVisible={isVisible}
+      style={backdropStyle}
+      customBackdrop={customBackdrop}
+      onBackdropPress={onBackdropPress}
+      animationInTiming={animationInTiming}
+      animationOutTiming={animationOutTiming}
+      animationInDelay={animationInDelay}
+      backdropOpacity={backdropOpacity}
+    />
+  );
+
+  if (!coverScreen && isVisibleState) {
+    return (
+      <View
+        pointerEvents="box-none"
+        style={[styles.modalBackdrop, styles.modalContainerBox]}>
+        {hasBackdrop && backdropView}
+        {containerView}
+      </View>
+    );
+  }
+  const isBackdropMounted =
+    isVisibleState ||
+    ((isTransitioning || isContainerOpen !== isVisibleState) &&
+      getPlatform() === CONST.PLATFORM.WEB);
+  const modalVisibility =
+    isVisibleState || isTransitioning || isContainerOpen !== isVisibleState;
+  return (
+    <LayoutAnimationConfig skipExiting={getPlatform() !== CONST.PLATFORM.WEB}>
+      <Modal
+        transparent
+        animationType="none"
+        visible={modalVisibility}
+        onRequestClose={onBackButtonPressHandler}
+        statusBarTranslucent={statusBarTranslucent}
+        testID={testID}
+        onDismiss={() => {
+          onDismiss?.();
+          if (getPlatform() !== CONST.PLATFORM.ANDROID) {
+            onModalHide();
+          }
+        }}
+        style={modalStyle}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}>
+        {isBackdropMounted && hasBackdrop && backdropView}
+        {avoidKeyboard ? (
+          <KeyboardAvoidingView
+            behavior="padding"
+            pointerEvents="box-none"
+            style={[style, {margin: 0}]}>
+            {isVisibleState && containerView}
+          </KeyboardAvoidingView>
+        ) : (
+          <FocusTrapForModal
+            active={modalVisibility}
+            initialFocus={initialFocus}>
+            {isVisibleState && containerView}
+          </FocusTrapForModal>
+        )}
+      </Modal>
+    </LayoutAnimationConfig>
+  );
+}
+
+export default ReanimatedModal;

--- a/src/components/Modal/ReanimatedModal/types.ts
+++ b/src/components/Modal/ReanimatedModal/types.ts
@@ -1,0 +1,226 @@
+import type {FocusTrapProps} from 'focus-trap-react';
+import type {ReactNode} from 'react';
+import type {
+  NativeSyntheticEvent,
+  StyleProp,
+  ViewProps,
+  ViewStyle,
+} from 'react-native';
+import type {SharedValue} from 'react-native-reanimated';
+import type {ValueOf} from 'type-fest';
+import type CONST from '@src/CONST';
+
+type FocusTrapOptions = Exclude<FocusTrapProps['focusTrapOptions'], undefined>;
+
+type GestureProps = {
+  /** Height of the device (used for positioning) */
+  deviceHeight?: number | null;
+
+  /** Width of the device (used for positioning) */
+  deviceWidth?: number | null;
+};
+
+type SwipeDirection = ValueOf<typeof CONST.SWIPE_DIRECTION>;
+
+type GestureHandlerProps = {
+  /** Callback to be fired on swipe gesture. */
+  onSwipeComplete?: () => void;
+
+  /** Threshold for swipe gesture. Defaults to 100 in the gesture handler. */
+  swipeThreshold?: number;
+
+  /** Threshold for swipe gesture. */
+  swipeDirection?: SwipeDirection | SwipeDirection[];
+};
+
+type AnimationIn = 'fadeIn' | 'slideInUp' | 'slideInRight';
+type AnimationOut = 'fadeOut' | 'slideOutDown' | 'slideOutRight';
+
+type ReanimatedModalProps = ViewProps &
+  GestureProps &
+  GestureHandlerProps & {
+    /** Content inside the modal */
+    children: ReactNode;
+
+    /** Style applied to the modal container */
+    style?: StyleProp<ViewStyle>;
+
+    /** Callback when the modal is dismissed */
+    onDismiss?: () => void;
+
+    /** Callback when the modal is shown */
+    onShow?: () => void;
+
+    /** Whether to use hardware acceleration for animations */
+    hardwareAccelerated?: boolean;
+
+    /** Callback when device orientation changes */
+    onOrientationChange?: (
+      orientation: NativeSyntheticEvent<{
+        orientation: 'portrait' | 'landscape';
+      }>,
+    ) => void;
+
+    /** The presentation style of the modal */
+    presentationStyle?:
+      | 'fullScreen'
+      | 'pageSheet'
+      | 'formSheet'
+      | 'overFullScreen';
+
+    /** Enum for animation type when modal appears */
+    animationIn?: AnimationIn;
+
+    /** Duration of the animation when modal appears */
+    animationInTiming?: number;
+
+    /** Enum for animation type when modal disappears */
+    animationOut?: AnimationOut;
+
+    /** Duration of the animation when modal disappears */
+    animationOutTiming?: number;
+
+    /** Duration of the animation delay when modal appears */
+    animationInDelay?: number;
+
+    /** Whether to avoid keyboard overlap during modal display */
+    avoidKeyboard?: boolean;
+
+    /** Whether the modal should cover the entire screen */
+    coverScreen?: boolean;
+
+    /** Whether the modal should have a backdrop */
+    hasBackdrop?: boolean;
+
+    /** Color of the backdrop */
+    backdropColor?: string;
+
+    /** Opacity of the backdrop */
+    backdropOpacity?: number;
+
+    /** Duration of backdrop transition when modal appears */
+    backdropTransitionInTiming?: number;
+
+    /** Duration of backdrop transition when modal disappears */
+    backdropTransitionOutTiming?: number;
+
+    /** Custom component to use as the backdrop */
+    customBackdrop?: ReactNode;
+
+    /** Whether to hide modal content during animations */
+    hideModalContentWhileAnimating?: boolean;
+
+    /** Whether the modal is visible */
+    isVisible?: boolean;
+
+    /** Callback when modal has fully appeared */
+    onModalShow?: () => void;
+
+    /** Callback when modal is about to appear */
+    onModalWillShow?: () => void;
+
+    /** Callback when modal has fully disappeared */
+    onModalHide?: () => void;
+
+    /** Callback when modal is about to disappear */
+    onModalWillHide?: () => void;
+
+    /** Callback when the backdrop is pressed */
+    onBackdropPress?: () => void;
+
+    /** Callback when the back button is pressed (on Android) */
+    onBackButtonPress?: () => void;
+
+    /** Whether the status bar should be translucent when the modal is visible */
+    statusBarTranslucent?: boolean;
+
+    /** List of supported orientations for the modal */
+    supportedOrientations?: Array<
+      | 'portrait'
+      | 'portrait-upside-down'
+      | 'landscape'
+      | 'landscape-left'
+      | 'landscape-right'
+    >;
+
+    navigationBarTranslucent?: boolean;
+
+    /** Modal type */
+    type?: ValueOf<typeof CONST.MODAL.MODAL_TYPE>;
+
+    /** Whether to prevent scroll on focus */
+    shouldPreventScrollOnFocus?: boolean;
+
+    /** Whether to use a custom backdrop for the modal? (This prevents focus issues on desktop) */
+    initialFocus?: FocusTrapOptions['initialFocus'];
+
+    /**
+     * Whether the modal should enable the new focus manager.
+     * We are attempting to migrate to a new refocus manager, adding this property for gradual migration.
+     * */
+    shouldEnableNewFocusManagement?: boolean;
+
+    /**
+     * Whether the focus of the previous element before showing the modal should be returned when the modal closes.
+     */
+    shouldReturnFocus?: boolean;
+
+    /** Whether to ignore the back handler during transition */
+    shouldIgnoreBackHandlerDuringTransition?: boolean;
+  };
+
+type BackdropProps = {
+  /** Style applied to the modal backdrop */
+  style: StyleProp<ViewStyle>;
+
+  /** Custom backdrop component */
+  customBackdrop?: ReactNode;
+
+  /** Callback fired when pressing the backdrop */
+  onBackdropPress?: () => void;
+
+  /** Delay set to animation on enter */
+  animationInDelay?: number;
+
+  /** Timing of animation on enter */
+  animationInTiming?: number;
+
+  /** Timing of animation on exit */
+  animationOutTiming?: number;
+
+  /** Opacity of the backdrop */
+  backdropOpacity?: number;
+
+  /** Shows backdrop content */
+  isBackdropVisible: boolean;
+};
+
+type ContainerProps = {
+  /** This function is called by open animation callback */
+  onOpenCallBack: () => void;
+
+  /** This function is called by close animation callback */
+  onCloseCallBack: () => void;
+
+  /** Position animated by pan gesture */
+  panPosition?: {
+    translateX: SharedValue<number>;
+    translateY: SharedValue<number>;
+  };
+
+  /** Animation played when modal shows */
+  animationIn: AnimationIn;
+
+  /** Animation played when modal disappears */
+  animationOut: AnimationOut;
+};
+
+export default ReanimatedModalProps;
+export type {
+  BackdropProps,
+  ContainerProps,
+  GestureHandlerProps,
+  AnimationIn,
+  AnimationOut,
+  SwipeDirection,
+};

--- a/src/components/Modal/ReanimatedModal/utils.ts
+++ b/src/components/Modal/ReanimatedModal/utils.ts
@@ -1,0 +1,98 @@
+import type {ViewStyle} from 'react-native';
+import {Easing} from 'react-native-reanimated';
+import type {ValidKeyframeProps} from 'react-native-reanimated/lib/typescript/commonTypes';
+import variables from '@styles/variables';
+import type {AnimationIn, AnimationOut} from './types';
+
+const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0).factory();
+
+function getModalInAnimation(animationType: AnimationIn): ValidKeyframeProps {
+  switch (animationType) {
+    case 'slideInRight':
+      return {
+        from: {transform: [{translateX: '100%'}]},
+        to: {
+          transform: [{translateX: '0%'}],
+          easing,
+        },
+      };
+    case 'slideInUp':
+      return {
+        from: {transform: [{translateY: '100%'}]},
+        to: {
+          transform: [{translateY: '0%'}],
+          easing,
+        },
+      };
+    case 'fadeIn':
+      return {
+        from: {opacity: 0},
+        to: {
+          opacity: variables.overlayOpacity,
+          easing,
+        },
+      };
+    default:
+      throw new Error('Unknown animation type');
+  }
+}
+
+/**
+ * @returns A function that takes a number between 0 and 1 and returns a ViewStyle object.
+ */
+function getModalInAnimationStyle(
+  animationType: AnimationIn,
+): (progress: number) => ViewStyle {
+  switch (animationType) {
+    case 'slideInRight':
+      return progress => ({
+        transform: [{translateX: `${100 * (1 - progress)}%`}],
+      });
+    case 'slideInUp':
+      return progress => ({
+        transform: [{translateY: `${100 * (1 - progress)}%`}],
+      });
+    case 'fadeIn':
+      return progress => ({opacity: progress});
+    default:
+      throw new Error('Unknown animation type');
+  }
+}
+
+function getModalOutAnimation(animationType: AnimationOut): ValidKeyframeProps {
+  switch (animationType) {
+    case 'slideOutRight':
+      return {
+        from: {transform: [{translateX: '0%'}]},
+        to: {
+          transform: [{translateX: '100%'}],
+          easing,
+        },
+      };
+    case 'slideOutDown':
+      return {
+        from: {transform: [{translateY: '0%'}]},
+        to: {
+          transform: [{translateY: '100%'}],
+          easing,
+        },
+      };
+    case 'fadeOut':
+      return {
+        from: {opacity: variables.overlayOpacity},
+        to: {
+          opacity: 0,
+          easing,
+        },
+      };
+    default:
+      throw new Error('Unknown animation type');
+  }
+}
+
+export {
+  getModalInAnimation,
+  getModalOutAnimation,
+  getModalInAnimationStyle,
+  easing,
+};

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -261,6 +261,9 @@ export default {
     blackout: 'Výpadek paměti',
     timezone: 'Časové pásmo',
   },
+  modal: {
+    backdropLabel: 'Zavřít',
+  },
   calendar: {
     monthNames: [
       'Leden',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -263,6 +263,9 @@ export default {
     blackout: 'Blackout',
     timezone: 'Timezone',
   },
+  modal: {
+    backdropLabel: 'Close',
+  },
   calendar: {
     monthNames: [
       'January',

--- a/src/libs/Accessibility/blurActiveElement/index.native.ts
+++ b/src/libs/Accessibility/blurActiveElement/index.native.ts
@@ -1,0 +1,3 @@
+const blurActiveElement = () => {};
+
+export default blurActiveElement;

--- a/src/libs/Accessibility/blurActiveElement/index.ts
+++ b/src/libs/Accessibility/blurActiveElement/index.ts
@@ -1,0 +1,8 @@
+const blurActiveElement = () => {
+  if (!(document.activeElement instanceof HTMLElement)) {
+    return;
+  }
+  document.activeElement.blur();
+};
+
+export default blurActiveElement;

--- a/src/screens/Settings/AppShareScreen.tsx
+++ b/src/screens/Settings/AppShareScreen.tsx
@@ -115,14 +115,8 @@ function AppShareScreen({route}: AppShareScreenProps) {
         isVisible={isQrModalVisible}
         onClose={onClose}
         type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
-        <View
-          style={[
-            styles.alignItemsCenter,
-            styles.justifyContentCenter,
-            styles.m5,
-            styles.mnh60,
-          ]}>
-          <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
+        <View style={[styles.alignItemsCenter, styles.m5]}>
+          <View style={styles.justifyContentCenter}>
             <Image
               source={KirokuIcons.KirokuQrCode}
               style={[

--- a/src/screens/Settings/AppShareScreen.tsx
+++ b/src/screens/Settings/AppShareScreen.tsx
@@ -115,7 +115,7 @@ function AppShareScreen({route}: AppShareScreenProps) {
         isVisible={isQrModalVisible}
         onClose={onClose}
         type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
-        <View style={[styles.alignItemsCenter, styles.m5]}>
+        <View style={[styles.alignItemsCenter, styles.m5, styles.mb0]}>
           <View style={styles.justifyContentCenter}>
             <Image
               source={KirokuIcons.KirokuQrCode}

--- a/src/screens/Settings/AppShareScreen.tsx
+++ b/src/screens/Settings/AppShareScreen.tsx
@@ -110,38 +110,38 @@ function AppShareScreen({route}: AppShareScreenProps) {
             </View>
           </Section>
         </View>
-        <Modal
-          isVisible={isQrModalVisible}
-          onClose={onClose}
-          type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
-          <View
-            style={[
-              styles.alignItemsCenter,
-              styles.justifyContentCenter,
-              styles.m5,
-              styles.mnh60,
-            ]}>
-            <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
-              <Image
-                source={KirokuIcons.KirokuQrCode}
-                style={[
-                  StyleUtils.getQrCodeSizeStyle(
-                    shouldUseNarrowLayout,
-                    windowWidth,
-                    windowHeight,
-                  ),
-                ]}
-              />
-            </View>
-            <Button
-              large
-              text={translate('common.close')}
-              style={[styles.p2, styles.mnw100]}
-              onPress={onClose}
+      </ScrollView>
+      <Modal
+        isVisible={isQrModalVisible}
+        onClose={onClose}
+        type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}>
+        <View
+          style={[
+            styles.alignItemsCenter,
+            styles.justifyContentCenter,
+            styles.m5,
+            styles.mnh60,
+          ]}>
+          <View style={[styles.flexGrow1, styles.justifyContentCenter]}>
+            <Image
+              source={KirokuIcons.KirokuQrCode}
+              style={[
+                StyleUtils.getQrCodeSizeStyle(
+                  shouldUseNarrowLayout,
+                  windowWidth,
+                  windowHeight,
+                ),
+              ]}
             />
           </View>
-        </Modal>
-      </ScrollView>
+          <Button
+            large
+            text={translate('common.close')}
+            style={[styles.p2, styles.mnw100]}
+            onPress={onClose}
+          />
+        </View>
+      </Modal>
     </ScreenWrapper>
   );
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -888,6 +888,23 @@ const styles = (theme: ThemeColors) =>
       borderColor: theme.transparent,
     },
 
+    modalAnimatedContainer: {width: '100%'},
+
+    modalContainerBox: {
+      zIndex: 2,
+      opacity: 1,
+      backgroundColor: 'transparent',
+    },
+
+    modalBackdrop: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: 'black',
+    },
+
     displayNameTooltipEllipsis: {
       position: 'absolute',
       opacity: 0,


### PR DESCRIPTION
### Details

**Problem.** On iOS the dimmed backdrop flickers (appears to "darken throughout the slide") during a modal's hide animation. This is general to the shared `Modal` component.

**Root cause.** It's a bug *inside* the `react-native-modal` library: it animates the backdrop opacity **imperatively** via `react-native-animatable`'s `transitionTo()`, which doesn't paint reliably on iOS (New Architecture/Fabric). No prop combination fixes it — we tried `backdropTransitionOutTiming`, `useNativeDriverForBackdrop`, and `hideModalContentWhileAnimating`, individually and combined; none worked, confirming the bug is in the library's animation engine, not its configuration.

**How Expensify solved it (we diffed `../Expensify`).** They removed `react-native-modal` entirely and wrote their own `ReanimatedModal` built on `react-native-reanimated`, where the backdrop fades via **declarative `entering`/`exiting` Keyframe animations on the UI thread** — symmetric on open and close, no imperative `transitionTo`, no flicker.

**This PR ports that approach into Kiroku.**
- New `src/components/Modal/ReanimatedModal/` — `index.tsx`, `types.ts`, `utils.ts`, `Backdrop/` (native + web), `Container/` (native + web) + `GestureHandler.tsx`.
- `BaseModal.tsx` now renders `<ReanimatedModal>` instead of `<ReactNativeModal>`. **All existing behavior is preserved**: Onyx modal-state (`setModalVisibility`/`willAlertModalBecomeVisible`/`closeTop`/`onModalDidClose`/`areAllModalsHidden`), `ComposerFocusManager` focus logic, `getModalStyles`/padding, keyboard handling, `ModalContext`, and the `collapsable={false}` new-arch wrapper.
- Supporting additions: `CONST.MODAL.ANIMATION_TIMING`, `CONST.SWIPE_DIRECTION`, `styles.modalBackdrop/modalContainerBox/modalAnimatedContainer`, a `blurActiveElement` util (web + native), and `modal.backdropLabel` translations (en + cs).
- `react-native-modal` stays installed but is now used **only for `ModalProps` types** (ModalStyleUtils, PopoverMenu, Modal/types).

**Adaptations vs. Expensify (leaner Kiroku):** dropped `TransitionTracker` (nav-perf infra Kiroku lacks) and `sentryLabel` props; the focus trap now lives in `ReanimatedModal` (removed the redundant `ModalContent`/outer `FocusTrapForModal` wrappers in `BaseModal`). One behavioral note: Kiroku's `RIGHT_DOCKED` previously used a custom `translateX` animation object; ReanimatedModal maps it to the `slideInRight`/`slideOutRight` keyframes (visually a right-edge slide; exact offset differs slightly).

### Tests

1. On **iOS**, open a bottom-docked modal (friend profile → tap a calendar day → drill-down sheet); close it → the dim fades out smoothly in step with the sheet, **no flicker/darkening**.
2. Exercise other modal types on iOS — **popover** menus, **confirm/centered** dialogs, **right-docked** (RHP) panels: open/close animate correctly, backdrop dims/clears correctly, no flicker; pay extra attention to the right-docked slide offset.
3. **Focus**: opening a modal traps focus; closing returns focus to the prior element (web especially).
4. **Back handling**: Android hardware back and web Escape close the modal.
5. **Swipe-to-dismiss** modals (if any) still dismiss on swipe.
6. Verify Android and Web modal behavior is unchanged.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Offline, open/close a bottom-docked modal — animation unaffected by network state.
- [ ] Verify that no errors appear in the JS console

### QA Steps

1. iOS device/simulator: open/close several modal types repeatedly; confirm no backdrop flicker on hide and no regressions in focus/back/swipe.
2. Android + Web regression pass across modal types.
- [ ] Verify that no errors appear in the JS console

> [!IMPORTANT]
> This replaces the modal animation engine for **every** modal in the app. Static checks (prettier/eslint incl. react-compiler rule, tsgo) are clean, but I cannot run the app — this needs a thorough on-device pass on **iOS, Android, and Web** across modal types before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)