### PR TITLE
refactor(realtime): cut drinking-session writes over to kiroku-api

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useEffect, useMemo, useRef} from 'react';
 import {BackHandler, View} from 'react-native';
-import type {Database} from 'firebase/database';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as DS from '@userActions/DrinkingSession';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
@@ -40,7 +39,7 @@ function DrinkingSessionWindow({
   shouldShowSyncPendingIndicator = false,
   shouldShowSyncSuccessIndicator = false,
 }: DrinkingSessionWindowProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const user = auth.currentUser;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -65,7 +64,7 @@ function DrinkingSessionWindow({
 
   const isSaveDisabled = totalUnits <= 0;
 
-  const saveSession = (database: Database, usr: User | null) => {
+  const saveSession = (usr: User | null) => {
     (async () => {
       if (!session || !usr) {
         return;
@@ -88,7 +87,6 @@ function DrinkingSessionWindow({
 
       try {
         await DS.saveDrinkingSessionData(
-          database,
           usr.uid,
           newSessionData,
           sessionId,
@@ -122,7 +120,6 @@ function DrinkingSessionWindow({
           }),
         );
         await DS.removeDrinkingSessionData(
-          db,
           user.uid,
           sessionId,
           onyxKey,
@@ -257,7 +254,7 @@ function DrinkingSessionWindow({
           isDisabled={isSaveDisabled}
           text={translate('liveSessionScreen.saveSession')}
           style={styles.buttonLargeSuccess}
-          onPress={() => saveSession(db, user)}
+          onPress={() => saveSession(user)}
         />
       </View>
       <ConfirmModal

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -51,6 +51,14 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/friends/remove',
   },
+  [WRITE_COMMANDS.UPDATE_SESSION]: {
+    method: 'post',
+    path: '/v1/sessions/update',
+  },
+  [WRITE_COMMANDS.DELETE_SESSION]: {
+    method: 'post',
+    path: '/v1/sessions/delete',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/DeleteSessionParams.ts
+++ b/src/libs/API/parameters/DeleteSessionParams.ts
@@ -1,0 +1,10 @@
+import type {DrinkingSessionId} from '@src/types/onyx';
+
+type DeleteSessionParams = {
+  /** ID of the session to remove (its GPS locations are removed too). */
+  sessionId: DrinkingSessionId;
+  /** When true, the server also clears the user's live status. */
+  sessionIsLive?: boolean;
+};
+
+export default DeleteSessionParams;

--- a/src/libs/API/parameters/UpdateSessionParams.ts
+++ b/src/libs/API/parameters/UpdateSessionParams.ts
@@ -1,0 +1,12 @@
+import type {DrinkingSession, DrinkingSessionId} from '@src/types/onyx';
+
+type UpdateSessionParams = {
+  /** ID of the session being upserted (also its key under the user's sessions). */
+  sessionId: DrinkingSessionId;
+  /** The full drinking-session payload to write (server stores it verbatim). */
+  session: DrinkingSession;
+  /** When true, the server also mirrors the session into the user's live status. */
+  sessionIsLive?: boolean;
+};
+
+export default UpdateSessionParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -3,6 +3,8 @@ export type {default as SendFriendRequestParams} from './SendFriendRequestParams
 export type {default as AcceptFriendRequestParams} from './AcceptFriendRequestParams';
 export type {default as DeleteFriendRequestParams} from './DeleteFriendRequestParams';
 export type {default as UnfriendParams} from './UnfriendParams';
+export type {default as UpdateSessionParams} from './UpdateSessionParams';
+export type {default as DeleteSessionParams} from './DeleteSessionParams';
 export type {default as GetMissingOnyxMessagesParams} from './GetMissingOnyxMessagesParams';
 export type {default as HandleRestrictedEventParams} from './HandleRestrictedEventParams';
 export type {default as OpenAppParams} from './OpenAppParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -33,6 +33,8 @@ const WRITE_COMMANDS = {
   ACCEPT_FRIEND_REQUEST: 'AcceptFriendRequest',
   DELETE_FRIEND_REQUEST: 'DeleteFriendRequest',
   UNFRIEND: 'Unfriend',
+  UPDATE_SESSION: 'UpdateSession',
+  DELETE_SESSION: 'DeleteSession',
   // ...
 } as const;
 
@@ -65,6 +67,8 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST]: Parameters.AcceptFriendRequestParams;
   [WRITE_COMMANDS.DELETE_FRIEND_REQUEST]: Parameters.DeleteFriendRequestParams;
   [WRITE_COMMANDS.UNFRIEND]: Parameters.UnfriendParams;
+  [WRITE_COMMANDS.UPDATE_SESSION]: Parameters.UpdateSessionParams;
+  [WRITE_COMMANDS.DELETE_SESSION]: Parameters.DeleteSessionParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -15,7 +15,6 @@ import type {
   DrinksToUnits,
   DrinksTimestamp,
   UserDataList,
-  UserStatus,
 } from '@src/types/onyx';
 import * as Localize from '@libs/Localize';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
@@ -25,6 +24,9 @@ import CONST from '@src/CONST';
 import type {FirebaseUpdates} from '@database/updates';
 import {generateDatabaseKey} from '@database/baseFunctions';
 import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import type {OnyxKey} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import Navigation from '@libs/Navigation/Navigation';
@@ -33,15 +35,10 @@ import ROUTES from '@src/ROUTES';
 import {differenceInDays, startOfDay} from 'date-fns';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import type {ValueOf} from 'type-fest';
-// eslint-disable-next-line you-dont-need-lodash-underscore/for-each
-import forEach from 'lodash/forEach';
 import DBPATHS from '@src/DBPATHS';
 import {Alert} from 'react-native';
 
-const drinkingSessionRef = DBPATHS.USER_DRINKING_SESSIONS_USER_ID_SESSION_ID;
 const userDrinkingSessionsRef = DBPATHS.USER_DRINKING_SESSIONS_USER_ID;
-const userStatusRef = DBPATHS.USER_STATUS_USER_ID;
-const userStatusLatestSessionRef = DBPATHS.USER_STATUS_USER_ID_LATEST_SESSION;
 const earliestSessionAtRef = DBPATHS.USERS_USER_ID_EARLIEST_SESSION_AT;
 
 let ongoingSessionData: DrinkingSession | undefined;
@@ -66,6 +63,54 @@ Onyx.connect({
     userDataList = value ?? undefined;
   },
 });
+
+/**
+ * Optimistic `merge cachedDrinkingSessions { [uid]: { [sessionId]: session } }`,
+ * mirroring the `onyxData` the kiroku-api sessions endpoints emit. A `null`
+ * `session` removes it from the cached snapshot (Onyx merge-delete semantics).
+ */
+function cachedSessionPatch(
+  uid: UserID,
+  sessionId: DrinkingSessionId,
+  session: DrinkingSession | null,
+): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.CACHED_DRINKING_SESSIONS,
+    value: {[uid]: {[sessionId]: session}},
+  };
+}
+
+/** Optimistic `merge userDataList { [uid]: { earliest_session_at } }`. */
+function earliestPatch(uid: UserID, earliest: number): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.USER_DATA_LIST,
+    value: {[uid]: {earliest_session_at: earliest}},
+  };
+}
+
+/**
+ * Optimistic data for a session upsert: the cached-snapshot merge plus, when the
+ * new `start_time` strictly lowers the floor (or there is no floor yet), the
+ * `earliest_session_at` merge. Non-strict edits (which may move the previously
+ * earliest session later) are left to the server, which recomputes the floor and
+ * returns/pushes the authoritative value — the inline response is idempotent.
+ */
+function sessionUpsertOptimisticData(
+  uid: UserID,
+  sessionId: DrinkingSessionId,
+  session: DrinkingSession,
+): OnyxUpdate[] {
+  const optimisticData: OnyxUpdate[] = [
+    cachedSessionPatch(uid, sessionId, session),
+  ];
+  const currentEarliest = userDataList?.[uid]?.earliest_session_at;
+  if (currentEarliest === undefined || session.start_time < currentEarliest) {
+    optimisticData.push(earliestPatch(uid, session.start_time));
+  }
+  return optimisticData;
+}
 
 /**
  * Query Firebase for the user's earliest remaining session and persist the
@@ -136,42 +181,24 @@ async function updateLocalData(
   await Onyx.set(onyxKey, dataToSet);
 }
 
-/** Write drinking session data into the database
- *
- * @param db Firebase Database object
- * @param string userID User ID
- * @param updates The updates to send, with base path set to the session ID
- * @param updateStatus Whether to update the user status data or not
- * @returnsPromise void.
- *  */
-async function updateDrinkingSessionData(
-  db: Database,
+/**
+ * Persist the full live (ongoing) drinking session via kiroku-api. Called from
+ * the live-session screen's batched sync as the user adds drinks/notes. The
+ * server upserts the session and — because `sessionIsLive` — mirrors it into the
+ * user's live status; the optimistic data mirrors the cached snapshot. The live
+ * editing state itself lives in `ONGOING_SESSION_DATA` and is owned by the
+ * screen; this only persists it.
+ */
+function updateLiveDrinkingSessionData(
   userID: UserID,
-  updates: FirebaseUpdates,
   sessionId: DrinkingSessionId,
-  updateStatus?: boolean,
-): Promise<void> {
-  const updatesToDB: FirebaseUpdates = {};
-
-  const dsPath = drinkingSessionRef.getRoute(userID, sessionId);
-
-  // Be mindful of using Object.forEach here, as that leads to an incorrect parsing of the object for some reason
-  // eslint-disable-next-line you-dont-need-lodash-underscore/for-each
-  forEach(updates, (value, key) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    updatesToDB[`${dsPath}/${key}`] = value;
-  });
-
-  if (updateStatus) {
-    const userStatusPath = userStatusLatestSessionRef.getRoute(userID);
-    // eslint-disable-next-line you-dont-need-lodash-underscore/for-each
-    forEach(updates, (value, key) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      updatesToDB[`${userStatusPath}/${key}`] = value;
-    });
-  }
-
-  await update(ref(db), updatesToDB);
+  session: DrinkingSession,
+): void {
+  API.write(
+    WRITE_COMMANDS.UPDATE_SESSION,
+    {sessionId, session, sessionIsLive: true},
+    {optimisticData: sessionUpsertOptimisticData(userID, sessionId, session)},
+  );
 }
 
 /**
@@ -232,36 +259,22 @@ async function startLiveDrinkingSession(
     timezone,
     ongoing: true,
   });
-  const newStatusData: UserStatus = {
-    last_online: new Date().getTime(),
-    latest_session_id: newSessionId,
-    latest_session: newSessionData,
-  };
 
-  // Update Firebase
-  const updates: FirebaseUpdates = {};
-  updates[userStatusRef.getRoute(user.uid)] = newStatusData;
-  updates[drinkingSessionRef.getRoute(user.uid, newSessionId)] = newSessionData;
-
-  // Live sessions start at "now", so they can only lower the earliest if the
-  // user has none yet. The strict-improvement guard keeps this branch a
-  // single-batch write — no extra Firebase read.
-  const currentEarliest = userDataList?.[user.uid]?.earliest_session_at;
-  const lowersEarliest =
-    currentEarliest === undefined ||
-    newSessionData.start_time < currentEarliest;
-  if (lowersEarliest) {
-    updates[earliestSessionAtRef.getRoute(user.uid)] =
-      newSessionData.start_time;
-  }
-
-  await update(ref(db), updates);
-
-  if (lowersEarliest) {
-    await Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-      [user.uid]: {earliest_session_at: newSessionData.start_time},
-    });
-  }
+  // The server upserts the session and, because `sessionIsLive`, mirrors it into
+  // the user's live status (`user_status`). Live sessions start at "now", so the
+  // strict-improvement floor only moves when the user has no earlier session —
+  // `sessionUpsertOptimisticData` handles that optimistically.
+  API.write(
+    WRITE_COMMANDS.UPDATE_SESSION,
+    {sessionId: newSessionId, session: newSessionData, sessionIsLive: true},
+    {
+      optimisticData: sessionUpsertOptimisticData(
+        user.uid,
+        newSessionId,
+        newSessionData,
+      ),
+    },
+  );
 
   await Onyx.set(ONYXKEYS.ONGOING_SESSION_DATA, newSessionData);
 }
@@ -275,45 +288,32 @@ async function startLiveDrinkingSession(
  * @returnsPromise void.
  *  */
 async function saveDrinkingSessionData(
-  db: Database,
   userID: string,
   newSessionData: DrinkingSession,
   sessionKey: string,
   onyxKey: OnyxKey,
   sessionIsLive?: boolean,
 ): Promise<void> {
-  const updates: FirebaseUpdates = {};
-  if (sessionIsLive) {
-    const userStatusData: UserStatus = {
-      // ETC - 1
-      last_online: new Date().getTime(),
-      latest_session_id: sessionKey,
-      latest_session: newSessionData,
-    };
-    updates[userStatusRef.getRoute(userID)] = userStatusData;
-  }
-  updates[drinkingSessionRef.getRoute(userID, sessionKey)] = newSessionData;
-
-  // If the new start_time strictly lowers the floor, batch the update — no
-  // extra Firebase read needed. Otherwise the edit may have moved the
-  // previously-earliest session later, so recompute via Firebase post-write.
-  const currentEarliest = userDataList?.[userID]?.earliest_session_at;
-  const newStartTime = newSessionData.start_time;
-  const isStrictImprovement =
-    currentEarliest === undefined || newStartTime < currentEarliest;
-  if (isStrictImprovement) {
-    updates[earliestSessionAtRef.getRoute(userID)] = newStartTime;
-  }
-
-  await update(ref(db), updates);
-
-  if (isStrictImprovement) {
-    await Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-      [userID]: {earliest_session_at: newStartTime},
-    });
-  } else {
-    await recomputeEarliestSessionAt(db, userID);
-  }
+  // The server upserts the session, owns the `earliest_session_at` floor
+  // (recomputing it when an edit moves the previously-earliest session later),
+  // and — when `sessionIsLive` — updates the user's live status. The optimistic
+  // data mirrors the server `onyxData`; non-strict floor changes are reconciled
+  // by the inline/pushed response.
+  API.write(
+    WRITE_COMMANDS.UPDATE_SESSION,
+    {
+      sessionId: sessionKey,
+      session: newSessionData,
+      sessionIsLive: !!sessionIsLive,
+    },
+    {
+      optimisticData: sessionUpsertOptimisticData(
+        userID,
+        sessionKey,
+        newSessionData,
+      ),
+    },
+  );
 
   await Onyx.set(onyxKey, null);
 }
@@ -326,31 +326,20 @@ async function saveDrinkingSessionData(
  * @returns
  *  */
 async function removeDrinkingSessionData(
-  db: Database,
   userID: string,
   sessionKey: string,
   onyxKey: OnyxKey,
   sessionIsLive?: boolean,
 ): Promise<void> {
-  const updates: FirebaseUpdates = {};
-  updates[drinkingSessionRef.getRoute(userID, sessionKey)] = null;
-  // Drop any GPS locations captured for this session in the same batch so
-  // they don't outlive the session they describe.
-  updates[`user_session_locations/${userID}/${sessionKey}`] = null;
-  if (sessionIsLive) {
-    const userStatusData: UserStatus = {
-      last_online: new Date().getTime(),
-      latest_session: null,
-      latest_session_id: null,
-    };
-    updates[userStatusRef.getRoute(userID)] = userStatusData;
-  }
-
-  await update(ref(db), updates);
-
-  // The removed session may have been the earliest; recompute the floor
-  // unconditionally post-delete (single indexed read, only fires on delete).
-  await recomputeEarliestSessionAt(db, userID);
+  // The server removes the session and its GPS locations, recomputes the
+  // `earliest_session_at` floor, and — when `sessionIsLive` — clears the user's
+  // live status. The optimistic data removes the session from the cached
+  // snapshot; the new floor is reconciled by the inline/pushed response.
+  API.write(
+    WRITE_COMMANDS.DELETE_SESSION,
+    {sessionId: sessionKey, sessionIsLive: !!sessionIsLive},
+    {optimisticData: [cachedSessionPatch(userID, sessionKey, null)]},
+  );
 
   await Onyx.set(onyxKey, null);
   await Onyx.set(`${ONYXKEYS.COLLECTION.SESSION_LOCATIONS}${sessionKey}`, null);
@@ -618,7 +607,7 @@ export {
   startLiveDrinkingSession,
   syncLocalLiveSessionData,
   updateBlackout,
-  updateDrinkingSessionData,
+  updateLiveDrinkingSessionData,
   updateDrinks,
   updateNote,
   updateLocalData,

--- a/src/screens/DrinkingSession/EditSessionScreen.tsx
+++ b/src/screens/DrinkingSession/EditSessionScreen.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useUserConnection} from '@context/global/UserConnectionContext';
 import CONST from '@src/CONST';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {DrinkingSessionNavigatorParamList} from '@libs/Navigation/types';
@@ -9,7 +8,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import DrinkingSessionWindow from '@components/DrinkingSessionWindow';
 import ScreenWrapper from '@components/ScreenWrapper';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
-import UserOfflineModal from '@components/UserOfflineModal';
 import useLocalize from '@hooks/useLocalize';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
 import Navigation from '@libs/Navigation/Navigation';
@@ -23,7 +21,6 @@ type EditSessionScreenProps = StackScreenProps<
 
 function EditSessionScreen({route}: EditSessionScreenProps) {
   const {sessionId, backTo} = route.params;
-  const {isOnline} = useUserConnection();
   const {translate} = useLocalize();
   const [session] = useOnyx(ONYXKEYS.EDIT_SESSION_DATA);
 
@@ -56,9 +53,6 @@ function EditSessionScreen({route}: EditSessionScreenProps) {
     }
   };
 
-  if (!isOnline) {
-    return <UserOfflineModal />;
-  }
   if (!session) {
     return (
       <FullScreenLoadingIndicator

--- a/src/screens/DrinkingSession/LiveSessionScreen.tsx
+++ b/src/screens/DrinkingSession/LiveSessionScreen.tsx
@@ -3,7 +3,6 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import * as DS from '@userActions/DrinkingSession';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import type {DrinkingSession} from '@src/types/onyx';
-import {useUserConnection} from '@context/global/UserConnectionContext';
 import CONST from '@src/CONST';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {DrinkingSessionNavigatorParamList} from '@libs/Navigation/types';
@@ -15,7 +14,6 @@ import LocationTaggingPrompt from '@components/LocationTaggingPrompt';
 import useBatchedUpdates from '@hooks/useBatchedUpdates';
 import ScreenWrapper from '@components/ScreenWrapper';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
-import UserOfflineModal from '@components/UserOfflineModal';
 import {computeFirebaseUpdates} from '@database/updates';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
 import Navigation from '@libs/Navigation/Navigation';
@@ -32,7 +30,6 @@ function LiveSessionScreen({route}: LiveSessionScreenProps) {
   const {sessionId, backTo} = route.params;
   const {auth} = useFirebase();
   const user = auth.currentUser;
-  const {isOnline} = useUserConnection();
   const [session] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
   const sessionRef = useRef<DrinkingSession | undefined>(undefined);
   const [dbSyncSuccessful, setDbSyncSuccessful] = useState(false);
@@ -101,9 +98,6 @@ function LiveSessionScreen({route}: LiveSessionScreenProps) {
     // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
   }, [session, user]); // Do not include enqueueUpdate in the dependencies, as it will cause an infinite loop
 
-  if (!isOnline) {
-    return <UserOfflineModal />;
-  }
   if (!session) {
     return <FullScreenLoadingIndicator />;
   }

--- a/src/screens/DrinkingSession/LiveSessionScreen.tsx
+++ b/src/screens/DrinkingSession/LiveSessionScreen.tsx
@@ -30,7 +30,7 @@ type LiveSessionScreenProps = StackScreenProps<
 
 function LiveSessionScreen({route}: LiveSessionScreenProps) {
   const {sessionId, backTo} = route.params;
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const user = auth.currentUser;
   const {isOnline} = useUserConnection();
   const [session] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
@@ -53,26 +53,23 @@ function LiveSessionScreen({route}: LiveSessionScreenProps) {
     }
   };
 
-  const syncWithDb = async (updates: Partial<DrinkingSession>) => {
-    if (!user) {
+  const syncWithDb = async () => {
+    if (!user || !session) {
       return;
     }
     try {
-      await DS.updateDrinkingSessionData(
-        db,
-        user.uid,
-        updates,
-        sessionId,
-        true, // Update live session status
-      );
+      // Persist the full current ongoing session (the live editing state lives in
+      // ONGOING_SESSION_DATA). The 500ms batch keeps the write frequency low; the
+      // server upserts it and mirrors it into the user's live status.
+      DS.updateLiveDrinkingSessionData(user.uid, sessionId, session);
       setDbSyncSuccessful(true);
     } catch (error) {
       ErrorUtils.raiseAppError(ERRORS.SESSION.SAVE_FAILED, error);
     }
   };
 
-  const processUpdates = async (updates: Partial<DrinkingSession>) => {
-    await syncWithDb(updates);
+  const processUpdates = async () => {
+    await syncWithDb();
   };
 
   const {isPending, enqueueUpdate: batchedEnqueue} = useBatchedUpdates(


### PR DESCRIPTION
First **write** slice of the action-cutover epic #778, and the prerequisite for the **sessions read** slice of #809.

## Summary
Routes all drinking-session DB writes through `API.write` (kiroku-api `POST /v1/sessions/{update,delete}`) instead of direct Firebase RTDB writes, with optimistic `onyxData` that mirrors the server. The **read path is untouched** — sessions still hydrate via the Firebase listener — so this **coexists safely with no behavior change** until the later read-listener removal.

Cut over (each had a single call site):
- **Start live session** (`StartSessionButtonAndPopover`) → `UPDATE_SESSION` (`sessionIsLive`). Session ID is still generated client-side as a Firebase push key (local key-gen, not a write).
- **Live batched sync** (`LiveSessionScreen`) → `UPDATE_SESSION` (`sessionIsLive`), sending the **full** ongoing session (which lives in `ONGOING_SESSION_DATA`), batched at 500ms.
- **Save / finish** (`DrinkingSessionWindow`) → `UPDATE_SESSION`.
- **Discard / delete** (`DrinkingSessionWindow`) → `DELETE_SESSION`.

Server contract (already live in kiroku-api): `/update {sessionId, session, sessionIsLive?}` and `/delete {sessionId, sessionIsLive?}` write Firebase **and** emit `onyxData` (`merge cachedDrinkingSessions` + `earliest_session_at`); the server owns the floor recompute and the `user_status` live mirror. Optimistic data mirrors this; non-strict floor changes are reconciled by the inline/pushed response (idempotent), matching the friends pattern.

Also removes the now-unused `db` props/args from the touched call sites and the dead `recomputeEarliestSessionAt` calls in the write paths (the helper stays — it's still used by the listener backfill).

## ⚠️ Merge gating — device-verify before merge
This is the **offline-critical core path**. Two reasons to hold:
1. Like #805, session mutations now flow through the reliable-updates spine (Pusher + `/v1/updates`), whose push/backfill path (#797) is **not yet device-verified**.
2. The live-session flow is central UX. Please verify on device before merging: start a live session, add drinks (batched sync), save → appears on calendar; edit a past session's date/drinks → save; discard a live session; delete a past session; and the **offline** case (writes queue and replay on reconnect — an improvement over the old direct-Firebase writes which failed offline).

## Notes / follow-ups
- Live-session syncs send a full-session upsert per 500ms batch. A **dedup conflict resolver** (collapse consecutive `UPDATE_SESSION` for the same `sessionId` in the queue) is a worthwhile follow-up — tracked alongside the other infra items in #810. Correctness holds without it (each upsert is idempotent).
- Does **not** touch reads (calendar/stats still read the Firebase listener) — that's the next slice in #809, now unblocked.

## Test plan
- [x] `npm run typecheck-tsgo` — passes
- [x] `./scripts/lint.sh <changed files>` — passes
- [x] React Compiler compliance — passes
- [x] `TZ=utc npx jest` — full suite green (64 passed, 1 skipped)
- [ ] **Device (gating):** the live/edit/save/discard/delete + offline flows above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)