### PR TITLE
fix(scripts): stop local runs from shallow-fetching the base branch

### DIFF
--- a/scripts/utils/Git.ts
+++ b/scripts/utils/Git.ts
@@ -386,10 +386,18 @@ class Git {
   static async getMainBranchCommitHash(remote?: string): Promise<string> {
     const baseRefName = GITHUB_BASE_REF ?? 'master';
 
-    // Fetch the base branch from the specified remote (or locally) to ensure it's available
+    // Ensure the base branch ref is available before we diff against it.
+    //
+    // `--depth=1` is a CI-only optimization: CI runs on a throwaway shallow
+    // clone and the `if (IS_CI)` block below reads the remote ref directly
+    // (no merge-base). Locally we must NOT shallow-fetch — `--depth=1`
+    // re-truncates the developer's full clone, which both breaks the
+    // merge-base computation further down AND leaves `origin/<base>` grafted,
+    // surfacing later as a phantom "diverged" `git status`.
     if (IS_CI || remote) {
+      const depthArg = IS_CI ? ' --depth=1' : '';
       await exec(
-        `git fetch ${remote ?? 'origin'} ${baseRefName} --no-tags --depth=1`,
+        `git fetch ${remote ?? 'origin'} ${baseRefName} --no-tags${depthArg}`,
       );
     }
 


### PR DESCRIPTION
## Summary

`Git.getMainBranchCommitHash()` (used by `react-compiler-compliance-check`) ran a `--depth=1` fetch in **local** runs, which re-shallowed the developer's full clone. The visible symptom was a recurring **phantom "diverged" `git status`** on `master` after working locally.

### Root cause

```ts
// scripts/utils/Git.ts
if (IS_CI || remote) {
  await exec(`git fetch ${remote ?? 'origin'} ${baseRefName} --no-tags --depth=1`);
}
```

`check-changed` always passes `remote = 'origin'`, so the guard fired **locally** too (not just in CI). The `--depth=1` is a CI-only optimization — CI runs on a throwaway shallow clone and the `if (IS_CI)` branch right below reads the remote ref directly, never computing a merge-base. But locally:

1. `git fetch … --depth=1` **re-truncates a full clone**, grafting `origin/<base>` at a single parentless commit.
2. The local code path immediately below then does `git merge-base origin/master HEAD`, which now **fails** (hence the `Warning: Could not find merge base …` that this script prints).
3. Worse, the graft persists: the next `git status` on `master` can't find a common ancestor with `origin/master` and reports a bogus *"Your branch and 'origin/master' have diverged, and have N and M different commits each"* — even though history is perfectly linear.

The `origin/master` reflog fingerprint:

```
… fetch origin master --no-tags --depth=1: forced-update
```

### Fix

Gate `--depth=1` on `IS_CI` only. Locally, fetch at full depth so the clone is never truncated and `merge-base` resolves normally.

```ts
if (IS_CI || remote) {
  const depthArg = IS_CI ? ' --depth=1' : '';
  await exec(`git fetch ${remote ?? 'origin'} ${baseRefName} --no-tags${depthArg}`);
}
```

CI behavior is unchanged (still `--depth=1`, still uses the remote ref directly).

## Verification

Ran the previously-offending command before/after on a full clone:

| | before fix | after fix |
|---|---|---|
| `is-shallow` after run | `true` (re-shallowed) | **`false`** (stays full) |
| `Could not find merge base` warning | printed | **gone** |
| changed-file detection | fell back to remote ref | resolves via real merge-base |

- `npm run typecheck-tsgo` — pass
- `./scripts/lint.sh scripts/utils/Git.ts` — pass
- `npx prettier` — no changes

## Notes

- This only changes the **local** path; CI is untouched.
- It prevents *creating* the shallow graft. A clone that's already shallow still needs a one-time `git fetch --unshallow` to repair — but local tooling will no longer put it back into that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)