### PR TITLE
fix(ci): retry flaky iOS platform SDK download in deploy

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -191,7 +191,15 @@ jobs:
         run: echo "IOS_VERSION=$(echo '${{ inputs.APP_VERSION }}' | tr '-' '.')" >> "$GITHUB_ENV"
 
       - name: Install iOS platform SDK
-        run: xcodebuild -downloadPlatform iOS
+        uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          # `xcodebuild -downloadPlatform iOS` intermittently fails with
+          # "Unable to connect to simulator." (exit 70) when CoreSimulator
+          # isn't ready yet on a fresh runner. Retry instead of failing the deploy.
+          command: xcodebuild -downloadPlatform iOS
 
       - name: Generate release notes
         if: ${{ inputs.SHOULD_DEPLOY_PRODUCTION }}

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -79,7 +79,15 @@ jobs:
       # simulator runtime — xcodebuild crashes with "iOS 26.1 is not installed"
       # otherwise. Same step that testBuild.yml uses.
       - name: Install iOS platform SDK
-        run: xcodebuild -downloadPlatform iOS
+        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          # `xcodebuild -downloadPlatform iOS` intermittently fails with
+          # "Unable to connect to simulator." (exit 70) when CoreSimulator
+          # isn't ready yet on a fresh runner. Retry instead of failing the run.
+          command: xcodebuild -downloadPlatform iOS
 
       # Trim the Snapfile device matrix when the dispatcher asked for a subset.
       # `Snapfile` resolves devices(...) eagerly so we rewrite the file in

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -183,7 +183,15 @@ jobs:
         run: npm run jsbundle
 
       - name: Install iOS platform SDK
-        run: xcodebuild -downloadPlatform iOS
+        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          # `xcodebuild -downloadPlatform iOS` intermittently fails with
+          # "Unable to connect to simulator." (exit 70) when CoreSimulator
+          # isn't ready yet on a fresh runner. Retry instead of failing the build.
+          command: xcodebuild -downloadPlatform iOS
 
       - name: Run Fastlane
         run: bundle exec fastlane ios build_internal


### PR DESCRIPTION
## Summary

The **Deploy code to staging or production** workflow has been failing on the iOS job. Root cause: the `Install iOS platform SDK` step runs `xcodebuild -downloadPlatform iOS`, which intermittently fails with:

```
Unable to connect to simulator.
##[error]Process completed with exit code 70.
```

This is a transient failure on the fresh `macOS-26` / Xcode 26 runner image — CoreSimulator isn't ready yet when the command runs. It killed the deploy of `0.3.13-76` ([run 26627230930](https://github.com/PetrCala/Kiroku/actions/runs/26627230930)).

This wraps the step in the SHA-pinned retry action each workflow already uses for its other flaky native steps (3 attempts, 30s backoff), so a transient simulator-connect failure retries instead of failing the whole deploy.

Applied identically to all three workflows that run this step:
- `platformDeploy.yml` (the failing deploy path) — `nick-fields/retry`
- `testBuild.yml` — `nick-invision/retry` (matches that file's existing pin)
- `screenshots.yml` — `nick-invision/retry`

## Test plan

- [ ] Next staging deploy push completes the iOS `Install iOS platform SDK` step (retries on transient failure rather than failing the run)
- [ ] YAML validated locally with `js-yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)