### PR TITLE
fix(stats): keep donut hole when one drink type fills the ring

### DIFF
--- a/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
+++ b/src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx
@@ -101,6 +101,16 @@ function arcSectorPath(
     innerR * 2,
   );
 
+  // A full sweep (a single 100% slice, or the empty-state ring) can't be drawn
+  // as an arc sector: arcToOval treats its sweep modulo 360, so a -360 inner
+  // sweep collapses to nothing and the slice fills solid. Draw two concentric
+  // ovals with opposite winding instead — the nonzero fill rule carves the hole.
+  if (Math.abs(sweepDeg) >= 360 - 1e-3) {
+    builder.addOval(outerRect);
+    builder.addOval(innerRect, true);
+    return builder.build();
+  }
+
   // Outer arc, start → end (clockwise).
   builder.addArc(outerRect, startDeg, sweepDeg);
   // Line from outer-end to inner-end.


### PR DESCRIPTION
## Summary
Follow-up to #712. When only one drink type has data (a single 100% slice), the chart rendered as a **solid pie** instead of a donut ring. The empty-state ring was affected the same way.

Root cause: a single 100% slice sweeps a full 360°. In `arcSectorPath` ([DrinkTypeDonut.tsx](src/screens/Statistics/tabs/breakdown/DrinkTypeDonut.tsx)), the inner edge is drawn with `arcToOval(..., -360, false)`. Per Skia's `SkPathBuilder` docs, `arcToOval` treats its sweep **modulo 360**, so `-360°` collapses to `0°` — no inner arc is drawn, no hole is carved, and the slice fills solid. (The previous `addArc` happened to special-case `|sweep| >= 360` as a full oval, which is why this only surfaced after #712.)

Fix: detect a full sweep and build the ring from **two concentric ovals with opposite winding**, which reliably carves the hole under the nonzero fill rule. This also repairs the empty-state ring, which shared the same degenerate path.

## Test plan
- [ ] Statistics → Breakdown with a single drink type logged (or chip-filter to one type): confirm it renders as a **donut ring**, not a solid pie.
- [ ] Multiple drink types: confirm normal multi-slice donut still renders correctly (regression check on the partial-sector path).
- [ ] Empty state (no data in range): confirm the grey ring renders as a ring with a hole.
- [ ] Tap the single full slice: selection lift / caption still behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)