### PR TITLE
feat: rename Statistics header and emphasize the back arrow

### DIFF
--- a/src/components/HeaderWithBackButton/index.tsx
+++ b/src/components/HeaderWithBackButton/index.tsx
@@ -152,7 +152,12 @@ function HeaderWithBackButton({
               role="button"
               accessibilityLabel={translate('common.back')}
               nativeID={CONST.BACK_BUTTON_NATIVE_ID}>
-              <Icon src={KirokuIcons.BackArrow} fill={iconFill ?? theme.icon} />
+              <Icon
+                src={KirokuIcons.BackArrow}
+                width={variables.iconSizeXLarge}
+                height={variables.iconSizeXLarge}
+                fill={iconFill ?? theme.heading}
+              />
             </PressableWithoutFeedback>
           </Tooltip>
         )}

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -970,7 +970,7 @@ export default {
     profileImage: 'Profilový obrázek',
   },
   statistics: {
-    title: 'Vaše statistiky',
+    title: 'Statistiky',
     tabs: {
       overview: {
         label: 'Přehled',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -966,7 +966,7 @@ export default {
     profileImage: 'Profile Image',
   },
   statistics: {
-    title: 'Your stats',
+    title: 'Statistics',
     tabs: {
       overview: {
         label: 'Overview',


### PR DESCRIPTION
### Details

Two small UI tweaks on the Statistics screen / navigation header:

1. **Statistics title** — renamed from `Your stats` → `Statistics` (en) and `Vaše statistiky` → `Statistiky` (cs_cz). Cleaner, more direct label.
2. **Back arrow emphasis** — the chevron in the navigation header was too subtle. Bumped it from `iconSizeNormal` (20px) → `iconSizeXLarge` (28px) and switched its fill from the muted `theme.icon` to the high-contrast `theme.heading`.

Note: the back arrow lives in the shared `HeaderWithBackButton` component, so this change applies consistently to the back button on **every** screen that uses it, not just Statistics. The separate onboarding back arrow (`OnboardingScreenLayout`) was intentionally left unchanged.

Czech is the only non-English locale touched; `Statistiky` is the standard term (matches the existing `statistiky` wording already used elsewhere in the file).

### Tests

1. Open the Statistics screen and verify the header title reads **Statistics** (English) / **Statistiky** (Czech).
2. Verify the back arrow in the header is noticeably larger and higher-contrast than before, on both light and dark themes.
3. Tap the back arrow and verify it still navigates back as expected.
4. Open a few other screens that use the standard header (e.g. settings/profile sub-pages) and verify their back arrow shares the new, more prominent style.

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed. Title strings and icon styling render identically offline.

- [ ] Verify the header renders correctly while offline

### QA Steps

1. Navigate to Statistics; confirm the title and the enlarged back arrow.
2. Switch between light and dark theme; confirm the arrow stays high-contrast in both.
3. Confirm back navigation works from Statistics and from other standard-header screens.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] Copy shown in the product is localized via `src/languages/*` (en + cs_cz updated; Czech follows the locale glossary)
- [x] Header/label capitalization follows guidelines (only first word capitalized)
- [x] `npm run typecheck-tsgo` passes
- [x] `npm run react-compiler-compliance-check check-changed` passes
- [x] Verified impact of modifying the shared `HeaderWithBackButton` component (back arrow style applies app-wide by design)
- [ ] Tested on Android
- [ ] Tested on iOS

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>