### PR TITLE
perf(nav): make Day Overview & Statistics taps feel instant

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -62,6 +62,10 @@ const CONST = {
   ANDROID_PACKAGE_NAME,
   ANIMATED_TRANSITION: 300,
   ANIMATED_TRANSITION_FROM_VALUE: 100,
+  // Safety-net upper bound for a screen's entry transition. Deferred heavy
+  // content flips on at `transitionEnd`; this only matters if that event never
+  // fires for a given platform/modal presentation.
+  SCREEN_TRANSITION_END_TIMEOUT: 1000,
   ANIMATION_IN_TIMING: 100,
   ANIMATION_DIRECTION: {
     IN: 'in',

--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useRef} from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
-import {PressableWithoutFeedback} from '@components/Pressable';
+import {PressableWithFeedback} from '@components/Pressable';
 import useStyleUtils from '@hooks/useStyleUtils';
 import type {DayComponentProps} from '@components/SessionsCalendar/types';
 
@@ -46,8 +46,9 @@ function DayComponent({
 
   return (
     <View ref={viewRef} collapsable={false}>
-      <PressableWithoutFeedback
+      <PressableWithFeedback
         accessibilityLabel=""
+        disabled={isDisabled}
         onPress={() => onPress && date && onPress(date)}>
         <View
           style={StyleUtils.getSessionsCalendarDayCellStyle(
@@ -68,7 +69,7 @@ function DayComponent({
             </Text>
           )}
         </View>
-      </PressableWithoutFeedback>
+      </PressableWithFeedback>
     </View>
   );
 }

--- a/src/hooks/useReadyAfterScreenTransition.ts
+++ b/src/hooks/useReadyAfterScreenTransition.ts
@@ -1,0 +1,44 @@
+import {useCallback, useEffect, useState} from 'react';
+import CONST from '@src/CONST';
+
+type ReadyAfterScreenTransition = {
+  /** Whether the screen's entry transition has finished (or the safety-net
+   *  timeout has elapsed), so deferred heavy content may now mount. */
+  isReady: boolean;
+
+  /** Wire to `ScreenWrapper`'s `onEntryTransitionEnd` prop. */
+  onEntryTransitionEnd: () => void;
+};
+
+/**
+ * Gates heavy work behind a screen's entry transition so the navigation slide
+ * can paint before the JS thread is blocked by a costly mount.
+ *
+ * Wire {@link ReadyAfterScreenTransition.onEntryTransitionEnd} to
+ * `ScreenWrapper`'s prop of the same name — it fires on react-navigation's
+ * `transitionEnd` event, i.e. *after* the slide.
+ * `InteractionManager.runAfterInteractions` is unsuitable for this: its
+ * interaction handle is created before the navigation card's, so it resolves
+ * before the slide finishes and the heavy mount still lands mid-transition,
+ * freezing the source screen.
+ *
+ * The timeout is a safety net only: if `transitionEnd` never fires for a given
+ * platform/modal presentation, `isReady` still flips so the screen can't get
+ * stuck on its skeleton.
+ */
+function useReadyAfterScreenTransition(): ReadyAfterScreenTransition {
+  const [isReady, setIsReady] = useState(false);
+  const onEntryTransitionEnd = useCallback(() => setIsReady(true), []);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(
+      () => setIsReady(true),
+      CONST.SCREEN_TRANSITION_END_TIMEOUT,
+    );
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return {isReady, onEntryTransitionEnd};
+}
+
+export default useReadyAfterScreenTransition;

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {InteractionManager, StyleSheet, View} from 'react-native';
+import React, {useCallback, useMemo, useState} from 'react';
+import {StyleSheet, View} from 'react-native';
 import {endOfToday} from 'date-fns';
 import UserOffline from '@components/UserOfflineModal';
 import {useUserConnection} from '@context/global/UserConnectionContext';
@@ -28,6 +28,7 @@ import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {PressableWithFeedback} from '@components/Pressable';
 import useLocalize from '@hooks/useLocalize';
+import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
@@ -91,17 +92,13 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const [isScrollReady, setIsScrollReady] = useState<boolean>(!date);
   const onInitialScrollReady = useCallback(() => setIsScrollReady(true), []);
 
-  // Defer mounting the (heavy) session list until after the navigation
-  // animation. `useLazyMarkedDates` filters/indexes all sessions synchronously
-  // on first render, which otherwise blocks the modal's slide-in ("nothing
-  // happens, then the screen appears"). Render only the skeleton first.
-  const [didInteract, setDidInteract] = useState(false);
-  useEffect(() => {
-    const handle = InteractionManager.runAfterInteractions(() =>
-      setDidInteract(true),
-    );
-    return () => handle.cancel();
-  }, []);
+  // Defer mounting the (heavy) session list until after the navigation slide.
+  // `useLazyMarkedDates` filters/indexes all sessions synchronously on first
+  // render, which otherwise blocks the modal's slide-in ("nothing happens,
+  // then the screen appears"). Gate on the screen's transition-end so the
+  // slide paints against the skeleton first, then mount the list.
+  const {isReady: didScreenTransitionEnd, onEntryTransitionEnd} =
+    useReadyAfterScreenTransition();
 
   const [isDatePickerVisible, setIsDatePickerVisible] = useState(false);
 
@@ -138,16 +135,18 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   }
 
   const isReady = !!user && !!preferences && drinkingSessionData !== undefined;
-  const showSkeleton = !didInteract || !isReady || !isScrollReady;
+  const showSkeleton = !didScreenTransitionEnd || !isReady || !isScrollReady;
 
   return (
-    <ScreenWrapper testID={DayOverviewScreen.displayName}>
+    <ScreenWrapper
+      testID={DayOverviewScreen.displayName}
+      onEntryTransitionEnd={onEntryTransitionEnd}>
       <HeaderWithBackButton
         title={translate('calendar.fullscreenTitle')}
         onBackButtonPress={Navigation.goBack}
       />
       <View style={styles.flex1}>
-        {isReady && didInteract && (
+        {isReady && didScreenTransitionEnd && (
           <View
             style={[
               styles.flex1,

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -11,6 +11,7 @@ import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useFetchData from '@hooks/useFetchData';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import useLocalize from '@hooks/useLocalize';
+import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {dateToDateData} from '@libs/DataHandling';
 import Navigation from '@libs/Navigation/Navigation';
@@ -88,10 +89,20 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
   const [isScrollReady, setIsScrollReady] = useState<boolean>(!monthYear);
   const onInitialScrollReady = useCallback(() => setIsScrollReady(true), []);
 
-  const showLoader = isLoading || !preferences || !isScrollReady;
+  // Defer the (heavy) fullscreen calendar mount until after the navigation
+  // slide. `useLazyMarkedDates` + the week-list build run synchronously on
+  // first render, which otherwise blocks the slide-in from the compact
+  // calendar's header tap. Render only the skeleton first.
+  const {isReady: didScreenTransitionEnd, onEntryTransitionEnd} =
+    useReadyAfterScreenTransition();
+
+  const showLoader =
+    !didScreenTransitionEnd || isLoading || !preferences || !isScrollReady;
 
   return (
-    <ScreenWrapper testID={SessionsCalendarScreen.displayName}>
+    <ScreenWrapper
+      testID={SessionsCalendarScreen.displayName}
+      onEntryTransitionEnd={onEntryTransitionEnd}>
       <HeaderWithBackButton
         title={translate('calendar.fullscreenTitle')}
         shouldShowBackButton={false}
@@ -99,7 +110,7 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
         onCloseButtonPress={() => Navigation.goBack()}
       />
       <View style={styles.flex1}>
-        {!isLoading && preferences && (
+        {didScreenTransitionEnd && !isLoading && preferences && (
           <View
             style={[
               styles.flex1,

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -1,77 +1,78 @@
 import React, {useEffect, useState} from 'react';
 import type {ComponentType} from 'react';
-import {InteractionManager} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import StatsContextProvider from '@components/StatsContextProvider';
 import useLocalize from '@hooks/useLocalize';
+import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import Navigation from '@libs/Navigation/Navigation';
 import DrillDownProvider from './drilldown/DrillDownContext';
 import StatisticsScreenSkeleton from './StatisticsScreenSkeleton';
 import StatsDrillDownSheet from './StatsDrillDownSheet';
 
 /**
- * The chart-tab tree (StatisticsTabs → 4 tabs → Skia/Victory imports) is the
- * dominant cost of entering this screen — heavy enough that a static
- * top-level import would block the JS thread on tap for 1–3 s while the
- * chart libraries evaluate, with React Navigation unable to paint a single
- * frame in the meantime. Deferring the import past the navigation
- * transition with `InteractionManager.runAfterInteractions` lets the
- * screen mount immediately with a layout-faithful skeleton, then swap in
- * the real tabs after the chart bundle has parsed.
+ * The chart-tab tree (StatisticsTabs → 4 tabs → Skia/Victory imports) plus the
+ * `StatsContextProvider` compute are the dominant cost of entering this screen
+ * — heavy enough to block the JS thread for 1–3 s on mount, with React
+ * Navigation unable to paint a single frame of the slide in the meantime.
  *
- * `useDrinkEvents` / `useAggregate` further defer the *data* compute past
- * the same interaction frame, so the skeletons stay visible until the
- * aggregates are ready.
+ * Gate the whole heavy subtree on the screen's entry-transition end so the
+ * slide plays first against a layout-faithful skeleton, then mount the
+ * providers and the dynamically imported tabs once the bundle has parsed.
+ * `runAfterInteractions` is unsuitable here: its handle resolves before the
+ * slide finishes (see `useReadyAfterScreenTransition`).
+ *
+ * `useDrinkEvents` / `useAggregate` further defer the *data* compute, so the
+ * skeleton stays visible until the aggregates are ready.
  */
 function StatisticsScreen() {
   const {translate} = useLocalize();
+  const {isReady: didScreenTransitionEnd, onEntryTransitionEnd} =
+    useReadyAfterScreenTransition();
   const [Tabs, setTabs] = useState<ComponentType | null>(null);
 
+  // Only kick off the chart-bundle import once the slide has finished, so its
+  // parse and the subsequent heavy mount never compete with the transition for
+  // the JS thread.
   useEffect(() => {
+    if (!didScreenTransitionEnd) {
+      return undefined;
+    }
     let cancelled = false;
-    const handle = InteractionManager.runAfterInteractions(() => {
-      if (cancelled) {
-        return;
-      }
-      import('./StatisticsTabs')
-        .then(mod => {
-          if (cancelled) {
-            return;
-          }
-          setTabs(() => mod.default);
-        })
-        .catch(() => {
-          // Dynamic import only fails when the underlying module itself
-          // throws — there is no network round-trip in Metro's single-bundle
-          // build. Surface the failure to the dev console so it is visible
-          // in QA; the screen stays on its skeleton state.
-        });
-    });
+    import('./StatisticsTabs')
+      .then(mod => {
+        if (cancelled) {
+          return;
+        }
+        setTabs(() => mod.default);
+      })
+      .catch(() => {
+        // Dynamic import only fails when the underlying module itself throws —
+        // there is no network round-trip in Metro's single-bundle build.
+      });
     return () => {
       cancelled = true;
-      handle.cancel?.();
     };
-  }, []);
+  }, [didScreenTransitionEnd]);
 
   return (
-    <ScreenWrapper testID={StatisticsScreen.displayName}>
+    <ScreenWrapper
+      testID={StatisticsScreen.displayName}
+      onEntryTransitionEnd={onEntryTransitionEnd}>
       <HeaderWithBackButton
         title={translate('statistics.title')}
         onBackButtonPress={Navigation.goBack}
       />
-      <StatsContextProvider>
-        <DrillDownProvider>
-          {Tabs ? (
-            <>
-              <Tabs />
-              <StatsDrillDownSheet />
-            </>
-          ) : (
-            <StatisticsScreenSkeleton />
-          )}
-        </DrillDownProvider>
-      </StatsContextProvider>
+      {Tabs ? (
+        <StatsContextProvider>
+          <DrillDownProvider>
+            <Tabs />
+            <StatsDrillDownSheet />
+          </DrillDownProvider>
+        </StatsContextProvider>
+      ) : (
+        <StatisticsScreenSkeleton />
+      )}
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## Summary

Tapping a calendar **day tile** (→ Day Overview) or the **Statistics** tab left the *source* screen frozen for the transition duration — no slide started, then the destination snapped in. Root cause: the destination's heavy synchronous mount blocked the JS thread *during* the RHP slide, so react-navigation couldn't paint a frame. The existing `InteractionManager.runAfterInteractions` defer was a no-op here because its interaction handle is created before the navigation card's, so it resolved **before** the slide.

Two-pronged fix:

- **Instant tap feedback.** `SessionsCalendar/DayComponent` now uses `PressableWithFeedback` (was `PressableWithoutFeedback`), so a day tile dims the moment your finger lands — a UI-thread Reanimated opacity that survives a JS-thread block. `disabled={isDisabled}` keeps out-of-range cells from giving false feedback. (The Statistics tab button already used `PressableWithFeedback`.)
- **Defer the heavy mount past the slide.** New `useReadyAfterScreenTransition` hook gates heavy content on `ScreenWrapper`'s `onEntryTransitionEnd` (react-navigation's `transitionEnd`, which fires *after* the slide), with a `CONST.SCREEN_TRANSITION_END_TIMEOUT` (1000 ms) safety-net so a missed event can never strand the screen on its skeleton. `DayOverviewScreen` gates `<SessionsCalendar mode="dayList">`; `StatisticsScreen` now defers **both** `StatsContextProvider` and the dynamically-imported chart-tab tree. The slide plays against the lightweight skeleton, then the heavy work runs.

Layout/positioning and day-overview scroll (owned by #798) are untouched — this is additive feedback + changing *when* the heavy mount runs. The day cell has fixed dimensions, so the added `OpacityView` wrapper doesn't shift the grid.

Based on current `master` (#798 already merged), so the diff is just this change (5 files).

## Test plan

- [x] `npx prettier --write` (clean)
- [x] `npm run typecheck-tsgo`
- [x] `./scripts/lint.sh <changed files>`
- [x] `npm run react-compiler-compliance-check check-changed`
- [x] `npm run test` (566 passed)
- [ ] **On device/sim:** tap a home-screen day tile → cell dims instantly, slide starts immediately against the skeleton, day list swaps in after the slide
- [ ] **On device/sim:** tap the Statistics tab → slide starts immediately against the skeleton, chart tabs mount after the slide
- [ ] Confirm no regression in calendar grid layout / day-overview scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)