### PR TITLE
feat(bac): all-session estimate with confidence band, breakdown, and decay graph

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -1032,6 +1032,10 @@ const CONST = {
       PERCENT: 'percent',
       BOTH: 'both',
     },
+    TIME_FORMAT: {
+      DURATION: 'duration',
+      CLOCK: 'clock',
+    },
   },
 
   // 6 numeric digits

--- a/src/components/Charts/BaseChart/BaseChart.tsx
+++ b/src/components/Charts/BaseChart/BaseChart.tsx
@@ -97,13 +97,14 @@ function BaseChart<TYKey extends string = 'y'>({
           ? {formatYLabel: (label: string | number) => formatY(Number(label))}
           : {}),
       };
-  // Custom axis labels need extra outset room so the leftmost Y label and edge
-  // X labels aren't clipped; keep the tighter default for unlabeled charts.
+  // Custom-axis charts inset the data symmetrically (28/28) so the plot sits
+  // centered rather than pushed right by the Y-label gutter; keep the tighter
+  // default for unlabeled charts.
   const hasCustomAxis = !hideAxes && axis !== undefined;
   const domainPadding = hideAxes
     ? 0
     : {
-        left: hasCustomAxis ? 40 : 24,
+        left: hasCustomAxis ? 28 : 24,
         right: hasCustomAxis ? 28 : 24,
         top: 16,
         bottom: 0,

--- a/src/components/Charts/BaseChart/BaseChart.tsx
+++ b/src/components/Charts/BaseChart/BaseChart.tsx
@@ -41,6 +41,7 @@ function BaseChart<TYKey extends string = 'y'>({
   emptyLabel,
   height = DEFAULT_HEIGHT,
   hideAxes = false,
+  axis,
   loading = false,
   children,
 }: BaseChartProps<TYKey>) {
@@ -75,12 +76,38 @@ function BaseChart<TYKey extends string = 'y'>({
     );
   }
 
+  // Adapt the consumer's numeric formatters to victory's `string | number`
+  // label type (BaseChart's data rows are structurally typed that way).
+  const formatX = axis?.formatXLabel;
+  const formatY = axis?.formatYLabel;
   const axisOptions = hideAxes
     ? undefined
-    : {labelColor: theme.axisLabel, lineColor: theme.axisLine};
+    : {
+        labelColor: theme.axisLabel,
+        lineColor: theme.axisLine,
+        ...(axis?.font ? {font: axis.font} : {}),
+        ...(axis?.tickCount !== undefined ? {tickCount: axis.tickCount} : {}),
+        ...(axis?.tickValues !== undefined
+          ? {tickValues: axis.tickValues}
+          : {}),
+        ...(formatX
+          ? {formatXLabel: (label: string | number) => formatX(Number(label))}
+          : {}),
+        ...(formatY
+          ? {formatYLabel: (label: string | number) => formatY(Number(label))}
+          : {}),
+      };
+  // Custom axis labels need extra outset room so the leftmost Y label and edge
+  // X labels aren't clipped; keep the tighter default for unlabeled charts.
+  const hasCustomAxis = !hideAxes && axis !== undefined;
   const domainPadding = hideAxes
     ? 0
-    : {left: 24, right: 24, top: 16, bottom: 0};
+    : {
+        left: hasCustomAxis ? 40 : 24,
+        right: hasCustomAxis ? 28 : 24,
+        top: 16,
+        bottom: 0,
+      };
 
   const resolvedYKeys =
     yKeys ?? (DEFAULT_Y_KEYS as unknown as readonly TYKey[]);

--- a/src/components/Charts/BaseChart/index.ts
+++ b/src/components/Charts/BaseChart/index.ts
@@ -1,12 +1,14 @@
 export {default as BaseChart} from './BaseChart';
 export {default as A11yOverlay} from './A11yOverlay';
 export {default as useChartTheme} from './useChartTheme';
+export {default as useChartFont} from './useChartFont';
 // Re-export Victory mark primitives so concrete chart components can draw
 // without importing `victory-native` directly (per design doc §6).
 export {Area, Bar, Line} from 'victory-native';
 export type {
   BaseChartDatum,
   BaseChartProps,
+  ChartAxisOptions,
   ChartRenderCtx,
   ChartTheme,
 } from './types';

--- a/src/components/Charts/BaseChart/types.ts
+++ b/src/components/Charts/BaseChart/types.ts
@@ -1,6 +1,25 @@
 import type {ReactNode} from 'react';
+import type {SkFont} from '@shopify/react-native-skia';
 import type {ChartBounds, PointsArray} from 'victory-native';
 import type {ChartDatum, ChartRange} from '@libs/Statistics';
+
+/**
+ * Optional axis customization forwarded to victory-native's `axisOptions`.
+ * When omitted, BaseChart's axis behavior is unchanged (no numeric labels —
+ * victory needs a `font` to render them).
+ */
+type ChartAxisOptions = {
+  /** Skia font for tick labels. Without it victory draws ticks but no numbers. */
+  font?: SkFont | null;
+  /** Approximate tick counts; victory picks nice values. */
+  tickCount?: number | {x: number; y: number};
+  /** Explicit tick positions (per-axis or a single x-array). */
+  tickValues?: number[] | {x: number[]; y: number[]};
+  /** Formats an x tick value into its label. */
+  formatXLabel?: (value: number) => string;
+  /** Formats a y tick value into its label. */
+  formatYLabel?: (value: number) => string;
+};
 
 /**
  * Theme colors a chart implementation can pull. Sourced from
@@ -62,6 +81,8 @@ type BaseChartProps<TYKey extends string = 'y'> = {
   height?: number;
   /** Suppresses axis labels, ticks, and padding. Use for inline sparklines. */
   hideAxes?: boolean;
+  /** Optional axis customization. When omitted, axis behavior is unchanged. */
+  axis?: ChartAxisOptions;
   /**
    * When true, short-circuits to a layout-faithful skeleton matching
    * `height` instead of rendering the Skia canvas. Used during the
@@ -72,4 +93,10 @@ type BaseChartProps<TYKey extends string = 'y'> = {
   children?: (ctx: ChartRenderCtx<TYKey>) => ReactNode;
 };
 
-export type {BaseChartDatum, BaseChartProps, ChartRenderCtx, ChartTheme};
+export type {
+  BaseChartDatum,
+  BaseChartProps,
+  ChartAxisOptions,
+  ChartRenderCtx,
+  ChartTheme,
+};

--- a/src/components/Charts/BaseChart/useChartFont.ts
+++ b/src/components/Charts/BaseChart/useChartFont.ts
@@ -1,0 +1,16 @@
+import {useFont} from '@shopify/react-native-skia';
+import type {SkFont} from '@shopify/react-native-skia';
+
+const CHART_FONT = require<number>('@assets/fonts/native/ExpensifyNeue-Regular.otf');
+
+/**
+ * Loads the app's brand font as a Skia `SkFont` for use in chart axis labels.
+ * victory-native renders axis tick *numbers* only when given a font; without
+ * one it draws ticks and lines but no labels. Returns `null` until the OTF
+ * asset has loaded, so callers must tolerate a font-less first render.
+ */
+function useChartFont(size = 11): SkFont | null {
+  return useFont(CHART_FONT, size);
+}
+
+export default useChartFont;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -6,7 +6,6 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
-  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,
@@ -1142,8 +1141,6 @@ export default {
         `Vystřízlivění přibližně za ${time}`,
       showDetails: 'Jak se to počítá?',
       decayChartLabel: 'Odhadovaná hladina alkoholu klesající k nule v čase',
-      decayAxes: ({unit}: BacAxesParams) =>
-        `Hodiny od teď (x) · alkohol v ${unit} (y)`,
       intro: {
         title: 'Alkokalkulačka',
         body1:

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -6,6 +6,9 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BacRangeParams,
+  BacSessionTotalParams,
+  BacSoberInParams,
   BreakdownCenterUnitsParams,
   BreakdownDrinkLabelParams,
   BreakdownPeriodParams,
@@ -1133,6 +1136,12 @@ export default {
       kg: 'kg',
       lb: 'lb',
       displayBoth: 'Obojí',
+      range: ({low, high}: BacRangeParams) => `Pravděpodobně ${low} – ${high}`,
+      soberIn: ({time}: BacSoberInParams) =>
+        `Vystřízlivění přibližně za ${time}`,
+      showDetails: 'Jak se to počítá?',
+      decayChartLabel: 'Odhadovaná hladina alkoholu klesající k nule v čase',
+      decayChartAxis: 'Hodiny od teď',
       intro: {
         title: 'Odhad alkoholu v krvi',
         body1:
@@ -1140,6 +1149,22 @@ export default {
         body2:
           'Používá Widmarkův vzorec a předpokládá rovnoměrné odbourávání alkoholu. Každé tělo je jiné, ber proto číslo jen jako orientační, nikoli jako fakt.',
         getStarted: 'Začít',
+      },
+      details: {
+        title: 'Jak se to počítá',
+        liveSession: 'Živá relace',
+        editSession: 'Upravená relace',
+        editNote:
+          'Nápoje v upravené relaci jsou zaznamenány k začátku relace, takže jejich přesné načasování není jisté.',
+        sessionTotal: ({grams, bac}: BacSessionTotalParams) =>
+          `Celkem: ${grams} g čistého alkoholu · přidává až ${bac}`,
+        bandNote:
+          'Protože některé nápoje pocházejí z upravených relací, zobrazujeme rozmezí: spodní hranice předpokládá, že byly vypity co nejdříve, horní co nejpozději.',
+        howTitle: 'Výpočet',
+        formula:
+          'Gramy alkoholu = objem (ml) × obsah alkoholu × 0,789. Hladina = gramy ÷ (váha × r × 10), kde r je 0,68 (muž), 0,55 (žena) nebo 0,615 (jiné).',
+        elimination:
+          'Tělo odbourává alkohol rovnoměrně přibližně 0,015 % za hodinu, takže odhad postupně klesá až k nule.',
       },
     },
   },

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1139,6 +1139,9 @@ export default {
       range: ({low, high}: BacRangeParams) => `Pravděpodobně ${low} – ${high}`,
       soberIn: ({time}: BacSoberInParams) =>
         `Vystřízlivění přibližně za ${time}`,
+      soberBy: ({time}: BacSoberInParams) => `Vystřízlivění v ${time}`,
+      timeDuration: 'Doba',
+      timeClock: 'Čas',
       showDetails: 'Jak se to počítá?',
       decayChartLabel: 'Odhadovaná hladina alkoholu klesající k nule v čase',
       intro: {

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -6,6 +6,7 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,
@@ -1121,7 +1122,7 @@ export default {
     },
   },
   achievementsScreen: {
-    title: 'Odhad alkoholu v krvi',
+    title: 'Alkokalkulačka',
     bac: {
       currentBac: 'Odhadovaná hladina alkoholu',
       noSession: 'Začni pít, abys viděl odhadovanou hladinu alkoholu v krvi.',
@@ -1141,9 +1142,10 @@ export default {
         `Vystřízlivění přibližně za ${time}`,
       showDetails: 'Jak se to počítá?',
       decayChartLabel: 'Odhadovaná hladina alkoholu klesající k nule v čase',
-      decayChartAxis: 'Hodiny od teď',
+      decayAxes: ({unit}: BacAxesParams) =>
+        `Hodiny od teď (x) · alkohol v ${unit} (y)`,
       intro: {
-        title: 'Odhad alkoholu v krvi',
+        title: 'Alkokalkulačka',
         body1:
           'Tento nástroj poskytuje hrubý odhad hladiny alkoholu v krvi na základě zaznamenaných nápojů, tvé váhy a pohlaví.',
         body2:

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -320,7 +320,7 @@ export default {
     profile: 'Profil',
     settings: 'Nastavení',
     achievements: 'Odznaky',
-    bac: 'Alkohol',
+    bac: 'Kalkulačka',
     statistics: 'Statistiky',
     menu: 'Menu',
   },

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1125,6 +1125,7 @@ export default {
     bac: {
       currentBac: 'Odhadovaná hladina alkoholu',
       noSession: 'Začni pít, abys viděl odhadovanou hladinu alkoholu v krvi.',
+      sober: 'Odhadovaná hladina alkoholu v krvi je nyní nulová.',
       disclaimer:
         'Toto je pouze hrubý odhad, nikoli lékařské nebo právní měření. Nikdy neřiď po požití alkoholu.',
       editDetails: 'Upravit mé údaje',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6,7 +6,6 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
-  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,
@@ -1151,8 +1150,6 @@ export default {
       soberIn: ({time}: BacSoberInParams) => `Sober in about ${time}`,
       showDetails: 'How is this calculated?',
       decayChartLabel: 'Estimated BAC declining to zero over time',
-      decayAxes: ({unit}: BacAxesParams) =>
-        `Hours from now (x) · BAC in ${unit} (y)`,
       intro: {
         title: 'BAC Estimator',
         body1:

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1135,6 +1135,7 @@ export default {
       currentBac: 'Estimated BAC',
       noSession:
         'Start a drinking session to see your estimated blood alcohol level.',
+      sober: 'Your estimated blood alcohol is back down to zero.',
       disclaimer:
         'This is a rough estimate, not a medical or legal measurement. Never drive after drinking.',
       editDetails: 'Edit my details',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6,6 +6,7 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,
@@ -1150,7 +1151,8 @@ export default {
       soberIn: ({time}: BacSoberInParams) => `Sober in about ${time}`,
       showDetails: 'How is this calculated?',
       decayChartLabel: 'Estimated BAC declining to zero over time',
-      decayChartAxis: 'Hours from now',
+      decayAxes: ({unit}: BacAxesParams) =>
+        `Hours from now (x) · BAC in ${unit} (y)`,
       intro: {
         title: 'BAC Estimator',
         body1:

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1148,6 +1148,9 @@ export default {
       displayBoth: 'Both',
       range: ({low, high}: BacRangeParams) => `Likely ${low} – ${high}`,
       soberIn: ({time}: BacSoberInParams) => `Sober in about ${time}`,
+      soberBy: ({time}: BacSoberInParams) => `Sober by ${time}`,
+      timeDuration: 'Duration',
+      timeClock: 'Clock',
       showDetails: 'How is this calculated?',
       decayChartLabel: 'Estimated BAC declining to zero over time',
       intro: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6,6 +6,9 @@ import type {
   UntilTimeParams,
 } from './types';
 import type {
+  BacRangeParams,
+  BacSessionTotalParams,
+  BacSoberInParams,
   BreakdownCenterUnitsParams,
   BreakdownDrinkLabelParams,
   BreakdownPeriodParams,
@@ -1143,6 +1146,11 @@ export default {
       kg: 'kg',
       lb: 'lb',
       displayBoth: 'Both',
+      range: ({low, high}: BacRangeParams) => `Likely ${low} – ${high}`,
+      soberIn: ({time}: BacSoberInParams) => `Sober in about ${time}`,
+      showDetails: 'How is this calculated?',
+      decayChartLabel: 'Estimated BAC declining to zero over time',
+      decayChartAxis: 'Hours from now',
       intro: {
         title: 'BAC Estimator',
         body1:
@@ -1150,6 +1158,22 @@ export default {
         body2:
           "It uses the Widmark formula and assumes a steady rate of alcohol elimination. Everyone's body is different, so treat the number as a ballpark, not a fact.",
         getStarted: 'Get started',
+      },
+      details: {
+        title: 'How this is calculated',
+        liveSession: 'Live session',
+        editSession: 'Edited session',
+        editNote:
+          'Drinks in an edited session are recorded at the session start, so their exact timing is uncertain.',
+        sessionTotal: ({grams, bac}: BacSessionTotalParams) =>
+          `Total: ${grams} g of pure alcohol · adds up to ${bac}`,
+        bandNote:
+          'Because some drinks come from edited sessions, we show a range: the low end assumes they were drunk as early as possible, the high end as late as possible.',
+        howTitle: 'The math',
+        formula:
+          'Grams of alcohol = volume (ml) × ABV × 0.789. BAC = grams ÷ (weight × r × 10), where r is 0.68 (male), 0.55 (female), or 0.615 (other).',
+        elimination:
+          'Your body clears alcohol at a steady ~0.015% per hour, so the estimate drops over time until it reaches zero.',
       },
     },
   },

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -114,6 +114,10 @@ type BacRangeParams = {
   high: string;
 };
 
+type BacAxesParams = {
+  unit: string;
+};
+
 type BacSoberInParams = {
   time: string;
 };
@@ -124,6 +128,7 @@ type BacSessionTotalParams = {
 };
 
 export type {
+  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -109,7 +109,24 @@ type SupporterRenewalDateParams = {
   date: string;
 };
 
+type BacRangeParams = {
+  low: string;
+  high: string;
+};
+
+type BacSoberInParams = {
+  time: string;
+};
+
+type BacSessionTotalParams = {
+  grams: number;
+  bac: string;
+};
+
 export type {
+  BacRangeParams,
+  BacSessionTotalParams,
+  BacSoberInParams,
   BreakdownCenterUnitsParams,
   BreakdownDrinkLabelParams,
   BreakdownPeriodParams,

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -114,10 +114,6 @@ type BacRangeParams = {
   high: string;
 };
 
-type BacAxesParams = {
-  unit: string;
-};
-
 type BacSoberInParams = {
   time: string;
 };
@@ -128,7 +124,6 @@ type BacSessionTotalParams = {
 };
 
 export type {
-  BacAxesParams,
   BacRangeParams,
   BacSessionTotalParams,
   BacSoberInParams,

--- a/src/libs/BACUtils.ts
+++ b/src/libs/BACUtils.ts
@@ -323,25 +323,23 @@ function getTimeToSoberHours(bacPercent: number): number {
 /**
  * Hour-by-hour BAC decline from `bacPercent` to zero, for the decay graph.
  * Returns an empty array when already sober so callers can hide the chart.
- * X is hours from now; the series is linear (zero-order) and ends exactly at 0.
+ * X is whole hours from now (clean integer ticks); Y is BAC scaled by
+ * `unitFactor` (10 for per-mille, 1 for percent). The series is linear
+ * (zero-order) and reaches 0 at the last hour.
  */
-function buildBacDecaySeries(bacPercent: number): ChartDatum[] {
+function buildBacDecaySeries(bacPercent: number, unitFactor = 1): ChartDatum[] {
   if (bacPercent <= 0) {
     return [];
   }
-  const hoursToSober = getTimeToSoberHours(bacPercent);
-  const wholeHours = Math.floor(hoursToSober);
+  const totalHours = Math.ceil(getTimeToSoberHours(bacPercent));
   const data: ChartDatum[] = [];
-  for (let hour = 0; hour <= wholeHours; hour++) {
+  for (let hour = 0; hour <= totalHours; hour++) {
     data.push({
       x: hour,
       y: roundToTwoDecimalPlaces(
-        Math.max(0, bacPercent - ELIMINATION_RATE * hour),
+        Math.max(0, bacPercent - ELIMINATION_RATE * hour) * unitFactor,
       ),
     });
-  }
-  if (wholeHours < hoursToSober) {
-    data.push({x: roundToTwoDecimalPlaces(hoursToSober), y: 0});
   }
   return data;
 }

--- a/src/libs/BACUtils.ts
+++ b/src/libs/BACUtils.ts
@@ -1,5 +1,7 @@
+import type {ChartDatum} from '@libs/Statistics';
 import CONST from '@src/CONST';
-import type {DrinkingSession} from '@src/types/onyx';
+import type {DrinkingSession, DrinkingSessionType} from '@src/types/onyx';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
 import {getDrinkAbv, getDrinkCount, getDrinkVolumeMl} from './DrinkEntryUtils';
 import {isDrinkTypeKey} from './DrinkingSessionUtils';
 import {roundToTwoDecimalPlaces} from './NumberUtils';
@@ -17,50 +19,79 @@ const WIDMARK_FACTOR_OTHER = 0.615;
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 
-/** Sum the grams of pure ethanol across every drink event in a session. */
-function getTotalEthanolGrams(session: DrinkingSession | undefined): number {
-  const drinks = session?.drinks;
-  if (!drinks) {
-    return 0;
-  }
+/**
+ * Only sessions whose drinks could still contribute to the current BAC matter.
+ * Under zero-order elimination (0.015 %/h) even an implausibly high ~0.36%
+ * peak fully decays within ~24h, so a 24h lookback captures every realistic
+ * case while keeping the scan cheap.
+ */
+const LOOKBACK_HOURS = 24;
+const LOOKBACK_MS = LOOKBACK_HOURS * MS_PER_HOUR;
 
-  let grams = 0;
-  Object.values(drinks).forEach(drinksAtTimestamp => {
-    Object.keys(drinksAtTimestamp).forEach(key => {
-      if (!isDrinkTypeKey(key)) {
-        return;
-      }
-      const entry = drinksAtTimestamp[key];
-      const count = getDrinkCount(entry);
-      if (count <= 0) {
-        return;
-      }
-      grams +=
-        getDrinkVolumeMl(key, entry) *
-        getDrinkAbv(key, entry) *
-        ETHANOL_DENSITY *
-        count;
-    });
-  });
+/** A single drink type's contribution within one session, aggregated for display. */
+type DrinkContribution = {
+  /** The drink type key (e.g. `beer`). */
+  key: DrinkKey;
+  /** Total number of drinks of this type/volume/abv combination. */
+  count: number;
+  /** Per-drink volume in millilitres. */
+  volumeMl: number;
+  /** Per-drink ABV as a fraction (e.g. 0.05 for 5%). */
+  abv: number;
+  /** Grams of pure ethanol contributed by this row. */
+  grams: number;
+};
 
-  return grams;
-}
+/** One session's contribution to the aggregate estimate, for the breakdown modal. */
+type SessionContribution = {
+  /** Session id (or a synthetic key for the ongoing session). */
+  sessionId: string;
+  /** The session type, defaulting to `live` when unset on legacy data. */
+  type: DrinkingSessionType;
+  /** Whether drink timing is uncertain (edited session — see {@link estimateBac}). */
+  isEdit: boolean;
+  /** Session start (UNIX ms). */
+  startTime: number;
+  /** Resolved session end (UNIX ms): `end_time`, else `now` when ongoing, else `start_time`. */
+  endTime: number;
+  /** Whether the session is still in progress. */
+  ongoing: boolean;
+  /** Total grams of pure ethanol in the session. */
+  totalGrams: number;
+  /** Peak BAC this session would add at full absorption, before any decay. */
+  peakBac: number;
+  /** Per-drink-type breakdown. */
+  drinks: DrinkContribution[];
+};
 
-/** Earliest drink-event timestamp (ms) in a session, or undefined when there are none. */
-function getFirstDrinkTimestamp(
-  session: DrinkingSession | undefined,
-): number | undefined {
-  const drinks = session?.drinks;
-  if (!drinks) {
-    return undefined;
-  }
+/**
+ * Aggregate BAC estimate across every recent session.
+ *
+ * `low`/`high` form a confidence band driven by edited sessions, whose drinks
+ * are all bucketed at the session start (their real consumption time is
+ * unknown). The band collapses to a point (`low === high`) when only live
+ * sessions — which stamp each drink at its true epoch — contribute.
+ */
+type BacEstimate = {
+  /** Lower bound: edited-session drinks assumed consumed as early as plausible. */
+  low: number;
+  /** Upper bound: edited-session drinks assumed consumed as late as plausible. */
+  high: number;
+  /** Headline value: band midpoint when banded, otherwise the single point. */
+  point: number;
+  /** True when the band is non-degenerate (`high > low`). */
+  hasBand: boolean;
+  /** Per-session breakdown of what was counted. */
+  contributions: SessionContribution[];
+};
 
-  const timestamps = Object.keys(drinks)
-    .map(Number)
-    .filter(timestamp => !Number.isNaN(timestamp));
-
-  return timestamps.length > 0 ? Math.min(...timestamps) : undefined;
-}
+/** A drink increment placed on the timeline for the forward simulation. */
+type BacEvent = {
+  /** When the drink is assumed consumed (UNIX ms). */
+  timestamp: number;
+  /** BAC this drink adds at full absorption (grams / divisor). */
+  bacIncrement: number;
+};
 
 /** Widmark distribution factor for a gender string, defaulting to the averaged factor. */
 function getWidmarkFactor(gender: string | undefined): number {
@@ -73,41 +104,263 @@ function getWidmarkFactor(gender: string | undefined): number {
   return WIDMARK_FACTOR_OTHER;
 }
 
+/** Grams of pure ethanol for a single drink-type entry. */
+function gramsForEntry(
+  key: DrinkKey,
+  count: number,
+  volumeMl: number,
+  abv: number,
+): number {
+  return volumeMl * abv * ETHANOL_DENSITY * count;
+}
+
 /**
- * Current estimated BAC (g/100ml, i.e. percent) for a session, decayed to `now`
- * via the Widmark formula. Returns 0 when inputs are missing or the estimate
- * has decayed below zero.
+ * Aggregate a session's drinks into one row per (type, volume, abv) tuple.
+ * Rows with the same key but different per-event overrides stay separate so
+ * the breakdown stays faithful; the common all-defaults case collapses to one
+ * row per drink type.
  */
-function estimateBacPercent(
-  session: DrinkingSession | undefined,
+function getSessionDrinkBreakdown(
+  session: DrinkingSession,
+): DrinkContribution[] {
+  const byTuple = new Map<string, DrinkContribution>();
+
+  Object.values(session.drinks ?? {}).forEach(drinksAtTimestamp => {
+    Object.keys(drinksAtTimestamp).forEach(key => {
+      if (!isDrinkTypeKey(key)) {
+        return;
+      }
+      const entry = drinksAtTimestamp[key];
+      const count = getDrinkCount(entry);
+      if (count <= 0) {
+        return;
+      }
+      const volumeMl = getDrinkVolumeMl(key, entry);
+      const abv = getDrinkAbv(key, entry);
+      const tupleKey = `${key}|${volumeMl}|${abv}`;
+      const existing = byTuple.get(tupleKey);
+      if (existing) {
+        existing.count += count;
+        existing.grams += gramsForEntry(key, count, volumeMl, abv);
+      } else {
+        byTuple.set(tupleKey, {
+          key,
+          count,
+          volumeMl,
+          abv,
+          grams: gramsForEntry(key, count, volumeMl, abv),
+        });
+      }
+    });
+  });
+
+  return [...byTuple.values()];
+}
+
+/** Resolve the latest moment a session's drinks could matter (UNIX ms). */
+function getSessionLatestTimestamp(
+  session: DrinkingSession,
+  now: number,
+): number {
+  if (session.ongoing) {
+    return now;
+  }
+  if (session.end_time) {
+    return session.end_time;
+  }
+  const drinkTimestamps = Object.keys(session.drinks ?? {})
+    .map(Number)
+    .filter(timestamp => !Number.isNaN(timestamp));
+  return drinkTimestamps.length > 0
+    ? Math.max(...drinkTimestamps, session.start_time)
+    : session.start_time;
+}
+
+/**
+ * Walk drink events forward, accumulating BAC and applying zero-order
+ * elimination between events (floored at 0 so a sober gap correctly resets the
+ * clock), then decay from the last event to `now`. Generalises the
+ * single-session Widmark formula: with one session that never hits 0 it
+ * reduces to `totalBac - rate * hoursSinceFirstDrink`.
+ */
+function simulateCurrentBac(events: BacEvent[], now: number): number {
+  if (events.length === 0) {
+    return 0;
+  }
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+  let bac = 0;
+  let lastTimestamp = sorted[0].timestamp;
+  sorted.forEach(event => {
+    const hours = Math.max(0, (event.timestamp - lastTimestamp) / MS_PER_HOUR);
+    bac = Math.max(0, bac - ELIMINATION_RATE * hours);
+    bac += event.bacIncrement;
+    lastTimestamp = event.timestamp;
+  });
+  const hoursToNow = Math.max(0, (now - lastTimestamp) / MS_PER_HOUR);
+  return Math.max(0, bac - ELIMINATION_RATE * hoursToNow);
+}
+
+/**
+ * Estimate the current BAC across every session within the lookback window,
+ * including the live ongoing session passed in `sessions`.
+ *
+ * Edited sessions (drinks bucketed at `start_time`) produce a band: the `low`
+ * timeline places their drinks at `start_time` (most elapsed decay), the
+ * `high` timeline at the session `end_time` (least decay). Live sessions use
+ * each drink's true timestamp on both timelines, so they collapse to a point.
+ */
+function estimateBac(
+  sessions: DrinkingSession[],
   weightKg: number | undefined,
   gender: string | undefined,
   now: number = Date.now(),
-): number {
+): BacEstimate {
+  const empty: BacEstimate = {
+    low: 0,
+    high: 0,
+    point: 0,
+    hasBand: false,
+    contributions: [],
+  };
+
   if (!weightKg || weightKg <= 0) {
-    return 0;
+    return empty;
   }
 
-  const grams = getTotalEthanolGrams(session);
-  if (grams <= 0) {
-    return 0;
+  const divisor = weightKg * getWidmarkFactor(gender) * 10;
+  if (divisor <= 0) {
+    return empty;
   }
 
-  const firstDrinkTimestamp = getFirstDrinkTimestamp(session);
-  if (firstDrinkTimestamp === undefined) {
-    return 0;
-  }
+  const contributions: SessionContribution[] = [];
+  const lowEvents: BacEvent[] = [];
+  const highEvents: BacEvent[] = [];
 
-  const r = getWidmarkFactor(gender);
-  const hours = Math.max(0, (now - firstDrinkTimestamp) / MS_PER_HOUR);
-  const bac = grams / (weightKg * r * 10) - ELIMINATION_RATE * hours;
+  sessions.forEach(session => {
+    if (getSessionLatestTimestamp(session, now) < now - LOOKBACK_MS) {
+      return;
+    }
 
-  return roundToTwoDecimalPlaces(Math.max(0, bac));
+    const breakdown = getSessionDrinkBreakdown(session);
+    const totalGrams = breakdown.reduce((sum, row) => sum + row.grams, 0);
+    if (totalGrams <= 0) {
+      return;
+    }
+
+    const isEdit = session.type === CONST.SESSION.TYPES.EDIT;
+    const startTime = session.start_time;
+    const endTime = session.end_time ?? (session.ongoing ? now : startTime);
+
+    contributions.push({
+      sessionId: session.id ?? String(startTime),
+      type: session.type ?? CONST.SESSION.TYPES.LIVE,
+      isEdit,
+      startTime,
+      endTime,
+      ongoing: session.ongoing === true,
+      totalGrams,
+      peakBac: totalGrams / divisor,
+      drinks: breakdown,
+    });
+
+    Object.entries(session.drinks ?? {}).forEach(
+      ([timestampKey, drinksAtTimestamp]) => {
+        const bucketTimestamp = Number(timestampKey);
+        if (Number.isNaN(bucketTimestamp)) {
+          return;
+        }
+        let bucketGrams = 0;
+        Object.keys(drinksAtTimestamp).forEach(key => {
+          if (!isDrinkTypeKey(key)) {
+            return;
+          }
+          const entry = drinksAtTimestamp[key];
+          const count = getDrinkCount(entry);
+          if (count <= 0) {
+            return;
+          }
+          bucketGrams += gramsForEntry(
+            key,
+            count,
+            getDrinkVolumeMl(key, entry),
+            getDrinkAbv(key, entry),
+          );
+        });
+        if (bucketGrams <= 0) {
+          return;
+        }
+        const increment = bucketGrams / divisor;
+        if (isEdit) {
+          lowEvents.push({timestamp: startTime, bacIncrement: increment});
+          highEvents.push({timestamp: endTime, bacIncrement: increment});
+        } else {
+          lowEvents.push({timestamp: bucketTimestamp, bacIncrement: increment});
+          highEvents.push({
+            timestamp: bucketTimestamp,
+            bacIncrement: increment,
+          });
+        }
+      },
+    );
+  });
+
+  const low = roundToTwoDecimalPlaces(simulateCurrentBac(lowEvents, now));
+  const high = roundToTwoDecimalPlaces(simulateCurrentBac(highEvents, now));
+  const hasBand = high > low;
+  const point = hasBand ? roundToTwoDecimalPlaces((low + high) / 2) : low;
+
+  return {low, high, point, hasBand, contributions};
 }
 
-export {
-  estimateBacPercent,
-  getFirstDrinkTimestamp,
-  getTotalEthanolGrams,
-  getWidmarkFactor,
-};
+/** Hours until BAC decays to zero from the given value (zero-order). */
+function getTimeToSoberHours(bacPercent: number): number {
+  if (bacPercent <= 0) {
+    return 0;
+  }
+  return bacPercent / ELIMINATION_RATE;
+}
+
+/**
+ * Hour-by-hour BAC decline from `bacPercent` to zero, for the decay graph.
+ * Returns an empty array when already sober so callers can hide the chart.
+ * X is hours from now; the series is linear (zero-order) and ends exactly at 0.
+ */
+function buildBacDecaySeries(bacPercent: number): ChartDatum[] {
+  if (bacPercent <= 0) {
+    return [];
+  }
+  const hoursToSober = getTimeToSoberHours(bacPercent);
+  const wholeHours = Math.floor(hoursToSober);
+  const data: ChartDatum[] = [];
+  for (let hour = 0; hour <= wholeHours; hour++) {
+    data.push({
+      x: hour,
+      y: roundToTwoDecimalPlaces(
+        Math.max(0, bacPercent - ELIMINATION_RATE * hour),
+      ),
+    });
+  }
+  if (wholeHours < hoursToSober) {
+    data.push({x: roundToTwoDecimalPlaces(hoursToSober), y: 0});
+  }
+  return data;
+}
+
+/** Format a BAC percentage for display in the chosen unit. */
+function formatBac(
+  bacPercent: number,
+  displayUnit: string = CONST.BAC.DISPLAY_UNIT.PER_MILLE,
+): string {
+  const perMille = `${(bacPercent * 10).toFixed(2)}‰`;
+  const percent = `${bacPercent.toFixed(2)}%`;
+  if (displayUnit === CONST.BAC.DISPLAY_UNIT.PERCENT) {
+    return percent;
+  }
+  if (displayUnit === CONST.BAC.DISPLAY_UNIT.BOTH) {
+    return `${perMille} (${percent})`;
+  }
+  return perMille;
+}
+
+export {buildBacDecaySeries, estimateBac, formatBac, getTimeToSoberHours};
+export type {BacEstimate, DrinkContribution, SessionContribution};

--- a/src/screens/Achievements/AchievementsScreen.tsx
+++ b/src/screens/Achievements/AchievementsScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
@@ -19,7 +19,8 @@ import * as Preferences from '@userActions/Preferences';
 import * as UserData from '@userActions/UserData';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {BacDisplayUnit} from '@src/types/onyx';
+import type {BacDisplayUnit, DrinkingSession} from '@src/types/onyx';
+import BACDetailsModal from './components/BACDetailsModal';
 import BACIntroModal from './components/BACIntroModal';
 import BACQuestionnaire from './components/BACQuestionnaire';
 import BACResult from './components/BACResult';
@@ -30,15 +31,15 @@ function AchievementsScreen() {
   const theme = useTheme();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
-  const {preferences} = useDatabaseData();
+  const {preferences, drinkingSessionData} = useDatabaseData();
   const [privateData] = useOnyx(ONYXKEYS.USER_PRIVATE_DATA);
   const [ongoingSession] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
   const [isEditing, setIsEditing] = useState(false);
   const [manualIntro, setManualIntro] = useState(false);
   const [autoDismissed, setAutoDismissed] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
 
   const hasDetails = !!privateData?.weight && !!privateData?.gender;
-  const isOngoing = ongoingSession?.ongoing === true;
   const showQuestionnaire = !hasDetails || isEditing;
 
   const introSeen = preferences?.bac_intro_seen;
@@ -47,6 +48,32 @@ function AchievementsScreen() {
 
   const displayUnit =
     preferences?.bac_display_unit ?? CONST.BAC.DISPLAY_UNIT.PER_MILLE;
+
+  // The ongoing session is held separately and may not yet be in the cached
+  // list; merge by id so an already-persisted live session isn't double-counted.
+  const sessions = useMemo<DrinkingSession[]>(() => {
+    const byId: Record<string, DrinkingSession> = {
+      ...(drinkingSessionData ?? {}),
+    };
+    if (ongoingSession?.ongoing) {
+      byId[ongoingSession.id ?? 'ongoing'] = ongoingSession;
+    }
+    return Object.values(byId);
+  }, [drinkingSessionData, ongoingSession]);
+
+  const estimate = useMemo(
+    () =>
+      BACUtils.estimateBac(sessions, privateData?.weight, privateData?.gender),
+    [sessions, privateData?.weight, privateData?.gender],
+  );
+
+  const decayData = useMemo(
+    () => BACUtils.buildBacDecaySeries(estimate.point),
+    [estimate.point],
+  );
+
+  const hoursToSober = BACUtils.getTimeToSoberHours(estimate.point);
+  const hasRecentSessions = estimate.contributions.length > 0;
 
   const dismissIntro = () => {
     if (!introSeen && user) {
@@ -98,15 +125,14 @@ function AchievementsScreen() {
       ) : (
         <>
           <View style={styles.flex1}>
-            {isOngoing ? (
+            {hasRecentSessions ? (
               <BACResult
-                bacPercent={BACUtils.estimateBacPercent(
-                  ongoingSession,
-                  privateData?.weight,
-                  privateData?.gender,
-                )}
+                estimate={estimate}
+                decayData={decayData}
+                hoursToSober={hoursToSober}
                 displayUnit={displayUnit}
                 onChangeDisplayUnit={onChangeDisplayUnit}
+                onShowDetails={() => setShowDetails(true)}
               />
             ) : (
               <View
@@ -130,6 +156,13 @@ function AchievementsScreen() {
           </View>
         </>
       )}
+
+      <BACDetailsModal
+        isVisible={showDetails}
+        estimate={estimate}
+        displayUnit={displayUnit}
+        onClose={() => setShowDetails(false)}
+      />
 
       <BACIntroModal
         isVisible={showIntro}

--- a/src/screens/Achievements/AchievementsScreen.tsx
+++ b/src/screens/Achievements/AchievementsScreen.tsx
@@ -79,7 +79,9 @@ function AchievementsScreen() {
   );
 
   const hoursToSober = BACUtils.getTimeToSoberHours(estimate.point);
-  const hasRecentSessions = estimate.contributions.length > 0;
+  // Show the result only when there's a non-zero estimate; a fully decayed
+  // (sober) or absent estimate falls back to the prompt message below.
+  const hasEstimate = estimate.point > 0;
 
   const dismissIntro = () => {
     if (!introSeen && user) {
@@ -140,7 +142,7 @@ function AchievementsScreen() {
       ) : (
         <>
           <View style={styles.flex1}>
-            {hasRecentSessions ? (
+            {hasEstimate ? (
               <BACResult
                 estimate={estimate}
                 decayData={decayData}

--- a/src/screens/Achievements/AchievementsScreen.tsx
+++ b/src/screens/Achievements/AchievementsScreen.tsx
@@ -19,7 +19,11 @@ import * as Preferences from '@userActions/Preferences';
 import * as UserData from '@userActions/UserData';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {BacDisplayUnit, DrinkingSession} from '@src/types/onyx';
+import type {
+  BacDisplayUnit,
+  BacTimeFormat,
+  DrinkingSession,
+} from '@src/types/onyx';
 import BACDetailsModal from './components/BACDetailsModal';
 import BACIntroModal from './components/BACIntroModal';
 import BACQuestionnaire from './components/BACQuestionnaire';
@@ -48,6 +52,8 @@ function AchievementsScreen() {
 
   const displayUnit =
     preferences?.bac_display_unit ?? CONST.BAC.DISPLAY_UNIT.PER_MILLE;
+  const timeFormat =
+    preferences?.bac_time_format ?? CONST.BAC.TIME_FORMAT.DURATION;
 
   // The ongoing session is held separately and may not yet be in the cached
   // list; merge by id so an already-persisted live session isn't double-counted.
@@ -94,6 +100,15 @@ function AchievementsScreen() {
     );
   };
 
+  const onChangeTimeFormat = (format: BacTimeFormat) => {
+    if (format === timeFormat || !user) {
+      return;
+    }
+    Preferences.updatePreferences(db, user, {bac_time_format: format}).catch(
+      () => undefined,
+    );
+  };
+
   const onQuestionnaireSubmit = (gender: string, weightKg: number) => {
     UserData.updateBacProfile(gender, weightKg);
     setIsEditing(false);
@@ -132,6 +147,8 @@ function AchievementsScreen() {
                 hoursToSober={hoursToSober}
                 displayUnit={displayUnit}
                 onChangeDisplayUnit={onChangeDisplayUnit}
+                timeFormat={timeFormat}
+                onChangeTimeFormat={onChangeTimeFormat}
                 onShowDetails={() => setShowDetails(true)}
               />
             ) : (

--- a/src/screens/Achievements/AchievementsScreen.tsx
+++ b/src/screens/Achievements/AchievementsScreen.tsx
@@ -79,9 +79,11 @@ function AchievementsScreen() {
   );
 
   const hoursToSober = BACUtils.getTimeToSoberHours(estimate.point);
-  // Show the result only when there's a non-zero estimate; a fully decayed
-  // (sober) or absent estimate falls back to the prompt message below.
+  // Show the result only when there's a non-zero estimate. Otherwise fall back
+  // to a message: a "sober" note when recent sessions exist but have decayed to
+  // zero, or the "start a session" prompt when there's nothing recent at all.
   const hasEstimate = estimate.point > 0;
+  const hasRecentSessions = estimate.contributions.length > 0;
 
   const dismissIntro = () => {
     if (!introSeen && user) {
@@ -162,7 +164,11 @@ function AchievementsScreen() {
                   styles.ph5,
                 ]}>
                 <Text style={[styles.textAlignCenter]}>
-                  {translate('achievementsScreen.bac.noSession')}
+                  {translate(
+                    hasRecentSessions
+                      ? 'achievementsScreen.bac.sober'
+                      : 'achievementsScreen.bac.noSession',
+                  )}
                 </Text>
               </View>
             )}

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -94,24 +94,27 @@ function BACDetailsModal({
 }: BACDetailsModalProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {windowHeight} = useWindowDimensions();
+  const {windowHeight, windowWidth} = useWindowDimensions();
 
-  // Cover most of the screen but leave a sliver of the page visible behind the
-  // sheet so it reads as sliding up over the BAC screen, not a new page.
-  const sheetHeight = Math.round(windowHeight * 0.92);
+  // A centered card that sizes to its content but never grows past ~80% of the
+  // screen; the body scrolls inside the cap. Width caps on large screens.
+  const cardWidth = Math.min(windowWidth - 40, 480);
+  const cardMaxHeight = Math.round(windowHeight * 0.8);
 
   return (
     <Modal
       isVisible={isVisible}
-      type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+      type={CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
+      animationIn="zoomIn"
+      animationOut="zoomOut"
       onClose={onClose}>
-      <View style={{height: sheetHeight}}>
+      <View style={{width: cardWidth, maxHeight: cardMaxHeight}}>
         <HeaderWithBackButton
           title={translate('achievementsScreen.bac.details.title')}
           onBackButtonPress={onClose}
         />
         <ScrollView
-          style={styles.flex1}
+          style={styles.flexShrink1}
           contentContainerStyle={[styles.ph5, styles.pb5]}>
           {estimate.contributions.length === 0 ? (
             <Text style={[styles.textLabelSupporting]}>

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import {View} from 'react-native';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import Modal from '@components/Modal';
+import ScrollView from '@components/ScrollView';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {formatBac} from '@libs/BACUtils';
+import type {BacEstimate, SessionContribution} from '@libs/BACUtils';
+import {findDrinkNameTranslationKey} from '@libs/DataHandling';
+import DateUtils from '@libs/DateUtils';
+import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
+import CONST from '@src/CONST';
+import type {BacDisplayUnit} from '@src/types/onyx';
+
+type BACDetailsModalProps = {
+  /** Whether the modal is shown. */
+  isVisible: boolean;
+
+  /** The aggregate estimate, including the per-session breakdown. */
+  estimate: BacEstimate;
+
+  /** Which unit BAC contributions are displayed in. */
+  displayUnit: BacDisplayUnit;
+
+  /** Called when the user dismisses the modal. */
+  onClose: () => void;
+};
+
+function SessionBlock({
+  contribution,
+  displayUnit,
+}: {
+  contribution: SessionContribution;
+  displayUnit: BacDisplayUnit;
+}) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  const typeLabel = contribution.isEdit
+    ? translate('achievementsScreen.bac.details.editSession')
+    : translate('achievementsScreen.bac.details.liveSession');
+
+  return (
+    <View style={[styles.mb6]}>
+      <View
+        style={[
+          styles.flexRow,
+          styles.justifyContentBetween,
+          styles.alignItemsCenter,
+        ]}>
+        <Text style={[styles.textStrong]}>
+          {DateUtils.getLocalizedDay(contribution.startTime)}
+        </Text>
+        <Text style={[styles.textLabelSupporting]}>{typeLabel}</Text>
+      </View>
+
+      {contribution.isEdit ? (
+        <Text style={[styles.textLabelSupporting, styles.mb2]}>
+          {translate('achievementsScreen.bac.details.editNote')}
+        </Text>
+      ) : null}
+
+      {contribution.drinks.map(drink => (
+        <View
+          key={`${drink.key}-${drink.volumeMl}-${drink.abv}`}
+          style={[styles.flexRow, styles.justifyContentBetween, styles.mt1]}>
+          <Text style={[styles.flex1]}>
+            {`${translate(findDrinkNameTranslationKey(drink.key))} ×${drink.count}`}
+          </Text>
+          <Text style={[styles.textLabelSupporting]}>
+            {`${drink.volumeMl} ml · ${(drink.abv * 100).toFixed(1)}% · ${roundToTwoDecimalPlaces(drink.grams)} g`}
+          </Text>
+        </View>
+      ))}
+
+      <Text style={[styles.textLabelSupporting, styles.mt2]}>
+        {translate('achievementsScreen.bac.details.sessionTotal', {
+          grams: roundToTwoDecimalPlaces(contribution.totalGrams),
+          bac: formatBac(contribution.peakBac, displayUnit),
+        })}
+      </Text>
+    </View>
+  );
+}
+
+function BACDetailsModal({
+  isVisible,
+  estimate,
+  displayUnit,
+  onClose,
+}: BACDetailsModalProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      type={CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
+      onClose={onClose}
+      innerContainerStyle={{flex: 1}}>
+      <View style={styles.flex1}>
+        <HeaderWithBackButton
+          title={translate('achievementsScreen.bac.details.title')}
+          onBackButtonPress={onClose}
+        />
+        <ScrollView
+          style={styles.flex1}
+          contentContainerStyle={[styles.ph5, styles.pb5]}>
+          {estimate.contributions.length === 0 ? (
+            <Text style={[styles.textLabelSupporting]}>
+              {translate('achievementsScreen.bac.noSession')}
+            </Text>
+          ) : (
+            estimate.contributions.map(contribution => (
+              <SessionBlock
+                key={contribution.sessionId}
+                contribution={contribution}
+                displayUnit={displayUnit}
+              />
+            ))
+          )}
+
+          {estimate.hasBand ? (
+            <Text style={[styles.textLabelSupporting, styles.mb4]}>
+              {translate('achievementsScreen.bac.details.bandNote')}
+            </Text>
+          ) : null}
+
+          <Text style={[styles.textStrong, styles.mt2, styles.mb2]}>
+            {translate('achievementsScreen.bac.details.howTitle')}
+          </Text>
+          <Text style={[styles.textLabelSupporting, styles.mb2]}>
+            {translate('achievementsScreen.bac.details.formula')}
+          </Text>
+          <Text style={[styles.textLabelSupporting]}>
+            {translate('achievementsScreen.bac.details.elimination')}
+          </Text>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+BACDetailsModal.displayName = 'BACDetailsModal';
+export default BACDetailsModal;

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -6,6 +6,7 @@ import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
 import {formatBac} from '@libs/BACUtils';
 import type {BacEstimate, SessionContribution} from '@libs/BACUtils';
 import {findDrinkNameTranslationKey} from '@libs/DataHandling';
@@ -93,14 +94,18 @@ function BACDetailsModal({
 }: BACDetailsModalProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  const {windowHeight} = useWindowDimensions();
+
+  // Cover most of the screen but leave a sliver of the page visible behind the
+  // sheet so it reads as sliding up over the BAC screen, not a new page.
+  const sheetHeight = Math.round(windowHeight * 0.92);
 
   return (
     <Modal
       isVisible={isVisible}
-      type={CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
-      onClose={onClose}
-      innerContainerStyle={{flex: 1}}>
-      <View style={styles.flex1}>
+      type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+      onClose={onClose}>
+      <View style={{height: sheetHeight}}>
         <HeaderWithBackButton
           title={translate('achievementsScreen.bac.details.title')}
           onBackButtonPress={onClose}

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -96,10 +96,11 @@ function BACDetailsModal({
   const {translate} = useLocalize();
   const {windowHeight, windowWidth} = useWindowDimensions();
 
-  // A centered card that sizes to its content but never grows past ~80% of the
-  // screen; the body scrolls inside the cap. Width caps on large screens.
+  // A centered card that hugs its content. The body scrolls within an explicit
+  // maxHeight (a bounded ScrollView reliably scrolls, where flex bounds don't
+  // engage inside this content-sized modal). Width caps on large screens.
   const cardWidth = Math.min(windowWidth - 40, 480);
-  const cardMaxHeight = Math.round(windowHeight * 0.8);
+  const scrollMaxHeight = Math.round(windowHeight * 0.7);
 
   return (
     <Modal
@@ -108,7 +109,7 @@ function BACDetailsModal({
       animationIn="zoomIn"
       animationOut="zoomOut"
       onClose={onClose}>
-      <View style={{width: cardWidth, maxHeight: cardMaxHeight}}>
+      <View style={{width: cardWidth}}>
         <HeaderWithBackButton
           title={translate('achievementsScreen.bac.details.title')}
           shouldShowBackButton={false}
@@ -116,7 +117,7 @@ function BACDetailsModal({
           onCloseButtonPress={onClose}
         />
         <ScrollView
-          style={[styles.flexShrink1, {minHeight: 0}]}
+          style={{maxHeight: scrollMaxHeight}}
           contentContainerStyle={[styles.ph5, styles.pb5]}>
           {estimate.contributions.length === 0 ? (
             <Text style={[styles.textLabelSupporting]}>

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -94,22 +94,22 @@ function BACDetailsModal({
 }: BACDetailsModalProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {windowHeight, windowWidth} = useWindowDimensions();
+  const {windowHeight} = useWindowDimensions();
 
-  // A centered card that hugs its content. The body scrolls within an explicit
-  // maxHeight (a bounded ScrollView reliably scrolls, where flex bounds don't
-  // engage inside this content-sized modal). Width caps on large screens.
-  const cardWidth = Math.min(windowWidth - 40, 480);
+  // The body scrolls within an explicit maxHeight. CONFIRM is used (not
+  // CENTERED_SMALL) because it has no swipe PanResponder — that gesture would
+  // otherwise swallow the drag before the ScrollView could scroll. The card
+  // still zooms in, shows an X, and dismisses on tap-outside.
   const scrollMaxHeight = Math.round(windowHeight * 0.7);
 
   return (
     <Modal
       isVisible={isVisible}
-      type={CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
+      type={CONST.MODAL.MODAL_TYPE.CONFIRM}
       animationIn="zoomIn"
       animationOut="zoomOut"
       onClose={onClose}>
-      <View style={{width: cardWidth}}>
+      <View style={styles.w100}>
         <HeaderWithBackButton
           title={translate('achievementsScreen.bac.details.title')}
           shouldShowBackButton={false}

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -111,10 +111,12 @@ function BACDetailsModal({
       <View style={{width: cardWidth, maxHeight: cardMaxHeight}}>
         <HeaderWithBackButton
           title={translate('achievementsScreen.bac.details.title')}
-          onBackButtonPress={onClose}
+          shouldShowBackButton={false}
+          shouldShowCloseButton
+          onCloseButtonPress={onClose}
         />
         <ScrollView
-          style={styles.flexShrink1}
+          style={[styles.flexShrink1, {minHeight: 0}]}
           contentContainerStyle={[styles.ph5, styles.pb5]}>
           {estimate.contributions.length === 0 ? (
             <Text style={[styles.textLabelSupporting]}>

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -1,43 +1,59 @@
 import React from 'react';
 import {View} from 'react-native';
+import {BaseChart, Line} from '@components/Charts/BaseChart';
 import Button from '@components/Button';
 import StatItem from '@components/Items/StatItem';
+import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {formatBac} from '@libs/BACUtils';
+import type {BacEstimate} from '@libs/BACUtils';
+import type {ChartDatum} from '@libs/Statistics';
 import CONST from '@src/CONST';
 import type {BacDisplayUnit} from '@src/types/onyx';
 
 type BACResultProps = {
-  /** Estimated BAC as a percentage (g/100ml). */
-  bacPercent: number;
+  /** The aggregate BAC estimate (point + confidence band). */
+  estimate: BacEstimate;
+
+  /** Hour-by-hour BAC decline to zero; empty when already sober. */
+  decayData: ChartDatum[];
+
+  /** Hours until BAC reaches zero, for the time-to-sober label. */
+  hoursToSober: number;
 
   /** Which unit to display the estimate in. */
   displayUnit: BacDisplayUnit;
 
   /** Called when the user picks a different display unit. */
   onChangeDisplayUnit: (unit: BacDisplayUnit) => void;
+
+  /** Opens the per-session breakdown modal. */
+  onShowDetails: () => void;
 };
 
+function formatSoberDuration(hoursToSober: number): string {
+  const wholeHours = Math.floor(hoursToSober);
+  const minutes = Math.round((hoursToSober - wholeHours) * 60);
+  if (wholeHours <= 0) {
+    return `${minutes}m`;
+  }
+  return `${wholeHours}h ${minutes}m`;
+}
+
 function BACResult({
-  bacPercent,
+  estimate,
+  decayData,
+  hoursToSober,
   displayUnit,
   onChangeDisplayUnit,
+  onShowDetails,
 }: BACResultProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
 
-  const perMille = `${(bacPercent * 10).toFixed(2)}‰`;
-  const percent = `${bacPercent.toFixed(2)}%`;
-
-  let content: string;
-  if (displayUnit === CONST.BAC.DISPLAY_UNIT.PERCENT) {
-    content = percent;
-  } else if (displayUnit === CONST.BAC.DISPLAY_UNIT.BOTH) {
-    content = `${perMille} (${percent})`;
-  } else {
-    content = perMille;
-  }
+  const content = formatBac(estimate.point, displayUnit);
 
   const unitOptions: Array<{value: BacDisplayUnit; label: string}> = [
     {value: CONST.BAC.DISPLAY_UNIT.PER_MILLE, label: '‰'},
@@ -48,18 +64,35 @@ function BACResult({
     },
   ];
 
+  const showGraph = decayData.length > 1;
+
   return (
-    <View
-      style={[
-        styles.flex1,
+    <ScrollView
+      style={styles.flex1}
+      contentContainerStyle={[
         styles.alignItemsCenter,
-        styles.justifyContentCenter,
         styles.ph5,
+        styles.pt4,
+        styles.pb5,
       ]}>
       <StatItem
         header={translate('achievementsScreen.bac.currentBac')}
         content={content}
       />
+
+      {estimate.hasBand ? (
+        <Text
+          style={[
+            styles.textLabelSupporting,
+            styles.textAlignCenter,
+            styles.mt2,
+          ]}>
+          {translate('achievementsScreen.bac.range', {
+            low: formatBac(estimate.low, displayUnit),
+            high: formatBac(estimate.high, displayUnit),
+          })}
+        </Text>
+      ) : null}
 
       <View style={[styles.flexRow, styles.mt4, {gap: 8}]}>
         {unitOptions.map(option => (
@@ -73,6 +106,46 @@ function BACResult({
         ))}
       </View>
 
+      {showGraph ? (
+        <View style={[styles.alignSelfStretch, styles.mt6]}>
+          <Text
+            style={[
+              styles.textLabelSupporting,
+              styles.textAlignCenter,
+              styles.mb2,
+            ]}>
+            {translate('achievementsScreen.bac.soberIn', {
+              time: formatSoberDuration(hoursToSober),
+            })}
+          </Text>
+          <BaseChart
+            data={decayData}
+            range="allTime"
+            height={160}
+            accessibilityLabel={translate(
+              'achievementsScreen.bac.decayChartLabel',
+            )}>
+            {({points, theme}) => (
+              <Line
+                points={points.y}
+                color={theme.primaryStroke}
+                strokeWidth={2}
+              />
+            )}
+          </BaseChart>
+          <Text style={[styles.textLabelSupporting, styles.textAlignCenter]}>
+            {translate('achievementsScreen.bac.decayChartAxis')}
+          </Text>
+        </View>
+      ) : null}
+
+      <Button
+        small
+        style={[styles.mt6]}
+        text={translate('achievementsScreen.bac.showDetails')}
+        onPress={onShowDetails}
+      />
+
       <Text
         style={[
           styles.textLabelSupporting,
@@ -81,7 +154,7 @@ function BACResult({
         ]}>
         {translate('achievementsScreen.bac.disclaimer')}
       </Text>
-    </View>
+    </ScrollView>
   );
 }
 

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {View} from 'react-native';
 import {BaseChart, Line} from '@components/Charts/BaseChart';
 import Button from '@components/Button';
@@ -9,6 +9,7 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {formatBac} from '@libs/BACUtils';
 import type {BacEstimate} from '@libs/BACUtils';
+import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import type {ChartDatum} from '@libs/Statistics';
 import CONST from '@src/CONST';
 import type {BacDisplayUnit} from '@src/types/onyx';
@@ -64,7 +65,20 @@ function BACResult({
     },
   ];
 
-  const showGraph = decayData.length > 1;
+  // The decay series carries raw BAC percent; scale it to the chosen unit so
+  // the y-axis ticks match the headline number (‰ = percent × 10).
+  const isPercentUnit = displayUnit === CONST.BAC.DISPLAY_UNIT.PERCENT;
+  const yUnitLabel = isPercentUnit ? '%' : '‰';
+  const chartData = useMemo<ChartDatum[]>(
+    () =>
+      decayData.map(point => ({
+        x: point.x,
+        y: roundToTwoDecimalPlaces(point.y * (isPercentUnit ? 1 : 10)),
+      })),
+    [decayData, isPercentUnit],
+  );
+
+  const showGraph = chartData.length > 1;
 
   return (
     <ScrollView
@@ -119,9 +133,9 @@ function BACResult({
             })}
           </Text>
           <BaseChart
-            data={decayData}
+            data={chartData}
             range="allTime"
-            height={160}
+            height={180}
             accessibilityLabel={translate(
               'achievementsScreen.bac.decayChartLabel',
             )}>
@@ -134,7 +148,7 @@ function BACResult({
             )}
           </BaseChart>
           <Text style={[styles.textLabelSupporting, styles.textAlignCenter]}>
-            {translate('achievementsScreen.bac.decayChartAxis')}
+            {translate('achievementsScreen.bac.decayAxes', {unit: yUnitLabel})}
           </Text>
         </View>
       ) : null}

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
 import Button from '@components/Button';
@@ -34,6 +34,10 @@ type BACResultProps = {
   onShowDetails: () => void;
 };
 
+type TimeFormat = 'duration' | 'clock';
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
 function formatSoberDuration(hoursToSober: number): string {
   const wholeHours = Math.floor(hoursToSober);
   const minutes = Math.round((hoursToSober - wholeHours) * 60);
@@ -41,6 +45,14 @@ function formatSoberDuration(hoursToSober: number): string {
     return `${minutes}m`;
   }
   return `${wholeHours}h ${minutes}m`;
+}
+
+/** Local wall-clock time as 24h HH:MM. */
+function formatClockTime(ms: number): string {
+  const date = new Date(ms);
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
 }
 
 function BACResult({
@@ -54,8 +66,29 @@ function BACResult({
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const axisFont = useChartFont(11);
+  const [timeFormat, setTimeFormat] = useState<TimeFormat>('duration');
+  // Captured once at mount so clock labels stay stable across re-renders.
+  const [nowMs] = useState(() => Date.now());
 
   const content = formatBac(estimate.point, displayUnit);
+
+  // Time-to-sober shown either as a remaining duration or an absolute clock
+  // time; the same choice drives the graph's X-axis labels below.
+  const isClock = timeFormat === 'clock';
+  const soberText = isClock
+    ? translate('achievementsScreen.bac.soberBy', {
+        time: formatClockTime(nowMs + hoursToSober * MS_PER_HOUR),
+      })
+    : translate('achievementsScreen.bac.soberIn', {
+        time: formatSoberDuration(hoursToSober),
+      });
+  const timeFormatOptions: Array<{value: TimeFormat; label: string}> = [
+    {
+      value: 'duration',
+      label: translate('achievementsScreen.bac.timeDuration'),
+    },
+    {value: 'clock', label: translate('achievementsScreen.bac.timeClock')},
+  ];
 
   const unitOptions: Array<{value: BacDisplayUnit; label: string}> = [
     {value: CONST.BAC.DISPLAY_UNIT.PER_MILLE, label: '‰'},
@@ -142,15 +175,30 @@ function BACResult({
 
       {showGraph ? (
         <View style={[styles.alignSelfStretch, styles.mt6]}>
+          <View
+            style={[
+              styles.flexRow,
+              styles.justifyContentCenter,
+              styles.mb2,
+              {gap: 8},
+            ]}>
+            {timeFormatOptions.map(option => (
+              <Button
+                key={option.value}
+                small
+                text={option.label}
+                success={timeFormat === option.value}
+                onPress={() => setTimeFormat(option.value)}
+              />
+            ))}
+          </View>
           <Text
             style={[
               styles.textLabelSupporting,
               styles.textAlignCenter,
               styles.mb2,
             ]}>
-            {translate('achievementsScreen.bac.soberIn', {
-              time: formatSoberDuration(hoursToSober),
-            })}
+            {soberText}
           </Text>
           <BaseChart
             data={chartData}
@@ -162,7 +210,10 @@ function BACResult({
             axis={{
               font: axisFont,
               tickValues: {x: xTicks, y: yTicks},
-              formatXLabel: hour => `${hour}h`,
+              formatXLabel: hour =>
+                isClock
+                  ? formatClockTime(nowMs + hour * MS_PER_HOUR)
+                  : `${hour}h`,
               formatYLabel: value =>
                 `${roundToTwoDecimalPlaces(value)}${yUnitLabel}`,
             }}>

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -188,7 +188,7 @@ function BACResult({
 
       <Button
         small
-        style={[styles.mt6]}
+        style={[styles.mt2]}
         text={translate('achievementsScreen.bac.showDetails')}
         onPress={onShowDetails}
       />

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import {View} from 'react-native';
-import {BaseChart, Line} from '@components/Charts/BaseChart';
+import {BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
 import Button from '@components/Button';
 import StatItem from '@components/Items/StatItem';
 import ScrollView from '@components/ScrollView';
@@ -53,6 +53,7 @@ function BACResult({
 }: BACResultProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  const axisFont = useChartFont(11);
 
   const content = formatBac(estimate.point, displayUnit);
 
@@ -79,6 +80,25 @@ function BACResult({
   );
 
   const showGraph = chartData.length > 1;
+
+  // Explicit ticks for a scientific-graph look: whole-hour steps on X
+  // (~6 labels max) and five evenly spaced BAC values on Y.
+  const {xTicks, yTicks} = useMemo(() => {
+    if (chartData.length === 0) {
+      return {xTicks: [] as number[], yTicks: [] as number[]};
+    }
+    const lastHour = chartData[chartData.length - 1].x as number;
+    const step = Math.max(1, Math.ceil(lastHour / 6));
+    const xs: number[] = [];
+    for (let hour = 0; hour <= lastHour; hour += step) {
+      xs.push(hour);
+    }
+    const maxY = chartData[0].y;
+    const ys = Array.from({length: 5}, (_, index) =>
+      roundToTwoDecimalPlaces((maxY * index) / 4),
+    ).filter((value, index, arr) => arr.indexOf(value) === index);
+    return {xTicks: xs, yTicks: ys};
+  }, [chartData]);
 
   return (
     <ScrollView
@@ -135,10 +155,17 @@ function BACResult({
           <BaseChart
             data={chartData}
             range="allTime"
-            height={180}
+            height={200}
             accessibilityLabel={translate(
               'achievementsScreen.bac.decayChartLabel',
-            )}>
+            )}
+            axis={{
+              font: axisFont,
+              tickValues: {x: xTicks, y: yTicks},
+              formatXLabel: hour => `${hour}h`,
+              formatYLabel: value =>
+                `${roundToTwoDecimalPlaces(value)}${yUnitLabel}`,
+            }}>
             {({points, theme}) => (
               <Line
                 points={points.y}
@@ -147,9 +174,6 @@ function BACResult({
               />
             )}
           </BaseChart>
-          <Text style={[styles.textLabelSupporting, styles.textAlignCenter]}>
-            {translate('achievementsScreen.bac.decayAxes', {unit: yUnitLabel})}
-          </Text>
         </View>
       ) : null}
 

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -177,13 +177,6 @@ function BACResult({
         </View>
       ) : null}
 
-      <Button
-        small
-        style={[styles.mt6]}
-        text={translate('achievementsScreen.bac.showDetails')}
-        onPress={onShowDetails}
-      />
-
       <Text
         style={[
           styles.textLabelSupporting,
@@ -192,6 +185,13 @@ function BACResult({
         ]}>
         {translate('achievementsScreen.bac.disclaimer')}
       </Text>
+
+      <Button
+        small
+        style={[styles.mt6]}
+        text={translate('achievementsScreen.bac.showDetails')}
+        onPress={onShowDetails}
+      />
     </ScrollView>
   );
 }

--- a/src/screens/Achievements/components/BACResult.tsx
+++ b/src/screens/Achievements/components/BACResult.tsx
@@ -12,7 +12,7 @@ import type {BacEstimate} from '@libs/BACUtils';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import type {ChartDatum} from '@libs/Statistics';
 import CONST from '@src/CONST';
-import type {BacDisplayUnit} from '@src/types/onyx';
+import type {BacDisplayUnit, BacTimeFormat} from '@src/types/onyx';
 
 type BACResultProps = {
   /** The aggregate BAC estimate (point + confidence band). */
@@ -30,11 +30,15 @@ type BACResultProps = {
   /** Called when the user picks a different display unit. */
   onChangeDisplayUnit: (unit: BacDisplayUnit) => void;
 
+  /** Whether time-to-sober shows as a duration or an absolute clock time. */
+  timeFormat: BacTimeFormat;
+
+  /** Called when the user switches the time format. */
+  onChangeTimeFormat: (format: BacTimeFormat) => void;
+
   /** Opens the per-session breakdown modal. */
   onShowDetails: () => void;
 };
-
-type TimeFormat = 'duration' | 'clock';
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 
@@ -61,12 +65,13 @@ function BACResult({
   hoursToSober,
   displayUnit,
   onChangeDisplayUnit,
+  timeFormat,
+  onChangeTimeFormat,
   onShowDetails,
 }: BACResultProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const axisFont = useChartFont(11);
-  const [timeFormat, setTimeFormat] = useState<TimeFormat>('duration');
   // Captured once at mount so clock labels stay stable across re-renders.
   const [nowMs] = useState(() => Date.now());
 
@@ -74,7 +79,7 @@ function BACResult({
 
   // Time-to-sober shown either as a remaining duration or an absolute clock
   // time; the same choice drives the graph's X-axis labels below.
-  const isClock = timeFormat === 'clock';
+  const isClock = timeFormat === CONST.BAC.TIME_FORMAT.CLOCK;
   const soberText = isClock
     ? translate('achievementsScreen.bac.soberBy', {
         time: formatClockTime(nowMs + hoursToSober * MS_PER_HOUR),
@@ -82,12 +87,15 @@ function BACResult({
     : translate('achievementsScreen.bac.soberIn', {
         time: formatSoberDuration(hoursToSober),
       });
-  const timeFormatOptions: Array<{value: TimeFormat; label: string}> = [
+  const timeFormatOptions: Array<{value: BacTimeFormat; label: string}> = [
     {
-      value: 'duration',
+      value: CONST.BAC.TIME_FORMAT.DURATION,
       label: translate('achievementsScreen.bac.timeDuration'),
     },
-    {value: 'clock', label: translate('achievementsScreen.bac.timeClock')},
+    {
+      value: CONST.BAC.TIME_FORMAT.CLOCK,
+      label: translate('achievementsScreen.bac.timeClock'),
+    },
   ];
 
   const unitOptions: Array<{value: BacDisplayUnit; label: string}> = [
@@ -188,7 +196,7 @@ function BACResult({
                 small
                 text={option.label}
                 success={timeFormat === option.value}
-                onPress={() => setTimeFormat(option.value)}
+                onPress={() => onChangeTimeFormat(option.value)}
               />
             ))}
           </View>

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -10,6 +10,9 @@ type Theme = DeepValueOf<typeof CONST.THEME>;
 /** Which unit the BAC estimator shows: per-mille, percent, or both. */
 type BacDisplayUnit = DeepValueOf<typeof CONST.BAC.DISPLAY_UNIT>;
 
+/** How the BAC estimator shows time-to-sober: a remaining duration or a clock time. */
+type BacTimeFormat = DeepValueOf<typeof CONST.BAC.TIME_FORMAT>;
+
 /** A model mapping units to session colors */
 type UnitsToColors = {
   /** At maximum how many units a session is still yellow */
@@ -87,6 +90,9 @@ type Preferences = {
   /** True once the user has dismissed the BAC estimator intro. Undefined means
    *  it has not been shown yet (so the intro auto-shows on first open). */
   bac_intro_seen?: boolean;
+
+  /** How the BAC estimator shows time-to-sober. Undefined defaults to duration. */
+  bac_time_format?: BacTimeFormat;
 };
 
 /** A collection of preferences of multiple users */
@@ -95,6 +101,7 @@ type PreferencesList = Record<UserID, Preferences>;
 export default Preferences;
 export type {
   BacDisplayUnit,
+  BacTimeFormat,
   UnitsToColors,
   DrinksToUnits,
   PreferencesList,

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -37,6 +37,7 @@ import type {
 import type Preferences from './Preferences';
 import type {
   BacDisplayUnit,
+  BacTimeFormat,
   PreferencesList,
   UnitsToColors,
   DrinksToUnits,
@@ -116,6 +117,7 @@ export type {
   NicknameToId,
   NicknameToIdList,
   BacDisplayUnit,
+  BacTimeFormat,
   PendingOAuthCredential,
   OnboardingData,
   OnyxUpdateEvent,


### PR DESCRIPTION
## Summary

PR B, the follow-up to #718. Extends the BAC estimator from a single ongoing-session number to an aggregate estimate across all recent sessions, with an uncertainty band, a details breakdown, and a decay graph.

- **All recent sessions** — `estimateBac` now scans every session within a **24h lookback** (justified: even an extreme ~0.36% peak fully decays in ~24h at 0.015 %/h) plus the live `ONGOING_SESSION_DATA`, merged by id so an already-persisted live session isn't double-counted. A forward event simulation accumulates BAC and applies zero-order elimination between drink events, **floored at zero** so a sober gap correctly resets the elimination clock. For a single live session that never hits zero it reduces exactly to the old Widmark formula.
- **Confidence band** — edited sessions bucket all drinks at `start_time`, so their real timing is unknown. The `low` timeline places those drinks at `start_time` (most decay → lower BAC), the `high` timeline at the session `end_time` (least decay → higher BAC). Live sessions use each drink's true epoch on both timelines and collapse to a point. The UI shows the band as a "Likely low – high" line; the headline stays a point when only live sessions contribute.
- **Details modal** — new `BACDetailsModal` (CENTERED_UNSWIPEABLE) lists each contributing session: live/edit type, date, per drink type (count, ml, ABV, grams of ethanol), the session total + peak BAC contribution, plus the formula and the elimination assumption. Opened from a button on `BACResult`.
- **Decay graph** — hour-by-hour BAC decline to zero rendered on the result screen below the number via `BaseChart`/`Line`, with a "Sober in about Xh Ym" label.

### Decisions (confirmed with the user)
- Lookback window: **24h**
- Edited-session high bound anchored at **start_time → end_time** (not → now)
- Decay graph placement: **on the result screen**
- Graph granularity: hourly (linear, zero-order)

## Test plan
- [ ] Live session only → single point estimate (no band), decay graph + time-to-sober shown
- [ ] Edited session contributes → "Likely low – high" range appears; modal shows the edit-timing note
- [ ] Mixed live + edited recent sessions → band reflects both; details modal lists each
- [ ] Sessions older than 24h excluded; BAC decayed to 0 shows 0.00 with no graph but sessions still listed in modal
- [ ] Unit toggle (‰ / % / both) reformats the number, range, and modal contributions
- [ ] cs_cz locale renders all new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)