### PR TITLE
fix(stats): use 24h hour markers on Patterns charts

### DIFF
--- a/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
+++ b/src/components/Charts/DowHourHeatmap/DowHourHeatmap.tsx
@@ -45,17 +45,8 @@ const SHORT_DAY_NAMES = [
   'Sat',
 ] as const;
 
-function formatHourTick(hour: number): string {
-  if (hour === 0) {
-    return '12a';
-  }
-  if (hour === 12) {
-    return '12p';
-  }
-  const label = hour > 12 ? hour - 12 : hour;
-  const suffix = hour < 12 ? 'a' : 'p';
-  return `${label}${suffix}`;
-}
+// Hour ticks rendered below the grid — every 3 hours, 24h clock.
+const HOUR_TICKS = [0, 3, 6, 9, 12, 15, 18, 21] as const;
 
 function intensityFor(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
   if (max <= 0 || value <= 0) {
@@ -200,8 +191,8 @@ function DowHourHeatmap({
               }}
             />
           ))}
-          {/* Hour ticks below the grid at 0 / 6 / 12 / 18. */}
-          {[0, 6, 12, 18].map(hour => (
+          {/* Hour ticks below the grid — 24h clock, every 3 hours. */}
+          {HOUR_TICKS.map(hour => (
             <View
               key={`tick-${hour}`}
               pointerEvents="none"
@@ -212,9 +203,7 @@ function DowHourHeatmap({
                 width: 24,
                 alignItems: 'center',
               }}>
-              <Text style={[styles.textMicroSupporting]}>
-                {formatHourTick(hour)}
-              </Text>
+              <Text style={[styles.textMicroSupporting]}>{hour}</Text>
             </View>
           ))}
           {!hasData && emptyLabel ? (

--- a/src/components/Charts/HourPolar/HourPolar.tsx
+++ b/src/components/Charts/HourPolar/HourPolar.tsx
@@ -193,7 +193,7 @@ function HourPolar({
                   width: 48,
                   alignItems: 'center',
                 }}>
-                <Text style={[styles.textMicroSupporting]}>{hour}</Text>
+                <Text style={[styles.textLabelSupporting]}>{hour}</Text>
               </View>
             );
           })}

--- a/src/components/Charts/HourPolar/HourPolar.tsx
+++ b/src/components/Charts/HourPolar/HourPolar.tsx
@@ -12,7 +12,7 @@ type HourPolarProps = {
   /** Bucket value (units) keyed by `localHour` 0..23. Missing hours = 0. */
   buckets: ReadonlyMap<number, number>;
   accessibilityLabel: string;
-  /** Optional label for hour 12 / 0 / 6 / 18; defaults to '12 AM' etc. */
+  /** Optional 24h label for a given hour; defaults to '0:00', '15:00' etc. Used for screen-reader spoke labels. */
   labelForHour?: (hour: number) => string;
   /** Optional spoke tap. v1 wires the prop; no-op until v2-K drill-down lands. */
   onSpokePress?: (hour: number) => void;
@@ -49,17 +49,11 @@ function intensityFor(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
   return 4;
 }
 
+// Cardinal hour ticks rendered around the dial — every 3 hours, 24h clock.
+const HOUR_TICKS = [0, 3, 6, 9, 12, 15, 18, 21] as const;
+
 function defaultLabelForHour(hour: number): string {
-  if (hour === 0) {
-    return '12 AM';
-  }
-  if (hour === 12) {
-    return '12 PM';
-  }
-  if (hour < 12) {
-    return `${hour} AM`;
-  }
-  return `${hour - 12} PM`;
+  return `${hour}:00`;
 }
 
 /**
@@ -182,8 +176,8 @@ function HourPolar({
               <Path key={w.hour} path={w.path} color={w.color} />
             ))}
           </Canvas>
-          {/* Cardinal hour labels — 12 AM at top, 6 AM right, 12 PM bottom, 6 PM left. */}
-          {[0, 6, 12, 18].map(hour => {
+          {/* Cardinal hour labels — 24h clock, every 3 hours, 0 at top. */}
+          {HOUR_TICKS.map(hour => {
             const angle = -Math.PI / 2 + hour * WEDGE_RAD;
             const labelR = radius + 4;
             const lx = cx + labelR * Math.cos(angle);
@@ -199,9 +193,7 @@ function HourPolar({
                   width: 48,
                   alignItems: 'center',
                 }}>
-                <Text style={[styles.textMicroSupporting]}>
-                  {labelForHour(hour)}
-                </Text>
+                <Text style={[styles.textMicroSupporting]}>{hour}</Text>
               </View>
             );
           })}

--- a/src/screens/Statistics/drilldown/bucketToTitle.ts
+++ b/src/screens/Statistics/drilldown/bucketToTitle.ts
@@ -17,16 +17,7 @@ const DRINK_LABEL_KEY: Readonly<Record<DrinkKey, TranslationPaths>> = {
 };
 
 function formatHour(hour: number): string {
-  if (hour === 0) {
-    return '12 AM';
-  }
-  if (hour === 12) {
-    return '12 PM';
-  }
-  if (hour < 12) {
-    return `${hour} AM`;
-  }
-  return `${hour - 12} PM`;
+  return `${hour}:00`;
 }
 
 function formatDay(dateKey: string): string {


### PR DESCRIPTION
### Details

The hour-of-day polar dial and the day-of-week×hour heatmap on the Statistics → Patterns tab labeled their hour ticks in 12-hour AM/PM time at only four positions (`0/6/12/18`). This read ambiguously — `12 AM` (midnight) vs `12 PM` (noon) is a well-known source of confusion — and the coarse 6-hour spacing gave an uneven sense of the day.

This switches both charts to clean 24-hour clock numbers at every 3 hours: `0, 3, 6, 9, 12, 15, 18, 21`. The 8 ticks divide the 24-wedge polar dial and the 24-column heatmap grid evenly (every 3 wedges/cells), removing AM/PM ambiguity and reading like a 24h clock face.

- `HourPolar.tsx` — dial ticks moved to the 8-position set (`HOUR_TICKS` const); visible labels are plain 24h hour numbers; screen-reader spoke labels use `H:00`.
- `DowHourHeatmap.tsx` — axis ticks moved to the same 8 positions with plain 24h numbers; removed the old `12a/12p` `formatHourTick` helper (per-cell a11y already announces `H:00`).
- `bucketToTitle.ts` — drill-down sheet hour titles switched from `12 PM` to `H:00` so the tap-through title matches the charts.

No user-facing copy strings were added (tick labels are numeric), so no localization changes were needed.

### Tests

1. Open the app and navigate to Statistics → Patterns tab.
2. On the **Hour of day** polar chart, verify the dial labels read `0, 3, 6, 9, 12, 15, 18, 21` (clockwise from the top), evenly spaced, with no AM/PM text.
3. Tap an hour wedge and verify the drill-down sheet title shows the hour as `H:00` (e.g. `15:00`).
4. On the **Day of week × hour** heatmap, verify the bottom axis shows `0, 3, 6, 9, 12, 15, 18, 21` evenly spaced and the labels don't overlap on a narrow screen.

- [ ] Verify that no errors appear in the JS console

### Offline tests

- [ ] Verify that no errors appear in the JS console

These charts render from already-loaded local session data; behavior is identical offline.

### QA Steps

1. Navigate to Statistics → Patterns tab.
2. Confirm the hour markers on both charts use 24h time (`0`–`21`) at every-3-hour spacing.
3. Confirm tapping an hour wedge shows a drill-down titled with `H:00`.

- [ ] Verify that no errors appear in the JS console