### PR TITLE
feat(stats): circular reset arrow for jump-to-current-month button

### DIFF
--- a/assets/images/rotate-left.svg
+++ b/assets/images/rotate-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" x="0" y="0" version="1.1" viewBox="0 0 20 20" xml:space="preserve"><path d="M13.5,3.94A7,7,0,1,1,6.5,3.94L7.85,6.28A4.3,4.3,0,1,0,12.15,6.28ZM14.35,2.46L10.2,4.35L11.3,7.75Z" fill-rule="nonzero"/></svg>

--- a/src/components/Icon/KirokuIcons.ts
+++ b/src/components/Icon/KirokuIcons.ts
@@ -47,6 +47,7 @@ import GoogleG from '@assets/images/google-g.svg';
 import QrCode from '@assets/images/qrcode.svg';
 import Profile from '@assets/images/profile.svg';
 import RemoveUser from '@assets/images/remove-user.svg';
+import RotateLeft from '@assets/images/rotate-left.svg';
 import Search from '@assets/images/search.svg';
 import Share from '@assets/images/share.svg';
 import Star from '@assets/images/star.svg';
@@ -115,6 +116,7 @@ export {
   Profile,
   QrCode,
   RemoveUser,
+  RotateLeft,
   Search,
   Gear as Settings,
   Share,

--- a/src/components/Statistics/StatsFilterToolbar/StatsRangeNavigator.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/StatsRangeNavigator.tsx
@@ -106,7 +106,7 @@ function StatsRangeNavigator({
                 )}
                 accessibilityRole="button"
                 style={styles.statsRangeNavigatorInlineJump}>
-                <Icon small src={KirokuIcons.Calendar} fill={textReversed} />
+                <Icon small src={KirokuIcons.RotateLeft} fill={textReversed} />
               </PressableWithFeedback>
             </Animated.View>
           )}


### PR DESCRIPTION
## Summary
- Replace the calendar glyph on the Statistics range-navigator "jump to latest" button with a custom counter-clockwise circular reset arrow, which reads more clearly as "return to current month / now".
- Add a new custom-owned `rotate-left.svg` icon (20×20, filled-path, recolors via the `fill` prop) and expose it as `KirokuIcons.RotateLeft`.

## Test plan
- [ ] Open the Statistics screen, navigate away from the current month, and confirm the inline jump button now shows the circular arrow and still returns to the latest range.
- [ ] Verify the icon recolors correctly (uses `textReversed` fill) in both light and dark themes.
🤖 Generated with [Claude Code](https://claude.com/claude-code)