### PR TITLE
fix(skeleton): shimmer Statistics KPI tiles as full blocks

### DIFF
--- a/src/components/Charts/ChartSkeleton/ChartSkeleton.tsx
+++ b/src/components/Charts/ChartSkeleton/ChartSkeleton.tsx
@@ -86,7 +86,10 @@ function ChartSkeleton({
   const cardFill = theme.highlightBG;
   const a11yLabel = accessibilityLabel ?? 'Loading';
 
-  if (variant === 'card') {
+  // A KPI tile and a generic chart card are both full shimmering blocks while
+  // loading — the tile's inner label/value structure is too small to read as a
+  // moving shimmer, so the whole tile shimmers instead.
+  if (variant === 'card' || variant === 'kpi') {
     return (
       <Skeleton
         width={width}
@@ -237,29 +240,6 @@ function ChartSkeleton({
             ))}
           </View>
         ))}
-      </View>
-    );
-  }
-
-  if (variant === 'kpi') {
-    return (
-      <View
-        accessible
-        accessibilityRole="progressbar"
-        accessibilityLabel={a11yLabel}
-        style={[
-          styles.p3,
-          styles.justifyContentBetween,
-          {
-            height: resolvedHeight,
-            width,
-            backgroundColor: cardFill,
-            borderRadius: 12,
-          },
-        ]}>
-        <Skeleton width="50%" height={10} radius={2} />
-        <Skeleton width="40%" height={24} radius={4} />
-        <Skeleton width="60%" height={10} radius={2} />
       </View>
     );
   }

--- a/src/components/Charts/ChartSkeleton/KpiRowSkeleton.tsx
+++ b/src/components/Charts/ChartSkeleton/KpiRowSkeleton.tsx
@@ -1,6 +1,5 @@
 import {View} from 'react-native';
 import Skeleton from '@components/Skeleton';
-import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import variables from '@styles/variables';
@@ -30,14 +29,12 @@ function KpiRowSkeleton({
   accessibilityLabel,
   count,
 }: KpiRowSkeletonProps) {
-  const theme = useTheme();
   const styles = useThemeStyles();
   const {windowWidth} = useWindowDimensions();
   const isNarrow = windowWidth < variables.mobileResponsiveWidthBreakpoint;
   const columns = isNarrow ? 2 : 3;
   const itemWidth = `${100 / columns}%` as const;
   const tiles = count ?? columns;
-  const cardFill = theme.highlightBG;
   return (
     <View
       accessible
@@ -49,20 +46,9 @@ function KpiRowSkeleton({
           // eslint-disable-next-line react/no-array-index-key
           key={`kpi-${i}`}
           style={[styles.ph1, styles.pv1, {width: itemWidth}]}>
-          <View
-            style={[
-              styles.p3,
-              styles.justifyContentBetween,
-              {
-                height,
-                backgroundColor: cardFill,
-                borderRadius: 12,
-              },
-            ]}>
-            <Skeleton width="50%" height={10} radius={2} />
-            <Skeleton width="40%" height={24} radius={4} />
-            <Skeleton width="60%" height={10} radius={2} />
-          </View>
+          {/* Whole tile shimmers — small inner bars read as static, so the tile
+           *  itself is the placeholder block (matches the `kpi`/`card` variant). */}
+          <Skeleton width="100%" height={height} radius={12} />
         </View>
       ))}
     </View>


### PR DESCRIPTION
## Summary

Follow-up to the Skeleton primitive refactor (#865). The Statistics KPI tiles were wired to shimmer, but only their tiny 10–24px inner bars animated — imperceptible next to the full-width blocks on the initial `StatisticsScreenSkeleton`. Since the Overview tab is the default landing tab, that loading state is what users see most, and it read as static.

- **`ChartSkeleton` `kpi` variant** and **`KpiRowSkeleton` tiles** now render the *whole tile* as a single shimmering `Skeleton` block (radius 12), instead of a static `highlightBG` card with three tiny inner bars.
- Folded `kpi` into the existing `card` branch — both are full shimmering blocks (they differ only in default height), matching the `card` treatment already confirmed to read well.
- This makes the Overview tab's **highlights / load / risk** sections (via `KpiCardGroup` → `KpiCard isLoading`) and the initial skeleton's KPI groups (`kpiRow`) shimmer visibly and consistently.

### Audit note (were these expected to shimmer?)

Yes — the chain `OverviewTab → KpiCardGroup → KpiCard isLoading → ChartSkeleton variant="kpi"` always included animated `Skeleton` bars. The issue was purely visibility: the sweep across small bars is too brief/subtle to perceive. The static chart-body variants (`grid`/`donut`/`polar`/`heatmapWeekHour`/`calendar`) remain intentionally static per the earlier perf decision.

## Test plan

- [x] `npm run typecheck-tsgo` clean
- [x] `npm run lint-changed` clean
- [x] `npm run react-compiler-compliance-check check-changed` passed
- [x] `ChartSkeleton.test.tsx` (11 tests) passing — `kpi`/`kpiRow` variants still render
- [ ] **Manual**: open Statistics in dark + light, confirm the highlights/load/risk tiles shimmer on load (Overview tab) and on the initial skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)