### PR TITLE
feat(session-date): show the full date in the live-session header

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -206,7 +206,7 @@ function DrinkingSessionWindow({
             <Text style={styles.textHeadlineH2}>
               {session?.ongoing
                 ? `${translate('liveSessionScreen.sessionFrom')} ${DateUtils.getLocalizedTime(session.start_time, session.timezone)}`
-                : `${translate('liveSessionScreen.sessionOn')} ${DateUtils.getLocalizedDay(session.start_time, session.timezone)}`}
+                : `${translate('liveSessionScreen.sessionOn')} ${DateUtils.getLocalizedDay(session.start_time, session.timezone, CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT)}`}
             </Text>
           </View>
         </View>


### PR DESCRIPTION
### Details

The completed-session header rendered the session date as `MM-dd` (e.g. **"Session on 08-20"**), which is terse and drops the year. This switches it to the `MMM d, yyyy` format — e.g. **"Session on Apr 1, 2026"**.

Rather than introduce a new format or change the shared `SHORT_DATE_FORMAT` constant (which is also used in compact spots like calendar cells and modals where a long date would break layout), this reuses `CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT` — the exact format the session's own `SessionSummaryScreen` already uses. The live-session header and the session summary now read consistently.

- Single-line change in `src/components/DrinkingSessionWindow/index.tsx`: pass `CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT` to the existing `DateUtils.getLocalizedDay` call.
- Ongoing sessions are unaffected — they still render `Session from <time>`.
- Date formatting goes through the existing timezone-aware `getLocalizedDay` helper; month abbreviations remain English, consistent with the established `MONTH_DAY_YEAR_ABBR_FORMAT` usages elsewhere in the app.

### Tests

1. Open a completed (non-ongoing) drinking session, or open an existing session in edit mode.
2. Look at the header at the top of the session window.
3. Verify it reads e.g. **"Session on Apr 1, 2026"** (abbreviated month, day, full year) instead of **"Session on 04-01"**.
4. Open an ongoing/live session and verify its header still reads **"Session from <time>"** (unchanged).
5. Confirm the date matches what `SessionSummaryScreen` shows for the same session.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Date formatting is entirely client-side with no network dependency, so behavior is identical offline.

1. Enable airplane mode / go offline.
2. Open a completed session and verify the header still renders the full date as above.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. On staging, open a completed drinking session.
2. Verify the header shows the full **"Session on Apr 1, 2026"** style date.
3. Verify ongoing sessions still show **"Session from <time>"**.

- [ ] Verify that no errors appear in the JS console

### Verification performed

- `npx prettier --write` on the changed file (no changes needed)
- `npm run typecheck-tsgo` — clean
- `npm run lint-changed` — nothing flagged
- Not exercised on a device/simulator in this environment; change mirrors an already-shipped pattern (`SessionSummaryScreen`).

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- not captured in this environment -->

</details>

<details>
<summary>iOS</summary>

<!-- not captured in this environment -->

</details>