### PR TITLE
fix(ui): vertically center CENTERED_SMALL modals

### DIFF
--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -65,7 +65,11 @@ function Container({
         <Animated.View
           style={[
             styles.modalAnimatedContainer,
-            type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED && styles.flex1,
+            // BOTTOM_DOCKED and CENTERED_SMALL stay content-sized so the outer
+            // `style` (flex-end / center) can position the sheet; the others fill.
+            type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED &&
+              type !== CONST.MODAL.MODAL_TYPE.CENTERED_SMALL &&
+              styles.flex1,
           ]}
           entering={Entering}
           exiting={Exiting}>

--- a/src/styles/utils/generators/ModalStyleUtils.ts
+++ b/src/styles/utils/generators/ModalStyleUtils.ts
@@ -170,11 +170,15 @@ const createModalStyleUtils: StyleUtilGenerator<GetModalStylesStyleUtil> = ({
         shouldAddBottomSafeAreaPadding = false;
         break;
       case CONST.MODAL.MODAL_TYPE.CENTERED_SMALL:
-        // A centered modal that takes up the minimum possible screen space on all devices
+        // A centered modal that takes up the minimum possible screen space on all devices.
+        // Unlike CENTERED it has no flex:1 container to fill the viewport, so it must
+        // center itself on both axes (and the native Container excludes it from the flex1
+        // fill, mirroring BOTTOM_DOCKED, so this justifyContent can take effect).
         modalStyle = {
           ...modalStyle,
           ...{
             alignItems: 'center',
+            justifyContent: 'center',
           },
         };
         modalContainerStyle = {


### PR DESCRIPTION
## Summary

`CENTERED_SMALL` modals rendered pinned to the **top** of the screen instead of centered. The type is documented as *"a centered modal that takes up the minimum possible screen space on all devices"*, so this was a layout bug.

**Root cause:** `CENTERED_SMALL` set only `alignItems: 'center'` (horizontal) on its outer modal style — never `justifyContent: 'center'`. The larger `CENTERED`/`CENTERED_UNSWIPEABLE` types get away without it because their container has `flex: 1` and fills the viewport; `CENTERED_SMALL` is content-sized, so vertical alignment fell back to `flex-start` (top).

**Fix** (mirrors the existing `BOTTOM_DOCKED` docking mechanism):
- Add `justifyContent: 'center'` to the `CENTERED_SMALL` modal style in `ModalStyleUtils.ts`.
- Exclude `CENTERED_SMALL` from the native `Container`'s inner `flex1` fill, so the content-sized box doesn't consume the vertical space and the outer `justifyContent: 'center'` can take effect. (Web uses a single flat container, so the style change alone centers it there.)

## Affected modals

All `CENTERED_SMALL` consumers are fixed at once:
- Test Tools modal (`src/components/TestToolsModal`)
- Statistics custom date-range picker (`src/components/Statistics/StatsRangePickerModal`)
- Upload-image popup (`src/components/Popups/UploadImagePopup`)

## Verification status

- ✅ `typecheck-tsgo` clean for changed files (the only error is a pre-existing `glob` types gap in `scripts/utils/FileUtils.ts`, unrelated to this change).
- ✅ Change follows the proven `BOTTOM_DOCKED` flex pattern already in the codebase.
- ⚠️ **Not yet visually verified in a running app** — there's no quick web target locally and the affected modals sit behind auth / a dev-only gesture. Please confirm on a simulator/device before merge.

## Test plan

- [ ] iOS: open the statistics **custom date-range** picker — modal is vertically centered, not pinned to top.
- [ ] iOS: open the **Test Tools** modal (⌘D → Open Test Preferences) — centered.
- [ ] iOS: trigger the **upload-image** popup — centered.
- [ ] Confirm `BOTTOM_DOCKED`, `CENTERED`, `POPOVER`, and `RIGHT_DOCKED` modals are unchanged.
- [ ] (If web build available) repeat the above on web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)