### PR TITLE
feat(home): rework home stats into a Units scorecard with drink breakdown

### DIFF
--- a/src/components/Charts/DrinkBreakdown/DrinkBreakdown.tsx
+++ b/src/components/Charts/DrinkBreakdown/DrinkBreakdown.tsx
@@ -1,0 +1,99 @@
+import {View} from 'react-native';
+import Icon from '@components/Icon';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {findDrinkNameTranslationKey} from '@libs/DataHandling';
+import DrinkData from '@libs/DrinkData';
+import type {DrinkKey} from '@src/types/onyx/Drinks';
+import type IconAsset from '@src/types/utils/IconAsset';
+
+type DrinkBreakdownItem = {
+  drinkKey: DrinkKey;
+  units: number;
+};
+
+type DrinkBreakdownProps = {
+  /** Already ordered and filtered to drink types with units > 0. */
+  items: DrinkBreakdownItem[];
+  accessibilityLabel: string;
+  isLoading?: boolean;
+};
+
+const ICON_BY_DRINK_KEY = DrinkData.reduce<
+  Partial<Record<DrinkKey, IconAsset>>
+>((acc, entry) => {
+  acc[entry.key] = entry.icon;
+  return acc;
+}, {});
+
+const ROW_HEIGHT = 34;
+
+function formatUnits(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+/**
+ * Composition row for a period's units — one chip per drink type the user
+ * actually logged (icon + total units), ordered by the shared drink-key
+ * order. Drink types with zero units are omitted by the caller, so the row
+ * only shows what's relevant.
+ */
+function DrinkBreakdown({
+  items,
+  accessibilityLabel,
+  isLoading,
+}: DrinkBreakdownProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+
+  if (isLoading) {
+    return (
+      <View
+        accessibilityLabel={accessibilityLabel}
+        style={{height: ROW_HEIGHT}}
+      />
+    );
+  }
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={accessibilityLabel}
+      style={[styles.flexRow, styles.flexWrap]}>
+      {items.map(item => {
+        const icon = ICON_BY_DRINK_KEY[item.drinkKey];
+        const name = translate(findDrinkNameTranslationKey(item.drinkKey));
+        return (
+          <View
+            key={item.drinkKey}
+            accessibilityLabel={`${name}: ${formatUnits(item.units)}`}
+            style={[
+              styles.flexRow,
+              styles.alignItemsCenter,
+              styles.mr1,
+              styles.mt1,
+              {
+                paddingHorizontal: 8,
+                paddingVertical: 4,
+                borderRadius: 999,
+                backgroundColor: theme.appBG,
+              },
+            ]}>
+            {icon ? (
+              <Icon src={icon} width={16} height={16} fill={theme.icon} />
+            ) : null}
+            <Text style={[styles.textMicro, styles.textStrong, styles.ml1]}>
+              {formatUnits(item.units)}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default DrinkBreakdown;
+export type {DrinkBreakdownItem, DrinkBreakdownProps};

--- a/src/components/Charts/DrinkBreakdown/index.ts
+++ b/src/components/Charts/DrinkBreakdown/index.ts
@@ -1,0 +1,2 @@
+export {default as DrinkBreakdown} from './DrinkBreakdown';
+export type {DrinkBreakdownItem, DrinkBreakdownProps} from './DrinkBreakdown';

--- a/src/components/Charts/KpiCard/KpiCard.tsx
+++ b/src/components/Charts/KpiCard/KpiCard.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
 import {PressableWithFeedback} from '@components/Pressable';
@@ -42,6 +43,10 @@ type KpiCardProps = {
   accessibilityLabel?: string;
   /** When true, shows a layout-faithful skeleton in place of the card. */
   isLoading?: boolean;
+  /** Optional accessory pinned to the card's top-right, level with the label. */
+  headerRight?: ReactNode;
+  /** Optional chart rendered below the value/delta (and any sparkline). */
+  chart?: ReactNode;
 };
 
 const ARROW: Record<KpiCardDelta['direction'], string> = {
@@ -70,6 +75,8 @@ function KpiCard({
   onPress,
   accessibilityLabel,
   isLoading,
+  headerRight,
+  chart,
 }: KpiCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -117,9 +124,25 @@ function KpiCard({
           minHeight: 96,
         },
       ]}>
-      <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
-        {label}
-      </Text>
+      {headerRight ? (
+        <View
+          style={[
+            styles.flexRow,
+            styles.justifyContentBetween,
+            styles.alignItemsCenter,
+          ]}>
+          <Text
+            style={[styles.textLabelSupporting, styles.flexShrink1]}
+            numberOfLines={1}>
+            {label}
+          </Text>
+          {headerRight}
+        </View>
+      ) : (
+        <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
+          {label}
+        </Text>
+      )}
       <View style={[styles.flexRow, styles.alignItemsBaseline, styles.mt1]}>
         <Text
           style={[
@@ -153,6 +176,7 @@ function KpiCard({
           />
         </View>
       ) : null}
+      {chart ? <View style={styles.mt2}>{chart}</View> : null}
     </View>
   );
 

--- a/src/components/Items/HomeStatsOverview.tsx
+++ b/src/components/Items/HomeStatsOverview.tsx
@@ -1,0 +1,116 @@
+import {View} from 'react-native';
+import type {DateData} from 'react-native-calendars';
+import {DrinkBreakdown} from '@components/Charts/DrinkBreakdown';
+import {KpiCard, KpiCardGroup} from '@components/Charts/KpiCard';
+import type {KpiCardProps} from '@components/Charts/KpiCard';
+import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import {PressableWithFeedback} from '@components/Pressable';
+import Text from '@components/Text';
+import useHomeStats from '@hooks/useHomeStats';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@navigation/Navigation';
+import ROUTES from '@src/ROUTES';
+
+type DeltaShape = NonNullable<KpiCardProps['delta']>;
+
+function formatUnits(value: number): string {
+  // 1 decimal for partial units, else integer — matches the Statistics tabs.
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+type HomeStatsOverviewProps = {
+  visibleDate: DateData;
+};
+
+/**
+ * Home-screen stats block: a "Units" hero (with a per-drink-type breakdown
+ * and a quiet shortcut to the Statistics screen) over a supporting pair of
+ * sessions and alcohol-free days. Every tile carries a "vs last month" delta.
+ */
+function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const {isLoading, current, previous, drinkBreakdown} =
+    useHomeStats(visibleDate);
+
+  const vsLastMonth = translate('homeScreen.stats.vsLastMonth');
+  const makeDelta = (cur: number, prev: number): DeltaShape => {
+    const diff = Number((cur - prev).toFixed(1));
+    let direction: DeltaShape['direction'] = 'flat';
+    if (diff > 0) {
+      direction = 'up';
+    } else if (diff < 0) {
+      direction = 'down';
+    }
+    return {value: diff, direction, label: vsLastMonth};
+  };
+
+  const statisticsLink = (
+    <PressableWithFeedback
+      accessibilityLabel={translate('homeScreen.stats.viewStatistics')}
+      accessibilityRole="button"
+      onPress={() => Navigation.navigate(ROUTES.STATISTICS)}
+      style={[styles.flexRow, styles.alignItemsCenter]}>
+      <Text style={[styles.textMicroSupporting, styles.mr1]}>
+        {translate('homeScreen.stats.statistics')}
+      </Text>
+      <Icon
+        src={KirokuIcons.ArrowRight}
+        width={12}
+        height={12}
+        fill={theme.icon}
+      />
+    </PressableWithFeedback>
+  );
+
+  const supportingCards: KpiCardProps[] = [
+    {
+      label: translate('homeScreen.stats.sessions'),
+      value: current.sessions,
+      delta: makeDelta(current.sessions, previous.sessions),
+      polarity: 'lower-is-supportive',
+    },
+    {
+      label: translate('homeScreen.stats.alcoholFree'),
+      value: current.afDays,
+      unit: `/${current.elapsedDays}`,
+      delta: makeDelta(current.afDays, previous.afDays),
+      tone: 'celebratory',
+      polarity: 'higher-is-supportive',
+    },
+  ];
+
+  return (
+    <View style={styles.mt2}>
+      <View style={styles.mb2}>
+        <KpiCard
+          label={translate('homeScreen.stats.units')}
+          value={formatUnits(current.totalUnits)}
+          delta={makeDelta(current.totalUnits, previous.totalUnits)}
+          polarity="lower-is-supportive"
+          headerRight={statisticsLink}
+          chart={
+            <DrinkBreakdown
+              items={drinkBreakdown}
+              accessibilityLabel={translate(
+                'homeScreen.stats.drinkBreakdownA11y',
+              )}
+              isLoading={isLoading}
+            />
+          }
+          isLoading={isLoading}
+        />
+      </View>
+      <KpiCardGroup cards={supportingCards} isLoading={isLoading} />
+    </View>
+  );
+}
+
+HomeStatsOverview.displayName = 'HomeStatsOverview';
+
+export default HomeStatsOverview;
+export type {HomeStatsOverviewProps};

--- a/src/hooks/useHomeStats.ts
+++ b/src/hooks/useHomeStats.ts
@@ -1,0 +1,87 @@
+import {useMemo} from 'react';
+import type {DateData} from 'react-native-calendars';
+import type {DrinkBreakdownItem} from '@components/Charts/DrinkBreakdown';
+import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
+import {aggregate, byDrinkKey, dateRange, sumUnits} from '@libs/Statistics';
+import {buildPeriodSummary} from '@libs/Statistics/overview';
+import type {PeriodSummary, Thresholds} from '@libs/Statistics/overview';
+import {DRINK_KEY_ORDER} from '@screens/Statistics/tabs/breakdown/drinkKeyColors';
+
+/** Mirrors the seeded `units_to_colors` default (see User onboarding). */
+const DEFAULT_THRESHOLDS: Thresholds = {yellow: 5, orange: 10};
+
+type HomeStats = {
+  /** True while the underlying event stream is still compiling. */
+  isLoading: boolean;
+  /** Scorecard metrics for the visible calendar month. */
+  current: PeriodSummary;
+  /** Same metrics for the month before, for "vs last month" deltas. */
+  previous: PeriodSummary;
+  /** Units per drink type for the visible month, ordered, zeros omitted. */
+  drinkBreakdown: DrinkBreakdownItem[];
+};
+
+/**
+ * Home-screen stats derived from the Statistics v2 event stream for the
+ * calendar month the user is currently viewing (`visibleDate`), plus its
+ * previous-month twin for deltas and a per-drink-type composition of the
+ * month's units. Thresholds come from the user's `units_to_colors`
+ * preference so "alcohol-free" means the same here as on the calendars and
+ * the Statistics screen.
+ */
+function useHomeStats(visibleDate: DateData): HomeStats {
+  const {events, isLoading} = useDrinkEvents();
+  const {preferences} = useDatabaseData();
+
+  const thresholds = useMemo(
+    () => preferences?.units_to_colors ?? DEFAULT_THRESHOLDS,
+    [preferences?.units_to_colors],
+  );
+
+  // Snapshot `now` once per mount so the current/previous clamps agree.
+  const now = useMemo(() => new Date(), []);
+
+  // `DateData.month` is 1-based; `new Date(year, monthIndex, 0)` resolves to
+  // the last day of the prior month, and JS normalises negative month indices
+  // (so month-2 in January rolls back into the previous year).
+  const {year, month} = visibleDate;
+  const {monthStart, monthEnd, prevStart, prevEnd} = useMemo(
+    () => ({
+      monthStart: new Date(year, month - 1, 1),
+      monthEnd: new Date(year, month, 0, 23, 59, 59, 999),
+      prevStart: new Date(year, month - 2, 1),
+      prevEnd: new Date(year, month - 1, 0, 23, 59, 59, 999),
+    }),
+    [year, month],
+  );
+
+  const current = useMemo(
+    () => buildPeriodSummary(events, monthStart, monthEnd, now, thresholds),
+    [events, monthStart, monthEnd, now, thresholds],
+  );
+
+  const previous = useMemo(
+    () => buildPeriodSummary(events, prevStart, prevEnd, now, thresholds),
+    [events, prevStart, prevEnd, now, thresholds],
+  );
+
+  const drinkBreakdown = useMemo<DrinkBreakdownItem[]>(() => {
+    const effectiveEndMs = Math.min(monthEnd.getTime(), now.getTime());
+    const unitsByDrinkKey = aggregate(
+      events,
+      byDrinkKey,
+      sumUnits,
+      dateRange(monthStart.getTime(), effectiveEndMs),
+    );
+    return DRINK_KEY_ORDER.map(drinkKey => ({
+      drinkKey,
+      units: unitsByDrinkKey.get(drinkKey) ?? 0,
+    })).filter(item => item.units > 0);
+  }, [events, monthStart, monthEnd, now]);
+
+  return {isLoading, current, previous, drinkBreakdown};
+}
+
+export default useHomeStats;
+export type {HomeStats};

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1246,6 +1246,15 @@ export default {
     currentlyInSession: 'Právě se nacházíte v relaci!',
     currentlyInSessionButton:
       'Tlačítko, které informuje, že se právě nacházíte v relaci',
+    stats: {
+      units: 'Jednotky',
+      sessions: 'Relace',
+      alcoholFree: 'Bez alkoholu',
+      statistics: 'Statistiky',
+      viewStatistics: 'Zobrazit statistiky',
+      vsLastMonth: 'vs minulý měsíc',
+      drinkBreakdownA11y: 'Jednotky podle druhu drinku tento měsíc',
+    },
   },
   sessionsCalendar: {
     dayOverviewButton: 'Přehled dne',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1257,6 +1257,15 @@ export default {
     currentlyInSession: 'You are currently in a session!',
     currentlyInSessionButton:
       'A button indicating you are currently in session',
+    stats: {
+      units: 'Units',
+      sessions: 'Sessions',
+      alcoholFree: 'Alcohol-free',
+      statistics: 'Statistics',
+      viewStatistics: 'View statistics',
+      vsLastMonth: 'vs last month',
+      drinkBreakdownA11y: 'Units by drink type this month',
+    },
   },
   sessionsCalendar: {
     dayOverviewButton: "Day's overview",

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,12 +1,8 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import SessionsCalendar from '@components/SessionsCalendar';
 import type {DateData} from 'react-native-calendars';
-import {
-  calculateThisMonthUnits,
-  timestampToDate,
-  dateToDateData,
-} from '@libs/DataHandling';
+import {dateToDateData} from '@libs/DataHandling';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import UserOffline from '@components/UserOfflineModal';
 import {synchronizeUserStatus} from '@userActions/User';
@@ -14,7 +10,6 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import ProfileImage from '@components/ProfileImage';
 import {SupporterBadgeForUser} from '@components/SupporterBadge';
 import CONST from '@src/CONST';
-import type {DrinkingSessionArray} from '@src/types/onyx';
 import ROUTES from '@src/ROUTES';
 import Navigation from '@navigation/Navigation';
 import type {StackScreenProps} from '@react-navigation/stack';
@@ -22,8 +17,7 @@ import {useFocusEffect} from '@react-navigation/native';
 import type {BottomTabNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
-import type {StatData} from '@components/Items/StatOverview';
-import StatOverview from '@components/Items/StatOverview';
+import HomeStatsOverview from '@components/Items/HomeStatsOverview';
 import ScreenWrapper from '@components/ScreenWrapper';
 import MessageBanner from '@components/Info/MessageBanner';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -36,7 +30,6 @@ import * as Session from '@userActions/Session';
 import Timing from '@userActions/Timing';
 import ScrollView from '@components/ScrollView';
 import useLocalize from '@hooks/useLocalize';
-import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import Text from '@components/Text';
 import BottomTabBar from '@libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar';
 import {useOnyx} from 'react-native-onyx';
@@ -69,47 +62,6 @@ function HomeScreen({route}: HomeScreenProps) {
     dateToDateData(new Date()),
   );
   const hasMarkedReadyRef = useRef(false);
-
-  // Derive stats synchronously from the visible month + drink unit mapping.
-  // Narrowed to `drinksToUnits` so unrelated preference updates (e.g. picking
-  // a color palette) don't recompute the stats.
-  const drinksToUnits = preferences?.drinks_to_units;
-  const {drinkingSessionsCount, unitsConsumed} = useMemo(() => {
-    if (!drinksToUnits || !drinkingSessionData) {
-      return {drinkingSessionsCount: 0, unitsConsumed: 0};
-    }
-    const drinkingSessionArray: DrinkingSessionArray =
-      Object.values(drinkingSessionData);
-    const monthUnits = calculateThisMonthUnits(
-      visibleDate,
-      drinkingSessionArray,
-      drinksToUnits,
-    );
-    const monthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
-      timestampToDate(visibleDate.timestamp),
-      drinkingSessionArray,
-      false,
-    ).length;
-    return {
-      drinkingSessionsCount: monthSessionCount,
-      unitsConsumed: monthUnits,
-    };
-  }, [drinkingSessionData, visibleDate, drinksToUnits]);
-
-  const statsData: StatData = [
-    {
-      header: translate('profileScreen.drinkingSessions', {
-        sessionsCount: drinkingSessionsCount,
-      }),
-      content: String(drinkingSessionsCount),
-    },
-    {
-      header: translate('profileScreen.unitsConsumed', {
-        unitCount: roundToTwoDecimalPlaces(unitsConsumed),
-      }),
-      content: String(roundToTwoDecimalPlaces(unitsConsumed)),
-    },
-  ];
 
   useEffect(() => {
     // Update the ongoing session local data
@@ -184,7 +136,7 @@ function HomeScreen({route}: HomeScreenProps) {
     }
     return (
       <>
-        <StatOverview statsData={statsData} />
+        <HomeStatsOverview visibleDate={visibleDate} />
         <SessionsCalendar
           userID={user.uid}
           visibleDate={visibleDate}

--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import type {StyleProp, ViewStyle} from 'react-native';
+import type {DimensionValue, StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
 
 type BlockProps = {
-  width: number;
-  height: number;
+  width: DimensionValue;
+  height: DimensionValue;
   radius?: number;
   style?: StyleProp<ViewStyle>;
 };
@@ -48,25 +48,32 @@ function HomeHeaderSkeleton() {
   );
 }
 
-/** Placeholder for the two stat cards (sessions + units this month). */
+/**
+ * Placeholder for the home stats block: a "Units" hero card (label + value +
+ * delta + drink-type breakdown) over a pair of supporting cards. Heights
+ * mirror HomeStatsOverview so the swap-in doesn't jolt the layout.
+ */
 function StatOverviewSkeleton() {
   const styles = useThemeStyles();
   return (
-    <View style={styles.statOverviewContainer}>
-      {['sessions', 'units'].map(slot => (
-        <View
-          key={slot}
-          style={[
-            styles.flexColumn,
-            styles.alignItemsCenter,
-            styles.justifyContentCenter,
-          ]}>
-          {/* Matches fontSizeXXXXLarge (36px) bold value text */}
-          <Block width={72} height={44} style={styles.mb2} />
-          {/* Matches fontSizeNormal (15px) label, 2 lines, max-width 150 */}
-          <Block width={130} height={36} />
-        </View>
-      ))}
+    <View style={styles.mt2}>
+      {/* Hero card (KpiCard + DrinkBreakdown). */}
+      <Block width="100%" height={130} radius={12} style={styles.mb2} />
+      {/* Supporting pair (sessions + alcohol-free). */}
+      <View style={styles.flexRow}>
+        <Block
+          width="100%"
+          height={96}
+          radius={12}
+          style={[styles.flex1, styles.mr1]}
+        />
+        <Block
+          width="100%"
+          height={96}
+          radius={12}
+          style={[styles.flex1, styles.ml1]}
+        />
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary

Approach **B** of the home-stats redesign (sibling of [#752](https://github.com/PetrCala/Kiroku/pull/752)). The two bare numbers on the home screen (sessions + units) felt thin next to the Statistics v2 rework (#734). This replaces them with a richer block that tells the month's **composition**:

- **Units hero** — the month's total units, a **"vs last month"** delta, and a **chip per drink type actually consumed** (real KirokuIcons + units). Drink types with 0 units are omitted, so the row only shows what's relevant.
- **Supporting pair** — Sessions and Alcohol-free days (`afDays /elapsedDays`), each with its own delta.
- **Quiet Statistics shortcut** in the hero's **top-right corner** (`ArrowRight` → `ROUTES.STATISTICS`). Easy to drop if it feels redundant with the bottom tab.

All numbers come from the shared Statistics v2 event stream, so the home screen and the Statistics screen always agree.

## Changes

- `components/Charts/DrinkBreakdown` — new chip row: one chip per consumed drink type (icon + units), ordered by the shared `DRINK_KEY_ORDER`.
- `components/Charts/KpiCard` — two optional, backwards-compatible slots: `headerRight` (top-right accessory) and `chart` (rendered below the value/delta).
- `hooks/useHomeStats` — derives current + previous-month `PeriodSummary` and the per-drink-type unit breakdown (`aggregate(byDrinkKey, sumUnits)`) for the visible calendar month from `useDrinkEvents`.
- `components/Items/HomeStatsOverview` — the new block; replaces `StatOverview` on the home screen (`StatOverview` is unchanged and still used by the Profile screen).
- `HomeScreenSkeleton` — stat skeleton resized to match the new block.
- `languages/en.ts` + `cs_cz.ts` — new `homeScreen.stats.*` keys (Czech filled via the `translate` skill / glossary).

## Notes

- This is the drink-breakdown variant; the **weekly-bars** variant is [#752](https://github.com/PetrCala/Kiroku/pull/752). Pick one.
- `small_beer` and `beer` both map to the same beer icon in `DrinkData`, so a month with both shows two beer-icon chips. Worth deciding whether to merge them into one chip — flagging for review rather than assuming.
- Local checks: `prettier`, `lint-changed`, `typecheck-tsgo` clean. The React Compiler compliance script couldn't run in this worktree due to a pre-existing `scripts/utils/FileUtils.ts` missing-`@types/glob` error (unrelated) — relying on CI for that gate.

## Test plan

- [ ] Home screen shows the Units hero with drink-type chips, delta, and the two supporting cards
- [ ] Only drink types with units > 0 appear; ordering follows DRINK_KEY_ORDER
- [ ] Paginating the calendar to other months updates the stats and chips
- [ ] Tapping the top-right "Statistics" affordance opens the Statistics screen
- [ ] Skeleton → content swap doesn't visibly jump
- [ ] Light + dark themes both look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)