### PR TITLE
chore(ci): bump third-party actions to node24-compatible versions

### DIFF
--- a/.github/actions/composite/setupBun/action.yml
+++ b/.github/actions/composite/setupBun/action.yml
@@ -12,7 +12,7 @@ runs:
     - uses: oven-sh/setup-bun@v2
 
     - id: cache-node-modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', 'patches/**') }}

--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: jq 'del(.version, .packages[""].version)' package-lock.json > normalized-package-lock.json
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version-file: '.nvmrc'
         cache: 'npm'
@@ -21,7 +21,7 @@ runs:
 
     - name: Cache node_modules
       id: node-modules-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('normalized-package-lock.json', 'patches/**') }}

--- a/.github/workflows/authorChecklist.yml
+++ b/.github/workflows/authorChecklist.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.actor != 'KirokuAdmin' && github.actor != 'imgbot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: authorChecklist.ts
         uses: ./.github/actions/javascript/authorChecklist

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -132,7 +132,7 @@ jobs:
           echo "CONFLICT_BRANCH=cherry-pick-${{ inputs.TARGET }}-${{ steps.extractPRInfo.outputs.PR_NUMBER }}-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.TARGET }}
           token: ${{ secrets.KIROKU_ADMIN_COMMIT_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,7 +37,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Make scripts executable
         run: chmod +x .claude/scripts/*.sh .github/scripts/extractAllowedRules.sh

--- a/.github/workflows/createDeployChecklist.yml
+++ b/.github/workflows/createDeployChecklist.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -65,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           # KIROKU_ADMIN_COMMIT_TOKEN is tied to KirokuAdmin. We keep the PR + admin
@@ -168,7 +168,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       STAGING_TAG: ${{ steps.deploy-metadata.outputs.STAGING_TAG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get deploy metadata
         id: deploy-metadata
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create or update deploy release
         env:

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -12,7 +12,7 @@ jobs:
       isValid: ${{ fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) && !fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           token: ${{ secrets.KIROKU_ADMIN_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Checkout the PR head ref (not the merge ref) so the bootstrap
           # step below can push the seatbelt baseline back to the branch.
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/composite/setupNode
 
       - name: Cache ESLint cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/eslint
           key: ${{ runner.os }}-eslint-${{ hashFiles('package-lock.json', 'eslint.config.mjs') }}

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           token: ${{ secrets.KIROKU_ADMIN_TOKEN }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
@@ -64,7 +64,7 @@ jobs:
         run: echo "REACT_NATIVE_DOWNLOADS_DIR=$HOME/.rn-downloads" >> "$GITHUB_ENV"
 
       - name: Cache Gradle and React Native downloads (Boost, etc.)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -135,7 +135,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         id: setup-node
@@ -147,7 +147,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache Pod dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: pods-cache
         with:
           path: |
@@ -233,7 +233,7 @@ jobs:
       # the dSYM for debugging.
       - name: Stash iOS dSYM as workflow artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-dsym-${{ inputs.APP_VERSION }}
           path: |
@@ -273,7 +273,7 @@ jobs:
     needs: [android, iOS]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Copy release assets
         env:
@@ -308,7 +308,7 @@ jobs:
     needs: [android, iOS, copyProductionReleaseAssets]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Warn deployers if staging deploy failed
         uses: ./.github/actions/composite/announceFailedWorkflowInDiscord
@@ -322,7 +322,7 @@ jobs:
     needs: [android, iOS, copyProductionReleaseAssets]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Announces the deploy in the #announce Discord channel'
         shell: bash
@@ -373,7 +373,7 @@ jobs:
     needs: [android, iOS]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -20,7 +20,7 @@ jobs:
     name: Seed macOS node_modules cache
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/composite/setupNode
 
   confirmPassingBuild:
@@ -29,7 +29,7 @@ jobs:
     if: ${{ always() }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Announce failed workflow in Discord
         if: ${{ needs.typecheck.result == 'failure' || needs.lint.result == 'failure' || needs.test.result == 'failure' }}
@@ -52,7 +52,7 @@ jobs:
       IS_AUTOMATION_PR: ${{ steps.shouldDeploy.outputs.IS_AUTOMATION_PR }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get merged pull request
         id: getMergedPullRequest

--- a/.github/workflows/react-compiler-compliance.yml
+++ b/.github/workflows/react-compiler-compliance.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Leave `ref` unset so the default `pull_request` merge ref
           # (refs/pull/N/merge = master + this PR) is checked out. The script

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Stage .env.production from secret
         run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
@@ -49,7 +49,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache Pod dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: pods-cache
         with:
           path: |
@@ -63,7 +63,7 @@ jobs:
         run: echo "IS_PODFILE_SAME_AS_MANIFEST=${{ hashFiles('ios/Podfile.lock') == hashFiles('ios/Pods/Manifest.lock') }}" >> "$GITHUB_OUTPUT"
 
       - name: Install cocoapods
-        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
@@ -79,7 +79,7 @@ jobs:
       # simulator runtime — xcodebuild crashes with "iOS 26.1 is not installed"
       # otherwise. Same step that testBuild.yml uses.
       - name: Install iOS platform SDK
-        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload iOS screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-screenshots-${{ github.sha }}
           path: fastlane/screenshots/ios/**/*.png
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload fastlane logs on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-fastlane-logs-${{ github.sha }}
           path: |

