### PR TITLE
refactor(realtime): cut session-locations writes over to kiroku-api

### DIFF
--- a/src/components/DrinkTypesView.tsx
+++ b/src/components/DrinkTypesView.tsx
@@ -7,7 +7,6 @@ import * as DS from '@userActions/DrinkingSession';
 import * as SessionLocations from '@userActions/SessionLocations';
 import {findDrinkNameTranslationKey} from '@libs/DataHandling';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
-import {useFirebase} from '@context/global/FirebaseContext';
 import CONST from '@src/CONST';
 import useTheme from '@hooks/useTheme';
 import * as KirokuIcons from './Icon/KirokuIcons';
@@ -24,7 +23,6 @@ type DrinkTypesViewProps = {
 function DrinkTypesView({session}: DrinkTypesViewProps) {
   const {translate} = useLocalize();
   const {preferences} = useDatabaseData();
-  const {auth, db} = useFirebase();
   const styles = useThemeStyles();
   const theme = useTheme();
 
@@ -45,12 +43,9 @@ function DrinkTypesView({session}: DrinkTypesViewProps) {
       // Fire-and-forget: capture must never block the drink-add UX.
       // captureForTimestamp swallows its own errors internally; the .catch
       // is a belt-and-suspenders no-op to satisfy no-floating-promises.
-      SessionLocations.captureForTimestamp(
-        db,
-        auth.currentUser,
-        session.id,
-        timestamp,
-      ).catch(() => {});
+      SessionLocations.captureForTimestamp(session.id, timestamp).catch(
+        () => {},
+      );
     }
   };
 

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -63,6 +63,18 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/preferences',
   },
+  [WRITE_COMMANDS.CAPTURE_SESSION_LOCATION]: {
+    method: 'post',
+    path: '/v1/session-locations/capture',
+  },
+  [WRITE_COMMANDS.CLEAR_SESSION_LOCATIONS]: {
+    method: 'post',
+    path: '/v1/session-locations/clear',
+  },
+  [WRITE_COMMANDS.PURGE_SESSION_LOCATIONS]: {
+    method: 'post',
+    path: '/v1/session-locations/purge',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/CaptureSessionLocationParams.ts
+++ b/src/libs/API/parameters/CaptureSessionLocationParams.ts
@@ -1,0 +1,10 @@
+import type {DrinkingSessionId, DrinksTimestamp} from '@src/types/onyx';
+import type {DrinkLocation} from '@src/types/onyx/SessionLocations';
+
+type CaptureSessionLocationParams = {
+  sessionId: DrinkingSessionId;
+  timestamp: DrinksTimestamp;
+  location: DrinkLocation;
+};
+
+export default CaptureSessionLocationParams;

--- a/src/libs/API/parameters/ClearSessionLocationsParams.ts
+++ b/src/libs/API/parameters/ClearSessionLocationsParams.ts
@@ -1,0 +1,7 @@
+import type {DrinkingSessionId} from '@src/types/onyx';
+
+type ClearSessionLocationsParams = {
+  sessionId: DrinkingSessionId;
+};
+
+export default ClearSessionLocationsParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -5,6 +5,8 @@ export type {default as DeleteFriendRequestParams} from './DeleteFriendRequestPa
 export type {default as UnfriendParams} from './UnfriendParams';
 export type {default as UpdateSessionParams} from './UpdateSessionParams';
 export type {default as DeleteSessionParams} from './DeleteSessionParams';
+export type {default as CaptureSessionLocationParams} from './CaptureSessionLocationParams';
+export type {default as ClearSessionLocationsParams} from './ClearSessionLocationsParams';
 export type {default as GetMissingOnyxMessagesParams} from './GetMissingOnyxMessagesParams';
 export type {default as HandleRestrictedEventParams} from './HandleRestrictedEventParams';
 export type {default as OpenAppParams} from './OpenAppParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -36,6 +36,9 @@ const WRITE_COMMANDS = {
   UPDATE_SESSION: 'UpdateSession',
   DELETE_SESSION: 'DeleteSession',
   UPDATE_PREFERENCES: 'UpdatePreferences',
+  CAPTURE_SESSION_LOCATION: 'CaptureSessionLocation',
+  CLEAR_SESSION_LOCATIONS: 'ClearSessionLocations',
+  PURGE_SESSION_LOCATIONS: 'PurgeSessionLocations',
   // ...
 } as const;
 
@@ -71,6 +74,9 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.UPDATE_SESSION]: Parameters.UpdateSessionParams;
   [WRITE_COMMANDS.DELETE_SESSION]: Parameters.DeleteSessionParams;
   [WRITE_COMMANDS.UPDATE_PREFERENCES]: Parameters.UpdatePreferencesParams;
