### PR TITLE
fix(lint): resolve ESLint failures on scripts/asc.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -513,13 +513,16 @@ export default defineConfig([
 
   // Build/CLI tooling under `scripts/` legitimately writes reports and prompts
   // to stdout/stderr, so the app-wide `no-console` allow-list (debug/error only)
-  // doesn't apply. Several files here (e.g. the CLI arg parser, Git helpers) are
+  // doesn't apply. These CLIs also make sequential App Store Connect / Git calls
+  // where awaiting in a loop is intentional, so `no-await-in-loop` is relaxed
+  // too. Several `.ts` files here (e.g. the CLI arg parser, Git helpers) are
   // vendored from Expensify and kept byte-faithful for easy re-syncs, so we also
   // relax `no-unnecessary-type-assertion` rather than diverging the source.
   {
-    files: ['scripts/**/*.ts'],
+    files: ['scripts/**/*.ts', 'scripts/**/*.mjs'],
     rules: {
       'no-console': 'off',
+      'no-await-in-loop': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
     },
   },

--- a/scripts/asc.mjs
+++ b/scripts/asc.mjs
@@ -35,7 +35,6 @@
  *   --yes              submit: actually execute (otherwise dry run)
  *   --help, -h         show this help
  */
-/* global fetch */
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
@@ -348,7 +347,7 @@ async function cmdSubmit(appId) {
     '\nPlan: POST reviewSubmissions → POST reviewSubmissionItems(appStoreVersion) → PATCH submitted=true',
   );
   if (problems.length) {
-    L('\nBLOCKED:\n' + problems.map(p => `  - ${p}`).join('\n'));
+    L(`\nBLOCKED:\n${problems.map(p => `  - ${p}`).join('\n')}`);
     process.exitCode = 1;
     return;
   }


### PR DESCRIPTION
## Summary

The `master` lint job ([run #26885299927](https://github.com/PetrCala/Kiroku/actions/runs/26885299927/job/79295750278)) failed with 6 ESLint errors, all in the newly added `scripts/asc.mjs`.

**Root cause:** the repo runs ESLint **flat config** (`eslint.config.mjs`), which no longer reads the legacy `scripts/.eslintrc.js` that historically turned off `no-console` / `no-await-in-loop` for Node scripts. The flat-config replacement override only matched `scripts/**/*.ts`, so the new `.mjs` CLI inherited none of those relaxations.

## Changes

- **`eslint.config.mjs`** — extend the `scripts/` override to `scripts/**/*.{ts,mjs}` and restore `no-await-in-loop: off` (the sequential App Store Connect API calls are intentional). Fixes the `no-console` + 3× `no-await-in-loop` errors.
- **`scripts/asc.mjs`** — drop the redundant `/* global fetch */` directive (`fetch` is already a built-in global, so it tripped `no-redeclare`) and replace a string concatenation with a template literal (`prefer-template`).

## Test plan

- [x] `./scripts/lint.sh scripts/asc.mjs eslint.config.mjs` → 0 errors (frozen seatbelt)
- [x] `node --check scripts/asc.mjs` + `node scripts/asc.mjs --help` run clean
- [x] `prettier --check` clean
- [ ] CI `lint` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)