### PR TITLE
feat: Kiroku client cutover — realtime transport + friends write slice

### DIFF
--- a/src/CONFIG.ts
+++ b/src/CONFIG.ts
@@ -36,12 +36,12 @@ const useWebProxy = get(Config, 'USE_WEB_PROXY', 'true') === 'true';
 const kirokuApiDevRoot = get(
   Config,
   'KIROKU_API_DEV_ROOT',
-  'https://europe-west1-dev-alcohol-tracker-db.cloudfunctions.net/api',
+  'https://api-dev.kiroku.cz',
 ).replace(/\/+$/, '');
 const kirokuApiProdRoot = get(
   Config,
   'KIROKU_API_PROD_ROOT',
-  'https://europe-west1-alcohol-tracker-db.cloudfunctions.net/api',
+  'https://api.kiroku.cz',
 ).replace(/\/+$/, '');
 // const kirokuComWithProxy = getPlatform() === 'web' && useWebProxy ? '/' : kirokuURL;
 const kirokuComWithProxy = kirokuURL;

--- a/src/CONFIG.ts
+++ b/src/CONFIG.ts
@@ -29,6 +29,20 @@ const secureKirokuUrl = Url.addTrailingForwardSlash(
 );
 const useNgrok = get(Config, 'USE_NGROK', 'false') === 'true';
 const useWebProxy = get(Config, 'USE_WEB_PROXY', 'true') === 'true';
+
+// kiroku-api (first-party HTTPS function) base URLs. No trailing slash — route
+// paths in `libs/API/kirokuRoutes.ts` already include the `/v1` prefix. The env
+// vars allow pointing at the emulator / a branded domain during development.
+const kirokuApiDevRoot = get(
+  Config,
+  'KIROKU_API_DEV_ROOT',
+  'https://europe-west1-dev-alcohol-tracker-db.cloudfunctions.net/api',
+).replace(/\/+$/, '');
+const kirokuApiProdRoot = get(
+  Config,
+  'KIROKU_API_PROD_ROOT',
+  'https://europe-west1-alcohol-tracker-db.cloudfunctions.net/api',
+).replace(/\/+$/, '');
 // const kirokuComWithProxy = getPlatform() === 'web' && useWebProxy ? '/' : kirokuURL;
 const kirokuComWithProxy = kirokuURL;
 
@@ -102,10 +116,18 @@ export default {
     STAGING_API_ROOT: stagingKirokuURL,
     STAGING_SECURE_API_ROOT: stagingSecureKirokuUrl,
   },
