### PR TITLE
feat: point app share link to kiroku.cz/get

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -67,7 +67,7 @@ const CONST = {
     IN: 'in',
     OUT: 'out',
   },
-  APP_DOWNLOAD_LINK: KIROKU_URL,
+  APP_DOWNLOAD_LINK: `${KIROKU_URL}/get`,
   APP_URLS: {
     DEV: 'https://dev.kiroku.cz',
     STAGING: 'https://staging.kiroku.cz',


### PR DESCRIPTION
### Details

The in-app share link (Settings → Share app) currently copies the apex domain `https://kiroku.cz`. This points it to the dedicated download landing page `https://kiroku.cz/get` instead.

Only `CONST.APP_DOWNLOAD_LINK` is changed — it is consumed solely by the "Copy link" action in `AppShareScreen`. `KIROKU_URL` is left untouched so terms/privacy/subscription URLs and the prod app URL are unaffected.

Note: the QR code shown on the same screen is a static image asset (`KirokuIcons.KirokuQrCode`) and still encodes the apex domain. Regenerating it is out of scope here; flagging in case we want the QR to match `/get` in a follow-up.

### Tests

1. Open the app, go to Settings → Share app.
2. Tap "Link" to copy the share link.
3. Paste it and verify it reads `https://kiroku.cz/get`.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. On staging/production build, navigate to Settings → Share app.
2. Copy the link and verify it resolves to the `kiroku.cz/get` download page.

- [ ] Verify that no errors appear in the JS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)