### PR TITLE
refactor(onyx): drop dead DeferredOnyxUpdates.process/enqueueAndProcess (removes require cycle)

### DIFF
--- a/src/libs/actions/OnyxUpdateManager/utils/DeferredOnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdateManager/utils/DeferredOnyxUpdates.ts
@@ -4,8 +4,6 @@ import * as SequentialQueue from '@libs/Network/SequentialQueue';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {OnyxUpdatesFromServer, Response} from '@src/types/onyx';
 import {isValidOnyxUpdateFromServer} from '@src/types/onyx/OnyxUpdatesFromServer';
-// eslint-disable-next-line import/no-cycle
-import * as OnyxUpdateManagerUtils from '.';
 
 let missingOnyxUpdatesQueryPromise:
   | Promise<Response | Response[] | void>
@@ -62,20 +60,6 @@ function isEmpty() {
   return Object.keys(deferredUpdates).length === 0;
 }
 
-/**
- * Manually processes and applies the updates from the deferred updates queue. (used e.g. for push notifications)
- */
-function process() {
-  if (missingOnyxUpdatesQueryPromise) {
-    missingOnyxUpdatesQueryPromise.finally(
-      () => OnyxUpdateManagerUtils.validateAndApplyDeferredUpdates,
-    );
-  }
-
-  missingOnyxUpdatesQueryPromise =
-    OnyxUpdateManagerUtils.validateAndApplyDeferredUpdates();
-}
-
 type EnqueueDeferredOnyxUpdatesOptions = {
   shouldPauseSequentialQueue?: boolean;
 };
@@ -111,18 +95,6 @@ function enqueue(
   }
 }
 
-/**
- * Adds updates to the deferred updates queue and processes them immediately
- * @param updates The updates that should be applied (e.g. updates from push notifications)
- */
-function enqueueAndProcess(
-  updates: OnyxUpdatesFromServer | DeferredUpdatesDictionary,
-  options?: EnqueueDeferredOnyxUpdatesOptions,
-) {
-  enqueue(updates, options);
-  process();
-}
-
 type ClearDeferredOnyxUpdatesOptions = {
   shouldResetGetMissingOnyxUpdatesPromise?: boolean;
   shouldUnpauseSequentialQueue?: boolean;
@@ -150,8 +122,6 @@ export {
   setMissingOnyxUpdatesQueryPromise,
   getUpdates,
   isEmpty,
-  process,
   enqueue,
-  enqueueAndProcess,
   clear,
 };

--- a/src/libs/actions/OnyxUpdateManager/utils/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/utils/index.ts
@@ -7,7 +7,6 @@ import type {
 } from '@libs/actions/OnyxUpdateManager/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {applyUpdates} from './applyUpdates';
-// eslint-disable-next-line import/no-cycle
 import * as DeferredOnyxUpdates from './DeferredOnyxUpdates';
 
 let lastUpdateIDAppliedToClient = 0;


### PR DESCRIPTION
## Summary
- Removes `process` and `enqueueAndProcess` from `OnyxUpdateManager/utils/DeferredOnyxUpdates.ts` — **dead code** with zero callers anywhere in the app (ported from Expensify's reliable-updates push-notification path, never wired up here). The live gap-detection/backfill path is `handleOnyxUpdateGap` (subscribed to `ONYX_UPDATES_FROM_SERVER`), which never used them.
- Deleting `process()` also drops the only `DeferredOnyxUpdates -> utils/index` back-import, which **breaks the require cycle** between the two modules — i.e. removes the Metro `Require cycle: …/utils/index.ts -> …/DeferredOnyxUpdates.ts -> …/utils/index.ts` warning — and lets us drop the now-redundant `// eslint-disable-next-line import/no-cycle` on the forward edge in `index.ts`.
- Note: `process()` also contained a latent (never-executed) bug — `.finally(() => OnyxUpdateManagerUtils.validateAndApplyDeferredUpdates)` returns the function instead of calling it, and the branch lacked a `return`. Rather than fix dead code, this deletes it.

**No behavioral change** — the removed code was never reached.

## Test plan
- [x] `grep` confirms zero callers of `process` / `enqueueAndProcess` repo-wide (and no `DeferredOnyxUpdates` mock references them).
- [x] ESLint on the two files: the `import/no-cycle` error does **not** reappear after removing the disable, confirming the cycle is genuinely broken; no new errors introduced.
- [x] Full `tsc` typecheck is green — this branch is based on `origin/master` (which includes #802's TS5095 fix), and a full local `tsc` run on that base exits 0 with no errors.
- [ ] Smoke: realtime friend updates still arrive (this PR doesn't touch the live `handleOnyxUpdateGap` path; verified separately on-device for the Pusher gap/backfill flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)