### PR TITLE
feat(session-tile): drink types as right-side columns

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -100,39 +100,42 @@ function DrinkingSessionOverview({
   })).filter(({count}) => count > 0);
 
   const sessionDetails = (
-    <View style={[styles.flexColumn, styles.flex1]}>
-      <Text style={[styles.textNormal, styles.textStrong]}>
-        {translate('common.units')}: {totalUnits}
-      </Text>
+    <View
+      style={[
+        styles.flexRow,
+        styles.alignItemsCenter,
+        styles.justifyContentBetween,
+        styles.flex1,
+      ]}>
+      {/* Left: units + (live) time */}
+      <View style={styles.flexColumn}>
+        <Text style={[styles.textNormal, styles.textStrong]}>
+          {translate('common.units')}: {totalUnits}
+        </Text>
+        {shouldDisplayTime && (
+          <Text style={[styles.textMicroSupporting, styles.mt1]}>
+            {translate('common.time')}: {timeString}
+          </Text>
+        )}
+      </View>
+      {/* Right: per-drink-type breakdown as compact icon-over-count columns */}
       {drinkBreakdown.length > 0 && (
         <View
-          style={[
-            styles.flexRow,
-            styles.alignItemsCenter,
-            styles.flexWrap,
-            styles.mt1,
-          ]}>
+          style={[styles.flexRow, styles.alignItemsCenter, styles.flexWrap]}>
           {drinkBreakdown.map(({key, icon, count}) => (
-            <View
-              key={key}
-              style={[styles.flexRow, styles.alignItemsCenter, styles.mr3]}>
+            <View key={key} style={[styles.alignItemsCenter, styles.ml3]}>
               <Icon
                 src={icon}
                 fill={theme.textSupporting}
-                width={16}
-                height={16}
+                width={18}
+                height={18}
               />
-              <Text style={[styles.textMicroSupporting, styles.ml1]}>
+              <Text style={[styles.textMicroSupporting, styles.mt1]}>
                 {count}
               </Text>
             </View>
           ))}
         </View>
-      )}
-      {shouldDisplayTime && (
-        <Text style={[styles.textMicroSupporting, styles.mt1]}>
-          {translate('common.time')}: {timeString}
-        </Text>
       )}
     </View>
   );


### PR DESCRIPTION
### Details

Stacked on top of #798. **Design experiment** — moves the per-drink-type
breakdown on each session tile from a full-width row beneath the units to compact
**icon-over-count columns on the right** of the tile, so the tile stays ~one row
tall and reads more compactly.

- Left: units (+ live-session time). Right: one small column per non-zero drink
  type (icon above its count).
- Applies to both the interactive and `readOnly` tile variants, so the day
  overview, friend day drill-down, and stats drill-down all get it.

Kept as a separate PR so the layout choice can be reviewed (and reverted) in
isolation from the day-overview polish in #798.

> Base branch is `claude/romantic-beaver-46e09a` (#798). Rebase/retarget to
> `master` once #798 merges.

### Tests

1. Open the day overview; confirm each tile shows units on the left and the
   drink-type icons with counts stacked as columns on the right.
2. Sessions with many drink types wrap without breaking the tile height much.
3. Friend profile day drill-down + stats drill-down show the same compact layout.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Pure presentational change; renders from already-loaded Onyx data. Verify offline.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Tap a calendar day → day overview; check the tile layout (units left, drink
   columns right).
2. Compare against #798 (drinks in a row) and confirm the compact version reads well.

- [ ] Verify that no errors appear in the JS console

### Notes for reviewer

Verified locally: prettier, typecheck-tsgo, eslint (incl. React Compiler rules).
No new strings. Not yet run on a device — needs a visual pass on Android/iOS.