### PR TITLE
fix(tooling): repair typecheck (TS5095) and standalone eslint gates

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -646,7 +646,6 @@
 "__mocks__/react-native-safe-area-context.tsx"	"react-hooks/refs"	2
 "__mocks__/react-native.ts"	"@typescript-eslint/no-unused-vars"	1
 "__tests__/unit/context/ConfigContext.test.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"__tests__/unit/useOnboardingFlow.test.ts"	"@typescript-eslint/no-unnecessary-type-assertion"	1
 "__tests__/utils/firebase/connections.ts"	"arrow-body-style"	1
 "__tests__/utils/firebase/mockAuth.ts"	"@typescript-eslint/switch-exhaustiveness-check"	1
 "scripts/generate-icons.mjs"	"@typescript-eslint/no-use-before-define"	1

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint-changed": "./scripts/lintChanged.sh",
     "react-compiler-compliance-check": "ts-node scripts/react-compiler-compliance-check.ts",
     "lint-watch": "onchange '**/*.{js,jsx,ts,tsx,mjs,cjs}' -- ./scripts/lint.sh {{changed}}",
-    "lint:quiet": "eslint . --max-warnings=0 --quiet --cache --cache-location=node_modules/.cache/eslint",
+    "lint:quiet": "NODE_OPTIONS='--max_old_space_size=8192 --experimental-require-module' eslint . --quiet --no-warn-ignored --cache --cache-location=node_modules/.cache/eslint",
     "gh-actions-build": "./.github/scripts/buildActions.sh",
     "gh-actions-validate": "./.github/scripts/validateActionsAndWorkflows.sh",
     "merge": "./scripts/mergeAndPush.sh",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "module": "commonjs",
+    // Inherit `module: preserve` from expo/tsconfig.base. Overriding it to
+    // `commonjs` while the base keeps `moduleResolution: bundler` trips TS5095
+    // (bundler resolution requires module preserve/es2015+), which aborts `tsc`.
     "types": ["react-native", "jest", "node"],
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "jsx": "react-native",


### PR DESCRIPTION
## Summary
Restores the local quality gates that were silently broken (CI was unaffected because it uses different runners). Closes #779.

- **typecheck (TS5095):** `tsconfig.json` overrode `module: commonjs` while inheriting `moduleResolution: bundler` from `expo/tsconfig.base`; bundler resolution requires `module` = `preserve`/es2015+, so plain `tsc` aborted before checking any files. Removed the override → inherits `module: preserve` (expo/Metro default). `npm run typecheck` now passes; `npm run typecheck-tsgo` (what CI runs) still passes.
- **standalone eslint (ERR_REQUIRE_ESM):** `eslint-plugin-rulesdir` (CJS) `require()`s `eslint-config-expensify`'s ESM rule files. `scripts/lint.sh` already injects `--experimental-require-module` (needed on the project's pinned Node 20.19.4); applied the same to the `lint:quiet` script and aligned its flags with the gate (dropped the inconsistent `--max-warnings=0`, added `--no-warn-ignored`) so it passes on a clean tree.
- **seatbelt baseline:** drops one stale type-aware entry (`useOnboardingFlow.test.ts` / `no-unnecessary-type-assertion`) that no longer fires under `module: preserve`. CI does not freeze the baseline, so this just keeps the committed file accurate.

## Verification (local)
- `npm run typecheck` → exit 0 (0 errors)
- `npm run typecheck-tsgo` → exit 0 (no regression)
- `npm run lint:quiet` → exit 0 (ERR_REQUIRE_ESM gone)

## Follow-up
Once the repo moves to Node ≥22.12 (`require(ESM)` is on by default there), the `--experimental-require-module` flag can be dropped from both `lint.sh` and `lint:quiet` — tie this to the Node 24 actions migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)