### PR TITLE
fix(ios): add Terms of Use (EULA) link to App Store description

### DIFF
--- a/fastlane/metadata/cs/description.txt
+++ b/fastlane/metadata/cs/description.txt
@@ -22,4 +22,7 @@ ZŮSTAŇTE VE SPOJENÍ (VOLITELNÉ)
 KIROKU SUPPORTER (VOLITELNÉ PŘEDPLATNÉ)
 Kiroku je zdarma. Pokud chcete podpořit vývoj, „Kiroku Supporter" je volitelné měsíční předplatné, které přidá kosmetický pivní odznak k vašemu profilu. Neodemyká žádné funkce sledování — vše podstatné je zdarma. Předplatné se automaticky obnovuje, dokud jej nezrušíte; spravovat či zrušit jej můžete kdykoli v nastavení účtu App Store.
 
+Podmínky použití (EULA): https://kiroku.cz/terms
+Zásady ochrany soukromí: https://kiroku.cz/privacy
+
 Kiroku je určeno pro dospělé (18+), kteří chtějí sledovat a reflektovat své vlastní pití. Neposkytuje lékařské rady. Máte-li obavy o své pití, obraťte se prosím na odborníka.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -22,4 +22,7 @@ STAY CONNECTED (OPTIONAL)
 KIROKU SUPPORTER (OPTIONAL SUBSCRIPTION)
 Kiroku is free to use. If you'd like to support development, "Kiroku Supporter" is an optional monthly subscription that adds a cosmetic beer badge to your profile. It unlocks no tracking functionality — every core feature is free. Subscriptions auto-renew unless cancelled; manage or cancel any time in your App Store account settings.
 
+Terms of Use (EULA): https://kiroku.cz/terms
+Privacy Policy: https://kiroku.cz/privacy
+
 Kiroku is intended for adults (18+) who want to monitor and reflect on their own drinking. It does not provide medical advice. If you are concerned about your drinking, please consult a healthcare professional.


### PR DESCRIPTION
## Summary

App Review rejected the production iOS submission under **Guideline 3.1.2**: an app offering auto-renewable subscriptions (Kiroku Supporter) must include a functional **Terms of Use (EULA)** link in its listing metadata. That link was missing.

This adds Terms of Use + Privacy Policy links to the App Store description for both locales so the requirement is **source-controlled** — the `production` lane runs with `skip_metadata: false` and re-uploads `description.txt` on every deploy, so fixing it only in App Store Connect would regress on the next release.

## What changed

- `fastlane/metadata/en-US/description.txt` — added `Terms of Use (EULA)` + `Privacy Policy` links after the subscription disclosure paragraph.
- `fastlane/metadata/cs/description.txt` — same, with localized labels.

Both `https://kiroku.cz/terms` and `https://kiroku.cz/privacy` were verified live (200).

## Reviewer notes

- Metadata-only change — **no new build required**. After merge, push the listing via `bundle exec fastlane ios upload_metadata` (writes to the editable ASC draft without submitting), then resubmit / reply to App Review.
- No change to the ASC License Agreement field — we use the in-description link route (standard Apple-sanctioned option), not a custom EULA.
- Privacy Policy URL is also already set via the existing `privacy_url.txt` ASC field; the in-description Privacy line is supplementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)