### PR TITLE
feat(realtime): route pushed Pusher events through gap detection + backfill

### DIFF
--- a/__tests__/actions/UserRealtime.test.ts
+++ b/__tests__/actions/UserRealtime.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+
+import * as OnyxUpdates from '@userActions/OnyxUpdates';
+import PusherUtils from '@libs/PusherUtils';
+import * as UserActions from '@userActions/User';
+import CONST from '@src/CONST';
+
+// Stub Onyx so importing User.ts doesn't start real Onyx.connect timers, which
+// otherwise fire after the jest environment is torn down and crash the run.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+  },
+  useOnyx: jest.fn(),
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({currentUser: {uid: 'user-1'}}),
+}));
+
+// User.ts pulls native-only modules (apple-auth via OAuthCredential, firebase via
+// the database helpers) that jest can't transform; stub them out so importing the
+// action under test doesn't load them.
+jest.mock('@libs/OAuthCredential', () => ({getOAuthCredential: jest.fn()}));
+jest.mock('@database/baseFunctions', () => ({readDataOnce: jest.fn()}));
+jest.mock('@userActions/Session', () => ({}));
+
+// Log schedules a periodic flush timer at import that fires after teardown.
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {info: jest.fn(), warn: jest.fn(), alert: jest.fn(), hmmm: jest.fn()},
+}));
+
+jest.mock('@libs/Pusher/pusher', () => ({
+  TYPE: {
+    ONYX_API_UPDATE: 'onyxApiUpdate',
+    MULTIPLE_EVENT_TYPE: {ONYX_API_UPDATE: 'onyxApiUpdate'},
+  },
+}));
+
+jest.mock('@libs/PusherUtils', () => ({
+  __esModule: true,
+  default: {
+    subscribeToMultiEvent: jest.fn(),
+    subscribeToPrivateUserChannelEvent: jest.fn(),
+  },
+}));
+
+jest.mock('@userActions/OnyxUpdates', () => ({
+  apply: jest.fn(),
+  saveUpdateInformation: jest.fn(),
+  doesClientNeedToBeUpdated: jest.fn(),
+}));
+
+const mockedSubscribe = jest.mocked(
+  PusherUtils.subscribeToPrivateUserChannelEvent,
+);
+const mockedApply = jest.mocked(OnyxUpdates.apply);
+const mockedSave = jest.mocked(OnyxUpdates.saveUpdateInformation);
+const mockedNeedsUpdate = jest.mocked(OnyxUpdates.doesClientNeedToBeUpdated);
+
+type PushCallback = (pushJSON: Record<string, unknown>) => void;
+
+/** Subscribe, then return the callback registered for the onyxApiUpdate event. */
+function getPushCallback(): PushCallback {
+  UserActions.subscribeToUserEvents();
+  const call = mockedSubscribe.mock.calls.at(-1);
+  return call?.[2] as PushCallback;
+}
+
+const pushEvent = {
+  eventType: 'onyxApiUpdate',
+  data: [{onyxMethod: 'merge', key: 'userDataList', value: {}}],
+  lastUpdateID: 5,
+  previousUpdateID: 4,
+};
+
+describe('subscribeToUserEvents pushed-update routing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies the update directly when there is no gap', () => {
+    mockedNeedsUpdate.mockReturnValue(false);
+
+    getPushCallback()(pushEvent);
+
+    expect(mockedNeedsUpdate).toHaveBeenCalledWith(4);
+    expect(mockedApply).toHaveBeenCalledTimes(1);
+    expect(mockedApply).toHaveBeenCalledWith({
+      type: CONST.ONYX_UPDATE_TYPES.PUSHER,
+      lastUpdateID: 5,
+      previousUpdateID: 4,
+      updates: [{eventType: 'onyxApiUpdate', data: pushEvent.data}],
+    });
+    expect(mockedSave).not.toHaveBeenCalled();
+  });
+
+  it('defers to backfill when the client is behind (gap detected)', () => {
+    mockedNeedsUpdate.mockReturnValue(true);
+
+    getPushCallback()(pushEvent);
+
+    expect(mockedNeedsUpdate).toHaveBeenCalledWith(4);
+    expect(mockedSave).toHaveBeenCalledTimes(1);
+    expect(mockedSave).toHaveBeenCalledWith({
+      type: CONST.ONYX_UPDATE_TYPES.PUSHER,
+      lastUpdateID: 5,
+      previousUpdateID: 4,
+      updates: [{eventType: 'onyxApiUpdate', data: pushEvent.data}],
+    });
+    expect(mockedApply).not.toHaveBeenCalled();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import CustomStatusBarAndBackgroundContextProvider from './components/CustomStat
 import AppleAuthWrapper from './components/SignInButtons/AppleAuthWrapper';
 import type {Route} from './ROUTES';
 import Kiroku from './Kiroku';
-// import OnyxUpdateManager from './libs/actions/OnyxUpdateManager';
+import OnyxUpdateManager from './libs/actions/OnyxUpdateManager';
 // import {LogBox} from 'react-native';
 
 type KirokuProps = {
@@ -42,7 +42,7 @@ type KirokuProps = {
 const fill = {flex: 1};
 
 function App({url}: KirokuProps): React.JSX.Element {
-  // OnyxUpdateManager(); // Fix the API first before enabling this
+  OnyxUpdateManager();
 
   return (
     <SplashScreenStateContextProvider>

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -5,6 +5,7 @@ import type {
   DrinkingSessionList,
   FriendRequestList,
   NicknameToId,
+  OnyxUpdatesFromServer,
   PendingOAuthCredential,
   Preferences,
   Profile,
@@ -928,12 +929,24 @@ function subscribeToUserEvents() {
     userID,
     pushJSON => {
       const event = pushJSON as unknown as KirokuOnyxApiUpdateEvent;
-      OnyxUpdates.apply({
+      const previousUpdateID = Number(event.previousUpdateID ?? 0);
+      const updateParams: OnyxUpdatesFromServer = {
         type: CONST.ONYX_UPDATE_TYPES.PUSHER,
         lastUpdateID: Number(event.lastUpdateID ?? 0),
-        previousUpdateID: Number(event.previousUpdateID ?? 0),
+        previousUpdateID,
         updates: [{eventType: event.eventType, data: event.data}],
-      });
+      };
+
+      // If the client missed updates (e.g. pushes that arrived while offline),
+      // there is a gap between previousUpdateID and what we've applied. Defer this
+      // update and let OnyxUpdateManager backfill the gap via GET /v1/updates,
+      // then apply the deferred updates in order. Otherwise apply it directly.
+      if (OnyxUpdates.doesClientNeedToBeUpdated(previousUpdateID)) {
+        OnyxUpdates.saveUpdateInformation(updateParams);
+        return;
+      }
+
+      OnyxUpdates.apply(updateParams);
     },
   );
 }


### PR DESCRIPTION
## Summary
Follow-up to #773. Pushed `onyxApiUpdate` events were applied directly via
`User.subscribeToUserEvents` → `OnyxUpdates.apply`, so a gap (a `previousUpdateID`
ahead of the client's applied id — e.g. pushes that arrived while offline) was
never detected and missed updates weren't backfilled until the next `app/open`.

- The push handler now checks `OnyxUpdates.doesClientNeedToBeUpdated(previousUpdateID)`.
  On a gap it routes to `OnyxUpdates.saveUpdateInformation`, which pauses the
  sequential queue and lets `OnyxUpdateManager` fetch the missing range via
  `GET /v1/updates?from=<applied>&to=<previousUpdateID>` and then apply the
  deferred update in order. With no gap it applies directly, as before.
- Enables `OnyxUpdateManager()` at boot in `src/App.tsx` (was commented out) so the
  deferred-update consumer actually runs — required for the saved gap to be
  processed and the paused queue to resume. The backfill route + server contract
  (`(from, to]`, ascending, stamped `lastUpdateID: to`) already shipped in #773.

Closes #775.

## Test plan
- [x] `tsc --noEmit` clean
- [x] New unit test `__tests__/actions/UserRealtime.test.ts` (2 cases): pushed
  update with no gap → `apply`; with a gap → `saveUpdateInformation`. Passes in ~1s.
- [x] Device check: take a client offline, have another account trigger updates
  (e.g. friend request), bring the first client online → the missed updates are
  backfilled via `GET /v1/updates` and applied in order (not dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)