### PR TITLE
fix(stats): render drink-type donut as smooth arcs

### DIFF
--- a/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
+++ b/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
@@ -108,8 +108,10 @@ function arcSectorPath(
     cx + innerR * Math.cos(endAngle),
     cy + innerR * Math.sin(endAngle),
   );
-  // Inner arc, end → start (anticlockwise).
-  builder.addArc(innerRect, startDeg + sweepDeg, -sweepDeg);
+  // Inner arc, end → start (anticlockwise) — connect to current point so the
+  // outer arc, lineTo, and inner arc stay in one contour. addArc would begin a
+  // new contour, leaving the sector open and filling as triangular spikes.
+  builder.arcToOval(innerRect, startDeg + sweepDeg, -sweepDeg, false);
   builder.close();
   return builder.build();
 }


### PR DESCRIPTION
## Summary
- The "Units by drink type" donut on the Statistics → Breakdown tab rendered as jagged triangular spikes instead of smooth ring segments.
- Root cause: in `arcSectorPath` ([DrinkTypeDonut.tsx](src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx)), the inner arc used Skia's `addArc`, which **begins a new contour** rather than connecting to the current point. That left each sector's contour open; Skia auto-closes an open contour with a straight chord, which cut across the center and produced the spikes.
- Fix: use `arcToOval(innerRect, ..., forceMoveTo=false)` for the inner arc so the outer arc, `lineTo`, and inner arc stay in one contour and `close()` forms a proper ring segment.

The empty-state ring used the same helper with a full 360° sweep, where the stray chord is zero-length — which is why the empty state looked fine and masked the bug.

## Test plan
- [ ] Open Statistics → Breakdown with multiple drink types logged; confirm the donut renders as smooth arc segments (no triangular spikes).
- [ ] Tap a slice; confirm hit-testing/selection and the selected-slice caption still work.
- [ ] Confirm the empty state (no data in range) still renders the full grey ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)