### PR TITLE
fix: stop home/profile calendar flicker when paging months

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -294,19 +294,21 @@ function SessionsCalendarView({
     <GestureDetector gesture={swipeGesture}>
       <View collapsable={false}>
         <Calendar
-          // Two remount triggers folded into one key:
-          //   • `themePreference` — belt-and-suspenders for the lib's first-
-          //     mount stylesheet snapshot (patched in
-          //     `patches/react-native-calendars+*.patch`).
-          //   • `visibleDate.dateString.slice(0, 7)` — the lib reads `current`
-          //     only on initial `useState`, so prop updates don't move its
-          //     internal cursor. Arrow presses sidestep this by calling
-          //     `subtractMonth`/`addMonth`; swipes have no such callback, so
-          //     we force a remount on month change to keep the grid in sync
-          //     with `visibleDate`. Slicing to 'YYYY-MM' avoids day-level
-          //     remounts when the date string changes within a month.
-          key={`${themePreference}-${visibleDate.dateString.slice(0, 7)}`}
-          current={visibleDate.dateString}
+          // Remount on theme change only — belt-and-suspenders for the lib's
+          // first-mount stylesheet snapshot (patched in
+          // `patches/react-native-calendars+*.patch`). The month must NOT be
+          // in this key: a key change unmounts + remounts the grid, blanking it
+          // for a frame — that remount was the month-paging flicker on the
+          // home/profile calendars.
+          key={themePreference}
+          // Drive the visible month from `initialDate`, not `current`. The lib
+          // seeds its internal cursor from `current` only once (initial
+          // `useState`) and never reacts to later `current` changes, but it
+          // *does* run a `useEffect([initialDate])` that pushes prop updates
+          // into that cursor. So both paths stay in sync without a remount:
+          // arrow presses (which also call the lib's `subtractMonth`/`addMonth`)
+          // and swipes (which only update `visibleDate` → `initialDate`).
+          initialDate={visibleDate.dateString}
           dayComponent={dayComponent}
           minDate={resolvedMinDate}
           maxDate={resolvedMaxDate}


### PR DESCRIPTION
## Summary

Navigating between months on the home and profile calendars caused a visible **flicker** — the grid blanked for a frame on every prev/next month change (arrows and swipes alike).

### Root cause

`SessionsCalendarView` folded the visible month into the `<Calendar>`'s React `key`:

```tsx
key={`${themePreference}-${visibleDate.dateString.slice(0, 7)}`}
current={visibleDate.dateString}
```

Changing a component's `key` forces React to **unmount the old instance and mount a fresh one**. So each month change tore down the entire `react-native-calendars` grid and rebuilt it from scratch — one blank frame = the flicker.

Why the key hack existed: `react-native-calendars` seeds its internal `currentMonth` cursor from the `current` prop **only once** (initial `useState`) and never reacts to later `current` changes. Arrow presses moved the month via the lib's own `subtractMonth`/`addMonth` callbacks, but swipes have no such callback — so the code force-remounted to keep the grid in sync with `visibleDate`.

### Fix

Drive the visible month from **`initialDate`** instead of `current`, and remove `visibleDate` from the `key`:

```tsx
key={themePreference}
initialDate={visibleDate.dateString}
```

The installed library (`react-native-calendars@1.1304.1`, `src/calendar/index.js`) has:

```js
useEffect(() => {
  if (initialDate) setCurrentMonth(parseDate(initialDate));
}, [initialDate]);
```

So prop updates to `initialDate` flow into the internal cursor **in place** — no remount. Both navigation paths now stay in sync without tearing down the grid:

- **Arrow press** — the lib's `subtractMonth`/`addMonth` moves the cursor *and* `onDateChange` updates `visibleDate → initialDate`; both target the same month (idempotent).
- **Swipe** — only `visibleDate → initialDate` changes, and the `useEffect([initialDate])` moves the cursor.

The `key` still varies on `themePreference` (unchanged behavior) as belt-and-suspenders for the lib's first-mount stylesheet snapshot.

## Scope

- One file: `src/components/SessionsCalendar/SessionsCalendarView.tsx` (the compact calendar shared by the home and profile screens).
- No change to the fullscreen `SessionsCalendarWeekListView` (FlashList-based, separate path) or to `useLazyMarkedDates`.
- The day-1 measure-ref used for fullscreen scroll positioning is unaffected: its `useEffect([... , date])` re-registers on in-place month changes exactly as it did across the old remount.

## Verification

- `npm run typecheck-tsgo` — pass
- `npm run lint-changed` / `lint.sh` — pass
- `npm run react-compiler-compliance-check check-changed` — pass
- `npx prettier` — no changes
- Confirmed against the installed library source that `initialDate` drives `currentMonth` via `useEffect`, and the header delegates arrow presses to our handler (no double-decrement).

## Test plan

- [ ] Home screen: tap the month arrows back/forth — grid updates with no blank frame/flicker.
- [ ] Home screen: swipe left/right between months — same, no flicker.
- [ ] Profile screen: repeat both.
- [ ] Tap a day / tap the month header (fullscreen) still works and positions correctly.
- [ ] Toggle light/dark theme while a calendar is visible — restyles correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)