### PR TITLE
feat(realtime): seed lastUpdateID baseline via App.openApp() at boot

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -220,15 +220,10 @@ function AuthScreensContent() {
       User.subscribeToUserEvents();
     });
 
-    // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
-    // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().
-    // TODO enable this after the API is working
-    // if (SessionUtils.didUserLogInDuringSession()) {
-    //   App.openApp();
-    // } else {
-    //   Log.info('[AuthScreens] Sending ReconnectApp');
-    //   App.reconnectApp(initialLastUpdateIDAppliedToClient);
-    // }
+    // Hydrate the signed-in user's data and seed the realtime `lastUpdateID`
+    // baseline via GET /v1/app/open. (The reconnectApp-vs-openApp optimization
+    // gated on `didUserLogInDuringSession` isn't wired yet — see #774.)
+    App.openApp();
 
     // PriorityMode.autoSwitchToFocusMode();
 


### PR DESCRIPTION
## Summary

Enables the `App.openApp()` call on the authenticated boot path (`AuthScreens`)
so the client hydrates the signed-in user's data and, crucially, sets
`ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` from `GET /v1/app/open`'s
`lastUpdateID`.

## Why

Follow-up to the realtime cutover (#773). Without a baseline the client stays at
`lastUpdateID = 0`, so `OnyxUpdateManager` takes the "first reliable update"
full-reconnect branch on every write instead of incremental gap detection. The
commented `didUserLogInDuringSession` reconnectApp/openApp branch couldn't be
un-commented as-is (that `SessionUtils` helper isn't wired), so this calls
`App.openApp()` directly; the reconnectApp optimization is left for later.

Closes #774.

## Notes
- Friend **reads** still come from the Firebase listeners; `openApp`'s `onyxData`
  merges coexist idempotently.
- `App.openApp()` routes through the existing `OPEN_APP` → `GET /v1/app/open`
  mapping (Bearer auth) added in #773.

## Test plan
- [ ] On a dev build, after sign-in confirm `OPEN_APP` fires (`GET /v1/app/open`,
      200) and `ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT` is set to the
      server baseline (no longer 0).
- [ ] A subsequent friend write does incremental gap detection rather than a full
      reconnect.
- [x] `tsc --module preserve` → 0 errors; CI typecheck/eslint/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)