### PR TITLE
fix(modal): opaque content, centered CONFIRM, no open-flicker

### DIFF
--- a/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {StyleSheet, View} from 'react-native';
-import Animated, {Keyframe} from 'react-native-reanimated';
+import Animated, {
+  Keyframe,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import type {BackdropProps} from '@components/Modal/ReanimatedModal/types';
 import {
-  getModalInAnimation,
+  easing,
   getModalOutAnimation,
 } from '@components/Modal/ReanimatedModal/utils';
 import {PressableWithoutFeedback} from '@components/Pressable';
@@ -22,23 +28,44 @@ function Backdrop({
 }: BackdropProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  const initProgress = useSharedValue(0);
+  const isInitiated = useSharedValue(false);
 
-  const Entering = new Keyframe(getModalInAnimation('fadeIn')).duration(
-    animationInTiming,
-  );
-  const Exiting = new Keyframe(getModalOutAnimation('fadeOut')).duration(
-    animationOutTiming,
+  // Reveal via a shared value + useAnimatedStyle (progress=0 applied on mount)
+  // instead of an `entering` Keyframe, whose `from` frame isn't applied before
+  // the first paint on the New Architecture — that flashed the dim backdrop at
+  // full opacity for a frame before the fade.
+  useEffect(() => {
+    if (isInitiated.get()) {
+      return;
+    }
+    isInitiated.set(true);
+    initProgress.set(
+      withTiming(1, {
+        duration: animationInTiming,
+        easing,
+        reduceMotion: ReduceMotion.Never,
+      }),
+    );
+  }, [animationInTiming, initProgress, isInitiated]);
+
+  const animatedStyles = useAnimatedStyle(
+    () => ({opacity: initProgress.get()}),
+    [initProgress],
   );
 
-  // The shared fadeIn/fadeOut keyframe animates opacity 0<->1 (so modal content
-  // rests fully opaque). The backdrop's dimness is a separate concern, so its
-  // target opacity lives on the fill child while the Animated.View just drives
-  // the reveal — the two compose to a 0 -> backdropOpacity fade.
+  const Exiting = new Keyframe(getModalOutAnimation('fadeOut'))
+    .duration(animationOutTiming)
+    .reduceMotion(ReduceMotion.Never);
+
+  // The reveal opacity (0->1) lives on the Animated.View; the dim color and its
+  // target opacity live on a plain fill child, so the two compose to a
+  // 0 -> backdropOpacity fade and the surface paints reliably.
   const {backgroundColor, ...frame} =
     StyleSheet.flatten([styles.modalBackdrop, style]) ?? {};
 
   const BackdropOverlay = (
-    <Animated.View entering={Entering} exiting={Exiting} style={frame}>
+    <Animated.View style={[frame, animatedStyles]} exiting={Exiting}>
       {customBackdrop ?? (
         <View
           style={[

--- a/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {StyleSheet, View} from 'react-native';
 import Animated, {Keyframe} from 'react-native-reanimated';
 import type {BackdropProps} from '@components/Modal/ReanimatedModal/types';
 import {
@@ -29,12 +30,23 @@ function Backdrop({
     animationOutTiming,
   );
 
+  // The shared fadeIn/fadeOut keyframe animates opacity 0<->1 (so modal content
+  // rests fully opaque). The backdrop's dimness is a separate concern, so its
+  // target opacity lives on the fill child while the Animated.View just drives
+  // the reveal — the two compose to a 0 -> backdropOpacity fade.
+  const {backgroundColor, ...frame} =
+    StyleSheet.flatten([styles.modalBackdrop, style]) ?? {};
+
   const BackdropOverlay = (
-    <Animated.View
-      entering={Entering}
-      exiting={Exiting}
-      style={[styles.modalBackdrop, {opacity: backdropOpacity}, style]}>
-      {!!customBackdrop && customBackdrop}
+    <Animated.View entering={Entering} exiting={Exiting} style={frame}>
+      {customBackdrop ?? (
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {backgroundColor, opacity: backdropOpacity},
+          ]}
+        />
+      )}
     </Animated.View>
   );
 

--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -1,11 +1,17 @@
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {View} from 'react-native';
-import Animated, {Keyframe} from 'react-native-reanimated';
+import Animated, {
+  Keyframe,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
 import type ReanimatedModalProps from '@components/Modal/ReanimatedModal/types';
 import type {ContainerProps} from '@components/Modal/ReanimatedModal/types';
 import {
-  getModalInAnimation,
+  easing,
   getModalOutAnimation,
 } from '@components/Modal/ReanimatedModal/utils';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -27,25 +33,63 @@ function Container({
   ...props
 }: Partial<ReanimatedModalProps> & ContainerProps) {
   const styles = useThemeStyles();
+  const initProgress = useSharedValue(0);
+  const isInitiated = useSharedValue(false);
 
-  const Entering = useMemo(() => {
-    const AnimationIn = new Keyframe(getModalInAnimation(animationIn));
+  // Drive the open animation through a shared value + useAnimatedStyle instead
+  // of an `entering` Keyframe. On the New Architecture a Keyframe's `from` frame
+  // is not applied before the first paint, so the modal flashes at its final
+  // state for one frame; applying progress=0 via useAnimatedStyle on mount
+  // avoids that. Mirrors the web Container (index.web.tsx).
+  useEffect(() => {
+    if (isInitiated.get()) {
+      return;
+    }
+    isInitiated.set(true);
+    initProgress.set(
+      withTiming(
+        1,
+        {
+          duration: animationInTiming,
+          easing,
+          // Without this the completion callback is skipped when the OS
+          // reduce-motion setting is on, leaving the modal stuck transitioning.
+          reduceMotion: ReduceMotion.Never,
+        },
+        () => {
+          'worklet';
 
-    return AnimationIn.duration(animationInTiming).withCallback(() => {
-      'worklet';
+          scheduleOnRN(onOpenCallBack);
+        },
+      ),
+    );
+  }, [animationInTiming, onOpenCallBack, initProgress, isInitiated]);
 
-      scheduleOnRN(onOpenCallBack);
-    });
-  }, [animationIn, animationInTiming, onOpenCallBack]);
+  // Equivalent to getModalInAnimationStyle (used by the web Container) but
+  // inlined: that helper isn't a worklet, so it can't be called from this
+  // UI-thread worklet on native.
+  const animatedStyles = useAnimatedStyle(() => {
+    const progress = initProgress.get();
+    if (animationIn === 'slideInUp') {
+      return {transform: [{translateY: `${100 * (1 - progress)}%`}]};
+    }
+    if (animationIn === 'slideInRight') {
+      return {transform: [{translateX: `${100 * (1 - progress)}%`}]};
+    }
+    // 'fadeIn' (and any default)
+    return {opacity: progress};
+  }, [initProgress, animationIn]);
 
   const Exiting = useMemo(() => {
     const AnimationOut = new Keyframe(getModalOutAnimation(animationOut));
 
-    return AnimationOut.duration(animationOutTiming).withCallback(() => {
-      'worklet';
+    return AnimationOut.duration(animationOutTiming)
+      .withCallback(() => {
+        'worklet';
 
-      scheduleOnRN(onCloseCallBack);
-    });
+        scheduleOnRN(onCloseCallBack);
+      })
+      .reduceMotion(ReduceMotion.Never);
   }, [animationOutTiming, onCloseCallBack, animationOut]);
 
   return (
@@ -72,8 +116,8 @@ function Container({
               type !== CONST.MODAL.MODAL_TYPE.CENTERED_SMALL &&
               type !== CONST.MODAL.MODAL_TYPE.CONFIRM &&
               styles.flex1,
+            animatedStyles,
           ]}
-          entering={Entering}
           exiting={Exiting}>
           {props.children}
         </Animated.View>

--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -65,10 +65,12 @@ function Container({
         <Animated.View
           style={[
             styles.modalAnimatedContainer,
-            // BOTTOM_DOCKED and CENTERED_SMALL stay content-sized so the outer
-            // `style` (flex-end / center) can position the sheet; the others fill.
+            // BOTTOM_DOCKED, CENTERED_SMALL and CONFIRM stay content-sized so the
+            // outer `style` (flex-end / center) can position the sheet; the
+            // others fill.
             type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED &&
               type !== CONST.MODAL.MODAL_TYPE.CENTERED_SMALL &&
+              type !== CONST.MODAL.MODAL_TYPE.CONFIRM &&
               styles.flex1,
           ]}
           entering={Entering}

--- a/src/components/Modal/ReanimatedModal/utils.ts
+++ b/src/components/Modal/ReanimatedModal/utils.ts
@@ -1,7 +1,6 @@
 import type {ViewStyle} from 'react-native';
 import {Easing} from 'react-native-reanimated';
 import type {ValidKeyframeProps} from 'react-native-reanimated/lib/typescript/commonTypes';
-import variables from '@styles/variables';
 import type {AnimationIn, AnimationOut} from './types';
 
 const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0).factory();
@@ -28,7 +27,7 @@ function getModalInAnimation(animationType: AnimationIn): ValidKeyframeProps {
       return {
         from: {opacity: 0},
         to: {
-          opacity: variables.overlayOpacity,
+          opacity: 1,
           easing,
         },
       };
@@ -79,7 +78,7 @@ function getModalOutAnimation(animationType: AnimationOut): ValidKeyframeProps {
       };
     case 'fadeOut':
       return {
-        from: {opacity: variables.overlayOpacity},
+        from: {opacity: 1},
         to: {
           opacity: 0,
           easing,

--- a/src/components/Modals/FullScreenModal.tsx
+++ b/src/components/Modals/FullScreenModal.tsx
@@ -1,5 +1,5 @@
 import type {StyleProp, ViewStyle} from 'react-native';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {useEffect, useState} from 'react';
 import Modal from '@components/Modal';
@@ -45,11 +45,15 @@ function FullScreenModal({
       isVisible={modalVisible}
       fullscreen
       shouldUseModalPaddingStyle={false}
-      innerContainerStyle={{borderWidth: 0}}
+      // Paint the surface on the modal container (the always-materialized
+      // Reanimated view) rather than a child view. On the New Architecture, RN
+      // can flatten a background-only child away, which left the modal
+      // see-through; the container is never flattened.
+      innerContainerStyle={StyleSheet.flatten([{borderWidth: 0}, style])}
       swipeDirection={['up', 'down']}
       animationIn="fadeIn"
       animationOut="fadeOut">
-      <View style={[styles.fullScreenCenteredContent, style]}>
+      <View style={styles.fullScreenCenteredContent}>
         {!hideCloseButton && (
           <Button
             onPress={handleCloseModal}

--- a/src/screens/Achievements/components/BACDetailsModal.tsx
+++ b/src/screens/Achievements/components/BACDetailsModal.tsx
@@ -99,15 +99,13 @@ function BACDetailsModal({
   // The body scrolls within an explicit maxHeight. CONFIRM is used (not
   // CENTERED_SMALL) because it has no swipe PanResponder — that gesture would
   // otherwise swallow the drag before the ScrollView could scroll. The card
-  // still zooms in, shows an X, and dismisses on tap-outside.
+  // fades in centered, shows an X, and dismisses on tap-outside.
   const scrollMaxHeight = Math.round(windowHeight * 0.7);
 
   return (
     <Modal
       isVisible={isVisible}
       type={CONST.MODAL.MODAL_TYPE.CONFIRM}
-      animationIn="zoomIn"
-      animationOut="zoomOut"
       onClose={onClose}>
       <View style={styles.w100}>
         <HeaderWithBackButton

--- a/src/styles/utils/generators/ModalStyleUtils.ts
+++ b/src/styles/utils/generators/ModalStyleUtils.ts
@@ -86,10 +86,14 @@ const createModalStyleUtils: StyleUtilGenerator<GetModalStylesStyleUtil> = ({
       case CONST.MODAL.MODAL_TYPE.CONFIRM:
         // A confirm modal is one that has a visible backdrop
         // and can be dismissed by clicking outside of the modal.
+        // Like CENTERED_SMALL it is content-sized (the native Container
+        // excludes it from the flex1 fill), so it must center itself on both
+        // axes — without justifyContent it pins to the top of the screen.
         modalStyle = {
           ...modalStyle,
           ...{
             alignItems: 'center',
+            justifyContent: 'center',
           },
         };
         modalContainerStyle = {

--- a/src/styles/utils/generators/ModalStyleUtils.ts
+++ b/src/styles/utils/generators/ModalStyleUtils.ts
@@ -101,6 +101,9 @@ const createModalStyleUtils: StyleUtilGenerator<GetModalStylesStyleUtil> = ({
           borderRadius: variables.componentBorderRadiusLarge,
           overflow: 'hidden',
           width: variables.sideBarWidth,
+          // The inner animated container is full-width with no alignItems, so a
+          // fixed-width card would pin to the left; center it explicitly.
+          alignSelf: 'center',
         };
 
         // setting this to undefined we effectively disable the


### PR DESCRIPTION
## Summary

Fixes a cluster of native modal regressions from the `react-native-modal` → Reanimated migration. The modal architecture matches Expensify (surface = `componentBG` from the container; dimness = backdrop); these are bugs in animation/layout, not the design. **PR scope is modal-only** (6 files).

## Fixes
1. **Semi-transparent content** — the shared `fadeIn` keyframe animated content opacity to `variables.overlayOpacity` (0.72) instead of `1`, so every fade-in modal (surface + children, e.g. the enlargeable image) rested at 72%. Now `fadeIn`→1 / `fadeOut`→0. (`utils.ts`)
2. **Enlargeable image** — surface routed through `innerContainerStyle` (the always-materialized container) so it's a solid dark fullscreen. (`FullScreenModal.tsx`)
3. **Open-flicker** — native animated entry with a Reanimated `entering` Keyframe, whose `from` frame isn't applied before the first paint on the New Architecture, flashed content + backdrop at their final state for one frame. Now driven by a shared value `0→1` via `useAnimatedStyle` (initial frame applied synchronously), mirroring the web Container. Exit stays a Keyframe. Adds `ReduceMotion.Never` so completion callbacks still fire under OS reduce-motion. (`Container/index.tsx`, `Backdrop/index.tsx`)
4. **CONFIRM positioning** — excluded from the `flex1` fill + `justifyContent:center` (vertical) and `alignSelf:center` (horizontal), so CONFIRM modals (e.g. BAC details) center instead of top/left-pinning. (`ModalStyleUtils.ts`, `Container/index.tsx`)
5. **BAC details animation** — dropped the unsupported `animationIn="zoomIn"`/`"zoomOut"` (silently fell back to slide-from-right); uses CONFIRM's default fade. (`BACDetailsModal.tsx`)

### Native specifics worth a look in review
- Entry math is **inlined** in the `useAnimatedStyle` worklet because `getModalInAnimationStyle` isn't a worklet and can't be called from the UI thread on native (web calls it directly since web worklets run on the JS thread).
- Completion callbacks use `scheduleOnRN` (they call React state setters, which can't run on the UI thread).

## Verified on device
Surfaces are opaque, enlargeable image is solid dark, pickers/confirm/BAC are correct and centered, and the open-flicker is resolved for fade/centered modals.

## Known follow-up (not blocking)
- The **bottom-docked sign-out** modal still flickers slightly on open (slide-up path). Tracked separately in #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)