+  KIROKU_API: {
+    // Base URL of the kiroku-api HTTPS function, selected by environment in
+    // `ApiUtils.getKirokuApiRoot()`. Route paths include the `/v1` prefix.
+    DEV_ROOT: kirokuApiDevRoot,
+    PROD_ROOT: kirokuApiProdRoot,
+  },
   PUSHER: {
     APP_KEY: get(Config, 'PUSHER_APP_KEY', ''),
+    // kiroku-api publishes to plain `private-user-<uid>` channels with no env
+    // suffix (dev/prod are separate Pusher apps), on the `eu` cluster.
     SUFFIX: get(Config, 'PUSHER_DEV_SUFFIX', ''),
-    CLUSTER: 'mt1',
+    CLUSTER: get(Config, 'PUSHER_CLUSTER', 'eu'),
   },
   APPLE_SIGN_IN: {
     SERVICE_ID: get(Config, 'APPLE_SIGN_IN_SERVICE_ID', ''),

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -838,7 +838,8 @@ const CONST = {
   },
   PULL_REQUEST_NUMBER,
   PUSHER: {
-    PRIVATE_USER_CHANNEL_PREFIX: 'private-encrypted-user-userID-',
+    // kiroku-api authorizes/publishes to plain `private-user-<uid>` channels.
+    PRIVATE_USER_CHANNEL_PREFIX: 'private-user-',
   },
   REASON_FOR_LEAVING: {
     DB_KEY_LENGTH: 32,

--- a/src/components/ManageFriendPopover.tsx
+++ b/src/components/ManageFriendPopover.tsx
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react';
 import {View} from 'react-native';
-import {unfriend} from '@database/friends';
+import * as Friends from '@userActions/Friends';
 import {setFriendDataHidden} from '@database/privacy';
 import {useFirebase} from '@src/context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -74,7 +74,7 @@ function ManageFriendPopover({
         return;
       }
       try {
-        await unfriend(db, user.uid, friendId);
+        Friends.unfriend(friendId);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.COULD_NOT_UNFRIEND, error);
       } finally {

--- a/src/components/Search/SendFriendRequestButton/index.tsx
+++ b/src/components/Search/SendFriendRequestButton/index.tsx
@@ -5,14 +5,13 @@ import * as ErrorUtils from '@libs/ErrorUtils';
 import Button from '@components/Button';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Text from '@components/Text';
-import {acceptFriendRequest, sendFriendRequest} from '@src/database/friends';
+import * as Friends from '@userActions/Friends';
 import type {TranslationPaths} from '@src/languages/types';
 import ERRORS from '@src/ERRORS';
 import useLocalize from '@hooks/useLocalize';
 import type SendFriendRequestButtonProps from './types';
 
 function SendFriendRequestButton({
-  db,
   userFrom,
   userTo,
   requestStatus,
@@ -26,7 +25,7 @@ function SendFriendRequestButton({
     (async (): Promise<void> => {
       try {
         setIsLoading(true);
-        await sendFriendRequest(db, userFrom, userTo);
+        Friends.sendFriendRequest(userTo);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.FRIEND_REQUEST_SEND_FAILED, error);
       } finally {
@@ -39,7 +38,7 @@ function SendFriendRequestButton({
     (async (): Promise<void> => {
       try {
         setIsLoading(true);
-        await acceptFriendRequest(db, userFrom, userTo);
+        Friends.acceptFriendRequest(userTo);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.FRIEND_REQUEST_SEND_FAILED, error);
       } finally {

--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -26,9 +26,11 @@ import type {
 Request.use(Middleware.Logging);
 
 // RecheckConnection - Sets a timer for a request that will "recheck" if we are connected to the internet if time runs out. Also triggers the connection recheck when we encounter any error.
+// eslint-disable-next-line react-hooks/rules-of-hooks -- Request.use is not a React hook (name heuristic false positive)
 Request.use(Middleware.RecheckConnection);
 
 // Reauthentication - Handles jsonCode 407 (expired Firebase ID token): force-refreshes the token and replays the request.
+// eslint-disable-next-line react-hooks/rules-of-hooks -- Request.use is not a React hook (name heuristic false positive)
 Request.use(Middleware.Reauthentication);
 
 // SaveResponseInOnyx - Merges either the successData or failureData (or finallyData, if included in place of the former two values) into Onyx depending on if the call was successful or not. This needs to be the LAST middleware we use, don't add any

--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -26,10 +26,10 @@ import type {
 Request.use(Middleware.Logging);
 
 // RecheckConnection - Sets a timer for a request that will "recheck" if we are connected to the internet if time runs out. Also triggers the connection recheck when we encounter any error.
-// Request.use(Middleware.RecheckConnection); // TODO enable this
+Request.use(Middleware.RecheckConnection);
 
-// Reauthentication - Handles jsonCode 407 which indicates an expired authToken. We need to reauthenticate and get a new authToken with our stored credentials.
-// Request.use(Middleware.Reauthentication);
+// Reauthentication - Handles jsonCode 407 (expired Firebase ID token): force-refreshes the token and replays the request.
+Request.use(Middleware.Reauthentication);
 
 // SaveResponseInOnyx - Merges either the successData or failureData (or finallyData, if included in place of the former two values) into Onyx depending on if the call was successful or not. This needs to be the LAST middleware we use, don't add any
 // middlewares after this, because the SequentialQueue depends on the result of this middleware to pause the queue (if needed) to bring the app to an up-to-date state.

--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -3,7 +3,7 @@ import Onyx from 'react-native-onyx';
 import Log from '@libs/Log';
 import * as Middleware from '@libs/Middleware';
 import * as SequentialQueue from '@libs/Network/SequentialQueue';
-// import * as Pusher from '@libs/Pusher/pusher';
+import * as Pusher from '@libs/Pusher/pusher';
 import * as Request from '@libs/Request';
 import CONST from '@src/CONST';
 import type OnyxRequest from '@src/types/onyx/Request';
@@ -79,7 +79,7 @@ function write<TCommand extends WriteCommand>(
 
     // We send the pusherSocketID with all write requests so that the api can include it in push events to prevent Pusher from sending the events to the requesting client. The push event
     // is sent back to the requesting client in the response data instead, which prevents a replay effect in the UI. See https://github.com/Expensify/App/issues/12775.
-    // pusherSocketID: Pusher.getPusherSocketID(),
+    pusherSocketID: Pusher.getPusherSocketID(),
   };
 
   // Assemble all the request data we'll be storing in the queue

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -1,0 +1,46 @@
+import type {RequestType} from '@src/types/onyx/Request';
+import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from './types';
+
+/**
+ * kiroku-api is a per-route REST surface (e.g. `GET /v1/app/open`,
+ * `POST /v1/friends/request`), unlike the legacy Expensify-style single endpoint
+ * (`{root}api/{Command}`). This map translates a command name to its
+ * `{method, path}` on kiroku-api. Commands NOT listed here fall through to the
+ * legacy request path in `HttpUtils.xhr`. Add an entry as each action is cut over.
+ */
+type KirokuRoute = {
+  /** HTTP method to use against kiroku-api. */
+  method: RequestType;
+  /** Path under the kiroku-api root, including the `/v1` prefix. */
+  path: string;
+  /** Optional builder for a GET route's query params, derived from request data. */
+  toQuery?: (data: Record<string, unknown>) => Record<string, string | number>;
+};
+
+const KIROKU_ROUTES: Record<string, KirokuRoute> = {
+  [WRITE_COMMANDS.OPEN_APP]: {
+    method: 'get',
+    path: '/v1/app/open',
+  },
+  // Reconnect re-hydrates full state + the lastUpdateID baseline, same as open.
+  [WRITE_COMMANDS.RECONNECT_APP]: {
+    method: 'get',
+    path: '/v1/app/open',
+  },
+  [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: {
+    method: 'get',
+    path: '/v1/updates',
+    toQuery: data => ({
+      from: Number(data.updateIDFrom ?? 0),
+      to: Number(data.updateIDTo ?? 0),
+    }),
+  },
+};
+
+/** Returns the kiroku-api route for a command, or undefined for legacy commands. */
+function getKirokuRoute(command: string): KirokuRoute | undefined {
+  return KIROKU_ROUTES[command];
+}
+
+export {getKirokuRoute};
+export type {KirokuRoute};

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -35,6 +35,22 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
       to: Number(data.updateIDTo ?? 0),
     }),
   },
+  [WRITE_COMMANDS.SEND_FRIEND_REQUEST]: {
+    method: 'post',
+    path: '/v1/friends/request',
+  },
+  [WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST]: {
+    method: 'post',
+    path: '/v1/friends/accept',
+  },
+  [WRITE_COMMANDS.DELETE_FRIEND_REQUEST]: {
+    method: 'post',
+    path: '/v1/friends/delete-request',
+  },
+  [WRITE_COMMANDS.UNFRIEND]: {
+    method: 'post',
+    path: '/v1/friends/remove',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/AcceptFriendRequestParams.ts
+++ b/src/libs/API/parameters/AcceptFriendRequestParams.ts
@@ -1,0 +1,5 @@
+type AcceptFriendRequestParams = {
+  fromUserId: string;
+};
+
+export default AcceptFriendRequestParams;

--- a/src/libs/API/parameters/DeleteFriendRequestParams.ts
+++ b/src/libs/API/parameters/DeleteFriendRequestParams.ts
@@ -1,0 +1,5 @@
+type DeleteFriendRequestParams = {
+  otherUserId: string;
+};
+
+export default DeleteFriendRequestParams;

--- a/src/libs/API/parameters/SendFriendRequestParams.ts
+++ b/src/libs/API/parameters/SendFriendRequestParams.ts
@@ -1,0 +1,5 @@
+type SendFriendRequestParams = {
+  toUserId: string;
+};
+
+export default SendFriendRequestParams;

--- a/src/libs/API/parameters/UnfriendParams.ts
+++ b/src/libs/API/parameters/UnfriendParams.ts
@@ -1,0 +1,5 @@
+type UnfriendParams = {
+  otherUserId: string;
+};
+
+export default UnfriendParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -1,4 +1,8 @@
 export type {default as CloseAccountParams} from './CloseAccountParams';
+export type {default as SendFriendRequestParams} from './SendFriendRequestParams';
+export type {default as AcceptFriendRequestParams} from './AcceptFriendRequestParams';
+export type {default as DeleteFriendRequestParams} from './DeleteFriendRequestParams';
+export type {default as UnfriendParams} from './UnfriendParams';
 export type {default as GetMissingOnyxMessagesParams} from './GetMissingOnyxMessagesParams';
 export type {default as HandleRestrictedEventParams} from './HandleRestrictedEventParams';
 export type {default as OpenAppParams} from './OpenAppParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -29,6 +29,10 @@ const WRITE_COMMANDS = {
   //   REQUEST_UNLINK_VALIDATION_LINK: 'RequestUnlinkValidationLink',
   OPT_IN_TO_PUSH_NOTIFICATIONS: 'OptInToPushNotifications',
   OPT_OUT_OF_PUSH_NOTIFICATIONS: 'OptOutOfPushNotifications',
+  SEND_FRIEND_REQUEST: 'SendFriendRequest',
+  ACCEPT_FRIEND_REQUEST: 'AcceptFriendRequest',
+  DELETE_FRIEND_REQUEST: 'DeleteFriendRequest',
+  UNFRIEND: 'Unfriend',
   // ...
 } as const;
 
@@ -57,6 +61,10 @@ type WriteCommandParameters = {
   //   [WRITE_COMMANDS.REQUEST_UNLINK_VALIDATION_LINK]: Parameters.RequestUnlinkValidationLinkParams;
   [WRITE_COMMANDS.OPT_IN_TO_PUSH_NOTIFICATIONS]: Parameters.OptInOutToPushNotificationsParams;
   [WRITE_COMMANDS.OPT_OUT_OF_PUSH_NOTIFICATIONS]: Parameters.OptInOutToPushNotificationsParams;
+  [WRITE_COMMANDS.SEND_FRIEND_REQUEST]: Parameters.SendFriendRequestParams;
+  [WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST]: Parameters.AcceptFriendRequestParams;
+  [WRITE_COMMANDS.DELETE_FRIEND_REQUEST]: Parameters.DeleteFriendRequestParams;
+  [WRITE_COMMANDS.UNFRIEND]: Parameters.UnfriendParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/ApiUtils.ts
+++ b/src/libs/ApiUtils.ts
@@ -74,4 +74,18 @@ function isUsingStagingApi(): boolean {
   return shouldUseStagingServer;
 }
 
-export {getApiRoot, getCommandURL, isUsingStagingApi};
+/**
+ * Base URL for the kiroku-api HTTPS function, selected by environment. Prod
+ * builds hit the prod project; everything else (dev/staging/adhoc) hits dev.
+ * Route paths (see `libs/API/kirokuRoutes.ts`) include the `/v1` prefix and are
+ * appended to this root.
+ */
+function getKirokuApiRoot(): string {
+  const root =
+    ENV_NAME === CONST.ENVIRONMENT.PROD
+      ? CONFIG.KIROKU_API.PROD_ROOT
+      : CONFIG.KIROKU_API.DEV_ROOT;
+  return root.replace(/\/+$/, '');
+}
+
+export {getApiRoot, getCommandURL, getKirokuApiRoot, isUsingStagingApi};

--- a/src/libs/HttpUtils.ts
+++ b/src/libs/HttpUtils.ts
@@ -9,8 +9,11 @@ import type Response from '@src/types/onyx/Response';
 import * as NetworkActions from './actions/Network';
 import * as UpdateRequired from './actions/UpdateRequired';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from './API/types';
+import {getKirokuRoute} from './API/kirokuRoutes';
+import type {KirokuRoute} from './API/kirokuRoutes';
 import * as ApiUtils from './ApiUtils';
 import HttpsError from './Errors/HttpsError';
+import {getFirebaseAuth} from './Firebase/FirebaseApp';
 
 let shouldFailAllRequests = false;
 let shouldForceOffline = false;
@@ -55,8 +58,9 @@ const APICommandRegex = /\/api\/([^&?]+)\??.*/;
 function processHTTPRequest(
   url: string,
   method: RequestType = 'get',
-  body: FormData | null = null,
+  body: FormData | string | null = null,
   canCancel = true,
+  headers?: Record<string, string>,
 ): Promise<Response> {
   const startTime = new Date().valueOf();
   return fetch(url, {
@@ -64,6 +68,7 @@ function processHTTPRequest(
     signal: canCancel ? cancellationController.signal : undefined,
     method,
     body,
+    headers,
   })
     .then(response => {
       // We are calculating the skew to minimize the delay when posting the messages
@@ -184,12 +189,87 @@ function processHTTPRequest(
  * @param type HTTP request type (get/post)
  * @param shouldUseSecure should we use the secure server
  */
+// Request-data fields internal to the legacy Expensify transport that must not
+// be forwarded in a kiroku-api JSON body (command params + pusherSocketID stay).
+const KIROKU_OMITTED_BODY_FIELDS = new Set<string>([
+  'authToken',
+  'platform',
+  'api_setCookie',
+  'email',
+  'isFromDevEnv',
+  'appversion',
+  'clientUpdateID',
+  'apiRequestType',
+  'shouldRetry',
+  'canCancel',
+]);
+
+function buildKirokuBody(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  Object.keys(data).forEach(key => {
+    if (KIROKU_OMITTED_BODY_FIELDS.has(key) || typeof data[key] === 'undefined') {
+      return;
+    }
+    body[key] = data[key];
+  });
+  return body;
+}
+
+/**
+ * Send a request to the kiroku-api REST surface: resolve `{method, path}` from
+ * the route map, attach the caller's Firebase ID token as a Bearer header, and
+ * send a JSON body (non-GET) or a query string (GET). Returns the same
+ * `{jsonCode, onyxData}` envelope the legacy path returns.
+ */
+async function kirokuXhr(
+  data: Record<string, unknown>,
+  route: KirokuRoute,
+): Promise<Response> {
+  const token = await getFirebaseAuth().currentUser?.getIdToken();
+  if (!token) {
+    throw new HttpsError({
+      message: CONST.ERROR.FAILED_TO_FETCH,
+      title: 'Not authenticated',
+    });
+  }
+
+  const headers: Record<string, string> = {Authorization: `Bearer ${token}`};
+  let url = `${ApiUtils.getKirokuApiRoot()}${route.path}`;
+  let body: string | null = null;
+
+  if (route.method === 'get') {
+    const query = route.toQuery?.(data) ?? {};
+    const queryString = Object.entries(query)
+      .map(
+        ([key, value]) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+      )
+      .join('&');
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+  } else {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(buildKirokuBody(data));
+  }
+
+  return processHTTPRequest(url, route.method, body, !!data.canCancel, headers);
+}
+
 function xhr(
   command: string,
   data: Record<string, unknown>,
   type: RequestType = CONST.NETWORK.METHOD.POST,
   shouldUseSecure = false,
 ): Promise<Response> {
+  // kiroku-api commands route to the per-route REST surface with Bearer auth.
+  const kirokuRoute = getKirokuRoute(command);
+  if (kirokuRoute) {
+    return kirokuXhr(data, kirokuRoute);
+  }
+
   const formData = new FormData();
   Object.keys(data).forEach(key => {
     if (typeof data[key] === 'undefined') {

--- a/src/libs/Middleware/Reauthentication.ts
+++ b/src/libs/Middleware/Reauthentication.ts
@@ -1,133 +1,106 @@
-// import * as Authentication from '@libs/Authentication';
-// import Log from '@libs/Log';
-// import * as MainQueue from '@libs/Network/MainQueue';
-// import * as NetworkStore from '@libs/Network/NetworkStore';
-// import NetworkConnection from '@libs/NetworkConnection';
-// import * as Request from '@libs/Request';
-// import CONST from '@src/CONST';
-// import type Middleware from './types';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import Log from '@libs/Log';
+import * as NetworkStore from '@libs/Network/NetworkStore';
+import NetworkConnection from '@libs/NetworkConnection';
+import * as Request from '@libs/Request';
+import CONST from '@src/CONST';
+import type OnyxRequest from '@src/types/onyx/Request';
+import type Middleware from './types';
 
-// // We store a reference to the active authentication request so that we are only ever making one request to authenticate at a time.
-// let isAuthenticating: Promise<void> | null = null;
+/**
+ * Reauthentication for the kiroku-api transport. kiroku-api authenticates with a
+ * Firebase ID token (Bearer); on an expired token it returns `{ jsonCode: 407 }`
+ * (NOT_AUTHENTICATED). "Reauthenticate" therefore means force-refreshing the
+ * Firebase ID token so the replayed request — which reads `getIdToken()` per
+ * call in `HttpUtils` — picks up a fresh one.
+ *
+ * This is a Kiroku-specific adaptation of Expensify's Reauthentication: it does
+ * not use the Expensify credential exchange (`Authentication`) or the deprecated
+ * `MainQueue` replay path, neither of which exists here.
+ */
 
-// function reauthenticate(commandName?: string): Promise<void> {
-//   if (isAuthenticating) {
-//     return isAuthenticating;
-//   }
+// Only one token refresh runs at a time; concurrent 407s share the same promise.
+let isReauthenticating: Promise<unknown> | null = null;
 
-//   isAuthenticating = Authentication.reauthenticate(commandName)
-//     .then(response => {
-//       isAuthenticating = null;
-//       return response;
-//     })
-//     .catch(error => {
-//       isAuthenticating = null;
-//       throw error;
-//     });
+// Requests already retried once after a refresh — prevents an infinite reauth
+// loop if the server keeps returning 407 (e.g. a revoked/disabled account).
+const reauthenticatedRequests = new WeakSet<OnyxRequest>();
 
-//   return isAuthenticating;
-// }
+function reauthenticate(): Promise<unknown> {
+  if (isReauthenticating) {
+    return isReauthenticating;
+  }
 
-// const Reauthentication: Middleware = (
-//   response,
-//   request,
-//   isFromSequentialQueue,
-// ) =>
-//   response
-//     .then(data => {
-//       // If there is no data for some reason then we cannot reauthenticate
-//       if (!data) {
-//         Log.hmmm('Undefined data in Reauthentication');
-//         return;
-//       }
+  const user = getFirebaseAuth().currentUser;
+  isReauthenticating = (
+    user
+      ? user.getIdToken(true)
+      : Promise.reject(new Error('No authenticated user to reauthenticate'))
+  )
+    .then(result => {
+      isReauthenticating = null;
+      return result;
+    })
+    .catch(error => {
+      isReauthenticating = null;
+      throw error;
+    });
 
-//       if (data.jsonCode === CONST.JSON_CODE.NOT_AUTHENTICATED) {
-//         if (NetworkStore.isOffline()) {
-//           // If we are offline and somehow handling this response we do not want to reauthenticate
-//           throw new Error('Unable to reauthenticate because we are offline');
-//         }
+  return isReauthenticating;
+}
 
-//         // There are some API requests that should not be retried when there is an auth failure like
-//         // creating and deleting logins. In those cases, they should handle the original response instead
-//         // of the new response created by handleExpiredAuthToken.
-//         const shouldRetry = request?.data?.shouldRetry;
-//         const apiRequestType = request?.data?.apiRequestType;
+const Reauthentication: Middleware = (
+  response,
+  request,
+  isFromSequentialQueue,
+) =>
+  response.then(data => {
+    if (!data) {
+      Log.hmmm('[Reauthentication] Undefined data in response');
+      return data;
+    }
 
-//         // For the SignInWithShortLivedAuthToken command, if the short token expires, the server returns a 407 error,
-//         // and credentials are still empty at this time, which causes reauthenticate to throw an error (requireParameters),
-//         // and the subsequent SaveResponseInOnyx also cannot be executed, so we need this parameter to skip the reauthentication logic.
-//         const skipReauthentication = request?.data?.skipReauthentication;
-//         if ((!shouldRetry && !apiRequestType) || skipReauthentication) {
-//           if (isFromSequentialQueue) {
-//             return data;
-//           }
+    if (data.jsonCode !== CONST.JSON_CODE.NOT_AUTHENTICATED) {
+      return data;
+    }
 
-//           if (request.resolve) {
-//             request.resolve(data);
-//           }
-//           return data;
-//         }
+    if (NetworkStore.isOffline()) {
+      throw new Error('Unable to reauthenticate because we are offline');
+    }
 
-//         // We are already authenticating and using the DeprecatedAPI so we will replay the request
-//         if (!apiRequestType && NetworkStore.isAuthenticating()) {
-//           MainQueue.replay(request);
-//           return data;
-//         }
+    // Already retried once after a refresh — give up rather than loop forever.
+    if (reauthenticatedRequests.has(request)) {
+      return data;
+    }
+    reauthenticatedRequests.add(request);
 
-//         return reauthenticate(request?.commandName)
-//           .then(authenticateResponse => {
-//             if (
-//               isFromSequentialQueue ||
-//               apiRequestType ===
-//                 CONST.API_REQUEST_TYPE.MAKE_REQUEST_WITH_SIDE_EFFECTS
-//             ) {
-//               return Request.processWithMiddleware(
-//                 request,
-//                 isFromSequentialQueue,
-//               );
-//             }
+    const apiRequestType = request?.data?.apiRequestType;
 
-//             if (apiRequestType === CONST.API_REQUEST_TYPE.READ) {
-//               NetworkConnection.triggerReconnectionCallbacks(
-//                 'read request made with expired authToken',
-//               );
-//               return Promise.resolve();
-//             }
+    return reauthenticate()
+      .then(() => {
+        // Queue writes and side-effect requests replay through the full chain
+        // (which re-reads a fresh Firebase ID token in HttpUtils).
+        if (
+          isFromSequentialQueue ||
+          apiRequestType ===
+            CONST.API_REQUEST_TYPE.MAKE_REQUEST_WITH_SIDE_EFFECTS
+        ) {
+          return Request.processWithMiddleware(request, isFromSequentialQueue);
+        }
 
-//             MainQueue.replay(request);
-//             return authenticateResponse;
-//           })
-//           .catch(() => {
-//             if (isFromSequentialQueue || apiRequestType) {
-//               throw new Error('Failed to reauthenticate');
-//             }
+        // Reads re-run via the reconnection callbacks (e.g. OpenApp).
+        if (apiRequestType === CONST.API_REQUEST_TYPE.READ) {
+          NetworkConnection.triggerReconnectionCallbacks(
+            'read request made with an expired token',
+          );
+          return undefined;
+        }
 
-//             // If we make it here, then our reauthenticate request could not be made due to a networking issue. The original request can be retried safely.
-//             MainQueue.replay(request);
-//           });
-//       }
+        return Request.processWithMiddleware(request, isFromSequentialQueue);
+      })
+      .catch(() => {
+        throw new Error('Failed to reauthenticate');
+      });
+  });
 
-//       if (isFromSequentialQueue) {
-//         return data;
-//       }
-
-//       if (request.resolve) {
-//         request.resolve(data);
-//       }
-
-//       // Return response data so we can chain the response with the following middlewares.
-//       return data;
-//     })
-//     .catch(error => {
-//       // If the request is on the sequential queue, re-throw the error so we can decide to retry or not
-//       if (isFromSequentialQueue) {
-//         throw error;
-//       }
-
-//       // If we have caught a networking error from a DeprecatedAPI request, resolve it as unable to retry, otherwise the request will never resolve or reject.
-//       if (request.resolve) {
-//         request.resolve({jsonCode: CONST.JSON_CODE.UNABLE_TO_RETRY});
-//       }
-//     });
-
-// export default Reauthentication;
+export default Reauthentication;

--- a/src/libs/Middleware/index.ts
+++ b/src/libs/Middleware/index.ts
@@ -1,11 +1,11 @@
 import Logging from './Logging';
-// import Reauthentication from './Reauthentication';
+import Reauthentication from './Reauthentication';
 import RecheckConnection from './RecheckConnection';
 import SaveResponseInOnyx from './SaveResponseInOnyx';
 
 export {
   Logging,
-  // Reauthentication,
+  Reauthentication,
   RecheckConnection,
   SaveResponseInOnyx,
 };

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -17,7 +17,7 @@ import * as Session from '@userActions/Session';
 import Timing from '@userActions/Timing';
 import * as User from '@userActions/User';
 import {getDatabase} from 'firebase/database';
-// import CONFIG from '@src/CONFIG';
+import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -30,6 +30,9 @@ import {
 import {useSplashScreenStateContext} from '@context/global/SplashScreenStateContext';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {FirebaseApp, getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import * as Pusher from '@libs/Pusher/pusher';
+import * as ApiUtils from '@libs/ApiUtils';
+import kirokuPusherAuthorizer from '@libs/Pusher/kirokuAuthorizer';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -208,13 +211,14 @@ function AuthScreensContent() {
     // NetworkConnection.listenForReconnect();
     // NetworkConnection.onReconnect(handleNetworkReconnect);
     // PusherConnectionManager.init();
-    // Pusher.init({
-    //   appKey: CONFIG.PUSHER.APP_KEY,
-    //   cluster: CONFIG.PUSHER.CLUSTER,
-    //   authEndpoint: `${CONFIG.KIROKU.DEFAULT_API_ROOT}api/AuthenticatePusher?`,
-    // }).then(() => {
-    //   User.subscribeToUserEvents();
-    // });
+    Pusher.registerCustomAuthorizer(kirokuPusherAuthorizer);
+    Pusher.init({
+      appKey: CONFIG.PUSHER.APP_KEY,
+      cluster: CONFIG.PUSHER.CLUSTER,
+      authEndpoint: `${ApiUtils.getKirokuApiRoot()}/v1/pusher/auth`,
+    }).then(() => {
+      User.subscribeToUserEvents();
+    });
 
     // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
     // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().

--- a/src/libs/Pusher/kirokuAuthorizer.ts
+++ b/src/libs/Pusher/kirokuAuthorizer.ts
@@ -1,4 +1,10 @@
-import type {ChannelAuthorizerGenerator} from 'pusher-js/with-encryption';
+import type {
+  ChannelAuthorizerGenerator,
+  ChannelAuthorizationCallback,
+} from 'pusher-js/with-encryption';
+
+/** The auth-data shape Pusher's authorization callback accepts (`{auth, ...}`). */
+type ChannelAuthData = Parameters<ChannelAuthorizationCallback>[1];
 import * as ApiUtils from '@libs/ApiUtils';
 import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 
@@ -25,6 +31,7 @@ const kirokuPusherAuthorizer: ChannelAuthorizerGenerator = channel => ({
           method: 'post',
           headers: {
             Authorization: `Bearer ${token}`,
+            // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
             'Content-Type': 'application/x-www-form-urlencoded',
           },
           body,
@@ -40,7 +47,7 @@ const kirokuPusherAuthorizer: ChannelAuthorizerGenerator = channel => ({
         }
         response
           .json()
-          .then(authData => callback(null, authData))
+          .then((authData: ChannelAuthData) => callback(null, authData))
           .catch((error: Error) => callback(error, null));
       })
       .catch((error: Error) => callback(error, null));

--- a/src/libs/Pusher/kirokuAuthorizer.ts
+++ b/src/libs/Pusher/kirokuAuthorizer.ts
@@ -2,11 +2,11 @@ import type {
   ChannelAuthorizerGenerator,
   ChannelAuthorizationCallback,
 } from 'pusher-js/with-encryption';
+import * as ApiUtils from '@libs/ApiUtils';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 
 /** The auth-data shape Pusher's authorization callback accepts (`{auth, ...}`). */
 type ChannelAuthData = Parameters<ChannelAuthorizationCallback>[1];
-import * as ApiUtils from '@libs/ApiUtils';
-import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 
 /**
  * Custom Pusher channel authorizer for kiroku-api. pusher-js's default

--- a/src/libs/Pusher/kirokuAuthorizer.ts
+++ b/src/libs/Pusher/kirokuAuthorizer.ts
@@ -1,0 +1,50 @@
+import type {ChannelAuthorizerGenerator} from 'pusher-js/with-encryption';
+import * as ApiUtils from '@libs/ApiUtils';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+
+/**
+ * Custom Pusher channel authorizer for kiroku-api. pusher-js's default
+ * authorizer POSTs `socket_id` + `channel_name` to the auth endpoint but cannot
+ * attach our `Authorization: Bearer <Firebase ID token>` header, which
+ * `POST /v1/pusher/auth` requires (it is guarded by the same `authenticate`
+ * middleware as every other endpoint). This authorizer adds that header.
+ */
+const kirokuPusherAuthorizer: ChannelAuthorizerGenerator = channel => ({
+  authorize(socketId, callback) {
+    const user = getFirebaseAuth().currentUser;
+    if (!user) {
+      callback(new Error('Cannot authorize Pusher: no authenticated user'), null);
+      return;
+    }
+
+    user
+      .getIdToken()
+      .then(token => {
+        const body = `socket_id=${encodeURIComponent(socketId)}&channel_name=${encodeURIComponent(channel.name)}`;
+        return fetch(`${ApiUtils.getKirokuApiRoot()}/v1/pusher/auth`, {
+          method: 'post',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body,
+        });
+      })
+      .then(response => {
+        if (!response.ok) {
+          callback(
+            new Error(`Pusher channel authorization failed (${response.status})`),
+            null,
+          );
+          return;
+        }
+        response
+          .json()
+          .then(authData => callback(null, authData))
+          .catch((error: Error) => callback(error, null));
+      })
+      .catch((error: Error) => callback(error, null));
+  },
+});
+
+export default kirokuPusherAuthorizer;

--- a/src/libs/Pusher/pusher.ts
+++ b/src/libs/Pusher/pusher.ts
@@ -1,433 +1,433 @@
-// import isObject from 'lodash/isObject';
-// import type {Channel, ChannelAuthorizerGenerator, Options} from 'pusher-js/with-encryption';
-// import {InteractionManager} from 'react-native';
-// import Onyx from 'react-native-onyx';
-// import type {LiteralUnion, ValueOf} from 'type-fest';
-// import Log from '@libs/Log';
-// import type CONST from '@src/CONST';
-// import ONYXKEYS from '@src/ONYXKEYS';
-// import type {OnyxUpdatesFromServer, ReportUserIsTyping} from '@src/types/onyx';
-// import type DeepValueOf from '@src/types/utils/DeepValueOf';
-// import TYPE from './EventType';
-// import Pusher from './library';
-// import type {SocketEventName} from './library/types';
-
-// type States = {
-//     previous: string;
-//     current: string;
-// };
-
-// type Args = {
-//     appKey: string;
-//     cluster: string;
-//     authEndpoint: string;
-// };
-
-// type UserIsTypingEvent = ReportUserIsTyping & {
-//     userLogin?: string;
-// };
-
-// type UserIsLeavingRoomEvent = Record<string, boolean> & {
-//     userLogin?: string;
-// };
-
-// type PusherEventMap = {
-//     [TYPE.USER_IS_TYPING]: UserIsTypingEvent;
-//     [TYPE.USER_IS_LEAVING_ROOM]: UserIsLeavingRoomEvent;
-// };
-
-// type EventData<EventName extends string> = {chunk?: string; id?: string; index?: number; final?: boolean} & (EventName extends keyof PusherEventMap
-//     ? PusherEventMap[EventName]
-//     : OnyxUpdatesFromServer);
-
-// type EventCallbackError = {type: ValueOf<typeof CONST.ERROR>; data: {code: number}};
-
-// type ChunkedDataEvents = {chunks: unknown[]; receivedFinal: boolean};
-
-// type SocketEventCallback = (eventName: SocketEventName, data?: States | EventCallbackError) => void;
-
-// type PusherWithAuthParams = InstanceType<typeof Pusher> & {
-//     config: {
-//         auth?: {
-//             params?: unknown;
-//         };
-//     };
-// };
-
-// type PusherEventName = LiteralUnion<DeepValueOf<typeof TYPE>, string>;
-
-// type PusherSubscribtionErrorData = {type?: string; error?: string; status?: string};
-
-// let shouldForceOffline = false;
-// Onyx.connect({
-//     key: ONYXKEYS.NETWORK,
-//     callback: (network) => {
-//         if (!network) {
-//             return;
-//         }
-//         shouldForceOffline = !!network.shouldForceOffline;
-//     },
-// });
-
-// let socket: PusherWithAuthParams | null;
-// let pusherSocketID = '';
-// const socketEventCallbacks: SocketEventCallback[] = [];
-// let customAuthorizer: ChannelAuthorizerGenerator;
-
-// const eventsBoundToChannels = new Map<Channel, Set<PusherEventName>>();
-
-// /**
-//  * Trigger each of the socket event callbacks with the event information
-//  */
-// function callSocketEventCallbacks(eventName: SocketEventName, data?: EventCallbackError | States) {
-//     socketEventCallbacks.forEach((cb) => cb(eventName, data));
-// }
-
-// /**
-//  * Initialize our pusher lib
-//  * @returns resolves when Pusher has connected
-//  */
-// function init(args: Args, params?: unknown): Promise<void> {
-//     return new Promise((resolve) => {
-//         if (socket) {
-//             resolve();
-//             return;
-//         }
-
-//         // Use this for debugging
-//         // Pusher.log = (message) => {
-//         //     if (window.console && window.console.log) {
-//         //         window.console.log(message);
-//         //     }
-//         // };
-
-//         const options: Options = {
-//             cluster: args.cluster,
-//             authEndpoint: args.authEndpoint,
-//         };
-
-//         if (customAuthorizer) {
-//             options.authorizer = customAuthorizer;
-//         }
-
-//         socket = new Pusher(args.appKey, options);
-//         // If we want to pass params in our requests to api.php we'll need to add it to socket.config.auth.params
-//         // as per the documentation
-//         // (https://pusher.com/docs/channels/using_channels/connection#channels-options-parameter).
-//         // Any param mentioned here will show up in $_REQUEST when we call "AuthenticatePusher". Params passed here need
-//         // to pass our inputRules to show up in the request.
-//         if (params) {
-//             socket.config.auth = {};
-//             socket.config.auth.params = params;
-//         }
-
-//         // Listen for connection errors and log them
-//         socket?.connection.bind('error', (error: EventCallbackError) => {
-//             callSocketEventCallbacks('error', error);
-//         });
-
-//         socket?.connection.bind('connected', () => {
-//             pusherSocketID = socket?.connection.socket_id ?? '';
-//             callSocketEventCallbacks('connected');
-//             resolve();
-//         });
-
-//         socket?.connection.bind('disconnected', () => {
-//             callSocketEventCallbacks('disconnected');
-//         });
-
-//         socket?.connection.bind('state_change', (states: States) => {
-//             callSocketEventCallbacks('state_change', states);
-//         });
-//     });
-// }
-
-// /**
-//  * Returns a Pusher channel for a channel name
-//  */
-// function getChannel(channelName: string): Channel | undefined {
-//     if (!socket) {
-//         return;
-//     }
-
-//     return socket.channel(channelName);
-// }
-
-// /**
-//  * Binds an event callback to a channel + eventName
-//  */
-// function bindEventToChannel<EventName extends PusherEventName>(channel: Channel | undefined, eventName?: EventName, eventCallback: (data: EventData<EventName>) => void = () => {}) {
-//     if (!eventName || !channel) {
-//         return;
-//     }
-
-//     const chunkedDataEvents: Record<string, ChunkedDataEvents> = {};
-//     const callback = (eventData: EventData<EventName>) => {
-//         if (shouldForceOffline) {
-//             Log.info('[Pusher] Ignoring a Push event because shouldForceOffline = true');
-//             return;
-//         }
-
-//         let data: EventData<EventName>;
-//         try {
-//             data = isObject(eventData) ? eventData : (JSON.parse(eventData) as EventData<EventName>);
-//         } catch (err) {
-//             Log.alert('[Pusher] Unable to parse single JSON event data from Pusher', {error: err, eventData});
-//             return;
-//         }
-//         if (data.id === undefined || data.chunk === undefined || data.final === undefined) {
-//             eventCallback(data);
-//             return;
-//         }
-
-//         // If we are chunking the requests, we need to construct a rolling list of all packets that have come through
-//         // Pusher. If we've completed one of these full packets, we'll combine the data and act on the event that it's
-//         // assigned to.
-
-//         // If we haven't seen this eventID yet, initialize it into our rolling list of packets.
-//         if (!chunkedDataEvents[data.id]) {
-//             chunkedDataEvents[data.id] = {chunks: [], receivedFinal: false};
-//         }
-
-//         // Add it to the rolling list.
-//         const chunkedEvent = chunkedDataEvents[data.id];
-//         if (data.index !== undefined) {
-//             chunkedEvent.chunks[data.index] = data.chunk;
-//         }
-
-//         // If this is the last packet, mark that we've hit the end.
-//         if (data.final) {
-//             chunkedEvent.receivedFinal = true;
-//         }
-
-//         // Only call the event callback if we've received the last packet and we don't have any holes in the complete
-//         // packet.
-//         if (chunkedEvent.receivedFinal && chunkedEvent.chunks.length === Object.keys(chunkedEvent.chunks).length) {
-//             try {
-//                 eventCallback(JSON.parse(chunkedEvent.chunks.join('')) as EventData<EventName>);
-//             } catch (err) {
-//                 Log.alert('[Pusher] Unable to parse chunked JSON response from Pusher', {
-//                     error: err,
-//                     eventData: chunkedEvent.chunks.join(''),
-//                 });
-
-//                 // Using console.error is helpful here because it will print a usable stack trace to the console to debug where the error comes from
-//                 console.error(err);
-//             }
-
-//             delete chunkedDataEvents[data.id];
-//         }
-//     };
-
-//     channel.bind(eventName, callback);
-//     if (!eventsBoundToChannels.has(channel)) {
-//         eventsBoundToChannels.set(channel, new Set());
-//     }
-//     eventsBoundToChannels.get(channel)?.add(eventName);
-// }
-
-// /**
-//  * Subscribe to a channel and an event
-//  * @param [onResubscribe] Callback to be called when reconnection happen
-//  */
-// function subscribe<EventName extends PusherEventName>(
-//     channelName: string,
-//     eventName?: EventName,
-//     eventCallback: (data: EventData<EventName>) => void = () => {},
-//     onResubscribe = () => {},
-// ): Promise<void> {
-//     return new Promise((resolve, reject) => {
-//         InteractionManager.runAfterInteractions(() => {
-//             // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
-//             if (!socket) {
-//                 throw new Error(`[Pusher] instance not found. Pusher.subscribe()
-//             most likely has been called before Pusher.init()`);
-//             }
-
-//             Log.info('[Pusher] Attempting to subscribe to channel', false, {channelName, eventName});
-//             let channel = getChannel(channelName);
-
-//             if (!channel?.subscribed) {
-//                 channel = socket.subscribe(channelName);
-//                 let isBound = false;
-//                 channel.bind('pusher:subscription_succeeded', () => {
-//                     // Check so that we do not bind another event with each reconnect attempt
-//                     if (!isBound) {
-//                         bindEventToChannel(channel, eventName, eventCallback);
-//                         resolve();
-//                         isBound = true;
-//                         return;
-//                     }
-
-//                     // When subscribing for the first time we register a success callback that can be
-//                     // called multiple times when the subscription succeeds again in the future
-//                     // e.g. as a result of Pusher disconnecting and reconnecting. This callback does
-//                     // not fire on the first subscription_succeeded event.
-//                     onResubscribe();
-//                 });
-
-//                 channel.bind('pusher:subscription_error', (data: PusherSubscribtionErrorData = {}) => {
-//                     const {type, error, status} = data;
-//                     Log.hmmm('[Pusher] Issue authenticating with Pusher during subscribe attempt.', {
-//                         channelName,
-//                         status,
-//                         type,
-//                         error,
-//                     });
-//                     reject(error);
-//                 });
-//             } else {
-//                 bindEventToChannel(channel, eventName, eventCallback);
-//                 resolve();
-//             }
-//         });
-//     });
-// }
-
-// /**
-//  * Unsubscribe from a channel and optionally a specific event
-//  */
-// function unsubscribe(channelName: string, eventName: PusherEventName = '') {
-//     const channel = getChannel(channelName);
-
-//     if (!channel) {
-//         Log.hmmm('[Pusher] Attempted to unsubscribe or unbind from a channel, but Pusher-JS has no knowledge of it', {channelName, eventName});
-//         return;
-//     }
-
-//     if (eventName) {
-//         Log.info('[Pusher] Unbinding event', false, {eventName, channelName});
-//         channel.unbind(eventName);
-//         eventsBoundToChannels.get(channel)?.delete(eventName);
-//         if (eventsBoundToChannels.get(channel)?.size === 0) {
-//             Log.info(`[Pusher] After unbinding ${eventName} from channel ${channelName}, no other events were bound to that channel. Unsubscribing...`, false);
-//             eventsBoundToChannels.delete(channel);
-//             socket?.unsubscribe(channelName);
-//         }
-//     } else {
-//         if (!channel.subscribed) {
-//             Log.info('Pusher] Attempted to unsubscribe from channel, but we are not subscribed to begin with', false, {channelName});
-//             return;
-//         }
-//         Log.info('[Pusher] Unsubscribing from channel', false, {channelName});
-
-//         channel.unbind();
-//         socket?.unsubscribe(channelName);
-//     }
-// }
-
-// /**
-//  * Are we already in the process of subscribing to this channel?
-//  */
-// function isAlreadySubscribing(channelName: string): boolean {
-//     if (!socket) {
-//         return false;
-//     }
-
-//     const channel = getChannel(channelName);
-//     return channel ? channel.subscriptionPending : false;
-// }
-
-// /**
-//  * Are we already subscribed to this channel?
-//  */
-// function isSubscribed(channelName: string): boolean {
-//     if (!socket) {
-//         return false;
-//     }
-
-//     const channel = getChannel(channelName);
-//     return channel ? channel.subscribed : false;
-// }
-
-// /**
-//  * Sends an event over a specific event/channel in pusher.
-//  */
-// function sendEvent<EventName extends PusherEventName>(channelName: string, eventName: EventName, payload: EventData<EventName>) {
-//     // Check to see if we are subscribed to this channel before sending the event. Sending client events over channels
-//     // we are not subscribed too will throw errors and cause reconnection attempts. Subscriptions are not instant and
-//     // can happen later than we expect.
-//     if (!isSubscribed(channelName)) {
-//         return;
-//     }
-
-//     if (shouldForceOffline) {
-//         Log.info('[Pusher] Ignoring a Send event because shouldForceOffline = true');
-//         return;
-//     }
-
-//     socket?.send_event(eventName, payload, channelName);
-// }
-
-// /**
-//  * Register a method that will be triggered when a socket event happens (like disconnecting)
-//  */
-// function registerSocketEventCallback(cb: SocketEventCallback) {
-//     socketEventCallbacks.push(cb);
-// }
-
-// /**
-//  * A custom authorizer allows us to take a more fine-grained approach to
-//  * authenticating Pusher. e.g. we can handle failed attempts to authorize
-//  * with an expired authToken and retry the attempt.
-//  */
-// function registerCustomAuthorizer(authorizer: ChannelAuthorizerGenerator) {
-//     customAuthorizer = authorizer;
-// }
-
-// /**
-//  * Disconnect from Pusher
-//  */
-// function disconnect() {
-//     if (!socket) {
-//         Log.info('[Pusher] Attempting to disconnect from Pusher before initialisation has occurred, ignoring.');
-//         return;
-//     }
-
-//     socket.disconnect();
-//     socket = null;
-//     pusherSocketID = '';
-// }
-
-// /**
-//  * Disconnect and Re-Connect Pusher
-//  */
-// function reconnect() {
-//     if (!socket) {
-//         Log.info('[Pusher] Unable to reconnect since Pusher instance does not yet exist.');
-//         return;
-//     }
-
-//     Log.info('[Pusher] Reconnecting to Pusher');
-//     socket.disconnect();
-//     socket.connect();
-// }
-
-// function getPusherSocketID(): string {
-//     return pusherSocketID;
-// }
-
-// if (window) {
-//     /**
-//      * Pusher socket for debugging purposes
-//      */
-//     window.getPusherInstance = () => socket;
-// }
-
-// export {
-//     init,
-//     subscribe,
-//     unsubscribe,
-//     getChannel,
-//     isSubscribed,
-//     isAlreadySubscribing,
-//     sendEvent,
-//     disconnect,
-//     reconnect,
-//     registerSocketEventCallback,
-//     registerCustomAuthorizer,
-//     TYPE,
-//     getPusherSocketID,
-// };
-
-// export type {EventCallbackError, States, UserIsTypingEvent, UserIsLeavingRoomEvent};
+import isObject from 'lodash/isObject';
+import type {Channel, ChannelAuthorizerGenerator, Options} from 'pusher-js/with-encryption';
+import {InteractionManager} from 'react-native';
+import Onyx from 'react-native-onyx';
+import type {LiteralUnion, ValueOf} from 'type-fest';
+import Log from '@libs/Log';
+import type CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {OnyxUpdatesFromServer, UserIsTyping} from '@src/types/onyx';
+import type DeepValueOf from '@src/types/utils/DeepValueOf';
+import TYPE from './EventType';
+import Pusher from './library';
+import type {SocketEventName} from './library/types';
+
+type States = {
+    previous: string;
+    current: string;
+};
+
+type Args = {
+    appKey: string;
+    cluster: string;
+    authEndpoint: string;
+};
+
+type UserIsTypingEvent = UserIsTyping & {
+    userLogin?: string;
+};
+
+type UserIsLeavingRoomEvent = Record<string, boolean> & {
+    userLogin?: string;
+};
+
+type PusherEventMap = {
+    [TYPE.USER_IS_TYPING]: UserIsTypingEvent;
+    [TYPE.USER_IS_LEAVING_ROOM]: UserIsLeavingRoomEvent;
+};
+
+type EventData<EventName extends string> = {chunk?: string; id?: string; index?: number; final?: boolean} & (EventName extends keyof PusherEventMap
+    ? PusherEventMap[EventName]
+    : OnyxUpdatesFromServer);
+
+type EventCallbackError = {type: ValueOf<typeof CONST.ERROR>; data: {code: number}};
+
+type ChunkedDataEvents = {chunks: unknown[]; receivedFinal: boolean};
+
+type SocketEventCallback = (eventName: SocketEventName, data?: States | EventCallbackError) => void;
+
+type PusherWithAuthParams = InstanceType<typeof Pusher> & {
+    config: {
+        auth?: {
+            params?: unknown;
+        };
+    };
+};
+
+type PusherEventName = LiteralUnion<DeepValueOf<typeof TYPE>, string>;
+
+type PusherSubscribtionErrorData = {type?: string; error?: string; status?: string};
+
+let shouldForceOffline = false;
+Onyx.connect({
+    key: ONYXKEYS.NETWORK,
+    callback: (network) => {
+        if (!network) {
+            return;
+        }
+        shouldForceOffline = !!network.shouldForceOffline;
+    },
+});
+
+let socket: PusherWithAuthParams | null;
+let pusherSocketID = '';
+const socketEventCallbacks: SocketEventCallback[] = [];
+let customAuthorizer: ChannelAuthorizerGenerator;
+
+const eventsBoundToChannels = new Map<Channel, Set<PusherEventName>>();
+
+/**
+ * Trigger each of the socket event callbacks with the event information
+ */
+function callSocketEventCallbacks(eventName: SocketEventName, data?: EventCallbackError | States) {
+    socketEventCallbacks.forEach((cb) => cb(eventName, data));
+}
+
+/**
+ * Initialize our pusher lib
+ * @returns resolves when Pusher has connected
+ */
+function init(args: Args, params?: unknown): Promise<void> {
+    return new Promise((resolve) => {
+        if (socket) {
+            resolve();
+            return;
+        }
+
+        // Use this for debugging
+        // Pusher.log = (message) => {
+        //     if (window.console && window.console.log) {
+        //         window.console.log(message);
+        //     }
+        // };
+
+        const options: Options = {
+            cluster: args.cluster,
+            authEndpoint: args.authEndpoint,
+        };
+
+        if (customAuthorizer) {
+            options.authorizer = customAuthorizer;
+        }
+
+        socket = new Pusher(args.appKey, options);
+        // If we want to pass params in our requests to api.php we'll need to add it to socket.config.auth.params
+        // as per the documentation
+        // (https://pusher.com/docs/channels/using_channels/connection#channels-options-parameter).
+        // Any param mentioned here will show up in $_REQUEST when we call "AuthenticatePusher". Params passed here need
+        // to pass our inputRules to show up in the request.
+        if (params) {
+            socket.config.auth = {};
+            socket.config.auth.params = params;
+        }
+
+        // Listen for connection errors and log them
+        socket?.connection.bind('error', (error: EventCallbackError) => {
+            callSocketEventCallbacks('error', error);
+        });
+
+        socket?.connection.bind('connected', () => {
+            pusherSocketID = socket?.connection.socket_id ?? '';
+            callSocketEventCallbacks('connected');
+            resolve();
+        });
+
+        socket?.connection.bind('disconnected', () => {
+            callSocketEventCallbacks('disconnected');
+        });
+
+        socket?.connection.bind('state_change', (states: States) => {
+            callSocketEventCallbacks('state_change', states);
+        });
+    });
+}
+
+/**
+ * Returns a Pusher channel for a channel name
+ */
+function getChannel(channelName: string): Channel | undefined {
+    if (!socket) {
+        return;
+    }
+
+    return socket.channel(channelName);
+}
+
+/**
+ * Binds an event callback to a channel + eventName
+ */
+function bindEventToChannel<EventName extends PusherEventName>(channel: Channel | undefined, eventName?: EventName, eventCallback: (data: EventData<EventName>) => void = () => {}) {
+    if (!eventName || !channel) {
+        return;
+    }
+
+    const chunkedDataEvents: Record<string, ChunkedDataEvents> = {};
+    const callback = (eventData: EventData<EventName>) => {
+        if (shouldForceOffline) {
+            Log.info('[Pusher] Ignoring a Push event because shouldForceOffline = true');
+            return;
+        }
+
+        let data: EventData<EventName>;
+        try {
+            data = isObject(eventData) ? eventData : (JSON.parse(eventData) as EventData<EventName>);
+        } catch (err) {
+            Log.alert('[Pusher] Unable to parse single JSON event data from Pusher', {error: err, eventData});
+            return;
+        }
+        if (data.id === undefined || data.chunk === undefined || data.final === undefined) {
+            eventCallback(data);
+            return;
+        }
+
+        // If we are chunking the requests, we need to construct a rolling list of all packets that have come through
+        // Pusher. If we've completed one of these full packets, we'll combine the data and act on the event that it's
+        // assigned to.
+
+        // If we haven't seen this eventID yet, initialize it into our rolling list of packets.
+        if (!chunkedDataEvents[data.id]) {
+            chunkedDataEvents[data.id] = {chunks: [], receivedFinal: false};
+        }
+
+        // Add it to the rolling list.
+        const chunkedEvent = chunkedDataEvents[data.id];
+        if (data.index !== undefined) {
+            chunkedEvent.chunks[data.index] = data.chunk;
+        }
+
+        // If this is the last packet, mark that we've hit the end.
+        if (data.final) {
+            chunkedEvent.receivedFinal = true;
+        }
+
+        // Only call the event callback if we've received the last packet and we don't have any holes in the complete
+        // packet.
+        if (chunkedEvent.receivedFinal && chunkedEvent.chunks.length === Object.keys(chunkedEvent.chunks).length) {
+            try {
+                eventCallback(JSON.parse(chunkedEvent.chunks.join('')) as EventData<EventName>);
+            } catch (err) {
+                Log.alert('[Pusher] Unable to parse chunked JSON response from Pusher', {
+                    error: err,
+                    eventData: chunkedEvent.chunks.join(''),
+                });
+
+                // Using console.error is helpful here because it will print a usable stack trace to the console to debug where the error comes from
+                console.error(err);
+            }
+
+            delete chunkedDataEvents[data.id];
+        }
+    };
+
+    channel.bind(eventName, callback);
+    if (!eventsBoundToChannels.has(channel)) {
+        eventsBoundToChannels.set(channel, new Set());
+    }
+    eventsBoundToChannels.get(channel)?.add(eventName);
+}
+
+/**
+ * Subscribe to a channel and an event
+ * @param [onResubscribe] Callback to be called when reconnection happen
+ */
+function subscribe<EventName extends PusherEventName>(
+    channelName: string,
+    eventName?: EventName,
+    eventCallback: (data: EventData<EventName>) => void = () => {},
+    onResubscribe = () => {},
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        InteractionManager.runAfterInteractions(() => {
+            // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
+            if (!socket) {
+                throw new Error(`[Pusher] instance not found. Pusher.subscribe()
+            most likely has been called before Pusher.init()`);
+            }
+
+            Log.info('[Pusher] Attempting to subscribe to channel', false, {channelName, eventName});
+            let channel = getChannel(channelName);
+
+            if (!channel?.subscribed) {
+                channel = socket.subscribe(channelName);
+                let isBound = false;
+                channel.bind('pusher:subscription_succeeded', () => {
+                    // Check so that we do not bind another event with each reconnect attempt
+                    if (!isBound) {
+                        bindEventToChannel(channel, eventName, eventCallback);
+                        resolve();
+                        isBound = true;
+                        return;
+                    }
+
+                    // When subscribing for the first time we register a success callback that can be
+                    // called multiple times when the subscription succeeds again in the future
+                    // e.g. as a result of Pusher disconnecting and reconnecting. This callback does
+                    // not fire on the first subscription_succeeded event.
+                    onResubscribe();
+                });
+
+                channel.bind('pusher:subscription_error', (data: PusherSubscribtionErrorData = {}) => {
+                    const {type, error, status} = data;
+                    Log.hmmm('[Pusher] Issue authenticating with Pusher during subscribe attempt.', {
+                        channelName,
+                        status,
+                        type,
+                        error,
+                    });
+                    reject(error);
+                });
+            } else {
+                bindEventToChannel(channel, eventName, eventCallback);
+                resolve();
+            }
+        });
+    });
+}
+
+/**
+ * Unsubscribe from a channel and optionally a specific event
+ */
+function unsubscribe(channelName: string, eventName: PusherEventName = '') {
+    const channel = getChannel(channelName);
+
+    if (!channel) {
+        Log.hmmm('[Pusher] Attempted to unsubscribe or unbind from a channel, but Pusher-JS has no knowledge of it', {channelName, eventName});
+        return;
+    }
+
+    if (eventName) {
+        Log.info('[Pusher] Unbinding event', false, {eventName, channelName});
+        channel.unbind(eventName);
+        eventsBoundToChannels.get(channel)?.delete(eventName);
+        if (eventsBoundToChannels.get(channel)?.size === 0) {
+            Log.info(`[Pusher] After unbinding ${eventName} from channel ${channelName}, no other events were bound to that channel. Unsubscribing...`, false);
+            eventsBoundToChannels.delete(channel);
+            socket?.unsubscribe(channelName);
+        }
+    } else {
+        if (!channel.subscribed) {
+            Log.info('Pusher] Attempted to unsubscribe from channel, but we are not subscribed to begin with', false, {channelName});
+            return;
+        }
+        Log.info('[Pusher] Unsubscribing from channel', false, {channelName});
+
+        channel.unbind();
+        socket?.unsubscribe(channelName);
+    }
+}
+
+/**
+ * Are we already in the process of subscribing to this channel?
+ */
+function isAlreadySubscribing(channelName: string): boolean {
+    if (!socket) {
+        return false;
+    }
+
+    const channel = getChannel(channelName);
+    return channel ? channel.subscriptionPending : false;
+}
+
+/**
+ * Are we already subscribed to this channel?
+ */
+function isSubscribed(channelName: string): boolean {
+    if (!socket) {
+        return false;
+    }
+
+    const channel = getChannel(channelName);
+    return channel ? channel.subscribed : false;
+}
+
+/**
+ * Sends an event over a specific event/channel in pusher.
+ */
+function sendEvent<EventName extends PusherEventName>(channelName: string, eventName: EventName, payload: EventData<EventName>) {
+    // Check to see if we are subscribed to this channel before sending the event. Sending client events over channels
+    // we are not subscribed too will throw errors and cause reconnection attempts. Subscriptions are not instant and
+    // can happen later than we expect.
+    if (!isSubscribed(channelName)) {
+        return;
+    }
+
+    if (shouldForceOffline) {
+        Log.info('[Pusher] Ignoring a Send event because shouldForceOffline = true');
+        return;
+    }
+
+    socket?.send_event(eventName, payload, channelName);
+}
+
+/**
+ * Register a method that will be triggered when a socket event happens (like disconnecting)
+ */
+function registerSocketEventCallback(cb: SocketEventCallback) {
+    socketEventCallbacks.push(cb);
+}
+
+/**
+ * A custom authorizer allows us to take a more fine-grained approach to
+ * authenticating Pusher. e.g. we can handle failed attempts to authorize
+ * with an expired authToken and retry the attempt.
+ */
+function registerCustomAuthorizer(authorizer: ChannelAuthorizerGenerator) {
+    customAuthorizer = authorizer;
+}
+
+/**
+ * Disconnect from Pusher
+ */
+function disconnect() {
+    if (!socket) {
+        Log.info('[Pusher] Attempting to disconnect from Pusher before initialisation has occurred, ignoring.');
+        return;
+    }
+
+    socket.disconnect();
+    socket = null;
+    pusherSocketID = '';
+}
+
+/**
+ * Disconnect and Re-Connect Pusher
+ */
+function reconnect() {
+    if (!socket) {
+        Log.info('[Pusher] Unable to reconnect since Pusher instance does not yet exist.');
+        return;
+    }
+
+    Log.info('[Pusher] Reconnecting to Pusher');
+    socket.disconnect();
+    socket.connect();
+}
+
+function getPusherSocketID(): string {
+    return pusherSocketID;
+}
+
+if (window) {
+    /**
+     * Pusher socket for debugging purposes
+     */
+    window.getPusherInstance = () => socket;
+}
+
+export {
+    init,
+    subscribe,
+    unsubscribe,
+    getChannel,
+    isSubscribed,
+    isAlreadySubscribing,
+    sendEvent,
+    disconnect,
+    reconnect,
+    registerSocketEventCallback,
+    registerCustomAuthorizer,
+    TYPE,
+    getPusherSocketID,
+};
+
+export type {EventCallbackError, States, UserIsTypingEvent, UserIsLeavingRoomEvent};

--- a/src/libs/Pusher/pusher.ts
+++ b/src/libs/Pusher/pusher.ts
@@ -59,6 +59,7 @@ type PusherEventName = LiteralUnion<DeepValueOf<typeof TYPE>, string>;
 type PusherSubscribtionErrorData = {type?: string; error?: string; status?: string};
 
 let shouldForceOffline = false;
+// eslint-disable-next-line rulesdir/no-onyx-connect -- module-level network state in the Pusher lib
 Onyx.connect({
     key: ONYXKEYS.NETWORK,
     callback: (network) => {

--- a/src/libs/PusherUtils.ts
+++ b/src/libs/PusherUtils.ts
@@ -1,77 +1,78 @@
-// import type {OnyxUpdate} from 'react-native-onyx';
-// import CONFIG from '@src/CONFIG';
-// import CONST from '@src/CONST';
-// import type {OnyxUpdatesFromServer} from '@src/types/onyx';
-// import Log from './Log';
-// import NetworkConnection from './NetworkConnection';
-// import * as Pusher from './Pusher/pusher';
+import type {OnyxUpdate} from 'react-native-onyx';
+import CONST from '@src/CONST';
+import type {OnyxUpdatesFromServer} from '@src/types/onyx';
+import Log from './Log';
+import NetworkConnection from './NetworkConnection';
+import * as Pusher from './Pusher/pusher';
 
-// type Callback = (data: OnyxUpdate[]) => Promise<void>;
+type Callback = (data: OnyxUpdate[]) => Promise<void>;
 
-// // Keeps track of all the callbacks that need triggered for each event type
-// const multiEventCallbackMapping: Record<string, Callback> = {};
+// Keeps track of all the callbacks that need triggered for each event type
+const multiEventCallbackMapping: Record<string, Callback> = {};
 
-// function subscribeToMultiEvent(eventType: string, callback: Callback) {
-//   multiEventCallbackMapping[eventType] = callback;
-// }
+function subscribeToMultiEvent(eventType: string, callback: Callback) {
+  multiEventCallbackMapping[eventType] = callback;
+}
 
-// function triggerMultiEventHandler(
-//   eventType: string,
-//   data: OnyxUpdate[],
-// ): Promise<void> {
-//   if (!multiEventCallbackMapping[eventType]) {
-//     return Promise.resolve();
-//   }
-//   return multiEventCallbackMapping[eventType](data);
-// }
+function triggerMultiEventHandler(
+  eventType: string,
+  data: OnyxUpdate[],
+): Promise<void> {
+  if (!multiEventCallbackMapping[eventType]) {
+    return Promise.resolve();
+  }
+  return multiEventCallbackMapping[eventType](data);
+}
 
-// /**
-//  * Abstraction around subscribing to private user channel events. Handles all logs and errors automatically.
-//  */
-// function subscribeToPrivateUserChannelEvent(
-//   eventName: string,
-//   userID: string,
-//   onEvent: (pushJSON: OnyxUpdatesFromServer) => void,
-// ) {
-//   const pusherChannelName =
-//     `${CONST.PUSHER.PRIVATE_USER_CHANNEL_PREFIX}${userID}${CONFIG.PUSHER.SUFFIX}` as const;
+/**
+ * Abstraction around subscribing to private user channel events. Handles all logs and errors automatically.
+ */
+function subscribeToPrivateUserChannelEvent(
+  eventName: string,
+  userID: string,
+  onEvent: (pushJSON: OnyxUpdatesFromServer) => void,
+) {
+  // Must equal the server's channel exactly: kiroku-api authorizes/publishes to
+  // `private-user-<uid>` with no environment suffix (dev/prod are separate apps).
+  const pusherChannelName =
+    `${CONST.PUSHER.PRIVATE_USER_CHANNEL_PREFIX}${userID}` as const;
 
-//   function logPusherEvent(pushJSON: OnyxUpdatesFromServer) {
-//     Log.info(
-//       `[Report] Handled ${eventName} event sent by Pusher`,
-//       false,
-//       pushJSON,
-//     );
-//   }
+  function logPusherEvent(pushJSON: OnyxUpdatesFromServer) {
+    Log.info(
+      `[Report] Handled ${eventName} event sent by Pusher`,
+      false,
+      pushJSON,
+    );
+  }
 
-//   function onPusherResubscribeToPrivateUserChannel() {
-//     NetworkConnection.triggerReconnectionCallbacks(
-//       'Pusher re-subscribed to private user channel',
-//     );
-//   }
+  function onPusherResubscribeToPrivateUserChannel() {
+    NetworkConnection.triggerReconnectionCallbacks(
+      'Pusher re-subscribed to private user channel',
+    );
+  }
 
-//   function onEventPush(pushJSON: OnyxUpdatesFromServer) {
-//     logPusherEvent(pushJSON);
-//     onEvent(pushJSON);
-//   }
+  function onEventPush(pushJSON: OnyxUpdatesFromServer) {
+    logPusherEvent(pushJSON);
+    onEvent(pushJSON);
+  }
 
-//   function onSubscriptionFailed(error: Error) {
-//     Log.hmmm('Failed to subscribe to Pusher channel', {
-//       error,
-//       pusherChannelName,
-//       eventName,
-//     });
-//   }
-//   Pusher.subscribe(
-//     pusherChannelName,
-//     eventName,
-//     onEventPush,
-//     onPusherResubscribeToPrivateUserChannel,
-//   ).catch(onSubscriptionFailed);
-// }
+  function onSubscriptionFailed(error: Error) {
+    Log.hmmm('Failed to subscribe to Pusher channel', {
+      error,
+      pusherChannelName,
+      eventName,
+    });
+  }
+  Pusher.subscribe(
+    pusherChannelName,
+    eventName,
+    onEventPush,
+    onPusherResubscribeToPrivateUserChannel,
+  ).catch(onSubscriptionFailed);
+}
 
-// export default {
-//   subscribeToPrivateUserChannelEvent,
-//   subscribeToMultiEvent,
-//   triggerMultiEventHandler,
-// };
+export default {
+  subscribeToPrivateUserChannelEvent,
+  subscribeToMultiEvent,
+  triggerMultiEventHandler,
+};

--- a/src/libs/actions/Friends.ts
+++ b/src/libs/actions/Friends.ts
@@ -1,0 +1,88 @@
+import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+/**
+ * Friend actions, cut over from direct Firebase RTDB writes
+ * (`src/database/friends.ts`) to kiroku-api `API.write` calls. Authority is
+ * server-side (the caller's Firebase ID token), so callers pass only the
+ * counterpart id; the caller's own uid is used solely for the optimistic Onyx
+ * update, which mirrors the server's `onyxData` so the inline response is
+ * idempotent. Friend reads still flow through the existing Firebase listeners.
+ */
+
+function getCurrentUserID(): string | undefined {
+  return getFirebaseAuth().currentUser?.uid ?? undefined;
+}
+
+/** Optimistic `merge userDataList { [uid]: patch }`, matching server onyxData. */
+function userDataPatch(uid: string, patch: Record<string, unknown>): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.USER_DATA_LIST,
+    value: {[uid]: patch},
+  } as OnyxUpdate;
+}
+
+function sendFriendRequest(toUserId: string) {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  const optimisticData: OnyxUpdate[] = [
+    userDataPatch(uid, {
+      friend_requests: {[toUserId]: CONST.FRIEND_REQUEST_STATUS.SENT},
+    }),
+  ];
+  API.write(WRITE_COMMANDS.SEND_FRIEND_REQUEST, {toUserId}, {optimisticData});
+}
+
+function acceptFriendRequest(fromUserId: string) {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  const optimisticData: OnyxUpdate[] = [
+    userDataPatch(uid, {
+      friend_requests: {[fromUserId]: null},
+      friends: {[fromUserId]: true},
+    }),
+  ];
+  API.write(
+    WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST,
+    {fromUserId},
+    {optimisticData},
+  );
+}
+
+function deleteFriendRequest(otherUserId: string) {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  const optimisticData: OnyxUpdate[] = [
+    userDataPatch(uid, {friend_requests: {[otherUserId]: null}}),
+  ];
+  API.write(
+    WRITE_COMMANDS.DELETE_FRIEND_REQUEST,
+    {otherUserId},
+    {optimisticData},
+  );
+}
+
+function unfriend(otherUserId: string) {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  const optimisticData: OnyxUpdate[] = [
+    userDataPatch(uid, {friends: {[otherUserId]: null}}),
+  ];
+  API.write(WRITE_COMMANDS.UNFRIEND, {otherUserId}, {optimisticData});
+}
+
+export {sendFriendRequest, acceptFriendRequest, deleteFriendRequest, unfriend};

--- a/src/libs/actions/Friends.ts
+++ b/src/libs/actions/Friends.ts
@@ -25,7 +25,7 @@ function userDataPatch(uid: string, patch: Record<string, unknown>): OnyxUpdate 
     onyxMethod: Onyx.METHOD.MERGE,
     key: ONYXKEYS.USER_DATA_LIST,
     value: {[uid]: patch},
-  } as OnyxUpdate;
+  };
 }
 
 function sendFriendRequest(toUserId: string) {

--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -3,6 +3,7 @@ import Onyx from 'react-native-onyx';
 import type {Merge} from 'type-fest';
 import Log from '@libs/Log';
 import * as SequentialQueue from '@libs/Network/SequentialQueue';
+import PusherUtils from '@libs/PusherUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {
@@ -66,26 +67,18 @@ function applyHTTPSOnyxUpdates(request: Request, response: Response) {
     });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function applyPusherOnyxUpdates(updates: OnyxUpdateEvent[]) {
-  pusherEventsPromise = pusherEventsPromise.then(() => {
-    console.debug('[OnyxUpdateManager] Applying pusher update');
-  });
-
-  console.debug('[OnyxUpdateManager] Pusher is not yet implemented');
-
-  // TODO enable
-  // pusherEventsPromise = updates
-  //   .reduce(
-  //     (promise, update) =>
-  //       promise.then(() =>
-  //         PusherUtils.triggerMultiEventHandler(update.eventType, update.data),
-  //       ),
-  //     pusherEventsPromise,
-  //   )
-  //   .then(() => {
-  //     console.debug('[OnyxUpdateManager] Done applying Pusher update');
-  //   });
+  pusherEventsPromise = updates
+    .reduce(
+      (promise, update) =>
+        promise.then(() =>
+          PusherUtils.triggerMultiEventHandler(update.eventType, update.data),
+        ),
+      pusherEventsPromise,
+    )
+    .then(() => {
+      console.debug('[OnyxUpdateManager] Done applying Pusher update');
+    });
 
   return pusherEventsPromise;
 }

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -39,10 +39,14 @@ import {getLastStartedSessionId} from '@libs/DataHandling';
 import * as Localize from '@libs/Localize';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {validateAppVersion} from '@libs/Validation';
-import type {OnyxEntry} from 'react-native-onyx';
+import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import PusherUtils from '@libs/PusherUtils';
+import * as Pusher from '@libs/Pusher/pusher';
+import * as OnyxUpdates from '@userActions/OnyxUpdates';
 import {getReasonForLeavingID} from '@libs/ReasonForLeaving';
 import {PALETTES} from '@libs/SessionColorPalettes';
 import Log from '@libs/Log';
@@ -894,7 +898,48 @@ async function signUp(
   }
 }
 
+/** The flat payload kiroku-api pushes on the `onyxApiUpdate` event. */
+type KirokuOnyxApiUpdateEvent = {
+  eventType: string;
+  data: OnyxUpdate[];
+  lastUpdateID: number;
+  previousUpdateID: number;
+};
+
+/**
+ * Subscribe the signed-in user to their realtime channel. kiroku-api pushes an
+ * `onyxApiUpdate` event on `private-user-<uid>` carrying an `OnyxUpdate[]`; we
+ * apply it to Onyx through the standard OnyxUpdates pipeline.
+ */
+function subscribeToUserEvents() {
+  const userID = getFirebaseAuth().currentUser?.uid;
+  if (!userID) {
+    return;
+  }
+
+  // The handler that applies an `onyxApiUpdate`'s OnyxUpdate[] to Onyx.
+  PusherUtils.subscribeToMultiEvent(
+    Pusher.TYPE.MULTIPLE_EVENT_TYPE.ONYX_API_UPDATE,
+    (updates: OnyxUpdate[]) => Onyx.update(updates),
+  );
+
+  PusherUtils.subscribeToPrivateUserChannelEvent(
+    Pusher.TYPE.ONYX_API_UPDATE,
+    userID,
+    pushJSON => {
+      const event = pushJSON as unknown as KirokuOnyxApiUpdateEvent;
+      OnyxUpdates.apply({
+        type: CONST.ONYX_UPDATE_TYPES.PUSHER,
+        lastUpdateID: Number(event.lastUpdateID ?? 0),
+        previousUpdateID: Number(event.previousUpdateID ?? 0),
+        updates: [{eventType: event.eventType, data: event.data}],
+      });
+    },
+  );
+}
+
 export {
+  subscribeToUserEvents,
   changeDisplayName,
   changeUserName,
   deleteUserData,

--- a/src/screens/Social/FriendRequestScreen.tsx
+++ b/src/screens/Social/FriendRequestScreen.tsx
@@ -8,7 +8,7 @@ import {useEffect, useState} from 'react';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
-import {acceptFriendRequest, deleteFriendRequest} from '@database/friends';
+import * as Friends from '@userActions/Friends';
 import type {Database} from 'firebase/database';
 import NoFriendUserOverview from '@components/Social/NoFriendUserOverview';
 import * as Profile from '@userActions/Profile';
@@ -50,7 +50,7 @@ type FriendRequestItemProps = {
 
 // Component to be shown for a received friend request
 function FriendRequestButtons({requestId}: FriendRequestButtonsProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const user = auth.currentUser;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -63,7 +63,7 @@ function FriendRequestButtons({requestId}: FriendRequestButtonsProps) {
     (async () => {
       try {
         setIsLoading(true);
-        await acceptFriendRequest(db, user.uid, requestId);
+        Friends.acceptFriendRequest(requestId);
         setIsLoading(false);
       } catch (error) {
         ErrorUtils.raiseAppError(
@@ -78,7 +78,7 @@ function FriendRequestButtons({requestId}: FriendRequestButtonsProps) {
     (async () => {
       try {
         setIsLoading(true);
-        await deleteFriendRequest(db, user.uid, requestId);
+        Friends.deleteFriendRequest(requestId);
         setIsLoading(false);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.FEEDBACK_REMOVAL_FAILED, error);
@@ -109,7 +109,7 @@ function FriendRequestButtons({requestId}: FriendRequestButtonsProps) {
 
 // Component to be shown when the friend request is pending
 function FriendRequestPending({requestId}: FriendRequestButtonsProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -123,7 +123,7 @@ function FriendRequestPending({requestId}: FriendRequestButtonsProps) {
     (async () => {
       try {
         setIsLoading(true);
-        await deleteFriendRequest(db, user.uid, requestId);
+        Friends.deleteFriendRequest(requestId);
         setIsLoading(false);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.FEEDBACK_REMOVAL_FAILED, error);


### PR DESCRIPTION
## Summary

Phase 2 client cutover onto **kiroku-api**: brings the (dormant, Expensify-shaped)
data layer to life **adapted to kiroku-api's contract**, and cuts the **friends**
feature's writes over as the first vertical slice — proving realtime cross-user
delivery end-to-end.

Five commits, each a coherent layer:
1. **Request layer** — `kirokuRoutes` maps commands → `{method, path}` on the
   `/v1` REST surface; `HttpUtils.xhr` branches kiroku-api commands to send a
   **Firebase ID token Bearer** header + JSON body / query string (legacy
   single-endpoint path untouched); CONFIG base URLs → `api-dev.kiroku.cz` /
   `api.kiroku.cz`.
2. **Reliability middleware** — enable `RecheckConnection` + a Kiroku-adapted
   `Reauthentication` (407 → `getIdToken(true)` → replay, with a loop guard).
3. **Pusher lib** — un-comment `pusher.ts` + `PusherUtils.ts`; un-stub
   `applyPusherOnyxUpdates`; channel prefix → `private-user-`, no suffix.
4. **Pusher boot** — `kirokuAuthorizer` (custom authorizer that calls
   `/v1/pusher/auth` with the Bearer header); `Pusher.init` (eu) +
   `User.subscribeToUserEvents` on auth; `pusherSocketID` echo-suppression.
5. **Friends slice** — 4 commands/params/routes + a `Friends` action
   (`API.write` with optimistic `userDataList` merges); call sites repointed.

## Why / context

The realtime/multi-device server side is built + deployed (dev + prod). This is
the client half. The API path was previously dormant (`authToken` never set, most
commands commented), so the transport changes are additive; only the friends
**writes** change live behavior. Friend **reads** stay on the existing
Firebase→Onyx listeners (coexist; merges are idempotent).

## Reviewer notes / caveats
- **Depends on** kiroku-api PR #35 (returns `{jsonCode:407}` on expired token) for
  the reauth path; not required for the happy-path slice.
- **Pusher event payload** is adapted **client-side**: kiroku-api pushes a flat
  `{eventType, data, lastUpdateID, previousUpdateID}` which `subscribeToUserEvents`
  maps into the `OnyxUpdatesFromServer` shape `apply()` expects — so **no server
  redeploy** is needed for your dev testing.
- **Gap handling for pushed events is simplified** (applies directly; gaps
  reconcile on the next `app/open`). Enabling `App.openApp()` at boot for the
  `lastUpdateID` baseline is a noted follow-up.
- **Tooling:** the repo's `npm run typecheck` is currently broken by a
  pre-existing `TS5095` (tsconfig `module: commonjs` vs `moduleResolution:
  bundler` from the expo base), and standalone `eslint` hits a pre-existing
  `ERR_REQUIRE_ESM` in `eslint-plugin-rulesdir`. I validated with
  `tsc --noEmit --module preserve` → **0 errors**; CI `lint.sh` should still run.
  Worth fixing the tsconfig separately.

## Test plan (on device, dev env — needs `PUSHER_APP_KEY` in env, already set)
- [x] Boot authenticated → Pusher connects + subscribes to `private-user-<uid>`
      (visible in the Pusher dashboard; `/v1/pusher/auth` returns a signature).
- [x] Device A sends B a friend request → A optimistic UI updates; **B receives it
      in near-real-time** via the `onyxApiUpdate` push (Pusher Debug Console + B's UI).
- [x] accept / remove / delete-request behave the same across two accounts.
- [ ] Offline: queue a request offline → it replays on reconnect (SequentialQueue).
- [ ] CI: `npm run typecheck` (after the tsconfig fix) + `lint.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)