### PR TITLE
style(header): shrink back arrow to match other nav icons

### DIFF
--- a/src/components/HeaderWithBackButton/index.tsx
+++ b/src/components/HeaderWithBackButton/index.tsx
@@ -154,8 +154,8 @@ function HeaderWithBackButton({
               nativeID={CONST.BACK_BUTTON_NATIVE_ID}>
               <Icon
                 src={KirokuIcons.BackArrow}
-                width={variables.iconSizeXLarge}
-                height={variables.iconSizeXLarge}
+                width={variables.iconBottomBar}
+                height={variables.iconBottomBar}
                 fill={iconFill ?? theme.heading}
               />
             </PressableWithoutFeedback>


### PR DESCRIPTION
### Details

The header back arrow rendered at `variables.iconSizeXLarge` (28px), noticeably larger than other navigation icons in the app — the bottom-bar icons (`iconBottomBar`, 24px) and settings-row icons (`iconSizeNormal`, 20px). This made the back chevron feel oversized relative to everything around it.

This PR drops the back arrow to `variables.iconBottomBar` (24px) so it visually matches the bottom-bar navigation icons.

The **tap target is unchanged** — the back arrow is wrapped in a `PressableWithoutFeedback` styled with `styles.touchableButtonImage` (fixed `componentSizeNormal`), so only the visible glyph shrank; the touchable area stays the same size.

Single-line change in `src/components/HeaderWithBackButton/index.tsx`.

### Tests

1. Open any screen that shows a header with a back button (e.g. a settings sub-page or the Day Overview).
2. Verify the back arrow in the top-left is now slightly smaller and visually consistent with the bottom-bar and settings-row icons.
3. Tap near the edges of where the old (larger) arrow was and verify the back action still triggers — the tap area is unchanged.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable — this is a purely visual sizing change with no network behavior.

### QA Steps

1. Navigate to any screen with a header back button.
2. Confirm the back arrow size matches the bottom navigation bar icons.
3. Confirm back navigation still works when tapping the icon.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] If the PR modifies the UI:
  - [x] Added `design` label / tagged design for review of the sizing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)