--- a/.github/workflows/seatbelt-baseline.yml
+++ b/.github/workflows/seatbelt-baseline.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     name: test (job ${{ fromJSON(matrix.chunk) }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache Jest cache
         id: cache-jest-cache
-        uses: actions/cache@ac25611caef967612169ab7e95533cf932c32270
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .jest-cache
           key: ${{ runner.os }}-jest-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check if pull request number is correct
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -45,7 +45,7 @@ jobs:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || needs.getBranchRef.outputs.REF }}
 
@@ -86,7 +86,7 @@ jobs:
           MYAPP_UPLOAD_KEY_PASSWORD: ${{ secrets.MYAPP_UPLOAD_KEY_PASSWORD }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/KirokuS3Upload
           aws-region: ${{ secrets.AWS_REGION }}
@@ -99,7 +99,7 @@ jobs:
           S3_REGION: ${{ secrets.AWS_REGION }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android
           path: ./android_paths.json
@@ -114,7 +114,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || needs.getBranchRef.outputs.REF }}
 
@@ -133,7 +133,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache Pod dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: pods-cache
         with:
           path: |
@@ -147,7 +147,7 @@ jobs:
         run: echo "IS_PODFILE_SAME_AS_MANIFEST=${{ hashFiles('ios/Podfile.lock') == hashFiles('ios/Pods/Manifest.lock') }}" >> "$GITHUB_OUTPUT"
 
       - name: Install cocoapods
-        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         if: steps.pods-cache.outputs.cache-hit != 'true' || steps.compare-podfile-and-manifest.outputs.IS_PODFILE_SAME_AS_MANIFEST != 'true' || steps.setup-node.outputs.cache-hit != 'true'
         with:
           timeout_minutes: 10
@@ -174,7 +174,7 @@ jobs:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/KirokuS3Upload
           aws-region: ${{ secrets.AWS_REGION }}
@@ -183,7 +183,7 @@ jobs:
         run: npm run jsbundle
 
       - name: Install iOS platform SDK
-        uses: nick-invision/retry@0711ba3d7808574133d713a0d92d2941be03a350
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -207,7 +207,7 @@ jobs:
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios
           path: ./ios_paths.json
@@ -221,12 +221,12 @@ jobs:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || needs.getBranchRef.outputs.REF }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
 
       - name: Read JSONs with android paths
         id: get_android_path

--- a/.github/workflows/translation-review.yml
+++ b/.github/workflows/translation-review.yml
@@ -38,7 +38,7 @@ jobs:
       PR_NUMBER: ${{ github.event.inputs.pr_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Make scripts executable
         run: chmod +x .claude/scripts/*.sh

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.actor != 'KirokuAdmin' || github.event_name == 'workflow_call' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/composite/setupNode
 

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.getSourceBranch.outputs.SOURCE_BRANCH }}
           token: ${{ secrets.KIROKU_ADMIN_COMMIT_TOKEN }}


### PR DESCRIPTION
## Summary
Follow-up to #791 (custom JS actions → node24). This bumps the **third-party** actions off the deprecated Node 20 runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/): forced to node24 on 2026-06-16, Node 20 removed 2026-09-16).

Targets are the **lowest node24-compatible major** of each action — minimal behavioral risk rather than chasing latest. Notably the artifact actions lag (their v5/v6 are still node20), so they need larger jumps:

| Action | From | To | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | |
| `actions/setup-node` | v4 | **v5** | |
| `actions/cache` | v4 / SHA | **v5** / v5.0.5 SHA | |
| `actions/upload-artifact` | v4 | **v6** | v5 still node20 |
| `actions/download-artifact` | v4 | **v7** | v5, v6 still node20 |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | v5 still node20 |
| `nick-invision/retry` | v2-era SHA | **nick-fields/retry v4** SHA | repo was renamed |

Pinning style preserved per occurrence: SHA-pinned stays SHA-pinned, major-tag stays major-tag. 52 `uses:` lines across 21 files; nothing else changed.

## Risk & validation
Unlike #791, these are external major bumps that can carry behavioral changes, and several sit in the **build/deploy path** (`configure-aws-credentials` → S3, `upload`/`download-artifact` → build outputs, `cache` → pods/node_modules). The `upload-artifact@v6` ↔ `download-artifact@v7` pair are both on the new artifact backend, so they remain compatible.

I'm applying the **`Ready To Build`** label to exercise the iOS + Android test build, which uses checkout, setup-node, cache, configure-aws-credentials, upload-artifact, and download-artifact end to end.

## Test plan
- [ ] `Ready To Build` test build passes for **both** iOS and Android
- [ ] Artifacts upload + the download-artifact comment job succeed (download links posted)
- [ ] No Node 20 deprecation annotations remain on the run
- [ ] Caches restore/save correctly (no cache-key breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)