### PR TITLE
refactor(force-update): render modal via early return instead of throwing

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -300,9 +300,6 @@ const CONST = {
     GATEWAY_TIMEOUT: 'Gateway Timeout',
     KIROKU_SERVICE_INTERRUPTED: 'Kiroku service interrupted',
     DUPLICATE_RECORD: 'A record already exists with this ID',
-
-    // The "Upgrade" is intentional as the 426 HTTP code means "Upgrade Required" and sent by the API. We use the "Update" language everywhere else in the front end when this gets returned.
-    UPDATE_REQUIRED: 'Upgrade Required',
   },
   EVENTS: {
     SCROLLING: 'scrolling',

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -19,6 +19,7 @@ import NavigationRoot from './libs/Navigation/NavigationRoot';
 import SplashScreenHider from './components/SplashScreenHider';
 import Log from './libs/Log';
 import migrateOnyx from './libs/migrateOnyx';
+import BootSplash from './libs/BootSplash';
 import * as ActiveClientManager from './libs/ActiveClientManager';
 import * as UserUtils from './libs/UserUtils';
 import Visibility from './libs/Visibility';
@@ -33,6 +34,7 @@ import UnderMaintenanceModal from './components/Modals/UnderMaintenanceModal';
 import UserOfflineModal from './components/UserOfflineModal';
 import CONFIG from './CONFIG';
 import UpdateAppModal from './components/UpdateAppModal';
+import ForceUpdateModal from './components/Modals/ForceUpdateModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
 import colors from './styles/theme/colors';
@@ -83,7 +85,11 @@ function Kiroku() {
   const [authenticationChecked, setAuthenticationChecked] = useState(false);
   const [isUnderMaintenance, setIsUnderMaintenance] = useState<boolean>(false);
   const [updateAvailable, setUpdateAvailable] = useState<boolean>(false);
-  const [updateRequired, setUpdateRequired] = useState<boolean>(false);
+  const [updateRequiredFromConfig, setUpdateRequiredFromConfig] =
+    useState<boolean>(false);
+  const [updateRequiredFromBackend] = useOnyx(ONYXKEYS.UPDATE_REQUIRED);
+  const updateRequired =
+    updateRequiredFromConfig || !!updateRequiredFromBackend;
   const [shouldShowVerifyEmailModal, setShouldShowVerifyEmailModal] =
     useState<boolean>(false);
   const [shouldShowUpdateModal, setShouldShowUpdateModal] =
@@ -126,9 +132,18 @@ function Kiroku() {
 
     setIsUnderMaintenance(underMaintenance);
     setUpdateAvailable(newUpdateAvailable);
-    setUpdateRequired(newUpdateRequired);
+    setUpdateRequiredFromConfig(newUpdateRequired);
     setShouldShowUpdateModal(newShouldShowUpdateModal);
   }, [config, shouldShowVerifyEmailModal]);
+
+  // A required update replaces the entire app tree via the early return below,
+  // so SplashScreenHider never mounts to hide the native splash — do it here.
+  useEffect(() => {
+    if (!updateRequired) {
+      return;
+    }
+    BootSplash.hide();
+  }, [updateRequired]);
 
   const shouldInit = isNavigationReady && hasCheckedAutoLogin;
 
@@ -279,7 +294,7 @@ function Kiroku() {
   }, [isAuthenticated, auth?.currentUser?.uid]);
 
   if (updateRequired) {
-    throw new Error(CONST.ERROR.UPDATE_REQUIRED);
+    return <ForceUpdateModal />;
   }
 
   // Always render the splash guard and SplashScreenHider, even before

--- a/src/components/ErrorBoundary/BaseErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/BaseErrorBoundary.tsx
@@ -1,8 +1,6 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {ErrorBoundary} from 'react-error-boundary';
 import BootSplash from '@libs/BootSplash';
-import ForceUpdateModal from '@components/Modals/ForceUpdateModal';
-import CONST from '@src/CONST';
 import GenericErrorScreen from '@screens/ErrorScreen/GenericErrorScreen';
 import type {BaseErrorBoundaryProps, LogError} from './types';
 
@@ -17,19 +15,14 @@ function BaseErrorBoundary({
   errorMessage,
   children,
 }: BaseErrorBoundaryProps) {
-  const [errorContent, setErrorContent] = useState('');
   const catchError = (errorObject: Error, errorInfo: React.ErrorInfo) => {
     logError(errorMessage, errorObject, JSON.stringify(errorInfo));
-    // We hide the splash screen since the error might happened during app init
+    // We hide the splash screen since the error might have happened during app init
     BootSplash.hide();
-    setErrorContent(errorObject.message);
   };
-  const updateRequired = errorContent === CONST.ERROR.UPDATE_REQUIRED;
 
   return (
-    <ErrorBoundary
-      fallback={updateRequired ? <ForceUpdateModal /> : <GenericErrorScreen />}
-      onError={catchError}>
+    <ErrorBoundary fallback={<GenericErrorScreen />} onError={catchError}>
       {children}
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary

The force-update wall was triggered by **throwing** `CONST.ERROR.UPDATE_REQUIRED` from `Kiroku`'s render and catching it in the error boundary, whose fallback rendered `ForceUpdateModal`. Two problems with that:

- It routed an **expected** app state through the crash logger (`Log.alert` in `BaseErrorBoundary`), so every forced update looked like a crash in telemetry — and it used an exception for control flow.
- The runtime path was **dead**: a `426` API response calls `UpdateRequired.alertUser()`, which sets `ONYXKEYS.UPDATE_REQUIRED`, but **nothing read that key**. A mid-session 426 did nothing; only the startup config check ever walled the app.

This PR:

- Makes `updateRequired` a **single signal** combining the startup config version check with the Onyx `UPDATE_REQUIRED` key (`useOnyx`). The previously-dead 426 path now actually works.
- Replaces the throw with an **early return** of `<ForceUpdateModal/>` in `Kiroku` — same full app-tree teardown as the throw (NavigationRoot and all other modals never render), but declarative and out of the crash path. The native splash is hidden directly in this branch since `SplashScreenHider` no longer mounts.
- Simplifies `BaseErrorBoundary` to only handle genuine crashes (always `GenericErrorScreen`) and removes the now-unused `CONST.ERROR.UPDATE_REQUIRED` message.

## Test plan

- [ ] Set `app_settings.min_supported_version` above the local version → force-update modal shows at boot, splash dissolves, **no** crash/alert logged.
- [ ] Simulate a `426` API response mid-session → `UPDATE_REQUIRED` Onyx key set → app switches to the force-update modal (previously did nothing).
- [ ] Normal version (no update needed) → app boots normally; the optional/dismissible update modal still appears when `latest_version` is newer.
- [ ] Trigger a genuine render error → `GenericErrorScreen` still renders via the error boundary.
- [ ] CI green: typecheck, lint, unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)