### PR TITLE
style(calendar): truly center the date label in the picker header

### DIFF
--- a/src/components/DateSelectorModal/Calendar.tsx
+++ b/src/components/DateSelectorModal/Calendar.tsx
@@ -55,6 +55,11 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  // Mirrors the trailing dropdown chevron (12px icon + ml1 4px) so the
+  // month/year label is the true horizontal center of the header.
+  headerTitleChevronSpacer: {
+    width: 16,
+  },
   overview: {
     height: OVERVIEW_HEIGHT,
   },
@@ -260,6 +265,7 @@ function Calendar(props: CalendarProps) {
           hoverDimmingValue={1}
           style={localStyles.headerTitle}
           accessibilityLabel={titleLabel}>
+          <View style={localStyles.headerTitleChevronSpacer} />
           <Text style={themeStyles.sidebarLinkTextBold}>{titleLabel}</Text>
           <Icon
             src={KirokuIcons.DownArrow}

--- a/src/components/DateSelectorModal/Calendar.tsx
+++ b/src/components/DateSelectorModal/Calendar.tsx
@@ -49,8 +49,14 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  headerTitle: {
+  // PressableWithFeedback applies `style` to the inner pressable, not to the
+  // OpacityView wrapper that is the actual flex child of the header row. The
+  // grow-to-fill must live on `wrapperStyle` or the title collapses to content
+  // width and the whole row packs to the left.
+  headerTitleWrapper: {
     flex: 1,
+  },
+  headerTitle: {
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -263,6 +269,7 @@ function Calendar(props: CalendarProps) {
         <PressableWithFeedback
           onPress={() => setView(view === 'month' ? 'overview' : 'month')}
           hoverDimmingValue={1}
+          wrapperStyle={localStyles.headerTitleWrapper}
           style={localStyles.headerTitle}
           accessibilityLabel={titleLabel}>
           <View style={localStyles.headerTitleChevronSpacer} />


### PR DESCRIPTION
## Summary
- The date-range picker (Statistics) and the new/edit-session date picker share one calendar header (`src/components/DateSelectorModal/Calendar.tsx`). The header centers `month/year label + dropdown chevron` as a group, which pushes the visible label ~8px left of true center.
- Add a 16px leading spacer inside the title pressable that mirrors the trailing chevron (12px icon + 4px `ml1`), so the label is the true horizontal center between the edge arrows. The chevron (year-overview affordance) is unchanged.
- Side effect: because the title content is now symmetric, the label no longer shifts horizontally when toggling between the month view and the year overview (where the arrows are hidden).

## Test plan
- [ ] Statistics → tap "Custom" range → date-selector modal: month/year label is centered between the edge arrows; tapping the label into the year overview and back does not shift it.
- [ ] New session / edit session date → full-screen `SessionDateScreen` calendar: same centered label + edge arrows, no jump on overview toggle.
- [ ] Long month names / RTL still center (equal flanks on both sides of the label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)