### PR TITLE
fix(calendar): size fullscreen skeleton day cells to match real grid

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarSkeleton.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native';
 import Skeleton from '@components/Skeleton';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
 
 // 7 day-name columns and a couple of month sections of ~6 week rows each —
 // enough to fill the viewport so the loading state reads as a calendar rather
@@ -25,6 +26,8 @@ const MONTH_SECTIONS = [0, 1];
 function SessionsCalendarSkeleton() {
   const styles = useThemeStyles();
   const theme = useTheme();
+  const daySize = variables.sessionsCalendarDaySize;
+  const dayRadius = variables.componentBorderRadiusNormal;
 
   return (
     <View
@@ -51,7 +54,12 @@ function SessionsCalendarSkeleton() {
                 <View
                   key={`c-${section}-${week}-${col}`}
                   style={styles.sessionsCalendarWeekCell}>
-                  <Skeleton width={20} height={20} radius={6} animate={false} />
+                  <Skeleton
+                    width={daySize}
+                    height={daySize}
+                    radius={dayRadius}
+                    animate={false}
+                  />
                 </View>
               ))}
             </View>


### PR DESCRIPTION
### Details

The fullscreen sessions-calendar skeleton (`SessionsCalendarSkeleton.tsx`) rendered each day cell as a fixed `20x20` `Skeleton` with `radius={6}`, while the real grid renders `44x44` tiles (`variables.sessionsCalendarDaySize`) with `borderRadius` `variables.componentBorderRadiusNormal` (8) via `StyleUtils.getSessionsCalendarDayCellStyle`. Because each skeleton cell was 24px shorter, every week row was ~24px shorter than the real one, so the skeleton→calendar swap jolted vertically and the placeholders read as small dots rather than full tiles.

This drives the skeleton cells from `variables.sessionsCalendarDaySize` / `variables.componentBorderRadiusNormal`, mirroring the already-corrected compact skeleton (`SessionsCalendarCompactSkeleton.tsx`). `animate={false}` is preserved.

Day-name and month-label alignment is unaffected: the skeleton and `SessionsCalendarWeekListView` share the same styles (`sessionsCalendarDayNamesRow`, `sessionsCalendarDayNameCell`, `sessionsCalendarMonthLabel`, `sessionsCalendarMonthLabelRule`) — only the day-cell size diverged.

### Tests

1. Navigate to the fullscreen sessions calendar so the skeleton shows during mount/initial scroll.
2. Verify the skeleton day cells are full `44x44` tiles (matching the real grid), not small dots.
3. Verify that when the real calendar replaces the skeleton, there is no vertical jolt — week rows stay at the same vertical position through the swap.
4. Verify the day-name header row and month-label spacing line up with the real `SessionsCalendarWeekListView`.

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed; this is a presentational-only fix.

### QA Steps

1. Open the fullscreen calendar.
2. Confirm the loading skeleton matches the calendar grid geometry and the transition does not visibly shift.

- [ ] Verify that no errors appear in the JS console

Notes for reviewer:
- Local tooling run on the changed file: prettier (no changes), `typecheck-tsgo` (clean), `react-compiler-compliance-check check-changed` (passed), `scripts/lint.sh` (clean).
- Not yet verified on a device/simulator — the geometry now matches by construction, but a visual confirmation of the swap is still worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)