### PR TITLE
fix(realtime): disconnect Pusher on logout to drop stale channel subscriptions

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -38,7 +38,7 @@ import navigationRef from '@libs/Navigation/navigationRef';
 import * as MainQueue from '@libs/Network/MainQueue';
 // import * as NetworkStore from '@libs/Network/NetworkStore';
 // import NetworkConnection from '@libs/NetworkConnection';
-// import * as Pusher from '@libs/Pusher/pusher';
+import * as Pusher from '@libs/Pusher/pusher';
 // import * as ReportUtils from '@libs/ReportUtils';
 import Timers from '@libs/Timers';
 // import {hideContextMenu} from '@pages/home/report/ContextMenu/ReportActionContextMenu';
@@ -662,8 +662,11 @@ function setHasCheckedAutoLogin(val: boolean) {
  * - Clears all current params of the Home route - the login page URL should not contain any parameter
  */
 function cleanupSession() {
-  // TODO enable this
-  // Pusher.disconnect();
+  // Tear down the realtime socket so stale `private-user-<uid>` subscriptions
+  // don't survive logout. Without this the socket is reused across account
+  // switches on the same device, leaving the previous user's channel bound and
+  // leaking their onyxApiUpdate stream into the next user's Onyx store.
+  Pusher.disconnect();
   Timers.clearAll();
   // PriorityMode.resetHasReadRequiredDataFromStorage();
   MainQueue.clear();


### PR DESCRIPTION
## Summary

`cleanupSession()` left the realtime Pusher socket open on sign-out — the `Pusher.disconnect()` call was stubbed behind a `// TODO enable this`. As a result the socket was reused across account switches on the same device.

This surfaced in the Pusher app debug log on dev: a single socket ID accumulated **three different users'** `private-user-<uid>` channels over one session, all vacating together at a single disconnect.

The stale subscription is also a privacy bug: after switching from user A to user B on the same device, A's `private-user-<A>` channel stays bound to the live socket (Pusher won't re-auth an already-subscribed channel), so A's `onyxApiUpdate` events keep arriving and get applied to B's Onyx store.

## Fix

- Enable `Pusher.disconnect()` in `cleanupSession()` (and uncomment its import). `disconnect()` already no-ops safely when no socket exists, so it's safe to call unconditionally on every logout.

## Notes

- Server-side enforcement was verified separately: `POST /v1/pusher/auth` in kiroku-api rejects any channel that isn't the caller's own `private-user-<uid>` (403), so this was never a client auth-bypass — only stale-subscription reuse on the client.

## Test plan

- [ ] Sign in as user A, confirm one `private-user-<A>` subscription on the socket (Pusher debug console).
- [ ] Sign out — confirm the socket disconnects and the channel vacates.
- [ ] Sign in as user B — confirm a fresh socket with only `private-user-<B>`, and that no A events reach B's Onyx store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)