+  [WRITE_COMMANDS.CAPTURE_SESSION_LOCATION]: Parameters.CaptureSessionLocationParams;
+  [WRITE_COMMANDS.CLEAR_SESSION_LOCATIONS]: Parameters.ClearSessionLocationsParams;
+  [WRITE_COMMANDS.PURGE_SESSION_LOCATIONS]: EmptyObject;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/SessionLocations.ts
+++ b/src/libs/actions/SessionLocations.ts
@@ -1,49 +1,53 @@
 import Onyx from 'react-native-onyx';
-import type {Database} from 'firebase/database';
-import {ref, remove, update} from 'firebase/database';
-import type {User} from 'firebase/auth';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {DrinkingSessionId, DrinksTimestamp} from '@src/types/onyx';
 import checkPermission from '@libs/Permissions/checkPermission';
 import getCurrentLocation from '@libs/getCurrentLocation';
 
-// NOTE: Onyx caches for `sessionLocations_*` are not consumed by any UI yet
-// (capture is the only producer in v1). On purge we delete the Firebase
-// subtree authoritatively; stale Onyx entries are inert until the app
-// restarts. When the map / pin view ships, this file must also invalidate
-// every matching Onyx key so the UI doesn't render purged pins.
+/**
+ * Session-location writes, cut over from direct Firebase RTDB writes to
+ * kiroku-api `API.write` calls. Authority is server-side (the caller's Firebase
+ * ID token), so callers pass only the sessionId/timestamp; the owner's uid is
+ * derived server-side. Optimistic Onyx data mirrors each endpoint's `onyxData`
+ * so the inline response is idempotent.
+ *
+ * The Firebase READ listener that hydrates `sessionLocations_*` is intentionally
+ * left in place and coexists with these writes until the read cutover (#809).
+ *
+ * NOTE: the `sessionLocations_*` Onyx caches are not consumed by any UI yet
+ * (capture is the only producer in v1). `purgeAll` deletes the Firebase subtree
+ * authoritatively and the server intentionally emits no `onyxData`; stale Onyx
+ * entries are inert until the app restarts. When the map / pin view ships, the
+ * purge path must also invalidate every matching Onyx key so the UI doesn't
+ * render purged pins.
+ */
 
 const onyxKeyForSession = (sessionId: DrinkingSessionId) =>
   `${ONYXKEYS.COLLECTION.SESSION_LOCATIONS}${sessionId}` as const;
 
