### PR TITLE
fix(stats): keep hour-of-day petals inside the dial ring

### DIFF
--- a/src/components/Charts/HourPolar/HourPolar.tsx
+++ b/src/components/Charts/HourPolar/HourPolar.tsx
@@ -82,6 +82,9 @@ function HourPolar({
   const cx = side / 2;
   const cy = side / 2;
   const radius = Math.max(0, side / 2 - CENTER_PADDING);
+  // Petals scale to the rim circle, not the full radius, so a max-value bucket
+  // lands exactly on the ring instead of overshooting it by RIM_INSET.
+  const axisRadius = Math.max(0, radius - RIM_INSET);
 
   const maxValue = useMemo(() => {
     let max = 0;
@@ -109,7 +112,7 @@ function HourPolar({
       // Always draw a hair-thin rim wedge when intensity > 0 but ratio < some
       // floor, so a non-zero bucket is visible even with one tiny event.
       const drawRatio = intensity === 0 ? 0 : Math.max(ratio, 0.08);
-      const r = drawRatio * radius;
+      const r = drawRatio * axisRadius;
       if (r <= 0) {
         continue;
       }
@@ -132,9 +135,7 @@ function HourPolar({
       });
     }
     return out;
-  }, [buckets, cx, cy, maxValue, radius, theme.intensityRamp]);
-
-  const axisRadius = Math.max(0, radius - RIM_INSET);
+  }, [buckets, cx, cy, maxValue, axisRadius, radius, theme.intensityRamp]);
 
   const hasData = maxValue > 0;
 


### PR DESCRIPTION
### Details

In the **Patterns → Hour of day** polar chart, the highest-value petals visibly extended **beyond** the reference circle.

Root cause: a radius mismatch in `src/components/Charts/HourPolar/HourPolar.tsx`.
- The reference circle is drawn at `axisRadius = radius - RIM_INSET` (4 dp inside the full radius).
- But petal length was scaled to the full `radius` (`r = drawRatio * radius`), and `drawRatio` reaches `1.0` for the max bucket.

So any bucket at/near the maximum overshot the visible ring by `RIM_INSET`.

Fix: scale petals to `axisRadius` instead of `radius`, so a full-magnitude bucket lands exactly on the rim and nothing crosses it. `axisRadius` was hoisted above the wedge `useMemo` and added to its dependency array.

### Tests

1. Open **Your stats → Patterns** tab.
2. Inspect the **Hour of day** dial.
3. Verify the largest petal(s) terminate exactly at the grey circle and no petal extends past it.

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A — purely client-side rendering geometry; no network behavior changed.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Open **Your stats → Patterns** tab with data present.
2. Confirm every petal in the **Hour of day** dial stays within the circle, with the max-value petal touching the rim.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

</details>

<details>
<summary>iOS</summary>

</details>