### PR TITLE
fix(ship): stop /ship from checking out the default branch

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(gh pr merge:*),Bash(gh pr view:*),Bash(gh pr list:*)
-argument-hint: "[PR number]"
+argument-hint: '[PR number]'
 description: Rebase-merge a PR and delete its branch. Targets the PR worked on in this session unless an argument is provided.
 ---
 
@@ -16,10 +16,26 @@ Rebase-merge a PR and delete its branch.
 
 ## Execute
 
-Once the target is resolved, run:
+Once the target is resolved, rebase-merge it and delete its branch **without
+checking out the default branch**. Do **not** use `gh`'s `--delete-branch`: it
+switches the local checkout to the default branch after merging, which is wrong
+inside a git worktree — and fails outright (`'master' is already used by
+worktree ...`) when the default branch is checked out in another worktree. So
+merge with `--rebase` only, then clean the branch up by hand:
 
 ```bash
-gh pr merge <N> --rebase --delete-branch
+BRANCH="$(gh pr view <N> --json headRefName --jq .headRefName)"
+gh pr merge <N> --rebase
+# If this checkout sits on the merged branch, step off onto a detached HEAD so
+# the branch can be deleted and we never land on the default branch.
+[ "$(git branch --show-current)" = "$BRANCH" ] && git checkout --detach
+git branch -D "$BRANCH" 2>/dev/null
+git push origin --delete "$BRANCH"
 ```
+
+`git branch -D` is required because a rebase-merge gives the local branch new
+commit hashes, so it isn't an ancestor of the default branch. A remote that
+auto-deletes head branches on merge will make the final `push --delete` report
+"remote ref does not exist" — that's a success, not an error.
 
 Report the result in one line (merged + branch deleted, or the error). Do not narrate the resolution step unless it failed.


### PR DESCRIPTION
## Summary

`/ship` ran `gh pr merge <N> --rebase --delete-branch`. The `--delete-branch` flag makes `gh` check out the **default branch** locally after merging (so it can delete the head branch). Inside a git **worktree** that's wrong — the worktree is left sitting on `master` — and it fails outright when `master` is already checked out in another worktree:

```
failed to run git: fatal: 'master' is already used by worktree at '/Users/.../Kiroku'
```

…which also leaves the branch un-deleted.

### Fix

`.claude/commands/ship.md` now merges with `--rebase` only, then deletes the branch by hand without ever checking out the default branch:

```bash
BRANCH="$(gh pr view <N> --json headRefName --jq .headRefName)"
gh pr merge <N> --rebase
[ "$(git branch --show-current)" = "$BRANCH" ] && git checkout --detach
git branch -D "$BRANCH" 2>/dev/null
git push origin --delete "$BRANCH"
```

The checkout ends on a **detached HEAD at the merged commit** instead of `master`.

### Notes

- `git branch -D` (force) is required because a rebase-merge re-hashes the commits, so the local branch isn't an ancestor of `master`.
- The git cleanup commands are **intentionally not** added to `allowed-tools`, so `/ship` will prompt before deleting branches (a deliberate, reviewable step). Add `Bash(git branch:*)`, `Bash(git checkout --detach:*)`, `Bash(git push origin --delete:*)` to the frontmatter later if you'd prefer silent execution.

## Test plan

- [ ] From a worktree on the PR's head branch, run `/ship` → PR rebase-merges, branch deleted locally + on remote, worktree ends on a detached HEAD (not `master`), no "already used by worktree" error.
- [ ] `/ship <N>` from the main checkout still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)