### PR TITLE
refactor(realtime): cut preferences writes over to kiroku-api

### DIFF
--- a/src/components/LocationTaggingPrompt.tsx
+++ b/src/components/LocationTaggingPrompt.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import {Alert} from 'react-native';
-import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useLocalize from '@hooks/useLocalize';
 import * as Preferences from '@userActions/Preferences';
@@ -20,8 +19,6 @@ import ConfirmModal from './ConfirmModal';
 function LocationTaggingPrompt() {
   const {translate} = useLocalize();
   const {preferences} = useDatabaseData();
-  const {auth, db} = useFirebase();
-  const user = auth.currentUser;
 
   const [dismissed, setDismissed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -44,7 +41,7 @@ function LocationTaggingPrompt() {
     checkPermission('location')
       .then(allowed => (allowed ? true : requestPermission('location')))
       .then(isGranted =>
-        Preferences.updatePreferences(db, user, {
+        Preferences.updatePreferences({
           location_prompt_seen: true,
           ...(isGranted ? {track_location_during_sessions: true} : {}),
         }),
@@ -60,12 +57,10 @@ function LocationTaggingPrompt() {
 
   const onCancel = () => {
     setDismissed(true);
-    Preferences.updatePreferences(db, user, {location_prompt_seen: true}).catch(
-      () => {
-        // Best-effort: if persisting "seen" fails (e.g. offline write error),
-        // the prompt may reappear on a future live session, which is acceptable.
-      },
-    );
+    Preferences.updatePreferences({location_prompt_seen: true}).catch(() => {
+      // Best-effort: if persisting "seen" fails (e.g. offline write error),
+      // the prompt may reappear on a future live session, which is acceptable.
+    });
   };
 
   return (

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -59,6 +59,10 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/sessions/delete',
   },
+  [WRITE_COMMANDS.UPDATE_PREFERENCES]: {
+    method: 'post',
+    path: '/v1/preferences',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/UpdatePreferencesParams.ts
+++ b/src/libs/API/parameters/UpdatePreferencesParams.ts
@@ -1,0 +1,11 @@
+import type {Preferences} from '@src/types/onyx';
+
+/**
+ * Partial preferences write sent to `POST /v1/preferences`. Field names map 1:1
+ * to the server's recognized preference keys (it reads each from the JSON body),
+ * so callers pass the same `Partial<Preferences>` shape the legacy Firebase
+ * `updatePreferences` accepted.
+ */
+type UpdatePreferencesParams = Partial<Preferences>;
+
+export default UpdatePreferencesParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -16,6 +16,7 @@ export type {default as UpdateDateOfBirthParams} from './UpdateDateOfBirthParams
 export type {default as UpdateDisplayNameParams} from './UpdateDisplayNameParams';
 export type {default as UpdateHomeAddressParams} from './UpdateHomeAddressParams';
 export type {default as UpdateLegalNameParams} from './UpdateLegalNameParams';
+export type {default as UpdatePreferencesParams} from './UpdatePreferencesParams';
 export type {default as UpdatePreferredLocaleParams} from './UpdatePreferredLocaleParams';
 export type {default as UpdatePronounsParams} from './UpdatePronounsParams';
 export type {default as UpdateSelectedTimezoneParams} from './UpdateSelectedTimezoneParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -35,6 +35,7 @@ const WRITE_COMMANDS = {
   UNFRIEND: 'Unfriend',
   UPDATE_SESSION: 'UpdateSession',
   DELETE_SESSION: 'DeleteSession',
+  UPDATE_PREFERENCES: 'UpdatePreferences',
   // ...
 } as const;
 
@@ -69,6 +70,7 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.UNFRIEND]: Parameters.UnfriendParams;
   [WRITE_COMMANDS.UPDATE_SESSION]: Parameters.UpdateSessionParams;
   [WRITE_COMMANDS.DELETE_SESSION]: Parameters.DeleteSessionParams;
+  [WRITE_COMMANDS.UPDATE_PREFERENCES]: Parameters.UpdatePreferencesParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/Preferences.ts
+++ b/src/libs/actions/Preferences.ts
@@ -1,67 +1,64 @@
 import Onyx from 'react-native-onyx';
-import type {Database} from 'firebase/database';
-import {update, ref, set} from 'firebase/database';
-import ONYXKEYS from '@src/ONYXKEYS';
-import * as Localize from '@libs/Localize';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import Navigation from '@libs/Navigation/Navigation';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type {Preferences, Theme} from '@src/types/onyx';
-import DBPATHS from '@src/DBPATHS';
-import type {User} from '@firebase/auth';
 
-/** Save preferences data into the database.
+/**
+ * Preference writes, cut over from direct Firebase RTDB writes to the kiroku-api
+ * `POST /v1/preferences` endpoint. The server validates the partial update and
+ * writes each recognized field under `user_preferences/$uid` (the same nodes the
+ * legacy writes targeted). Authority is server-side (the caller's Firebase ID
+ * token), so callers pass only the changed fields.
  *
- * Throw an error in case the save attempt fails.
- *
- * @param db Firebase database object
- * @param userID User ID
- * @param preferencesData New preferences
- * @returns
- *
- * @example
- * ```ts
- * const db = getDatabase();
- * const user = getCurrentUser();
- * const newDrinksToUnits = getDrinksToUnits();
- * await savePreferences(db, user.uid, {drinks_to_units: newDrinksToUnits});
- * ```
+ * Reads are untouched: every preference field still hydrates through the Firebase
+ * preferences listener (`DatabaseDataContext`), so this coexists with no behavior
+ * change until the read cutover (#809).
  */
-async function updatePreferences(
-  db: Database,
-  user: User | null,
+
+/**
+ * Optimistic Onyx updates mirroring the server's `onyxData`. Only `theme` and
+ * `locale` have dedicated top-level Onyx keys, so only those are echoed; the
+ * remaining fields have no top-level key and are reflected by the Firebase
+ * listener after the write lands. Mirroring the server keeps the inline/pushed
+ * response idempotent.
+ */
+function preferencesOptimisticData(
   updates: Partial<Preferences>,
-): Promise<void> {
-  if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
+): OnyxUpdate[] {
+  const optimisticData: OnyxUpdate[] = [];
+  if (updates.theme !== undefined) {
+    optimisticData.push({
+      onyxMethod: Onyx.METHOD.SET,
+      key: ONYXKEYS.PREFERRED_THEME,
+      value: updates.theme,
+    });
   }
-  const preferencesRoute = DBPATHS.USER_PREFERENCES_USER_ID.getRoute(user.uid);
-  await update(ref(db, preferencesRoute), updates);
+  if (updates.locale !== undefined) {
+    optimisticData.push({
+      onyxMethod: Onyx.METHOD.SET,
+      key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+      value: updates.locale,
+    });
+  }
+  return optimisticData;
 }
 
-/** Update the user's preferred theme */
-async function updateTheme(db: Database, user: User | null, theme: Theme) {
-  if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
-  }
-  // const optimisticData: OnyxUpdate[] = [
-  //   {
-  //     onyxMethod: Onyx.METHOD.SET,
-  //     key: ONYXKEYS.PREFERRED_THEME,
-  //     value: theme,
-  //   },
-  // ];
+/** Persist a partial preferences update via kiroku-api. */
+function updatePreferences(updates: Partial<Preferences>): Promise<void> {
+  API.write(WRITE_COMMANDS.UPDATE_PREFERENCES, updates, {
+    optimisticData: preferencesOptimisticData(updates),
+  });
+  return Promise.resolve();
+}
 
-  // const parameters: UpdateThemeParams = {
-  //   value: theme,
-  // };
-
-  // API.write(WRITE_COMMANDS.UPDATE_THEME, parameters, {optimisticData});
-
-  const dbPath = DBPATHS.USER_PREFERENCES_USER_ID_THEME;
-
-  await set(ref(db, dbPath.getRoute(user.uid)), theme);
-  await Onyx.set(ONYXKEYS.PREFERRED_THEME, theme);
-
+/** Update the user's preferred theme, then navigate back. */
+function updateTheme(theme: Theme): Promise<void> {
+  const result = updatePreferences({theme});
   Navigation.goBack();
+  return result;
 }
 
 export {updatePreferences, updateTheme};

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import {Alert, View} from 'react-native';
-import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import Navigation from '@libs/Navigation/Navigation';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -58,8 +57,6 @@ function ColorPaletteScreen() {
   const StyleUtils = useStyleUtils();
   const theme = useTheme();
   const {translate} = useLocalize();
-  const {auth, db} = useFirebase();
-  const user = auth.currentUser;
   const {preferences} = useDatabaseData();
   const [pendingPaletteId, setPendingPaletteId] = useState<PaletteId | null>(
     null,
@@ -88,7 +85,7 @@ function ColorPaletteScreen() {
     }
     setPendingPaletteId(id);
     setSaving(true);
-    Preferences.updatePreferences(db, user, {
+    Preferences.updatePreferences({
       session_color_palette: PALETTES[id],
     })
       .catch(error => {
@@ -110,7 +107,7 @@ function ColorPaletteScreen() {
     }
     setPendingUseOwnForOthers(next);
     setSavingUseOwnForOthers(true);
-    Preferences.updatePreferences(db, user, {
+    Preferences.updatePreferences({
       use_own_palette_for_others: next,
     })
       .catch(error => {

--- a/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
+++ b/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Alert, View} from 'react-native';
-import {useFirebase} from '@context/global/FirebaseContext';
 import {getDefaultPreferences} from '@userActions/User';
 import type {DrinksToUnits} from '@src/types/onyx';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -35,8 +34,6 @@ type PreferencesSliderConfig = NumericSliderProps & {
 function DrinksToUnitsScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {auth, db} = useFirebase();
-  const user = auth.currentUser;
   const {preferences} = useDatabaseData();
   const initialValues = useRef(preferences?.drinks_to_units);
   const [saving, setSaving] = useState<boolean>(false);
@@ -67,7 +64,7 @@ function DrinksToUnitsScreen() {
     (async () => {
       try {
         setSaving(true);
-        await Preferences.updatePreferences(db, user, {
+        await Preferences.updatePreferences({
           drinks_to_units: currentValues,
         });
         initialValues.current = currentValues;

--- a/src/screens/Settings/Preferences/ThemeScreen.tsx
+++ b/src/screens/Settings/Preferences/ThemeScreen.tsx
@@ -15,13 +15,11 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Theme} from '@src/types/onyx';
 import ERRORS from '@src/ERRORS';
-import {useFirebase} from '@context/global/FirebaseContext';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 
 function ThemeScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {auth, db} = useFirebase();
   const [preferredTheme] = useOnyx(ONYXKEYS.PREFERRED_THEME);
   const [isLoading, setIsLoading] = React.useState(false);
   const {DEFAULT, FALLBACK, ...themes} = CONST.THEME;
@@ -36,7 +34,7 @@ function ThemeScreen() {
     (async () => {
       try {
         setIsLoading(true);
-        await Preferences.updateTheme(db, auth.currentUser, theme);
+        await Preferences.updateTheme(theme);
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.USER.THEME_UPDATE_FAILED, error);
       } finally {

--- a/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
+++ b/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Alert, View} from 'react-native';
-import {useFirebase} from '@context/global/FirebaseContext';
 import {getDefaultPreferences} from '@userActions/User';
 import type {UnitsToColors} from '@src/types/onyx';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -35,8 +34,6 @@ type PreferencesSliderConfig = NumericSliderProps & {
 function UnitsToColorsScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {auth, db} = useFirebase();
-  const user = auth.currentUser;
   const {preferences} = useDatabaseData();
   const initialValues = useRef(preferences?.units_to_colors);
   const [saving, setSaving] = useState<boolean>(false);
@@ -67,7 +64,7 @@ function UnitsToColorsScreen() {
     (async () => {
       try {
         setSaving(true);
-        await Preferences.updatePreferences(db, user, {
+        await Preferences.updatePreferences({
           units_to_colors: currentValues,
         });
         initialValues.current = currentValues;

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -75,7 +75,7 @@ function PrivacyScreen() {
     }
     setPendingCrashReporting(next);
     setSavingCrashReporting(true);
-    Preferences.updatePreferences(db, user, {
+    Preferences.updatePreferences({
       crash_reporting_enabled: next,
     })
       .catch(error => {
@@ -105,7 +105,7 @@ function PrivacyScreen() {
           setPendingTrackLocation(null);
           return undefined;
         }
-        return Preferences.updatePreferences(db, user, {
+        return Preferences.updatePreferences({
           track_location_during_sessions: next,
         });
       })


### PR DESCRIPTION
## Summary

Cuts the **user-preferences write path** over from direct Firebase RTDB writes to the first-party `kiroku-api`, continuing the strangler-fig migration (epic #778).

- `src/libs/actions/Preferences.ts`: `updatePreferences` / `updateTheme` now call `API.write(UPDATE_PREFERENCES, params, {optimisticData})` against the existing `POST /v1/preferences` endpoint, instead of `update(ref(db, …))` / `set(ref(…))`.
- New infra: `UPDATE_PREFERENCES` write command + `UpdatePreferencesParams` (`Partial<Preferences>`) param type + `{method: 'post', path: '/v1/preferences'}` route in `kirokuRoutes.ts`.
- Optimistic data **mirrors the server `onyxData`**: only `theme` (→ `PREFERRED_THEME`) and `locale` (→ `NVP_PREFERRED_LOCALE`) have dedicated top-level Onyx keys, so only those are echoed. The remaining preference fields have no top-level Onyx key and are reflected by the Firebase listener after the write lands — so their optimistic data is intentionally empty (no behavior change vs. today).
- `updateTheme` preserves its `Navigation.goBack()` side effect.
- Call sites (Theme / UnitsToColors / DrinksToUnits / ColorPalette / Privacy screens + `LocationTaggingPrompt`) drop the now-unused `db`/`user` args; fully-unused `useFirebase` blocks/imports removed.

## Coexistence note (no behavior change yet)

The Firebase **read** path is intentionally left untouched — every preference field still hydrates through the listener in `DatabaseDataContext`. This write cutover coexists with the existing listener with no user-visible behavior change until the read cutover lands (#809).

## ⚠️ Merge gating

This rides the same Pusher + `/v1/updates` realtime path as the other write cutovers under #778. **Do not merge until device-verified.**

## Notes

- Rebased onto latest `master` (now includes the sessions write cutover #815). Conflicts in `API/types.ts` + `kirokuRoutes.ts` were resolved by keeping both the session and preferences command entries.
- `AchievementsScreen` was deleted on `master` (software BAC removed for App Store 1.4 compliance; Achievements→Badges rename), so it's no longer a call site. The `bac_*` fields remain valid `Preferences` keys and are still handled generically by `updatePreferences`.

## Test plan

- [x] `npx prettier --check` (clean)
- [x] `./scripts/lint.sh <changed files>` (exit 0)
- [x] `npm run typecheck-tsgo` (clean)
- [x] `npm run react-compiler-compliance-check check-changed` (passed)
- [x] `TZ=utc npx jest` (608 passed, 6 skipped)
- [ ] **Device verification** of the realtime path (gating — see above)

Refs #778, #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)