### PR TITLE
fix(calendar): cap persisted months-loaded at the earliest tracked month

### DIFF
--- a/__tests__/unit/components/StatsContextProvider/StatsContextProvider.test.tsx
+++ b/__tests__/unit/components/StatsContextProvider/StatsContextProvider.test.tsx
@@ -144,4 +144,29 @@ describe('StatsContextProvider', () => {
     ]);
     expect(getCtx().comparison).toBe('none');
   });
+
+  it('does not widen the calendar-depth lever past the earliest session for an All + comparison range', () => {
+    mockOnyxValue = undefined; // monthsLoaded resolves to 0
+
+    renderProvider();
+
+    act(() => {
+      getCtx().setRange({preset: 'All'});
+    });
+    act(() => {
+      getCtx().setComparison('previous-period');
+    });
+
+    // earliest_session_at ≈ 2023-11-14, now = 2026-05-15 → 30 calendar months.
+    // Without the earliest clamp the previous-period window sits a full span
+    // (~30 months) *before* the first session, which would request ~60 months.
+    const calendarWidens = merge.mock.calls.filter(
+      ([key]) => key === 'sessionsCalendarMonthsByUserID_u1',
+    );
+    expect(calendarWidens.length).toBeGreaterThan(0);
+    const deepestRequested = Math.max(
+      ...calendarWidens.map(([, value]) => value as number),
+    );
+    expect(deepestRequested).toBe(30);
+  });
 });

--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -3,7 +3,7 @@
 import {act, renderHook} from '@testing-library/react-native';
 import {addMonths, differenceInMonths, subMonths} from 'date-fns';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
