### PR TITLE
feat(calendar): skeleton instead of spinner on fullscreen calendar open

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {StyleSheet, View} from 'react-native';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+// 7 day-name columns and a couple of month sections of ~6 week rows each —
+// enough to fill the viewport so the loading state reads as a calendar rather
+// than a blank spinner. Value arrays (not map indexes) keep the keys lint-clean.
+const DAY_COLUMNS = [0, 1, 2, 3, 4, 5, 6];
+const WEEK_ROWS = [0, 1, 2, 3, 4, 5];
+const MONTH_SECTIONS = [0, 1];
+
+const internalStyles = StyleSheet.create({
+  // Mirrors `variables.sessionColorMarkerSize` (20) — the day cell's marker.
+  dayCell: {width: 20, height: 20, borderRadius: 6},
+  dayNamePlaceholder: {width: 18, height: 10, borderRadius: 3},
+  monthLabelPlaceholder: {width: 96, height: 11, borderRadius: 3},
+});
+
+/**
+ * Layout-faithful placeholder for the fullscreen sessions calendar, shown
+ * while the week-list mounts and applies its initial scroll. Mirrors the
+ * day-name header + month-label + 7-column week-row geometry so the swap to
+ * the real grid is visually quiet — the same match-the-destination strategy
+ * as `DayOverviewSkeleton` / `StatisticsScreenSkeleton`.
+ */
+function SessionsCalendarSkeleton() {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const block = {backgroundColor: theme.highlightBG};
+
+  return (
+    <View
+      style={[styles.flex1, {backgroundColor: theme.appBG}]}
+      testID="SessionsCalendarSkeleton">
+      <View style={styles.sessionsCalendarDayNamesRow}>
+        {DAY_COLUMNS.map(col => (
+          <View key={`dn-${col}`} style={styles.sessionsCalendarDayNameCell}>
+            <View style={[internalStyles.dayNamePlaceholder, block]} />
+          </View>
+        ))}
+      </View>
+      {MONTH_SECTIONS.map(section => (
+        <View key={`sec-${section}`}>
+          <View style={styles.sessionsCalendarMonthLabel}>
+            <View style={[internalStyles.monthLabelPlaceholder, block]} />
+            <View style={styles.sessionsCalendarMonthLabelRule} />
+          </View>
+          {WEEK_ROWS.map(week => (
+            <View
+              key={`wk-${section}-${week}`}
+              style={styles.sessionsCalendarWeekRow}>
+              {DAY_COLUMNS.map(col => (
+                <View
+                  key={`c-${section}-${week}-${col}`}
+                  style={styles.sessionsCalendarWeekCell}>
+                  <View style={[internalStyles.dayCell, block]} />
+                </View>
+              ))}
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+SessionsCalendarSkeleton.displayName = 'SessionsCalendarSkeleton';
+export default SessionsCalendarSkeleton;

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -3,9 +3,9 @@ import {StyleSheet, View} from 'react-native';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {DateData} from 'react-native-calendars';
 import SessionsCalendar from '@components/SessionsCalendar';
+import SessionsCalendarSkeleton from '@components/SessionsCalendar/SessionsCalendarSkeleton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useFetchData from '@hooks/useFetchData';
@@ -98,28 +98,34 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
         shouldShowCloseButton
         onCloseButtonPress={() => Navigation.goBack()}
       />
-      {!isLoading && preferences && (
-        <View
-          style={[
-            styles.flex1,
-            styles.ph2,
-            !isScrollReady && internalStyles.hidden,
-          ]}>
-          <SessionsCalendar
-            userID={userID}
-            visibleDate={visibleDate}
-            onDateChange={setVisibleDate}
-            drinkingSessionData={drinkingSessionData}
-            preferences={preferences}
-            isFetchingOlderMonths={isFetchingOlderMonths}
-            mode="fullscreen"
-            initialMonthYear={monthYear}
-            initialFirstWeekY={firstWeekY}
-            onInitialScrollReady={onInitialScrollReady}
-          />
-        </View>
-      )}
-      {showLoader && <FullScreenLoadingIndicator />}
+      <View style={styles.flex1}>
+        {!isLoading && preferences && (
+          <View
+            style={[
+              styles.flex1,
+              styles.ph2,
+              !isScrollReady && internalStyles.hidden,
+            ]}>
+            <SessionsCalendar
+              userID={userID}
+              visibleDate={visibleDate}
+              onDateChange={setVisibleDate}
+              drinkingSessionData={drinkingSessionData}
+              preferences={preferences}
+              isFetchingOlderMonths={isFetchingOlderMonths}
+              mode="fullscreen"
+              initialMonthYear={monthYear}
+              initialFirstWeekY={firstWeekY}
+              onInitialScrollReady={onInitialScrollReady}
+            />
+          </View>
+        )}
+        {showLoader && (
+          <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            <SessionsCalendarSkeleton />
+          </View>
+        )}
+      </View>
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## Summary
The fullscreen (infinite-scroll) calendar shows a full-screen `ActivityIndicator` on open until the week-list mounts, measures its layout, and applies the initial scroll — `showLoader = isLoading || !preferences || !isScrollReady` ([SessionsCalendarScreen.tsx:91](src/screens/SessionsCalendar/SessionsCalendarScreen.tsx)).

A profiling pass showed that gate window is **mount/layout/scroll-bound, not session-compute-bound** (the `useLazyMarkedDates` first pass + `buildMonthSections` is ~3–8 ms desktop / ~15–30 ms Hermes for realistic data). The loader can't simply be dropped, because it hides the latest→target scroll jump that #798's positioning relies on.

So this is the **safe interim**: swap the blank spinner for a layout-faithful calendar **skeleton** (day-name header + month label + 7-column week rows of placeholder cells), so the unavoidable wait reads as content loading and the hand-off to the real grid is visually quiet. Gating timing is unchanged — only the loading visual changes.

- New `SessionsCalendarSkeleton` mirrors the real calendar geometry (`sessionColorMarkerSize`, week-row/day-name styles).
- `SessionsCalendarScreen` renders it as an `absoluteFill` overlay inside a content `View` (same pattern as `DayOverviewScreen` + `DayOverviewSkeleton`).

## Stacking
> ⚠️ **Stacked on #798** (`claude/romantic-beaver-46e09a`). It touches `SessionsCalendarScreen`, which was rewritten on that branch, so it can't base cleanly off `master`. Retarget to `master` once #798 lands.

## Scope / what this does NOT do
- Does **not** speed up the open — the real lever (mount/layout/scroll) lives in #798's positioning flow and should be tackled there.
- Closed #832 (compute cache) confirmed unrelated; this replaces that direction.

## Test plan
- [x] `npx prettier --check`, `./scripts/lint.sh`, `npm run typecheck-tsgo`, `react-compiler-compliance-check check-changed`, `npm run test` (566 passed) all green
- [ ] Manual: open the fullscreen calendar — confirm the skeleton shows during the gate and swaps cleanly to the grid with no jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)