### PR TITLE
perf(calendar): hand-roll day-key instead of date-fns format (~466ms → ~single-digit ms)

### DIFF
--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -10,7 +10,6 @@ import CONST from '@src/CONST';
 import {
   differenceInCalendarMonths,
   eachDayOfInterval,
-  format,
   isWithinInterval,
   startOfMonth,
   subDays,
@@ -25,6 +24,22 @@ import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as Calendar from '@userActions/Calendar';
 import type {UserID, DateString} from '@src/types/onyx/OnyxCommon';
+
+// Hand-rolled 'yyyy-MM-dd' (matches CONST.DATE.FNS_FORMAT_STRING). date-fns
+// `format` is ~100× slower and this runs once per day across the whole loaded
+// range — which can be years deep — so it dominated the day-overview mount
+// (e.g. 77 months ≈ 2.3k `format` calls ≈ ~460ms on Hermes). The Date's local
+// fields already carry the right wall-clock day (`toZonedTime` shifted them to
+// the session's zone for the per-session key; the day list is built in local
+// time), so reading them directly is both correct and cheap.
+function toDateKey(date: Date): DateString {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}-${month < 10 ? '0' : ''}${month}-${
+    day < 10 ? '0' : ''
+  }${day}` as DateString;
+}
 
 /**
  * Custom hook to derive a calendar's markedDates and per-day unit counts from a
@@ -94,10 +109,7 @@ function useLazyMarkedDates(
             session.start_time,
             session.timezone ?? defaultTimezone,
           );
-          const dayKey = format(
-            sessionDate,
-            CONST.DATE.FNS_FORMAT_STRING,
-          ) as DateString;
+          const dayKey = toDateKey(sessionDate);
           const existing = index.get(dayKey);
           if (existing) {
             existing.push(session);
@@ -112,9 +124,7 @@ function useLazyMarkedDates(
           }
         });
 
-      const days = eachDayOfInterval({start, end}).map(
-        day => format(day, CONST.DATE.FNS_FORMAT_STRING) as DateString,
-      );
+      const days = eachDayOfInterval({start, end}).map(toDateKey);
 
       return {
         sessionIndex: index,


### PR DESCRIPTION
## The fix
On-device profiling of the **day-overview open** (tap a day tile) localized the entire ~550ms skeleton window to **one synchronous pass**: `useLazyMarkedDates`' first `useMemo`. The marked timing:

```
[CALPROF] useLazyMarkedDates firstPass (loadedMonths=77, sessions=171) took 466ms
```

Only **171 sessions** — but the user's loaded range was **77 months**, so `eachDayOfInterval(start, end).map(d => format(d, 'yyyy-MM-dd'))` made **~2,300 date-fns `format` calls**, and `format` is ~100× slower than reading the Date's local fields. That single loop was ~466ms on Hermes.

This replaces both day-key derivations (the per-session key and the per-day `dayKeys`) with a tiny `toDateKey(date)` that builds `yyyy-MM-dd` directly. Same string, ~100× cheaper:
- `toZonedTime` already shifts the session Date's local fields into its zone, so `getFullYear/getMonth/getDate` give the correct zoned day.
- Keys are **byte-identical** to `CONST.DATE.FNS_FORMAT_STRING` (`'yyyy-MM-dd'`), so `markedDates` / `sessionIndex` / `sessionEntriesByDay` lookups are unchanged (the existing `useLazyMarkedDates.test.ts` passes untouched).

Benefits **every** calendar surface (home compact, fullscreen week-list, day-overview list), since they all go through this hook.

## Stacking
> ⚠️ **Stacked on #798** (`claude/romantic-beaver-46e09a`) — `useLazyMarkedDates` differs there (the `sessionEntriesByDay` index). Retarget to `master` once #798 lands. (The same hot loop exists on `master`, so this is worth cherry-picking there too for the home calendar.)

## Follow-up (not in this PR)
`loadedMonths=77` for a 171-session user is itself suspicious — a persisted scroll depth far deeper than the data. Worth investigating separately; this fix makes the range cheap regardless.

## Test plan
- [x] prettier / lint / `typecheck-tsgo` / react-compiler / `npm run test` (566 passed, incl. `useLazyMarkedDates.test.ts`)
- [ ] Re-run the `[CALPROF]` profile on-device — expect `firstPass` to drop from ~466ms to single-digit ms and `GATE END` to fall accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)