### PR TITLE
feat(skeleton): unified shimmering Skeleton primitive + migrate all skeletons

### DIFF
--- a/__tests__/unit/ChartSkeleton.test.tsx
+++ b/__tests__/unit/ChartSkeleton.test.tsx
@@ -30,7 +30,9 @@ jest.mock('@hooks/useResponsiveLayout', () => ({
 // Stub the animation engine so variants built on the Skeleton primitive render
 // without the react-content-loader SVG (not transformed under jest).
 jest.mock('@components/SkeletonViewContentLoader', () => {
-  const {View} = require('react-native') as typeof import('react-native');
+  const {View} = require('react-native') as {
+    View: React.ComponentType<{testID?: string}>;
+  };
   return {
     __esModule: true,
     default: () => <View testID="skeleton-loader" />,

--- a/__tests__/unit/ChartSkeleton.test.tsx
+++ b/__tests__/unit/ChartSkeleton.test.tsx
@@ -1,14 +1,24 @@
 /* eslint-disable @typescript-eslint/naming-convention -- jest module-factory keys (__esModule) are Node-module shape, not our convention */
 
 import React from 'react';
+import type {ViewStyle} from 'react-native';
 import {render} from '@testing-library/react-native';
 import {ChartSkeleton} from '@components/Charts/ChartSkeleton';
+
+function flattenStyle(style: unknown): ViewStyle {
+  return ([] as unknown[])
+    .concat(style ?? [])
+    .filter(Boolean)
+    .reduce<ViewStyle>((acc, s) => ({...acc, ...(s as ViewStyle)}), {});
+}
 
 jest.mock('@hooks/useTheme', () => ({
   __esModule: true,
   default: () => ({
     borderLighter: '#eeeeee',
     highlightBG: '#f7f7f7',
+    skeletonBase: '#262d36',
+    skeletonHighlight: '#3d444d',
   }),
 }));
 
@@ -16,6 +26,16 @@ jest.mock('@hooks/useResponsiveLayout', () => ({
   __esModule: true,
   default: () => ({shouldUseNarrowLayout: false}),
 }));
+
+// Stub the animation engine so variants built on the Skeleton primitive render
+// without the react-content-loader SVG (not transformed under jest).
+jest.mock('@components/SkeletonViewContentLoader', () => {
+  const {View} = require('react-native');
+  return {
+    __esModule: true,
+    default: () => <View testID="skeleton-loader" />,
+  };
+});
 
 describe('ChartSkeleton', () => {
   const VARIANTS = [
@@ -48,8 +68,10 @@ describe('ChartSkeleton', () => {
       />,
     );
 
-    const tree = toJSON() as {props: {style?: {height?: number}}} | null;
+    const tree = toJSON() as {
+      props: {style?: ViewStyle | ViewStyle[]};
+    } | null;
     expect(tree).not.toBeNull();
-    expect(tree?.props.style?.height).toBe(321);
+    expect(flattenStyle(tree?.props.style).height).toBe(321);
   });
 });

--- a/__tests__/unit/ChartSkeleton.test.tsx
+++ b/__tests__/unit/ChartSkeleton.test.tsx
@@ -30,7 +30,7 @@ jest.mock('@hooks/useResponsiveLayout', () => ({
 // Stub the animation engine so variants built on the Skeleton primitive render
 // without the react-content-loader SVG (not transformed under jest).
 jest.mock('@components/SkeletonViewContentLoader', () => {
-  const {View} = require('react-native');
+  const {View} = require('react-native') as typeof import('react-native');
   return {
     __esModule: true,
     default: () => <View testID="skeleton-loader" />,

--- a/__tests__/unit/Skeleton.test.tsx
+++ b/__tests__/unit/Skeleton.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@hooks/useTheme', () => ({
 // logic without rendering the react-content-loader SVG (which isn't transformed
 // under jest). The stub surfaces the `animate` flag it receives for assertion.
 jest.mock('@components/SkeletonViewContentLoader', () => {
-  const {View} = require('react-native');
+  const {View} = require('react-native') as typeof import('react-native');
   return {
     __esModule: true,
     default: ({animate}: {animate?: boolean}) => (

--- a/__tests__/unit/Skeleton.test.tsx
+++ b/__tests__/unit/Skeleton.test.tsx
@@ -17,7 +17,9 @@ jest.mock('@hooks/useTheme', () => ({
 // logic without rendering the react-content-loader SVG (which isn't transformed
 // under jest). The stub surfaces the `animate` flag it receives for assertion.
 jest.mock('@components/SkeletonViewContentLoader', () => {
-  const {View} = require('react-native') as typeof import('react-native');
+  const {View} = require('react-native') as {
+    View: React.ComponentType<{testID?: string; animate?: boolean}>;
+  };
   return {
     __esModule: true,
     default: ({animate}: {animate?: boolean}) => (

--- a/__tests__/unit/Skeleton.test.tsx
+++ b/__tests__/unit/Skeleton.test.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest module-factory keys (__esModule) are Node-module shape, not our convention */
+
+import {render} from '@testing-library/react-native';
+import React from 'react';
+import type {ViewStyle} from 'react-native';
+import Skeleton from '@components/Skeleton';
+
+jest.mock('@hooks/useTheme', () => ({
+  __esModule: true,
+  default: () => ({
+    skeletonBase: '#262d36',
+    skeletonHighlight: '#3d444d',
+  }),
+}));
+
+// Stub the animation engine so the unit test exercises Skeleton's box/prop
+// logic without rendering the react-content-loader SVG (which isn't transformed
+// under jest). The stub surfaces the `animate` flag it receives for assertion.
+jest.mock('@components/SkeletonViewContentLoader', () => {
+  const {View} = require('react-native');
+  return {
+    __esModule: true,
+    default: ({animate}: {animate?: boolean}) => (
+      <View testID="skeleton-loader" animate={animate} />
+    ),
+  };
+});
+
+type Json = {
+  props?: Record<string, unknown>;
+  children?: Json[] | null;
+} | null;
+
+function flattenStyle(style: unknown): ViewStyle {
+  return ([] as unknown[])
+    .concat(style ?? [])
+    .filter(Boolean)
+    .reduce<ViewStyle>((acc, s) => ({...acc, ...(s as ViewStyle)}), {});
+}
+
+function findByTestId(node: Json, testID: string): Json {
+  if (!node) {
+    return null;
+  }
+  if (node.props?.testID === testID) {
+    return node;
+  }
+  for (const child of node.children ?? []) {
+    const found = findByTestId(child, testID);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+describe('Skeleton', () => {
+  test('renders without throwing', () => {
+    const {toJSON} = render(<Skeleton width={100} height={20} />);
+    expect(toJSON()).not.toBeNull();
+  });
+
+  test('applies explicit width and height to the container', () => {
+    const {toJSON} = render(<Skeleton width={120} height={40} />);
+    const style = flattenStyle((toJSON() as Json)?.props?.style);
+    expect(style.width).toBe(120);
+    expect(style.height).toBe(40);
+  });
+
+  test('defaults width to fill the parent', () => {
+    const {toJSON} = render(<Skeleton height={40} />);
+    expect(flattenStyle((toJSON() as Json)?.props?.style).width).toBe('100%');
+  });
+
+  test('circle forces a square box', () => {
+    const {toJSON} = render(<Skeleton circle height={50} />);
+    const style = flattenStyle((toJSON() as Json)?.props?.style);
+    expect(style.width).toBe(50);
+    expect(style.height).toBe(50);
+  });
+
+  test('animates by default and forwards animate={false}', () => {
+    const animated = findByTestId(
+      render(<Skeleton height={10} />).toJSON() as Json,
+      'skeleton-loader',
+    );
+    expect(animated?.props?.animate).toBe(true);
+
+    const still = findByTestId(
+      render(<Skeleton height={10} animate={false} />).toJSON() as Json,
+      'skeleton-loader',
+    );
+    expect(still?.props?.animate).toBe(false);
+  });
+
+  test('is decorative unless given an accessibilityLabel', () => {
+    const plain = render(<Skeleton height={10} />).toJSON() as Json;
+    expect(plain?.props?.accessibilityRole).toBeUndefined();
+
+    const labelled = render(
+      <Skeleton height={10} accessibilityLabel="Loading" />,
+    ).toJSON() as Json;
+    expect(labelled?.props?.accessibilityRole).toBe('progressbar');
+    expect(labelled?.props?.accessibilityLabel).toBe('Loading');
+  });
+});

--- a/src/components/Charts/ChartSkeleton/ChartSkeleton.tsx
+++ b/src/components/Charts/ChartSkeleton/ChartSkeleton.tsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
 import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import KpiRowSkeleton from './KpiRowSkeleton';
@@ -46,17 +47,19 @@ const DEFAULT_HEIGHT: Record<ChartSkeletonVariant, number> = {
 };
 
 /**
- * Layout-faithful skeleton placeholder for a chart. Renders a static grey
- * scaffold sized to match the real chart's bounding box plus a hint of its
- * internal structure (grid lines, ring, bars). No animation — the goal is
- * a non-distracting hint that "something is loading here," not a moving
- * shimmer that competes for attention with the rest of the screen.
+ * Layout-faithful skeleton placeholder for a chart. Sized to match the real
+ * chart's bounding box plus a hint of its internal structure (bars, ring,
+ * cells). Built on the shared `Skeleton` primitive: the prominent block
+ * placeholders (card body, bars, KPI tiles, etc.) shimmer with the unified
+ * `skeletonBase`/`skeletonHighlight` tokens, while the decorative structure
+ * that doesn't read well as a moving block — thin grid lines, ring outlines,
+ * and the dense calendar/heatmap cell grids — stays static in `skeletonBase`.
  *
  * Variants:
  * - `card`: plain rounded rectangle, matches generic ChartCard body.
- * - `bars`: row of faint vertical rectangles.
+ * - `bars`: row of vertical bars.
  * - `barList`: stack of horizontal label + track rows — matches BarList.
- * - `line`: single faint horizontal stripe — matches sparkline/trend-line.
+ * - `line`: single thin horizontal stripe — matches sparkline/trend-line.
  * - `distribution`: thin segmented bar + legend — matches DistributionBar.
  * - `calendar`: 6×7 grid of small rounded cells — matches CalendarHeatmap.
  * - `kpiRow`: 3 (or 2 narrow) tile placeholders side by side.
@@ -76,22 +79,20 @@ function ChartSkeleton({
   const theme = useTheme();
   const styles = useThemeStyles();
   const resolvedHeight = height ?? DEFAULT_HEIGHT[variant];
-  const fill = theme.borderLighter;
+  // Static fill for decorative structure that doesn't shimmer (rings, grid
+  // lines, dense cell grids) — the resting tone of the shimmering blocks so
+  // every skeleton reads as one colour family.
+  const fill = theme.skeletonBase;
   const cardFill = theme.highlightBG;
   const a11yLabel = accessibilityLabel ?? 'Loading';
 
   if (variant === 'card') {
     return (
-      <View
-        accessible
-        accessibilityRole="progressbar"
+      <Skeleton
+        width={width}
+        height={resolvedHeight}
+        radius={12}
         accessibilityLabel={a11yLabel}
-        style={{
-          height: resolvedHeight,
-          width,
-          backgroundColor: cardFill,
-          borderRadius: 12,
-        }}
       />
     );
   }
@@ -109,21 +110,17 @@ function ChartSkeleton({
           styles.ph2,
           {height: resolvedHeight, width},
         ]}>
-        {[0.5, 0.8, 0.65, 0.95, 0.55, 0.75, 0.6].map((h, idx) => (
-          <View
-            // eslint-disable-next-line react/no-array-index-key
-            key={`bar-${idx}`}
-            style={[
-              styles.flex1,
-              styles.mh1,
-              {
-                height: `${h * 100}%`,
-                backgroundColor: fill,
-                borderRadius: 4,
-              },
-            ]}
-          />
-        ))}
+        {[0.5, 0.8, 0.65, 0.95, 0.55, 0.75, 0.6].map((h, idx) => {
+          const barHeight = Math.round(h * resolvedHeight);
+          return (
+            <View
+              // eslint-disable-next-line react/no-array-index-key
+              key={`bar-${idx}`}
+              style={[styles.flex1, styles.mh1, {height: barHeight}]}>
+              <Skeleton width="100%" height={barHeight} radius={4} />
+            </View>
+          );
+        })}
       </View>
     );
   }
@@ -135,14 +132,7 @@ function ChartSkeleton({
         accessibilityRole="progressbar"
         accessibilityLabel={a11yLabel}
         style={[styles.justifyContentCenter, {height: resolvedHeight, width}]}>
-        <View
-          style={{
-            height: 2,
-            width: '100%',
-            backgroundColor: fill,
-            borderRadius: 1,
-          }}
-        />
+        <Skeleton width="100%" height={2} radius={1} />
       </View>
     );
   }
@@ -162,32 +152,11 @@ function ChartSkeleton({
             // eslint-disable-next-line react/no-array-index-key
             key={`barlist-${idx}`}
             style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-            <View
-              style={{
-                width: 28,
-                height: 8,
-                backgroundColor: fill,
-                borderRadius: 2,
-              }}
-            />
+            <Skeleton width={28} height={8} radius={2} />
             <View style={[styles.flex1, styles.mh1]}>
-              <View
-                style={{
-                  width: `${frac * 100}%`,
-                  height: 8,
-                  backgroundColor: fill,
-                  borderRadius: 4,
-                }}
-              />
+              <Skeleton width={`${frac * 100}%`} height={8} radius={4} />
             </View>
-            <View
-              style={{
-                width: 22,
-                height: 8,
-                backgroundColor: fill,
-                borderRadius: 2,
-              }}
-            />
+            <Skeleton width={22} height={8} radius={2} />
           </View>
         ))}
       </View>
@@ -203,36 +172,14 @@ function ChartSkeleton({
         accessibilityRole="progressbar"
         accessibilityLabel={a11yLabel}
         style={{height: resolvedHeight, width}}>
-        <View
-          style={{
-            height: 12,
-            width: '100%',
-            backgroundColor: fill,
-            borderRadius: 6,
-          }}
-        />
+        <Skeleton width="100%" height={12} radius={6} />
         <View style={[styles.flexRow, styles.flexWrap, styles.mt2]}>
           {[0, 1, 2, 3].map(i => (
             <View
               key={`legend-${i}`}
               style={[styles.flexRow, styles.alignItemsCenter, styles.mr3]}>
-              <View
-                style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: 4,
-                  backgroundColor: fill,
-                  marginRight: 4,
-                }}
-              />
-              <View
-                style={{
-                  width: 36,
-                  height: 8,
-                  borderRadius: 2,
-                  backgroundColor: fill,
-                }}
-              />
+              <Skeleton circle height={8} style={styles.mr1} />
+              <Skeleton width={36} height={8} radius={2} />
             </View>
           ))}
         </View>
@@ -310,30 +257,9 @@ function ChartSkeleton({
             borderRadius: 12,
           },
         ]}>
-        <View
-          style={{
-            height: 10,
-            width: '50%',
-            backgroundColor: fill,
-            borderRadius: 2,
-          }}
-        />
-        <View
-          style={{
-            height: 24,
-            width: '40%',
-            backgroundColor: fill,
-            borderRadius: 4,
-          }}
-        />
-        <View
-          style={{
-            height: 10,
-            width: '60%',
-            backgroundColor: fill,
-            borderRadius: 2,
-          }}
-        />
+        <Skeleton width="50%" height={10} radius={2} />
+        <Skeleton width="40%" height={24} radius={4} />
+        <Skeleton width="60%" height={10} radius={2} />
       </View>
     );
   }

--- a/src/components/Charts/ChartSkeleton/KpiRowSkeleton.tsx
+++ b/src/components/Charts/ChartSkeleton/KpiRowSkeleton.tsx
@@ -1,4 +1,5 @@
 import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
@@ -36,7 +37,6 @@ function KpiRowSkeleton({
   const columns = isNarrow ? 2 : 3;
   const itemWidth = `${100 / columns}%` as const;
   const tiles = count ?? columns;
-  const fill = theme.borderLighter;
   const cardFill = theme.highlightBG;
   return (
     <View
@@ -59,30 +59,9 @@ function KpiRowSkeleton({
                 borderRadius: 12,
               },
             ]}>
-            <View
-              style={{
-                height: 10,
-                width: '50%',
-                backgroundColor: fill,
-                borderRadius: 2,
-              }}
-            />
-            <View
-              style={{
-                height: 24,
-                width: '40%',
-                backgroundColor: fill,
-                borderRadius: 4,
-              }}
-            />
-            <View
-              style={{
-                height: 10,
-                width: '60%',
-                backgroundColor: fill,
-                borderRadius: 2,
-              }}
-            />
+            <Skeleton width="50%" height={10} radius={2} />
+            <Skeleton width="40%" height={24} radius={4} />
+            <Skeleton width="60%" height={10} radius={2} />
           </View>
         </View>
       ))}

--- a/src/components/SessionsCalendar/SessionsCalendarCompactSkeleton.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarCompactSkeleton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
 
 // One month: a centered month-year header, the 7-column day-name row, and a
 // 6×7 day grid — the geometry of the compact `SessionsCalendarView`.
@@ -12,22 +14,25 @@ const WEEK_ROWS = [0, 1, 2, 3, 4, 5];
  * (e.g. ProfileScreen), shown while the real grid — and its synchronous
  * `useLazyMarkedDates` indexing — is deferred past the navigation slide.
  * Mirrors `SessionsCalendarView`'s header + day-name row + single 6×7 month
- * grid. Sibling to the fullscreen `SessionsCalendarSkeleton`.
+ * grid. Sibling to the fullscreen `SessionsCalendarSkeleton`; cells stay static
+ * (`animate={false}`) for the same dense-grid reason.
  */
 function SessionsCalendarCompactSkeleton() {
   const styles = useThemeStyles();
+  const daySize = variables.sessionsCalendarDaySize;
+  const dayRadius = variables.componentBorderRadiusNormal;
 
   return (
     <View
       style={styles.sessionsCalendarContainer}
       testID="SessionsCalendarCompactSkeleton">
       <View style={styles.sessionsCalendarCompactSkeletonHeader}>
-        <View style={styles.sessionsCalendarCompactSkeletonMonthLabel} />
+        <Skeleton width={120} height={16} radius={3} animate={false} />
       </View>
       <View style={styles.sessionsCalendarDayNamesRow}>
         {DAY_COLUMNS.map(col => (
           <View key={`dn-${col}`} style={styles.sessionsCalendarDayNameCell}>
-            <View style={styles.sessionsCalendarCompactSkeletonDayName} />
+            <Skeleton width={18} height={10} radius={3} animate={false} />
           </View>
         ))}
       </View>
@@ -37,7 +42,12 @@ function SessionsCalendarCompactSkeleton() {
             <View
               key={`c-${week}-${col}`}
               style={styles.sessionsCalendarWeekCell}>
-              <View style={styles.sessionsCalendarCompactSkeletonDayCell} />
+              <Skeleton
+                width={daySize}
+                height={daySize}
+                radius={dayRadius}
+                animate={false}
+              />
             </View>
           ))}
         </View>

--- a/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
@@ -10,24 +11,20 @@ const DAY_COLUMNS = [0, 1, 2, 3, 4, 5, 6];
 const WEEK_ROWS = [0, 1, 2, 3, 4, 5];
 const MONTH_SECTIONS = [0, 1];
 
-const internalStyles = StyleSheet.create({
-  // Mirrors `variables.sessionColorMarkerSize` (20) — the day cell's marker.
-  dayCell: {width: 20, height: 20, borderRadius: 6},
-  dayNamePlaceholder: {width: 18, height: 10, borderRadius: 3},
-  monthLabelPlaceholder: {width: 96, height: 11, borderRadius: 3},
-});
-
 /**
  * Layout-faithful placeholder for the fullscreen sessions calendar, shown
  * while the week-list mounts and applies its initial scroll. Mirrors the
  * day-name header + month-label + 7-column week-row geometry so the swap to
  * the real grid is visually quiet — the same match-the-destination strategy
  * as `DayOverviewSkeleton` / `StatisticsScreenSkeleton`.
+ *
+ * Cells use the shared `Skeleton` primitive but stay static (`animate={false}`):
+ * this is a dense grid (up to ~84 day markers) and mounting that many
+ * simultaneous shimmer animations on the navigation transition would risk jank.
  */
 function SessionsCalendarSkeleton() {
   const styles = useThemeStyles();
   const theme = useTheme();
-  const block = {backgroundColor: theme.highlightBG};
 
   return (
     <View
@@ -36,14 +33,14 @@ function SessionsCalendarSkeleton() {
       <View style={styles.sessionsCalendarDayNamesRow}>
         {DAY_COLUMNS.map(col => (
           <View key={`dn-${col}`} style={styles.sessionsCalendarDayNameCell}>
-            <View style={[internalStyles.dayNamePlaceholder, block]} />
+            <Skeleton width={18} height={10} radius={3} animate={false} />
           </View>
         ))}
       </View>
       {MONTH_SECTIONS.map(section => (
         <View key={`sec-${section}`}>
           <View style={styles.sessionsCalendarMonthLabel}>
-            <View style={[internalStyles.monthLabelPlaceholder, block]} />
+            <Skeleton width={96} height={11} radius={3} animate={false} />
             <View style={styles.sessionsCalendarMonthLabelRule} />
           </View>
           {WEEK_ROWS.map(week => (
@@ -54,7 +51,7 @@ function SessionsCalendarSkeleton() {
                 <View
                   key={`c-${section}-${week}-${col}`}
                   style={styles.sessionsCalendarWeekCell}>
-                  <View style={[internalStyles.dayCell, block]} />
+                  <Skeleton width={20} height={20} radius={6} animate={false} />
                 </View>
               ))}
             </View>

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Rect} from 'react-native-svg';
+import SkeletonViewContentLoader from '@components/SkeletonViewContentLoader';
+import useTheme from '@hooks/useTheme';
+import variables from '@styles/variables';
+import type SkeletonProps from './types';
+
+/**
+ * A single shimmering placeholder block — the reusable skeleton primitive.
+ *
+ * Drop it in anywhere a `<View>` placeholder would go: it sizes itself from
+ * `width`/`height`, rounds with `radius` (or `circle`), and animates a gradient
+ * sweep using the shared `skeletonBase` → `skeletonHighlight` theme tokens.
+ * Animation is delegated to `SkeletonViewContentLoader` (the app's
+ * `react-content-loader` wrapper), which handles the web/native split.
+ *
+ * Each block is its own content loader, so compose freely with flexbox. For
+ * dense grids (calendars, heatmaps) pass `animate={false}` to avoid mounting
+ * many simultaneous SVG animations.
+ */
+function Skeleton({
+  width = '100%',
+  height,
+  radius = variables.componentBorderRadiusMedium,
+  circle = false,
+  animate = true,
+  style,
+  accessibilityLabel,
+}: SkeletonProps) {
+  const theme = useTheme();
+  const resolvedRadius = circle ? height / 2 : radius;
+  const resolvedWidth = circle ? height : width;
+  const a11yProps = accessibilityLabel
+    ? ({
+        accessible: true,
+        accessibilityRole: 'progressbar' as const,
+        accessibilityLabel,
+      } as const)
+    : null;
+
+  return (
+    <View
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...a11yProps}
+      style={[{width: resolvedWidth, height}, style]}>
+      <SkeletonViewContentLoader
+        animate={animate}
+        height={height}
+        backgroundColor={theme.skeletonBase}
+        foregroundColor={theme.skeletonHighlight}>
+        <Rect
+          x="0"
+          y="0"
+          rx={resolvedRadius}
+          ry={resolvedRadius}
+          width="100%"
+          height="100%"
+        />
+      </SkeletonViewContentLoader>
+    </View>
+  );
+}
+
+Skeleton.displayName = 'Skeleton';
+
+export default Skeleton;
+export type {SkeletonProps};

--- a/src/components/Skeleton/types.ts
+++ b/src/components/Skeleton/types.ts
@@ -1,0 +1,30 @@
+import type {StyleProp, ViewStyle} from 'react-native';
+
+type SkeletonProps = {
+  /** Block width — dp number or percentage string. Defaults to filling the parent. */
+  width?: number | `${number}%`;
+
+  /** Block height in dp. A skeleton block always has an intrinsic height. */
+  height: number;
+
+  /** Corner radius in dp. */
+  radius?: number;
+
+  /** Render as a circle: radius becomes height/2 and width is forced to height. */
+  circle?: boolean;
+
+  /** Whether to run the shimmer sweep. Disable for dense grids to avoid mounting many SVG animations at once. */
+  animate?: boolean;
+
+  /** Outer container style — margins, flex, absolute positioning. */
+  style?: StyleProp<ViewStyle>;
+
+  /**
+   * When set, the block is announced to screen readers as a loading
+   * progressbar. Leave undefined for decorative blocks so a multi-block
+   * skeleton announces once (from its container), not once per block.
+   */
+  accessibilityLabel?: string;
+};
+
+export default SkeletonProps;

--- a/src/components/Skeletons/ItemListSkeletonView.tsx
+++ b/src/components/Skeletons/ItemListSkeletonView.tsx
@@ -69,8 +69,8 @@ function ItemListSkeletonView({
           <SkeletonViewContentLoader
             animate={shouldAnimate}
             height={itemViewHeight}
-            backgroundColor={theme.skeletonLHNIn}
-            foregroundColor={theme.skeletonLHNOut}>
+            backgroundColor={theme.skeletonBase}
+            foregroundColor={theme.skeletonHighlight}>
             {renderSkeletonItem({itemIndex: i})}
           </SkeletonViewContentLoader>
         </View>,

--- a/src/components/Skeletons/SearchStatusSkeleton.tsx
+++ b/src/components/Skeletons/SearchStatusSkeleton.tsx
@@ -20,8 +20,8 @@ function SearchStatusSkeleton({
       <SkeletonViewContentLoader
         animate={shouldAnimate}
         height={40}
-        backgroundColor={theme.skeletonLHNIn}
-        foregroundColor={theme.skeletonLHNOut}>
+        backgroundColor={theme.skeletonBase}
+        foregroundColor={theme.skeletonHighlight}>
         <Rect x={0} y={0} rx={20} ry={20} width={68} height={40} />
         <Rect x={80} y={14} width={12} height={12} />
         <Rect x={100} y={16} width={40} height={8} />

--- a/src/components/Statistics/StatsFilterToolbar/StatsFilterToolbarSkeleton.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/StatsFilterToolbarSkeleton.tsx
@@ -1,4 +1,5 @@
 import {StyleSheet, View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 
 type StatsFilterToolbarSkeletonProps = {
@@ -28,31 +29,10 @@ const styles = StyleSheet.create({
   segmented: {
     flex: 1,
     height: 32,
-    borderRadius: 8,
-  },
-  comparison: {
-    width: 88,
-    height: 32,
-    borderRadius: 8,
-  },
-  navArrow: {
-    width: 28,
-    height: 28,
-    borderRadius: 6,
-  },
-  navLabel: {
-    height: 18,
-    width: 140,
-    borderRadius: 6,
   },
   chipRow: {
     flexDirection: 'row',
     columnGap: 8,
-  },
-  chip: {
-    width: 56,
-    height: 28,
-    borderRadius: 14,
   },
 });
 
@@ -61,14 +41,13 @@ const CHIP_COUNT = 4;
 /**
  * Static, layout-faithful placeholder for `StatsFilterToolbar`. Used by the
  * Statistics loading skeletons (full-screen skeleton + per-tab lazy
- * placeholder). Imports nothing heavy — only `View` + the theme — so it stays
- * out of the deferred chart bundle.
+ * placeholder). Imports nothing heavy — only `View` + the shared `Skeleton`
+ * primitive — so it stays out of the deferred chart bundle.
  */
 function StatsFilterToolbarSkeleton({
   showDrinkTypeFilter = true,
 }: StatsFilterToolbarSkeletonProps) {
   const theme = useTheme();
-  const fill = theme.highlightBG;
 
   return (
     <View
@@ -80,21 +59,25 @@ function StatsFilterToolbarSkeleton({
         {backgroundColor: theme.appBG, borderBottomColor: theme.border},
       ]}>
       <View style={styles.row}>
-        <View style={[styles.segmented, {backgroundColor: fill}]} />
-        <View style={[styles.comparison, {backgroundColor: fill}]} />
+        <View style={styles.segmented}>
+          <Skeleton width="100%" height={32} radius={8} />
+        </View>
+        <Skeleton width={88} height={32} radius={8} />
       </View>
       <View style={styles.row}>
-        <View style={[styles.navArrow, {backgroundColor: fill}]} />
-        <View style={[styles.navLabel, {backgroundColor: fill}]} />
-        <View style={[styles.navArrow, {backgroundColor: fill}]} />
+        <Skeleton width={28} height={28} radius={6} />
+        <Skeleton width={140} height={18} radius={6} />
+        <Skeleton width={28} height={28} radius={6} />
       </View>
       {showDrinkTypeFilter ? (
         <View style={styles.chipRow}>
           {Array.from({length: CHIP_COUNT}, (_v, i) => (
-            <View
+            <Skeleton
               // eslint-disable-next-line react/no-array-index-key
               key={`chip-${i}`}
-              style={[styles.chip, {backgroundColor: fill}]}
+              width={56}
+              height={28}
+              radius={14}
             />
           ))}
         </View>

--- a/src/screens/DayOverview/DayOverviewSkeleton.tsx
+++ b/src/screens/DayOverview/DayOverviewSkeleton.tsx
@@ -1,32 +1,8 @@
 import React from 'react';
-import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-
-type BlockProps = {
-  width: number | `${number}%`;
-  height: number;
-  radius?: number;
-  style?: StyleProp<ViewStyle>;
-};
-
-function Block({width, height, radius = 6, style}: BlockProps) {
-  const theme = useTheme();
-  return (
-    <View
-      style={[
-        {
-          width,
-          height,
-          borderRadius: radius,
-          backgroundColor: theme.skeletonBlockBG,
-        },
-        style,
-      ]}
-    />
-  );
-}
 
 // One placeholder day section: a day-header row (date + units) followed by a
 // couple of session-tile placeholders (~84px, matching DrinkingSessionOverview).
@@ -45,9 +21,9 @@ function DayOverviewSkeleton() {
         <View key={`section-${section}`}>
           {/* Day header — mirrors sessionsCalendarMonthLabel (date + rule + units) */}
           <View style={styles.sessionsCalendarMonthLabel}>
-            <Block width={110} height={14} />
+            <Skeleton width={110} height={14} />
             <View style={[styles.sessionsCalendarMonthLabelRule, styles.mh2]} />
-            <Block width={60} height={14} />
+            <Skeleton width={60} height={14} />
           </View>
           {/* Session tiles — match the ~84px tile rows */}
           {SESSIONS_PER_DAY.map(tile => (
@@ -60,8 +36,8 @@ function DayOverviewSkeleton() {
                 styles.justifyContentCenter,
                 {minHeight: 84, borderRadius: 8, backgroundColor: theme.cardBG},
               ]}>
-              <Block width={90} height={16} />
-              <Block width={140} height={12} style={styles.mt2} />
+              <Skeleton width={90} height={16} />
+              <Skeleton width={140} height={12} style={styles.mt2} />
             </View>
           ))}
         </View>

--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -1,33 +1,8 @@
 import React from 'react';
-import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
-import useTheme from '@hooks/useTheme';
+import Skeleton from '@components/Skeleton';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
-
-type BlockProps = {
-  width: number;
-  height: number;
-  radius?: number;
-  style?: StyleProp<ViewStyle>;
-};
-
-function Block({width, height, radius = 6, style}: BlockProps) {
-  const theme = useTheme();
-  return (
-    <View
-      style={[
-        {
-          width,
-          height,
-          borderRadius: radius,
-          backgroundColor: theme.highlightBG,
-        },
-        style,
-      ]}
-    />
-  );
-}
 
 /** Placeholder for the home-screen header (profile avatar + display name). */
 function HomeHeaderSkeleton() {
@@ -42,8 +17,8 @@ function HomeHeaderSkeleton() {
         styles.alignItemsCenter,
         styles.ph2,
       ]}>
-      <Block width={avatarSize} height={avatarSize} radius={avatarSize / 2} />
-      <Block width={140} height={16} style={styles.ml3} />
+      <Skeleton circle height={avatarSize} />
+      <Skeleton width={140} height={16} style={styles.ml3} />
     </View>
   );
 }
@@ -62,9 +37,9 @@ function StatOverviewSkeleton() {
             styles.justifyContentCenter,
           ]}>
           {/* Matches fontSizeXXXXLarge (36px) bold value text */}
-          <Block width={72} height={44} style={styles.mb2} />
+          <Skeleton width={72} height={44} style={styles.mb2} />
           {/* Matches fontSizeNormal (15px) label, 2 lines, max-width 150 */}
-          <Block width={130} height={36} />
+          <Skeleton width={130} height={36} />
         </View>
       ))}
     </View>
@@ -87,7 +62,7 @@ function SessionsCalendarSkeleton() {
       {/* Month header — matches the custom renderHeader in SessionsCalendarView
        *  (single centered text, no nav arrows). */}
       <View style={[styles.sessionsCalendarHeader, styles.pv3]}>
-        <Block width={100} height={18} />
+        <Skeleton width={100} height={18} animate={false} />
       </View>
       {/* Day-name row — matches the library's `stylesheet.calendar.header`
        *  spacing (marginTop:7 on the week, marginBottom:7 on each dayHeader). */}
@@ -102,14 +77,15 @@ function SessionsCalendarSkeleton() {
           <View
             key={`name-${day}`}
             style={[styles.flex1, styles.alignItemsCenter]}>
-            <Block width={20} height={12} />
+            <Skeleton width={20} height={12} animate={false} />
           </View>
         ))}
       </View>
       {/* Week rows — each cell mirrors the real DayComponent: a single
        *  heatmap-tile square sized via variables.sessionsCalendarDaySize.
        *  marginVertical:6 matches stylesheet.calendar.main.week in
-       *  getSessionsCalendarStyle, so swap-in lands at the same Y. */}
+       *  getSessionsCalendarStyle, so swap-in lands at the same Y. Dense grid,
+       *  so cells stay static (animate={false}) — see the Skeleton primitive. */}
       {CALENDAR_WEEKS.map(week => (
         <View
           key={`week-${week}`}
@@ -119,11 +95,12 @@ function SessionsCalendarSkeleton() {
             {marginVertical: 6},
           ]}>
           {CALENDAR_DAYS.map(day => (
-            <Block
+            <Skeleton
               key={`day-${week}-${day}`}
               width={daySize}
               height={daySize}
               radius={dayRadius}
+              animate={false}
             />
           ))}
         </View>

--- a/src/screens/Statistics/StatisticsScreenSkeleton.tsx
+++ b/src/screens/Statistics/StatisticsScreenSkeleton.tsx
@@ -2,6 +2,7 @@ import {StyleSheet, View} from 'react-native';
 import {ChartCard} from '@components/Charts/ChartCard';
 import {ChartSkeleton} from '@components/Charts/ChartSkeleton';
 import ScrollView from '@components/ScrollView';
+import Skeleton from '@components/Skeleton';
 import {StatsFilterToolbarSkeleton} from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
@@ -40,9 +41,6 @@ const skeletonStyles = StyleSheet.create({
     textAlign: 'center',
   },
   sectionLabel: {
-    height: 10,
-    width: '30%',
-    borderRadius: 2,
     marginBottom: 4,
   },
 });
@@ -107,11 +105,11 @@ function StatisticsScreenSkeleton() {
             // eslint-disable-next-line react/no-array-index-key
             key={`kpi-group-${idx}`}
             style={styles.mb3}>
-            <View
-              style={[
-                skeletonStyles.sectionLabel,
-                {backgroundColor: theme.borderLighter},
-              ]}
+            <Skeleton
+              width="30%"
+              height={10}
+              radius={2}
+              style={skeletonStyles.sectionLabel}
             />
             <ChartSkeleton variant="kpiRow" count={groupCount} />
           </View>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1661,34 +1661,13 @@ const styles = (theme: ThemeColors) =>
       fontSize: variables.fontSizeSmall,
     },
 
-    // Placeholder blocks for the compact-calendar loading skeleton
-    // (`SessionsCalendarCompactSkeleton`). Geometry mirrors the real compact
-    // grid so the swap to the live calendar doesn't shift surrounding content.
+    // Container for the compact-calendar loading skeleton header
+    // (`SessionsCalendarCompactSkeleton`). The placeholder blocks themselves
+    // are rendered with the shared `Skeleton` primitive.
     sessionsCalendarCompactSkeletonHeader: {
       paddingVertical: 10,
       alignItems: 'center',
       justifyContent: 'center',
-    },
-
-    sessionsCalendarCompactSkeletonMonthLabel: {
-      width: 120,
-      height: 16,
-      borderRadius: 3,
-      backgroundColor: theme.highlightBG,
-    },
-
-    sessionsCalendarCompactSkeletonDayName: {
-      width: 18,
-      height: 10,
-      borderRadius: 3,
-      backgroundColor: theme.highlightBG,
-    },
-
-    sessionsCalendarCompactSkeletonDayCell: {
-      width: variables.sessionsCalendarDaySize,
-      height: variables.sessionsCalendarDaySize,
-      borderRadius: variables.componentBorderRadiusNormal,
-      backgroundColor: theme.highlightBG,
     },
 
     // Inline month-section label rendered as a FlashList sticky header.

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -26,7 +26,7 @@ const colors: Record<string, Color> = {
   productDark100: '#0D1117', // appBG
   productDark200: '#151B23', // card
   productDark300: '#212830', // search
-  productDark350: '#262D36', // skeleton block
+  productDark350: '#262D36', // skeleton base
   productDark400: '#3D444D', // border
   productDark500: '#1E2329', // button hovered
   productDark600: '#23282D', // button pressed
@@ -38,7 +38,7 @@ const colors: Record<string, Color> = {
   productLight100: '#FFFFFF', // appBG
   productLight200: '#F6F8FA', // card
   productLight300: '#F6F8FA', // search // TODO
-  productLight350: '#E5E9ED', // skeleton block
+  productLight350: '#E5E9ED', // skeleton base
   productLight400: '#D0D9E0', // border
   productLight500: '#F2F3F4', // button hovered
   productLight600: '#EDEEEF', // button pressed

--- a/src/styles/theme/themes/dark.ts
+++ b/src/styles/theme/themes/dark.ts
@@ -83,9 +83,8 @@ const darkTheme = {
   tooltipHighlightText: colors.orange500, // TODO check
   tooltipSupportingText: colors.productDark800,
   tooltipPrimaryText: colors.productDark900,
-  skeletonLHNIn: colors.productDark400,
-  skeletonLHNOut: colors.productDark600,
-  skeletonBlockBG: colors.productDark350,
+  skeletonBase: colors.productDark350,
+  skeletonHighlight: colors.productDark400,
   QRLogo: colors.yellow,
   appLogo: colors.productDark900,
   white: colors.white,

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -82,9 +82,8 @@ const lightTheme = {
   tooltipHighlightText: colors.orange500, // TODO check
   tooltipSupportingText: colors.productDark800,
   tooltipPrimaryText: colors.productDark900,
-  skeletonLHNIn: colors.productLight400,
-  skeletonLHNOut: colors.productLight600,
-  skeletonBlockBG: colors.productLight350,
+  skeletonBase: colors.productLight350,
+  skeletonHighlight: colors.productLight200,
   QRLogo: colors.yellow,
   appLogo: colors.productLight900,
   white: colors.white,

--- a/src/styles/theme/types.ts
+++ b/src/styles/theme/types.ts
@@ -87,9 +87,8 @@ type ThemeColors = {
   tooltipHighlightText: Color;
   tooltipSupportingText: Color;
   tooltipPrimaryText: Color;
-  skeletonLHNIn: Color;
-  skeletonLHNOut: Color;
-  skeletonBlockBG: Color;
+  skeletonBase: Color;
+  skeletonHighlight: Color;
   QRLogo: Color;
   appLogo: Color;
   white: Color;


### PR DESCRIPTION
## Summary

Introduces a single, reusable `Skeleton` primitive with built-in shimmer and migrates every bespoke skeleton onto it, replacing the duplicated `Block` helpers and ad-hoc fill `View`s.

- **New primitive** `src/components/Skeleton/` (`index.tsx` + `types.ts`): a prop-driven placeholder block (`width`/`height`/`radius`/`circle`/`animate`/`style`/`accessibilityLabel`) that shimmers via the existing `SkeletonViewContentLoader` engine. Decorative by default; announces as a `progressbar` only when given a label.
- **Consolidated theme tokens**: replaced `skeletonLHNIn`/`skeletonLHNOut` with a semantic `skeletonBase` / `skeletonHighlight` pair. Added palette `productDark350 #262D36` / `productLight350 #E5E9ED` as the resting tone, with a one-step-lighter sweep (dark `#3D444D`, light `#F6F8FA`).
- **Migrated skeletons** onto the primitive, preserving each one's existing layout/dimensions — only gaining shimmer + unified color:
  - Shimmer (above the fold): DayOverview, Home header/stat cards, Stats filter toolbar, and ChartSkeleton's `card`/`kpi`/`kpiRow`/`bars`/`barList`/`line`/`distribution` variants + the Statistics KPI-group labels.
  - Static but unified color (dense grids / ring & line decoration): full + compact Sessions calendars, Home calendar grid, and ChartSkeleton's `grid`/`polar`/`donut`/`calendar`/`heatmapWeekHour`. Each dense cell is its own SVG, so animating dozens-to-hundreds of them on the navigation transition would risk jank.
- The list-skeleton family (`ItemListSkeletonView`, Card/Search/Table/Options/SearchStatus rows) keeps its render-prop SVG pattern and just inherits the new tokens.

## Design notes

- DayOverview session tiles now sit on `cardBG` (the real card surface) so the shimmer blocks read with correct contrast in both themes — this is the "Option A base + Option B shimmer" combination previously discussed.
- `ChartSkeleton`'s public API (`variant`/`height`/`width`/`count`) is unchanged; all 6 consumers are untouched.

## Test plan

- [x] `Skeleton.test.tsx` (new): dimensions, `circle`, `animate` forwarding, a11y opt-in
- [x] `ChartSkeleton.test.tsx`: updated theme mock + stubbed animation engine; all variants render
- [x] `npm run typecheck-tsgo` clean
- [x] `npm run lint-changed` clean
- [x] `npm run react-compiler-compliance-check check-changed` passed
- [ ] **Manual**: run the app and watch loading states in **dark + light** — Day Overview (shimmer), Home (header/stats shimmer, calendar static), Statistics/Charts, Calendar — to confirm shimmer reads well and nothing shifts on swap-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)