### PR TITLE
fix(day-overview): soften the loading skeleton so it is less prominent

### DIFF
--- a/src/screens/DayOverview/DayOverviewSkeleton.tsx
+++ b/src/screens/DayOverview/DayOverviewSkeleton.tsx
@@ -20,7 +20,7 @@ function Block({width, height, radius = 6, style}: BlockProps) {
           width,
           height,
           borderRadius: radius,
-          backgroundColor: theme.highlightBG,
+          backgroundColor: theme.skeletonBlockBG,
         },
         style,
       ]}
@@ -58,7 +58,7 @@ function DayOverviewSkeleton() {
                 styles.mb2,
                 styles.p4,
                 styles.justifyContentCenter,
-                {minHeight: 84, borderRadius: 8, backgroundColor: theme.border},
+                {minHeight: 84, borderRadius: 8, backgroundColor: theme.cardBG},
               ]}>
               <Block width={90} height={16} />
               <Block width={140} height={12} style={styles.mt2} />

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -26,6 +26,7 @@ const colors: Record<string, Color> = {
   productDark100: '#0D1117', // appBG
   productDark200: '#151B23', // card
   productDark300: '#212830', // search
+  productDark350: '#262D36', // skeleton block
   productDark400: '#3D444D', // border
   productDark500: '#1E2329', // button hovered
   productDark600: '#23282D', // button pressed
@@ -37,6 +38,7 @@ const colors: Record<string, Color> = {
   productLight100: '#FFFFFF', // appBG
   productLight200: '#F6F8FA', // card
   productLight300: '#F6F8FA', // search // TODO
+  productLight350: '#E5E9ED', // skeleton block
   productLight400: '#D0D9E0', // border
   productLight500: '#F2F3F4', // button hovered
   productLight600: '#EDEEEF', // button pressed

--- a/src/styles/theme/themes/dark.ts
+++ b/src/styles/theme/themes/dark.ts
@@ -85,6 +85,7 @@ const darkTheme = {
   tooltipPrimaryText: colors.productDark900,
   skeletonLHNIn: colors.productDark400,
   skeletonLHNOut: colors.productDark600,
+  skeletonBlockBG: colors.productDark350,
   QRLogo: colors.yellow,
   appLogo: colors.productDark900,
   white: colors.white,

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -84,6 +84,7 @@ const lightTheme = {
   tooltipPrimaryText: colors.productDark900,
   skeletonLHNIn: colors.productLight400,
   skeletonLHNOut: colors.productLight600,
+  skeletonBlockBG: colors.productLight350,
   QRLogo: colors.yellow,
   appLogo: colors.productLight900,
   white: colors.white,

--- a/src/styles/theme/types.ts
+++ b/src/styles/theme/types.ts
@@ -89,6 +89,7 @@ type ThemeColors = {
   tooltipPrimaryText: Color;
   skeletonLHNIn: Color;
   skeletonLHNOut: Color;
+  skeletonBlockBG: Color;
   QRLogo: Color;
   appLogo: Color;
   white: Color;


### PR DESCRIPTION
## Summary

The Day Overview (per-day drinking sessions) loading skeleton felt too prominent in the **dark** theme. Each placeholder session tile was filled with `theme.border` (`#3D444D`) on the near-black `appBG` (`#0D1117`) — a medium gray on near-black that reads as a solid filled card rather than a loading placeholder. The inner bars used `theme.highlightBG` (`#151B23`), which is actually *darker* than the tile (inverted vs. real content, where text is light on a colored tile).

This applies the "soft card" treatment chosen from a set of HTML mockups: the tile drops to the card tone so it sits just above the background, and the inner bars use a dedicated, subtler skeleton tone that's a step above the card.

## What changed

- **Palette** (`src/styles/theme/colors.ts`): new `productDark350: #262D36` and `productLight350: #E5E9ED`, slotted between the `card` and `border` shades (`// skeleton block`).
- **Theme token**: new semantic `skeletonBlockBG` declared in `src/styles/theme/types.ts` and mapped in `themes/dark.ts` / `themes/light.ts` — keeps the bar color out of the component (no hardcoded hex).
- **Recolor** (`src/screens/DayOverview/DayOverviewSkeleton.tsx`): tile fill `theme.border` → `theme.cardBG`; placeholder bars `theme.highlightBG` → `theme.skeletonBlockBG`.

Net result — dark: `#151B23` tiles with `#262D36` bars; light: `#F6F8FA` tiles with `#E5E9ED` bars. Layout, sizes, and structure are unchanged; this is purely a recolor.

## Reviewer notes

- The bar tone needed a value between the existing `card` and `border` shades, so a new palette entry was unavoidable; it's defined once and referenced via a theme token, consistent with the rest of the theming system.
- A separate follow-up was queued to unify **all** skeletons onto one reusable, shimmer-enabled primitive (à la `Button`/`Card`) — including adding shimmer to this screen. This PR is the static recolor only; no shimmer here.

## Test plan

- [x] `npm run typecheck-tsgo` (the `skeletonBlockBG` key must satisfy the `ThemeColors` `satisfies` check in both theme files)
- [x] `npm run react-compiler-compliance-check check-changed`
- [x] `npx prettier --write` on changed files
- [ ] Manual: open a day with sessions in **dark** theme and watch the skeleton during load — tiles sit just above the background (card tone) with subtle `#262D36` bars, no heavy gray boxes. Repeat in **light** theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)