-import type {Preferences} from '@src/types/onyx';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
 
 jest.mock('@hooks/useResolvedPalette', () => ({
   __esModule: true,
@@ -99,5 +99,32 @@ describe('useLazyMarkedDates.loadUpTo', () => {
     });
 
     expect(result.current.loadedFrom.current).toBe(initial);
+  });
+});
+
+describe('useLazyMarkedDates earliest-month cap', () => {
+  test('clamps the loaded window to the earliest tracked month, ignoring an inflated depth', () => {
+    // One session ~10 months ago is the user's entire history.
+    const earliest = subMonths(new Date(), 10);
+    const sessions = {
+      s1: {start_time: earliest.getTime(), timezone: 'UTC', drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    act(() => {
+      // Stats-style overshoot: a comparison/All range can push the shared
+      // depth lever far deeper than any data ever reaches.
+      result.current.loadUpTo(subMonths(new Date(), 60));
+    });
+
+    // The build floor is clamped to the earliest session's month (~10 months
+    // back), not the requested 60 — so the day-key build never spans empty
+    // pre-tracking months.
+    const depth = differenceInMonths(new Date(), getLoadedFrom(result));
+    expect(depth).toBeGreaterThanOrEqual(9);
+    expect(depth).toBeLessThanOrEqual(11);
   });
 });

--- a/src/components/StatsContextProvider/index.tsx
+++ b/src/components/StatsContextProvider/index.tsx
@@ -272,13 +272,21 @@ function StatsContextProvider({children, now}: StatsContextProviderProps) {
   // calendar happened to lazy-load. Reuses the calendar's months-back lever
   // (the global listener in DatabaseDataContext re-subscribes when it grows)
   // and only ever widens.
-  const loadStart = useMemo(
-    () =>
+  const loadStart = useMemo(() => {
+    const rawStart =
       comparisonRange && comparisonRange.start < range.start
         ? comparisonRange.start
-        : range.start,
-    [range.start, comparisonRange],
-  );
+        : range.start;
+    // Never widen the shared calendar-depth lever past the user's first
+    // session. A comparison window — and the `All` preset — can sit a full
+    // span *before* `earliest_session_at`; there are no sessions to fetch
+    // there, and the calendar reuses this lever to size its day-key build, so
+    // an unclamped value inflates that build to years of empty months.
+    if (earliestSessionAt && rawStart < earliestSessionAt) {
+      return earliestSessionAt;
+    }
+    return rawStart;
+  }, [range.start, comparisonRange, earliestSessionAt]);
 
   useEffect(() => {
     if (!firebaseUid) {

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -23,6 +23,7 @@ import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as Calendar from '@userActions/Calendar';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
 import type {UserID, DateString} from '@src/types/onyx/OnyxCommon';
 
 // Hand-rolled 'yyyy-MM-dd' (matches CONST.DATE.FNS_FORMAT_STRING). date-fns
@@ -85,13 +86,43 @@ function useLazyMarkedDates(
     setLoadedMonths(monthsLoaded ?? 0);
   }, [userID, monthsLoaded, monthsLoadedMeta.status]);
 
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
+
+  // Cap the effective scroll depth at the user's earliest tracked month. The
+  // `SESSIONS_CALENDAR_MONTHS_BY_USER_ID` lever is shared with the Statistics
+  // fetch-window widener (`StatsContextProvider`), which a comparison/All
+  // range can push a full span *before* the first session — inflating the
+  // persisted depth well past the user's data. There are no sessions (and no
+  // tracking) before `earliest_session_at`, so building day-keys / week-rows
+  // there is pure waste and would paint "sober day" dots on untracked days.
+  // Prefer the canonical backfilled floor, falling back to the earliest loaded
+  // session for friend profiles and pre-backfill accounts.
+  const earliestTracked = useMemo<Date | null>(() => {
+    const persistedEarliest = userDataList?.[userID]?.earliest_session_at;
+    if (persistedEarliest !== undefined) {
+      return new Date(persistedEarliest);
+    }
+    return DSUtils.getUserTrackingStartDate(sessions);
+  }, [userDataList, userID, sessions]);
+
+  const cappedMonths = useMemo(() => {
+    if (!earliestTracked) {
+      return loadedMonths;
+    }
+    const monthsToEarliest = Math.max(
+      0,
+      differenceInCalendarMonths(new Date(), earliestTracked),
+    );
+    return Math.min(loadedMonths, monthsToEarliest);
+  }, [loadedMonths, earliestTracked]);
+
   // First pass — rebuild the session-by-day index only when sessions or the
   // visible range change. Preferences are *not* a dependency here: a palette
   // or threshold change must not trigger the O(N) session filter+index pass.
   const {sessionIndex, sessionEntriesByDay, dayKeys, loadedFromDate} =
     useMemo(() => {
       const today = new Date();
-      const start = subDays(startOfMonth(subMonths(today, loadedMonths)), 1);
+      const start = subDays(startOfMonth(subMonths(today, cappedMonths)), 1);
       const end = today;
 
       const index = new Map<DateString, DrinkingSessionArray>();
@@ -132,7 +163,7 @@ function useLazyMarkedDates(
         dayKeys: days,
         loadedFromDate: start,
       };
-    }, [sessions, loadedMonths, defaultTimezone]);
+    }, [sessions, cappedMonths, defaultTimezone]);
 
   // Resolve which palette to render with. When the viewer has enabled
   // `use_own_palette_for_others`, this swaps the viewed user's palette for the


### PR DESCRIPTION
## Summary

The `SESSIONS_CALENDAR_MONTHS_BY_USER_ID{uid}` Onyx value is a **shared lever**: it sizes both the Firebase session-fetch window (`useListenToData` / `useDrinkingSessionsFetch`) **and** the calendar's day-key/week-row build range (`useLazyMarkedDates`).

`StatsContextProvider` widens that lever to cover the selected Statistics range with **no floor**. For the **`All`** preset `range.start = earliest_session_at`; add a **comparison** and `shiftRange` places the previous-period window *a full span before* the first session, so the persisted depth jumps to roughly **2× the user's data span**. On-device profiling showed `loadedMonths=77` (~6.4y) for a 171-session account. The value only ever grows, persists, and re-hydrates into `useLazyMarkedDates`, forcing the day-overview/calendar first pass to build ~2,300 day keys across mostly-empty months.

(The calendar's own scroll writers were already clamped at `minDateFloor`; Statistics was the unclamped source.)

## Changes

- **`StatsContextProvider`** — clamp `loadStart` at `earliest_session_at`. No sessions exist before the first one, so the comparison/`All` window before it is empty and never needs fetching. *(prevents future inflation)*
- **`useLazyMarkedDates`** — cap the effective scroll depth at the earliest tracked month for the day-key/week-row build (same `earliest_session_at` source the calendar's `minDate` uses, falling back to `getUserTrackingStartDate(sessions)`). *(repairs already-persisted oversized values at read time — a migration can't, since migrations run pre-auth before the UID is known — and stops "sober day" dots on untracked pre-tracking days)*

## Test plan

**Repro the inflation trigger**
- [ ] Open **Statistics** → select **All** preset → enable a **comparison** (previous period / previous year). This is what inflated the shared depth.

**Core fix**
- [ ] After the above, open the **day-overview** and **fullscreen calendar** — they mount quickly and only render back to your earliest session (no years of empty pre-tracking months).
- [ ] Scroll older in day-overview / fullscreen calendar — older months load only down to your earliest tracked session, then stop (the "loading older" indicator disappears; no infinite empty months).

**No regressions**
- [ ] Home (compact) calendar: left/right month arrows work; left arrow stops at the earliest-session month; drink-day colors render.
- [ ] Days **before** your first-ever session show **no** green "sober day" dot (new correct behavior).
- [ ] Statistics presets **W / M / 6M / Y / All** show correct totals and cover the full selected range (e.g. a session ~5 months ago appears in **6M**); period back/forward nav works and stops at earliest.
- [ ] Statistics **comparison** still renders where data exists (comparison windows before the first session correctly show no data).
- [ ] **Friend profile** calendar opens, shows the friend's sessions, scrolls back to their earliest, doesn't over-build.
- [ ] **New / short-history** account (e.g. one session today): day-overview/calendar open instantly; no pre-built empty months.
- [ ] **Long-history** account: all real history still renders — nothing within the actual data range is truncated.

**Note for testers:** the persisted Onyx value `sessionsCalendarMonthsByUserID_<uid>` may still read large for already-affected users — expected and benign. The build now ignores the excess; it only sets an earlier session-fetch `startAt`, which returns the same data.

**Automated:** `npm run test` (two suites updated), typecheck, lint, and React Compiler checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)