### PR TITLE
fix(tooling): run ts-node scripts as CommonJS to stop ERR_UNKNOWN_FILE_EXTENSION

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,19 @@
       "@userActions/*": ["./src/libs/actions/*"]
     }
   },
+  // ts-node-only overrides (ignored by tsc). The root config inherits
+  // `module: preserve` + `moduleResolution: bundler` from expo/tsconfig.base so
+  // `tsc` passes, but ts-node would then hand `.ts` entries to Node's native ESM
+  // loader (ERR_UNKNOWN_FILE_EXTENSION on Node 20). Force CommonJS so ts-node's
+  // require hook compiles `.ts` itself; `node` resolution avoids TS5095 (bundler
+  // requires module preserve/es2015+); tsconfig-paths resolves `@src/*` aliases.
+  "ts-node": {
+    "require": ["tsconfig-paths/register"],
+    "compilerOptions": {
+      "module": "CommonJS",
+      "moduleResolution": "node"
+    }
+  },
   "include": [
     "__mocks__",
     "__tests__",


### PR DESCRIPTION
## Summary

The **React Compiler Compliance** check (and every other `ts-node` script) fails on CI before evaluating any source:

```
> ts-node scripts/react-compiler-compliance-check.ts check-changed
TypeError: Unknown file extension ".ts" for .../scripts/react-compiler-compliance-check.ts
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
```

### Root cause
[#802](https://github.com/PetrCala/Kiroku/pull/802) dropped the root `module: commonjs` override so `tsc` inherits `module: preserve` from `expo/tsconfig.base` (correctly fixing the TS5095 typecheck abort). But ts-node read that same root config: with an ESM-ish `module`, ts-node delegates the `.ts` entry to Node's **native ESM loader**, which has no `.ts` handler on the Node `20.19.4` runner → `ERR_UNKNOWN_FILE_EXTENSION`. This broke `react-compiler-compliance-check`, `bumpVersion`, `release-profile`, etc.

### Fix
Add a `ts-node`-only override block to `tsconfig.json` (the same mechanism the repo used historically):

- `module: CommonJS` → ts-node's require hook compiles `.ts` itself instead of handing off to the native ESM loader.
- `moduleResolution: node` → avoids re-triggering TS5095 (bundler resolution requires module preserve/es2015+).
- `tsconfig-paths/register` → resolves the `@src/*` alias used by `scripts/utils/CLI.ts`.

`tsc`/`tsgo` ignore the `ts-node` key, so #802's typecheck fix stays fully intact.

## Test plan

Verified locally on Node `20.19.4` (the CI version):

- [x] Before fix: `npx ts-node scripts/react-compiler-compliance-check.ts check` → `ERR_UNKNOWN_FILE_EXTENSION` (reproduced).
- [x] After fix: `CI=true npm run react-compiler-compliance-check check-changed` runs and passes (no ESM error, `@src/*` alias resolves).
- [x] Checker still flags real violations: `check` on a file with a conditional hook call → `FAILED` + "Rules of Hooks" error, exit 1.
- [x] `npx tsc -p tsconfig.json --showConfig` → exit 0 (config still valid, `ts-node` key ignored by tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)