### PR TITLE
feat(social): use skeletons for friend list loading

### DIFF
--- a/src/components/Skeletons/UserListSkeleton.tsx
+++ b/src/components/Skeletons/UserListSkeleton.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {Circle, Rect} from 'react-native-svg';
+import variables from '@styles/variables';
+import ItemListSkeletonView from './ItemListSkeletonView';
+
+// Mirror the UserOverview row: a large avatar with the display name to its
+// right and the session status pinned to the far right. Keeping the geometry
+// aligned with the real row avoids a layout jump when the list swaps in.
+const avatarRadius = variables.avatarSizeLarge / 2;
+const horizontalPadding = 12; // userOverviewContainer ph3
+const verticalPadding = 8; // userOverviewContainer p2
+const itemHeight = variables.avatarSizeLarge + verticalPadding * 2;
+
+const barHeight = 10;
+const avatarCx = horizontalPadding + avatarRadius;
+const avatarCy = itemHeight / 2;
+const barY = avatarCy - barHeight / 2;
+const nameX = avatarCx + avatarRadius + 12; // ml3 gap after the avatar
+
+type UserListSkeletonProps = {
+  shouldAnimate?: boolean;
+  fixedNumItems?: number;
+  gradientOpacityEnabled?: boolean;
+};
+
+function UserListSkeleton({
+  shouldAnimate = true,
+  fixedNumItems,
+  gradientOpacityEnabled = false,
+}: UserListSkeletonProps) {
+  return (
+    <ItemListSkeletonView
+      shouldAnimate={shouldAnimate}
+      fixedNumItems={fixedNumItems}
+      gradientOpacityEnabled={gradientOpacityEnabled}
+      itemViewHeight={itemHeight}
+      renderSkeletonItem={() => (
+        <>
+          <Circle cx={avatarCx} cy={avatarCy} r={avatarRadius} />
+          {/* display name */}
+          <Rect x={nameX} y={barY} width="40%" height={barHeight} />
+          {/* session status, pinned to the right */}
+          <Rect x="72%" y={barY} width="20%" height={barHeight} />
+        </>
+      )}
+    />
+  );
+}
+
+UserListSkeleton.displayName = 'UserListSkeleton';
+
+export default UserListSkeleton;

--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -14,10 +14,10 @@ import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import {sleep} from '@libs/TimeUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {View} from 'react-native';
 import FlatList from '@components/FlatList';
 import {PressableWithFeedback} from '@components/Pressable';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
+import UserListSkeleton from '@components/Skeletons/UserListSkeleton';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useLocalize from '@hooks/useLocalize';
 import UserOverview from './UserOverview';
@@ -220,16 +220,7 @@ function UserListComponent({
     (hasLoadedProfiles || !loadingDisplayData);
 
   if (isLoading || !isListReady) {
-    return (
-      <View
-        style={[
-          styles.flex1,
-          styles.justifyContentCenter,
-          styles.alignItemsCenter,
-        ]}>
-        <FlexibleLoadingIndicator />
-      </View>
-    );
+    return <UserListSkeleton />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- The friend list previously showed a centered `FlexibleLoadingIndicator` (a plain `ActivityIndicator` spinner) while loading — it did not use the repo's skeleton system.
- Adds `UserListSkeleton`, a skeleton built on `ItemListSkeletonView` whose geometry mirrors the `UserOverview` row (large avatar + display-name bar + right-aligned status bar) so the placeholder lines up with the real list and minimizes layout shift on swap-in.
- Wires it into `UserListComponent`'s loading branch in place of the spinner. The "load more" footer spinner (pagination append) is intentionally left as-is.

## Test plan
- [ ] Open the Social → Friends tab and confirm animated skeleton rows render during initial load, then swap to the real list without a visible jump.
- [ ] Search within the friend list and confirm the skeleton shows briefly while filtering.
- [ ] Verify on both light and dark themes.
- [ ] Verify on narrow (mobile) and wide (web) layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)