### PR TITLE
Friends: offline feedback (pattern B)

### DIFF
--- a/__tests__/actions/Friends.test.ts
+++ b/__tests__/actions/Friends.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-in-views -- this is a test that asserts on the mocked API.write, not a view */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this is a test that asserts on the mocked Onyx.merge, not app code */
+
+import Onyx from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import * as Friends from '@userActions/Friends';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+// Stub Onyx so importing the action under test doesn't start real Onyx.connect
+// timers, which otherwise fire after the jest environment is torn down.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+// jest.mock factories are hoisted above the const declarations below, so they
+// must inline literals rather than reference out-of-scope variables.
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({currentUser: {uid: 'user-1'}}),
+}));
+
+jest.mock('@libs/API', () => ({write: jest.fn()}));
+
+// Isolate the action's Onyx-shaping from the Localize/Onyx-backed error builder.
+jest.mock('@libs/ErrorUtils', () => ({
+  getMicroSecondOnyxErrorWithTranslationKey: (key: string) => ({
+    '1700000000000000': key,
+  }),
+}));
+
+const ME = 'user-1';
+const OTHER = 'friend-2';
+const ERROR_KEY = '1700000000000000';
+const {ADD, UPDATE, DELETE} = CONST.RED_BRICK_ROAD_PENDING_ACTION;
+
+const mockedWrite = jest.mocked(API.write);
+const mockedMerge = jest.mocked(Onyx.merge);
+
+function lastWrite() {
+  const call = mockedWrite.mock.calls.at(-1);
+  return {command: call?.[0], params: call?.[1], onyxData: call?.[2]};
+}
+
+const metaPatch = (uid: string, value: unknown) => ({
+  onyxMethod: 'merge',
+  key: ONYXKEYS.FRIENDS_METADATA,
+  value: {[uid]: value},
+});
+
+const userDataPatch = (uid: string, value: unknown) => ({
+  onyxMethod: 'merge',
+  key: ONYXKEYS.USER_DATA_LIST,
+  value: {[uid]: value},
+});
+
+describe('Friends actions — offline feedback (pattern B)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('sendFriendRequest: additive ADD that survives failure', () => {
+    Friends.sendFriendRequest(OTHER);
+    const {command, params, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.SEND_FRIEND_REQUEST);
+    expect(params).toEqual({toUserId: OTHER});
+    expect(onyxData?.optimisticData).toEqual([
+      userDataPatch(ME, {
+        friend_requests: {[OTHER]: CONST.FRIEND_REQUEST_STATUS.SENT},
+      }),
+      metaPatch(OTHER, {pendingAction: ADD, errors: null}),
+    ]);
+    expect(onyxData?.successData).toEqual([metaPatch(OTHER, null)]);
+    // Failure keeps the optimistic SENT row and only marks it errored.
+    expect(onyxData?.failureData).toEqual([
+      metaPatch(OTHER, {
+        errors: {[ERROR_KEY]: 'friendAction.error.couldNotSendRequest'},
+      }),
+    ]);
+  });
+
+  it('acceptFriendRequest: keep-and-dim, applies the move on success only', () => {
+    Friends.acceptFriendRequest(OTHER);
+    const {command, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST);
+    // Optimistic only marks pending — the request is NOT moved yet.
+    expect(onyxData?.optimisticData).toEqual([
+      metaPatch(OTHER, {pendingAction: UPDATE, errors: null}),
+    ]);
+    expect(onyxData?.successData).toEqual([
+      userDataPatch(ME, {
+        friend_requests: {[OTHER]: null},
+        friends: {[OTHER]: true},
+      }),
+      metaPatch(OTHER, null),
+    ]);
+    expect(onyxData?.failureData).toEqual([
+      metaPatch(OTHER, {
+        errors: {[ERROR_KEY]: 'friendAction.error.couldNotAcceptRequest'},
+      }),
+    ]);
+  });
+
+  it('deleteFriendRequest: keep-and-dim DELETE, removes on success only', () => {
+    Friends.deleteFriendRequest(OTHER);
+    const {command, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.DELETE_FRIEND_REQUEST);
+    expect(onyxData?.optimisticData).toEqual([
+      metaPatch(OTHER, {pendingAction: DELETE, errors: null}),
+    ]);
+    expect(onyxData?.successData).toEqual([
+      userDataPatch(ME, {friend_requests: {[OTHER]: null}}),
+      metaPatch(OTHER, null),
+    ]);
+    expect(onyxData?.failureData).toEqual([
+      metaPatch(OTHER, {
+        errors: {[ERROR_KEY]: 'friendAction.error.couldNotRemoveRequest'},
+      }),
+    ]);
+  });
+
+  it('unfriend: keep-and-dim DELETE, removes the friend on success only', () => {
+    Friends.unfriend(OTHER);
+    const {command, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.UNFRIEND);
+    expect(onyxData?.optimisticData).toEqual([
+      metaPatch(OTHER, {pendingAction: DELETE, errors: null}),
+    ]);
+    expect(onyxData?.successData).toEqual([
+      userDataPatch(ME, {friends: {[OTHER]: null}}),
+      metaPatch(OTHER, null),
+    ]);
+    expect(onyxData?.failureData).toEqual([
+      metaPatch(OTHER, {
+        errors: {[ERROR_KEY]: 'friendAction.error.couldNotUnfriend'},
+      }),
+    ]);
+  });
+
+  it('clearFriendActionError(ADD): rolls back the optimistic request + clears metadata', () => {
+    Friends.clearFriendActionError(OTHER, ADD);
+
+    expect(mockedMerge).toHaveBeenCalledWith(ONYXKEYS.USER_DATA_LIST, {
+      [ME]: {friend_requests: {[OTHER]: null}},
+    });
+    expect(mockedMerge).toHaveBeenCalledWith(ONYXKEYS.FRIENDS_METADATA, {
+      [OTHER]: null,
+    });
+  });
+
+  it('clearFriendActionError(DELETE): clears only metadata, no rollback', () => {
+    Friends.clearFriendActionError(OTHER, DELETE);
+
+    expect(mockedMerge).toHaveBeenCalledTimes(1);
+    expect(mockedMerge).toHaveBeenCalledWith(ONYXKEYS.FRIENDS_METADATA, {
+      [OTHER]: null,
+    });
+  });
+});

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -54,6 +54,13 @@ const ONYXKEYS = {
   /** Contains all the userData the user has access to, keyed by userID */
   USER_DATA_LIST: 'userDataList',
 
+  /**
+   * Per-friend offline-feedback state (pendingAction + dismissible errors),
+   * keyed by the counterpart's userID. Client-only: the server never writes
+   * this, so it survives `/v1/updates` + Pusher userData merges.
+   */
+  FRIENDS_METADATA: 'friendsMetadata',
+
   /** Contains all the private user data details of the user */
   USER_PRIVATE_DATA: 'private_userData',
 
@@ -306,6 +313,7 @@ type OnyxValuesMapping = {
   //   [ONYXKEYS.CUSTOM_STATUS_DRAFT]: OnyxTypes.CustomStatusDraft;
   //   [ONYXKEYS.INPUT_FOCUSED]: boolean;
   [ONYXKEYS.USER_DATA_LIST]: OnyxTypes.UserDataList;
+  [ONYXKEYS.FRIENDS_METADATA]: OnyxTypes.FriendsMetadata;
   [ONYXKEYS.USER_PRIVATE_DATA]: OnyxTypes.UserPrivateData;
   [ONYXKEYS.USER_DATA_METADATA]: Record<string, OnyxTypes.UserDataMetadata>;
   [ONYXKEYS.UPDATE_AVAILABLE]: boolean;

--- a/src/components/Search/SearchResult.tsx
+++ b/src/components/Search/SearchResult.tsx
@@ -7,6 +7,7 @@ import type {FriendRequestStatus, Profile} from '@src/types/onyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
+import FriendOfflineFeedback from '@components/Social/FriendOfflineFeedback';
 import SendFriendRequestButton from './SendFriendRequestButton';
 
 type SearchResultProps = {
@@ -31,33 +32,35 @@ function SearchResult({
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   return (
-    <View style={styles.userOverviewContainer}>
-      <View style={styles.userOverviewLeftContent}>
-        <ProfileImage
-          key={`${userID}-profile-icon`}
-          storage={storage}
-          userID={userID}
-          downloadPath={userDisplayData?.photo_url}
-          style={styles.avatarLarge}
-        />
-        <Text style={[styles.headerText, styles.ml3, styles.flexShrink1]}>
-          {userDisplayData?.display_name
-            ? userDisplayData.display_name
-            : translate('common.unknown')}
-        </Text>
-        <View style={styles.ml1}>
-          <SupporterBadgeForUser userID={userID} size="small" />
+    <FriendOfflineFeedback userID={userID}>
+      <View style={styles.userOverviewContainer}>
+        <View style={styles.userOverviewLeftContent}>
+          <ProfileImage
+            key={`${userID}-profile-icon`}
+            storage={storage}
+            userID={userID}
+            downloadPath={userDisplayData?.photo_url}
+            style={styles.avatarLarge}
+          />
+          <Text style={[styles.headerText, styles.ml3, styles.flexShrink1]}>
+            {userDisplayData?.display_name
+              ? userDisplayData.display_name
+              : translate('common.unknown')}
+          </Text>
+          <View style={styles.ml1}>
+            <SupporterBadgeForUser userID={userID} size="small" />
+          </View>
         </View>
+        {customButton ?? (
+          <SendFriendRequestButton
+            userFrom={userFrom}
+            userTo={userID}
+            requestStatus={requestStatus}
+            alreadyAFriend={alreadyAFriend}
+          />
+        )}
       </View>
-      {customButton ?? (
-        <SendFriendRequestButton
-          userFrom={userFrom}
-          userTo={userID}
-          requestStatus={requestStatus}
-          alreadyAFriend={alreadyAFriend}
-        />
-      )}
-    </View>
+    </FriendOfflineFeedback>
   );
 }
 

--- a/src/components/Social/FriendOfflineFeedback.tsx
+++ b/src/components/Social/FriendOfflineFeedback.tsx
@@ -1,0 +1,53 @@
+import React, {useCallback} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import type {OnyxEntry} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
+import OfflineWithFeedback from '@components/OfflineWithFeedback';
+import * as Friends from '@userActions/Friends';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {FriendsMetadata} from '@src/types/onyx';
+import type ChildrenProps from '@src/types/utils/ChildrenProps';
+
+type FriendOfflineFeedbackProps = ChildrenProps & {
+  /** The counterpart user's ID whose pending friend action is reflected */
+  userID: string;
+
+  /** Additional container styles */
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Wraps a friend row in OfflineWithFeedback, sourcing the pending/error state
+ * for that counterpart from FRIENDS_METADATA and wiring up error dismissal.
+ */
+function FriendOfflineFeedback({
+  userID,
+  style,
+  children,
+}: FriendOfflineFeedbackProps) {
+  const selector = useCallback(
+    (data: OnyxEntry<FriendsMetadata>) => data?.[userID],
+    [userID],
+  );
+  const [metadata] = useOnyx(ONYXKEYS.FRIENDS_METADATA, {selector});
+
+  const pendingAction = metadata?.pendingAction;
+  const onClose = useCallback(
+    () => Friends.clearFriendActionError(userID, pendingAction ?? null),
+    [userID, pendingAction],
+  );
+
+  return (
+    <OfflineWithFeedback
+      pendingAction={pendingAction}
+      errors={metadata?.errors}
+      onClose={onClose}
+      style={style}>
+      {children}
+    </OfflineWithFeedback>
+  );
+}
+
+FriendOfflineFeedback.displayName = 'FriendOfflineFeedback';
+
+export default FriendOfflineFeedback;

--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -20,6 +20,7 @@ import {PressableWithFeedback} from '@components/Pressable';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useLocalize from '@hooks/useLocalize';
+import FriendOfflineFeedback from './FriendOfflineFeedback';
 import UserOverview from './UserOverview';
 
 type UserListProps = {
@@ -175,18 +176,19 @@ function UserListComponent({
       }
 
       return (
-        <PressableWithFeedback
-          key={`${index}-user-button`}
-          accessibilityLabel={`${index}-user-button`}
-          onPress={() => navigateToProfile(userID)}>
-          <UserOverview
-            key={`${index}-user-overview`}
-            userID={userID}
-            profileData={profileData}
-            userStatusData={userStatusData}
-            timezone={userData?.timezone}
-          />
-        </PressableWithFeedback>
+        <FriendOfflineFeedback key={`${index}-user-feedback`} userID={userID}>
+          <PressableWithFeedback
+            accessibilityLabel={`${index}-user-button`}
+            onPress={() => navigateToProfile(userID)}>
+            <UserOverview
+              key={`${index}-user-overview`}
+              userID={userID}
+              profileData={profileData}
+              userStatusData={userStatusData}
+              timezone={userData?.timezone}
+            />
+          </PressableWithFeedback>
+        </FriendOfflineFeedback>
       );
     },
     [profileList, userStatusList, userData?.timezone],

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -511,6 +511,18 @@ export default {
     searchYourFriendList: 'Prohledat seznam přátel',
     userList: 'List vašich přátel',
   },
+  friendAction: {
+    error: {
+      couldNotSendRequest:
+        'Nepodařilo se odeslat žádost o přátelství. Zkuste to prosím znovu.',
+      couldNotAcceptRequest:
+        'Nepodařilo se přijmout žádost o přátelství. Zkuste to prosím znovu.',
+      couldNotRemoveRequest:
+        'Nepodařilo se odstranit žádost o přátelství. Zkuste to prosím znovu.',
+      couldNotUnfriend:
+        'Nepodařilo se odebrat tohoto přítele. Zkuste to prosím znovu.',
+    },
+  },
   notFoundScreen: {
     title: 'Nenalezeno',
   },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -508,6 +508,17 @@ export default {
     searchYourFriendList: 'Search your friend list',
     userList: 'The list of your friends',
   },
+  friendAction: {
+    error: {
+      couldNotSendRequest:
+        'Could not send the friend request. Please try again.',
+      couldNotAcceptRequest:
+        'Could not accept the friend request. Please try again.',
+      couldNotRemoveRequest:
+        'Could not remove the friend request. Please try again.',
+      couldNotUnfriend: 'Could not remove this friend. Please try again.',
+    },
+  },
   notFoundScreen: {
     title: 'Not Found',
   },

--- a/src/libs/actions/Friends.ts
+++ b/src/libs/actions/Friends.ts
@@ -2,26 +2,39 @@ import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import * as ErrorUtils from '@libs/ErrorUtils';
 import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {TranslationPaths} from '@src/languages/types';
+import type {PendingAction} from '@src/types/onyx/OnyxCommon';
+import type {FriendActionMetadata} from '@src/types/onyx/FriendsMetadata';
 
 /**
  * Friend actions, cut over from direct Firebase RTDB writes to kiroku-api
  * `API.write` calls. Authority is server-side (the caller's Firebase ID token),
  * so callers pass only the counterpart id; the caller's own uid is used solely
- * for the optimistic Onyx update, which mirrors the server's `onyxData` so the
- * inline response is idempotent. Friend reads are sourced from Onyx
+ * for the optimistic Onyx update. Friend reads are sourced from Onyx
  * `userDataList` (the signed-in user's `friends`/`friend_requests`), hydrated by
  * `app/open` and kept in sync via Pusher + `/v1/updates` — not Firebase
  * listeners.
+ *
+ * Offline feedback (pattern B): each action marks a `pendingAction` in
+ * `FRIENDS_METADATA` (keyed by the counterpart uid) so the row can dim while the
+ * write is queued, clears it in `successData`, and surfaces a dismissible error
+ * in `failureData`. Additive actions (send) apply their data change optimistically
+ * and keep the row on failure; destructive actions (accept/reject/unfriend) defer
+ * the data mutation to `successData` so the row stays visible and dimmed until the
+ * server confirms (keep-and-dim).
  */
+
+const {ADD, UPDATE, DELETE} = CONST.RED_BRICK_ROAD_PENDING_ACTION;
 
 function getCurrentUserID(): string | undefined {
   return getFirebaseAuth().currentUser?.uid ?? undefined;
 }
 
-/** Optimistic `merge userDataList { [uid]: patch }`, matching server onyxData. */
+/** Optimistic `merge userDataList { [uid]: patch }`. */
 function userDataPatch(
   uid: string,
   patch: Record<string, unknown>,
@@ -30,6 +43,24 @@ function userDataPatch(
     onyxMethod: Onyx.METHOD.MERGE,
     key: ONYXKEYS.USER_DATA_LIST,
     value: {[uid]: patch},
+  };
+}
+
+/** `merge friendsMetadata { [otherUserId]: meta }` (null removes the entry). */
+function metaPatch(
+  otherUserId: string,
+  meta: FriendActionMetadata | null,
+): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.FRIENDS_METADATA,
+    value: {[otherUserId]: meta},
+  };
+}
+
+function errorMeta(message: TranslationPaths): FriendActionMetadata {
+  return {
+    errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey(message),
   };
 }
 
@@ -42,8 +73,19 @@ function sendFriendRequest(toUserId: string) {
     userDataPatch(uid, {
       friend_requests: {[toUserId]: CONST.FRIEND_REQUEST_STATUS.SENT},
     }),
+    metaPatch(toUserId, {pendingAction: ADD, errors: null}),
   ];
-  API.write(WRITE_COMMANDS.SEND_FRIEND_REQUEST, {toUserId}, {optimisticData});
+  const successData: OnyxUpdate[] = [metaPatch(toUserId, null)];
+  // Keep the optimistic request row on failure and mark it errored; dismissing
+  // it (clearFriendActionError) removes the row because pendingAction is ADD.
+  const failureData: OnyxUpdate[] = [
+    metaPatch(toUserId, errorMeta('friendAction.error.couldNotSendRequest')),
+  ];
+  API.write(
+    WRITE_COMMANDS.SEND_FRIEND_REQUEST,
+    {toUserId},
+    {optimisticData, successData, failureData},
+  );
 }
 
 function acceptFriendRequest(fromUserId: string) {
@@ -51,16 +93,27 @@ function acceptFriendRequest(fromUserId: string) {
   if (!uid) {
     return;
   }
+  // Keep-and-dim: don't move the request to `friends` until the server confirms.
   const optimisticData: OnyxUpdate[] = [
+    metaPatch(fromUserId, {pendingAction: UPDATE, errors: null}),
+  ];
+  const successData: OnyxUpdate[] = [
     userDataPatch(uid, {
       friend_requests: {[fromUserId]: null},
       friends: {[fromUserId]: true},
     }),
+    metaPatch(fromUserId, null),
+  ];
+  const failureData: OnyxUpdate[] = [
+    metaPatch(
+      fromUserId,
+      errorMeta('friendAction.error.couldNotAcceptRequest'),
+    ),
   ];
   API.write(
     WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST,
     {fromUserId},
-    {optimisticData},
+    {optimisticData, successData, failureData},
   );
 }
 
@@ -69,13 +122,24 @@ function deleteFriendRequest(otherUserId: string) {
   if (!uid) {
     return;
   }
+  // Keep-and-dim: don't drop the request until the server confirms.
   const optimisticData: OnyxUpdate[] = [
+    metaPatch(otherUserId, {pendingAction: DELETE, errors: null}),
+  ];
+  const successData: OnyxUpdate[] = [
     userDataPatch(uid, {friend_requests: {[otherUserId]: null}}),
+    metaPatch(otherUserId, null),
+  ];
+  const failureData: OnyxUpdate[] = [
+    metaPatch(
+      otherUserId,
+      errorMeta('friendAction.error.couldNotRemoveRequest'),
+    ),
   ];
   API.write(
     WRITE_COMMANDS.DELETE_FRIEND_REQUEST,
     {otherUserId},
-    {optimisticData},
+    {optimisticData, successData, failureData},
   );
 }
 
@@ -84,10 +148,49 @@ function unfriend(otherUserId: string) {
   if (!uid) {
     return;
   }
+  // Keep-and-dim: don't drop the friend until the server confirms.
   const optimisticData: OnyxUpdate[] = [
-    userDataPatch(uid, {friends: {[otherUserId]: null}}),
+    metaPatch(otherUserId, {pendingAction: DELETE, errors: null}),
   ];
-  API.write(WRITE_COMMANDS.UNFRIEND, {otherUserId}, {optimisticData});
+  const successData: OnyxUpdate[] = [
+    userDataPatch(uid, {friends: {[otherUserId]: null}}),
+    metaPatch(otherUserId, null),
+  ];
+  const failureData: OnyxUpdate[] = [
+    metaPatch(otherUserId, errorMeta('friendAction.error.couldNotUnfriend')),
+  ];
+  API.write(
+    WRITE_COMMANDS.UNFRIEND,
+    {otherUserId},
+    {optimisticData, successData, failureData},
+  );
 }
 
-export {sendFriendRequest, acceptFriendRequest, deleteFriendRequest, unfriend};
+/**
+ * Dismiss the offline-feedback error for a friend action. For a failed ADD
+ * (send request) this also rolls back the optimistic request entry, since the
+ * request never reached the server; for UPDATE/DELETE the data was never mutated
+ * optimistically, so clearing the metadata returns the row to its normal state.
+ */
+function clearFriendActionError(
+  otherUserId: string,
+  pendingAction: PendingAction,
+) {
+  if (pendingAction === ADD) {
+    const uid = getCurrentUserID();
+    if (uid) {
+      Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
+        [uid]: {friend_requests: {[otherUserId]: null}},
+      });
+    }
+  }
+  Onyx.merge(ONYXKEYS.FRIENDS_METADATA, {[otherUserId]: null});
+}
+
+export {
+  sendFriendRequest,
+  acceptFriendRequest,
+  deleteFriendRequest,
+  unfriend,
+  clearFriendActionError,
+};

--- a/src/screens/Social/FriendRequestScreen.tsx
+++ b/src/screens/Social/FriendRequestScreen.tsx
@@ -11,6 +11,7 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import * as Friends from '@userActions/Friends';
 import type {Database} from 'firebase/database';
 import NoFriendUserOverview from '@components/Social/NoFriendUserOverview';
+import FriendOfflineFeedback from '@components/Social/FriendOfflineFeedback';
 import * as Profile from '@userActions/Profile';
 import GrayHeader from '@components/Header/GrayHeader';
 import {objKeys} from '@libs/DataHandling';
@@ -180,15 +181,18 @@ function FriendRequestItem({
   const requestStatus = friendRequests[requestId];
 
   return (
-    <NoFriendUserOverview
+    <FriendOfflineFeedback
       key={`${requestId}-friend-request`}
-      userID={requestId}
-      profileData={profileData}
-      RightSideComponent={FriendRequestComponent({
-        requestId,
-        requestStatus,
-      })}
-    />
+      userID={requestId}>
+      <NoFriendUserOverview
+        userID={requestId}
+        profileData={profileData}
+        RightSideComponent={FriendRequestComponent({
+          requestId,
+          requestStatus,
+        })}
+      />
+    </FriendOfflineFeedback>
   );
 }
 

--- a/src/types/onyx/FriendsMetadata.ts
+++ b/src/types/onyx/FriendsMetadata.ts
@@ -1,0 +1,16 @@
+import type {Errors, PendingAction, UserID} from './OnyxCommon';
+
+/** Offline-feedback state for a single friend action, keyed by counterpart userID. */
+type FriendActionMetadata = {
+  /** The type of friend action that is pending (add/update/delete) */
+  pendingAction?: PendingAction;
+
+  /** Dismissible errors surfaced when the queued friend write fails */
+  errors?: Errors | null;
+};
+
+/** Per-friend offline-feedback state, keyed by the counterpart's userID. */
+type FriendsMetadata = Record<UserID, FriendActionMetadata>;
+
+export default FriendsMetadata;
+export type {FriendActionMetadata};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -22,6 +22,8 @@ import type {
   FriendRequestArray,
   FriendRequestStatus,
 } from './FriendRequestList';
+import type FriendsMetadata from './FriendsMetadata';
+import type {FriendActionMetadata} from './FriendsMetadata';
 import type Locale from './Locale';
 import type Login from './Login';
 import type Modal from './Modal';
@@ -106,6 +108,8 @@ export type {
   FriendRequestArray,
   FriendRequestList,
   FriendRequestStatus,
+  FriendsMetadata,
+  FriendActionMetadata,
   Locale,
   Log,
   Login,


### PR DESCRIPTION
## Summary

Wires the (already-ported but unused) `OfflineWithFeedback` into all four friend actions so queued writes get pending/error feedback. Friends were the natural place to start since the API cutover (#805) is merged.

**Stacked on #823** (base = `feature/offline-non-blocking-ux`). The pending-dim visual reads `useNetwork().isOffline`, which only reflects reality once #823's NetInfo→NETWORK bridge lands; the error + rollback half works independently. Retarget base to `master` once #823 merges.

Refs #805, #778.

## The design problem

`OfflineWithFeedback`, the Onyx types, `RED_BRICK_ROAD_PENDING_ACTION`, and `API.write`'s `successData`/`failureData` plumbing already exist — friends just never used them. Two friend-specific snags drove the design:

1. **No per-item home.** `friends` is `Record<uid, true>` and `friend_requests` is `Record<uid, status>` — scalars, nowhere to hang `pendingAction`/`errors`.
2. **Destructive optimism.** Accept/reject/unfriend removed the row immediately, leaving nothing to dim.

## What this does

- **New client-only Onyx key `FRIENDS_METADATA`** = `Record<uid, {pendingAction, errors}>`, keyed by the counterpart. The server never writes it, so it survives `/v1/updates` + Pusher userData merges.
- **`Friends.ts` reworked** to the three-part shape:
  - **send** (additive `ADD`): optimistic request + pending marker; `successData` clears; `failureData` keeps the row and marks it errored (dismiss rolls it back, since pendingAction is `ADD`).
  - **accept/reject/unfriend** (`UPDATE`/`DELETE`, **keep-and-dim**): optimistic sets **only** the pending marker; the destructive `userDataList` mutation is deferred to `successData`, so the row stays visible and dimmed until the server confirms. `failureData` surfaces a dismissible error (no data mutation to roll back).
  - **`clearFriendActionError(uid, pendingAction)`**: dismiss handler — `ADD` also rolls back the optimistic request row; `UPDATE`/`DELETE` just clear the marker.
- **UI**: a small `FriendOfflineFeedback` helper reads the per-uid metadata and wraps rows; dropped into the search result, friend-request, and friend-list rows.
- **Locale**: English failure strings + Czech filled via the `translate` skill (glossary-compliant, parity test passes).
- **Tests**: `__tests__/actions/Friends.test.ts` asserts the optimistic/success/failure Onyx shapes for all four actions + the two `clearFriendActionError` branches.

## Known limitations / follow-ups

- **Unfriend is initiated from the profile popover** (`ManageFriendPopover`), which `Navigation.goBack()`s after firing. With keep-and-dim the friend isn't removed optimistically, so the friend *list* row dims/hides correctly, but the **profile screen itself isn't wrapped** and will still show the user as a friend until the server confirms. Wrapping the profile surface is a follow-up.
- **No button-disabling while pending**: re-tapping accept/reject re-queues an idempotent write. Harmless; left out to limit churn.
- Sessions (#815) get the same treatment once you've finished verifying them — each session is an object keyed by id, so it won't need the parallel-metadata-key workaround.

## Test plan

- [x] `./scripts/lint.sh <changed>` — clean
- [x] `npm run typecheck-tsgo` — exit 0
- [x] `npm run react-compiler-compliance-check check-changed` — pass
- [x] `TZ=utc npx jest Friends Translate TranslationContext` — 14/14
- [ ] **On-device (needs #823 merged/checked out)**: offline send/accept/reject/unfriend → row dims (and strikes through for delete); on reconnect the queued write replays and the row finalizes; a simulated server failure shows a dismissible error and (for send) rolling back on dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)