### PR TITLE
chore(ci): migrate custom JS actions from node20 to node24

### DIFF
--- a/.github/actions/javascript/authorChecklist/action.yml
+++ b/.github/actions/javascript/authorChecklist/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: Auth token for Kiroku Github
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/awaitStagingDeploys/action.yml
+++ b/.github/actions/javascript/awaitStagingDeploys/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: If provided, this action will only wait for deploys on this branch.
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/bumpVersion/action.yml
+++ b/.github/actions/javascript/bumpVersion/action.yml
@@ -13,5 +13,5 @@ outputs:
   NEW_IOS_VERSION:
     description: The new CFBundleVersion written to the iOS plist files.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/checkDeployBlockers/action.yml
+++ b/.github/actions/javascript/checkDeployBlockers/action.yml
@@ -11,5 +11,5 @@ outputs:
   HAS_DEPLOY_BLOCKERS:
     description: A true/false indicating whether or not a deploy blocker was found.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/.github/actions/javascript/createOrUpdateStagingDeploy/action.yml
+++ b/.github/actions/javascript/createOrUpdateStagingDeploy/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/getDeployPullRequestList/action.yml
+++ b/.github/actions/javascript/getDeployPullRequestList/action.yml
@@ -14,5 +14,5 @@ outputs:
     PR_LIST:
         description: Array of pull request numbers
 runs:
-    using: 'node20'
+    using: 'node24'
     main: './index.js'

--- a/.github/actions/javascript/getPreviousVersion/action.yml
+++ b/.github/actions/javascript/getPreviousVersion/action.yml
@@ -8,5 +8,5 @@ outputs:
   PREVIOUS_VERSION:
     description: The previous semver version of the application, according to the SEMVER_LEVEL provided
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'

--- a/.github/actions/javascript/isStagingDeployLocked/action.yml
+++ b/.github/actions/javascript/isStagingDeployLocked/action.yml
@@ -10,5 +10,5 @@ outputs:
     NUMBER:
         description: StagingDeployCash issue number
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'index.js'

--- a/.github/actions/javascript/markPullRequestsAsDeployed/action.yml
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/action.yml
@@ -22,5 +22,5 @@ inputs:
         description: "iOS job result ('success', 'failure', 'cancelled', or 'skipped')"
         required: true
 runs:
-    using: "node20"
+    using: "node24"
     main: "./index.js"

--- a/.github/actions/javascript/postTestBuildComment/action.yml
+++ b/.github/actions/javascript/postTestBuildComment/action.yml
@@ -20,5 +20,5 @@ inputs:
         description: "Link for the iOS build"
         required: false
 runs:
-    using: "node20"
+    using: "node24"
     main: "./index.js"

--- a/.github/actions/javascript/reopenIssueWithComment/action.yml
+++ b/.github/actions/javascript/reopenIssueWithComment/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: The comment string we want to leave on the issue after we reopen it.
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: './index.js'


### PR DESCRIPTION
## Summary
GitHub forces JavaScript actions to Node.js 24 starting **2026-06-16**, and removes the Node 20 runtime on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps `using: node20` → `node24` across all 11 custom JS actions.

This is the **safe, validated half** of the deprecation. Third-party action `v4→v5` bumps (`checkout`, `setup-node`, `cache`, `upload/download-artifact`, `configure-aws-credentials`, `nick-invision/retry`) carry behavioral risk and touch the build/deploy pipelines, so they're deliberately left for a separate follow-up PR with test builds.

### Changes
- `using: 'node20'` → `'node24'` in all 11 `.github/actions/javascript/*/action.yml` (quote styles preserved; only the `using:` line changes).

### Validation
Verified on a throwaway branch that node24 runs the compiled action bundles correctly on `ubuntu-24.04` runners — ran `isStagingDeployLocked` under `using: node24` and it executed successfully (read the StagingDeployCash issue, returned `IS_LOCKED=false`). The change is a uniform one-liner per action, and `node24` is a schema-valid `using` value.

> Note: the repo has a `validateActionsAndWorkflows.sh` script but it is **not** wired into any CI workflow, so nothing schema-validates these files automatically on PR. The only required check here is CLA. Confidence comes from the live runner test above.

### Note on `getPreviousVersion`
It's dormant — commented out of `.github/scripts/buildActions.sh`, has no committed `index.js` bundle, and isn't referenced by any workflow. Bumped for uniformity; if it's ever revived its bundle must be built first.

## Test plan
- [x] node24 confirmed running a custom action bundle on `ubuntu-24.04` (live run on throwaway branch)
- [ ] After merge: confirm no Node 20 deprecation annotations on the next run of a workflow using these actions (e.g. preDeploy's `isStagingDeployLocked` on next master merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)