-const firebasePathForSession = (uid: string, sessionId: DrinkingSessionId) =>
-  `user_session_locations/${uid}/${sessionId}` as const;
-
-const firebasePathForTimestamp = (
-  uid: string,
-  sessionId: DrinkingSessionId,
-  timestamp: DrinksTimestamp,
-) => `user_session_locations/${uid}/${sessionId}/${timestamp}` as const;
-
-const firebasePathForUser = (uid: string) =>
-  `user_session_locations/${uid}` as const;
+function getCurrentUserID(): string | undefined {
+  return getFirebaseAuth().currentUser?.uid ?? undefined;
+}
 
 /**
  * Fire-and-forget: try to capture the device's current GPS fix and attach it
- * to the given (sessionId, timestamp). No-ops silently when location permission
- * isn't granted (don't re-prompt mid-session) or when the GPS lookup fails
- * or times out. Never throws — capture must never break the drink-add UX.
+ * to the given (sessionId, timestamp). No-ops silently when the user isn't
+ * signed in, when location permission isn't granted (don't re-prompt
+ * mid-session), or when the GPS lookup fails or times out. Never throws —
+ * capture must never break the drink-add UX.
  *
  * The caller is responsible for gating on the in-app preference
  * (track_location_during_sessions) and on session.ongoing === true.
  */
 async function captureForTimestamp(
-  db: Database,
-  user: User | null,
   sessionId: DrinkingSessionId,
   timestamp: DrinksTimestamp,
 ): Promise<void> {
-  if (!user) {
+  if (!getCurrentUserID()) {
     return;
   }
   try {
@@ -55,29 +59,43 @@ async function captureForTimestamp(
     if (!location) {
       return;
     }
-    await Onyx.merge(onyxKeyForSession(sessionId), {[timestamp]: location});
-    await update(ref(db), {
-      [firebasePathForTimestamp(user.uid, sessionId, timestamp)]: location,
-    });
+    const optimisticData: OnyxUpdate[] = [
+      {
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: onyxKeyForSession(sessionId),
+        value: {[timestamp]: location},
+      },
+    ];
+    API.write(
+      WRITE_COMMANDS.CAPTURE_SESSION_LOCATION,
+      {sessionId, timestamp, location},
+      {optimisticData},
+    );
   } catch {
     // Silent — location capture is best-effort.
   }
 }
 
 /**
- * Delete every location captured for a single session. Called from the
- * session-delete path so locations don't outlive the sessions they describe.
+ * Delete every location captured for a single session, so locations don't
+ * outlive the sessions they describe.
  */
-async function removeAllForSession(
-  db: Database,
-  user: User | null,
-  sessionId: DrinkingSessionId,
-): Promise<void> {
-  if (!user) {
+function removeAllForSession(sessionId: DrinkingSessionId) {
+  if (!getCurrentUserID()) {
     return;
   }
-  await Onyx.set(onyxKeyForSession(sessionId), null);
-  await remove(ref(db, firebasePathForSession(user.uid, sessionId)));
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.SET,
+      key: onyxKeyForSession(sessionId),
+      value: null,
+    },
+  ];
+  API.write(
+    WRITE_COMMANDS.CLEAR_SESSION_LOCATIONS,
+    {sessionId},
+    {optimisticData},
+  );
 }
 
 /**
@@ -85,14 +103,14 @@ async function removeAllForSession(
  * across all sessions. Sessions themselves are untouched. Used by the
  * "Clear location history" settings entry.
  *
- * Firebase is authoritative — see the file header for why we intentionally
- * do not invalidate the Onyx caches here in v1.
+ * Firebase is authoritative and the server emits no `onyxData` — see the file
+ * header for why we intentionally do not invalidate the Onyx caches here in v1.
  */
-async function purgeAll(db: Database, user: User | null): Promise<void> {
-  if (!user) {
+function purgeAll() {
+  if (!getCurrentUserID()) {
     return;
   }
-  await remove(ref(db, firebasePathForUser(user.uid)));
+  API.write(WRITE_COMMANDS.PURGE_SESSION_LOCATIONS, {});
 }
 
 export {captureForTimestamp, removeAllForSession, purgeAll};

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -122,19 +122,13 @@ function PrivacyScreen() {
       return;
     }
     setIsPurging(true);
-    SessionLocations.purgeAll(db, user)
-      .then(() => {
-        setShowPurgeConfirmModal(false);
-        Alert.alert(translate('privacyScreen.clearLocationHistory.success'));
-      })
-      .catch(error => {
-        const errorMessage = error instanceof Error ? error.message : '';
-        Alert.alert(
-          translate('privacyScreen.clearLocationHistory.error'),
-          errorMessage,
-        );
-      })
-      .finally(() => setIsPurging(false));
+    // Fire-and-forget: the write is queued and replayed offline, so reflect it
+    // optimistically. There is no Onyx state to roll back and the queued write
+    // never throws here.
+    SessionLocations.purgeAll();
+    setShowPurgeConfirmModal(false);
+    Alert.alert(translate('privacyScreen.clearLocationHistory.success'));
+    setIsPurging(false);
   };
 
   // Match PreferencesScreen: the system back press goes back through the


### PR DESCRIPTION
## Summary

Cuts the **session-locations write path** over from direct Firebase RTDB writes to `kiroku-api` `API.write` calls, following the friends (#773) and drinking-session (#815, now merged) write-cutover pattern.

- `src/libs/actions/SessionLocations.ts`: `captureForTimestamp`, `removeAllForSession`, and `purgeAll` now call `API.write` against `POST /v1/session-locations/{capture,clear,purge}` instead of writing to Firebase. Authority is server-side (the caller's Firebase ID token); callers no longer pass `db`/`user`.
  - **capture** → optimistic `merge(sessionLocations_<id>, {[timestamp]: location})`, mirroring the server `onyxData`.
  - **clear** → optimistic `set(sessionLocations_<id>, null)`.
  - **purge** → no optimistic data (server emits empty `onyxData`; Firebase is authoritative and the inert Onyx caches are intentionally left in place in v1, as documented in the file header).
- New API infra: `CaptureSessionLocation` / `ClearSessionLocations` / `PurgeSessionLocations` `WRITE_COMMANDS`, param types (`CaptureSessionLocationParams`, `ClearSessionLocationsParams`; purge is `EmptyObject`), and `kirokuRoutes` entries.
- Call sites updated: `DrinkTypesView` (drops now-unused `useFirebase`) and `PrivacyScreen` (purge is now fire-and-forget/optimistic; the old promise `.then/.catch/.finally` chain is gone).

## Coexistence (reads untouched)

The Firebase **read** listener that hydrates `sessionLocations_*` is deliberately **left in place** and coexists with these writes — no read behavior changes until the read cutover (#809). No listeners were removed.

## Merge-gating

This rides the same realtime transport path still being device-verified (same gate as #815). **Do not merge until that verification lands.**

Rebased onto current `master` (now includes the merged #815); the earlier infra conflict in `types.ts` / `parameters/index.ts` / `kirokuRoutes.ts` — both slices appended new `WRITE_COMMANDS` after `UNFRIEND` — was resolved by keeping both sets of entries.

Refs #778 (write cutovers), #809 (read cutovers).

## Test plan

- [x] `npx prettier --check` — clean
- [x] `./scripts/lint.sh <changed files>` — exit 0
- [x] `npm run typecheck-tsgo` — clean
- [x] `npm run react-compiler-compliance-check check-changed` — passed
- [x] `TZ=utc npx jest` — 68 suites pass (1 skipped), 608 tests pass
- [ ] On-device: capture a GPS fix in a live session, clear a session's locations, and "Clear location history" all round-trip through kiroku-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)