### PR TITLE
fix(stats): allow Trends tab to scroll to the bottom

### DIFF
--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -15,7 +15,7 @@ import {useStatsDrillDown} from '@src/screens/Statistics/drilldown/DrillDownCont
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     paddingHorizontal: 12,
     paddingBottom: 24,
   },


### PR DESCRIPTION
## Summary
On the Statistics → Trends tab, the page couldn't be scrolled to the bottom — the last chart card was clipped.

Root cause: the scroll content style (`styles.container` in [TrendsTab.tsx](src/screens/Statistics/tabs/TrendsTab.tsx)) applied `flex: 1` to the `ScrollView`'s `contentContainerStyle`. `flex: 1` clamps the content to exactly the viewport height, so when the stacked chart cards overflow the screen the content can't grow past it and there's nothing to scroll to. The sibling tabs (Overview, Breakdown, Patterns) all keep `flex: 1` on the ScrollView's `style` and use a padding-only `contentContainerStyle`, which is why they scroll correctly.

Fix: use `flexGrow: 1` instead. It still fills a short viewport but lets the content grow and scroll when it overflows.

## Test plan
- [ ] Statistics → Trends with enough data that the three chart cards exceed the screen height: confirm you can scroll all the way to the bottom (the `paddingBottom: 24` is reachable).
- [ ] Short-content case (little/no data): confirm the content still fills the viewport and doesn't collapse.
- [ ] Sanity-check the other Statistics tabs still scroll normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)