### PR TITLE
investigation(statistics): timezone offset-table regresses on Hermes — keep baseline

### DIFF
--- a/STATS_PERF_REPORT.md
+++ b/STATS_PERF_REPORT.md
@@ -11,14 +11,39 @@ per-timestamp `formatInTimeZone` (date-fns-tz) calls were collapsed into one
 cached `Intl.DateTimeFormat` + `formatToParts`, with ISO-week / day-of-week
 derived arithmetically. **That is the baseline this report measures against.**
 
-**TL;DR:** The per-timestamp `Intl` call is still ~60–66% of the pass. Resolving
-each timezone's UTC-offset transitions _once_ into a small table and then
-deriving every local field by pure integer arithmetic (candidate **c**) is
-**~2× faster on large datasets (up to ~4× on small/no-DST)**, allocates ~30%
-fewer GC cycles, is byte-identical across an exhaustive timezone sweep, and is in
-fact _more_ correct than date-fns-tz at DST boundaries. **Candidate (c) has been
-adopted into `events.ts`**; the public signature and `DrinkEvent` shape are
-unchanged and all existing tests pass.
+**TL;DR (node):** The per-timestamp `Intl` call is ~60–66% of the pass.
+Resolving each timezone's UTC-offset transitions _once_ into a table and deriving
+every local field by integer arithmetic (candidate **c**) is **~2× faster on
+large datasets in node (V8)**, allocates ~30% fewer GC cycles, is byte-identical
+across an exhaustive timezone sweep, and is _more_ correct than date-fns-tz at
+DST boundaries.
+
+> ## ⚠️ Device result: candidate (c) REGRESSES on Hermes — reverted
+>
+> Candidate (c) was adopted, **device-tested, and reverted.** On Hermes it is
+> **~3.5× _slower_** than the baseline for the real workload:
+>
+> | build                                 | `buildDrinkEvents` | dataset                   |
+> | ------------------------------------- | ------------------ | ------------------------- |
+> | master (baseline, 1× `formatToParts`) | **1039 ms**        | 163 sessions → 724 events |
+> | PR (candidate c, offset-table)        | **3703 ms**        | 163 sessions → 724 events |
+>
+> **Why the node benchmark lied** (see the on-device caveat in §1): (1) Hermes
+> `Intl` is ~1000× slower
+> than V8's — the cost is ~linear in the _number of `Intl` calls_ (~2–3 ms each
+> on Hermes). (2) The offset-table replaces "1 `Intl` call per timestamp" with
+> "many `Intl` calls to build a transition table" (coarse scan + ~30-probe binary
+> search per DST transition); cheap on V8, the bottleneck on Hermes. (3) The
+> table-build cost scales with the **data time-span, not the event count** — the
+> real dataset is small (724 events) but spans years (and can contain outlier
+> timestamps that inflate the range), so it did _more_ `Intl` work than the
+> baseline.
+>
+> **Conclusion:** the already-landed 5→1 fix captured the real win (~5×, matching
+> the ~5× drop from 5096 ms → 1039 ms). The baseline is near-optimal for any
+> per-timestamp-`Intl` approach. `events.ts` is left on the baseline. The
+> harness, candidate code, and correctness suite are kept as an investigation
+> record. Real next steps in §6.
 
 ---
 
@@ -55,10 +80,14 @@ unchanged and all existing tests pass.
   from the civil date at noon. See §4 for why date-fns is _not_ used as the
   wall-clock oracle.
 
-> **On-device caveat:** V8 (node) has a relatively fast `Intl`. Hermes' `Intl`
-> is comparatively slower vs. plain arithmetic, so eliminating the per-timestamp
-> `Intl` call should yield a **larger** relative win on device than the node
-> numbers below.
+> **On-device caveat (this prediction was WRONG — see the device-result box
+> above):** I expected Hermes' slower `Intl` to make (c)'s win _larger_ on
+> device. The opposite happened. The flaw: V8's `Intl` is so fast that the
+> offset-table's table-build calls are invisible in node, so the benchmark only
+> measured the per-timestamp savings. On Hermes every `Intl` call costs ~2–3 ms,
+> the table-build calls dominate, and (c) regresses. **Lesson: an `Intl`-heavy
+> setup cost that is free on V8 can be the entire cost on Hermes — micro-benchmark
+> the call _count_, not just node wall-time, and always confirm on device.**
 
 Reproduce:
 
@@ -291,36 +320,53 @@ alone (`useLazyMarkedDates` is a React-Compiler-sensitive hook).
 
 ## 6. Recommendation
 
-**Adopt candidate (c) — done.** It is the only candidate that meaningfully moves
-the ~60% per-timestamp `Intl` cost, delivering ~2× on large data (more on
-device), ~30% fewer GC cycles, byte-identical output validated across an
-exhaustive timezone sweep, and improved DST correctness. Risk is contained: the
-public API is unchanged, output is proven identical, and a permanent oracle suite
-guards it. The one assumption (offset-transition spacing ≥ scan stride) is safe
-for the app's data domain (recent timestamps, standard IANA zones).
+**Keep the baseline; do NOT ship candidate (c).** Device testing (see the box in
+the header) showed (c) is ~3.5× _slower_ on Hermes. `events.ts` has been reverted
+to the baseline on this branch. The already-landed 5→1 `formatInTimeZone` fix
+captured the real win (~5×); the baseline is near-optimal for any approach that
+calls `Intl` per timestamp. This branch/PR keeps the benchmark harness, candidate
+code, and correctness suite as an investigation record — no `events.ts` change
+ships.
 
-Status of the change on this branch:
+What this investigation establishes for the next round:
 
-- `src/libs/Statistics/events.ts` — candidate (c) adopted; signature + shape
-  unchanged.
-- `__tests__/unit/libs/Statistics/events.test.ts` — unchanged, **29/29 pass**.
-- `__tests__/unit/libs/Statistics/eventsCandidates.test.ts` — new, **30/30 pass**
-  (full Statistics suite: 151/151).
-- `npm run typecheck-tsgo` clean · `./scripts/lint.sh` clean.
-- `scripts/perf/` — reproducible benchmark + profiler harness (dev-only, not
-  shipped).
+- **On Hermes, the metric that matters is the _number_ of `Intl` calls** (~2–3 ms
+  each). Any "optimization" that adds `Intl` setup cost — even cost that is free
+  on V8 — can regress. Profile call _count_, and always confirm on device.
+- **`buildDrinkEvents` (1039 ms) is not the biggest cold-open cost — the "chart
+  bundle parsed" step is ~2000 ms** on both builds (lazy-loading the charting
+  library). That is the larger lever.
+- A genuine further win in `buildDrinkEvents` requires **removing `Intl` from the
+  cold path entirely**, not a faster `Intl` strategy.
 
-**Follow-ups (not in this change):**
+**Next steps (each its own session):**
 
-1. Extract the offset resolver into a shared util; migrate `sessionCounts.ts` and
-   `useLazyMarkedDates.ts` off `formatInTimeZone` / `toZonedTime` (§5).
-2. Audit remaining `formatInTimeZone` call sites for the spring-forward
-   off-by-one (§4) — anything still on date-fns-tz inherits the bug.
-3. Optional: persist/precompute the event stream or daily aggregates so cold
-   launches skip the recompute entirely. Feasibility: high (the stream is a pure
-   function of sessions + prefs); rough win: eliminates the build cost on cold
-   open at the price of a cache-invalidation story (sessions, timezone, weekStart,
-   drinkDefaults are all inputs). Worth it only if §6's compute time is still
-   user-visible after (c) — measure on device first.
+1. **Chart bundle (~2 s).** Investigate the ~2000 ms "chart bundle parsed" gate —
+   the single biggest cold-open cost. Likely code-split / lazy-load or lighten
+   the charting library (Skia / victory-native).
+2. **Persist precomputed local fields.** Compute `localDay` / `localHour` /
+   `localIsoWeek` / `localDow` once when a drink is logged (a single `Intl` call
+   at write time, when the user is already interacting) and store them on the
+   record, so `buildDrinkEvents` does **zero `Intl`** on cold open — eliminating
+   the 1039 ms. Feasibility: high (pure function of sessions + prefs); the cost is
+   a migration/backfill for existing drinks + a small write-path change. This is
+   the real `events.ts` win.
+
+**Other follow-ups:**
+
+3. The date-fns-tz spring-forward off-by-one (§4) is real regardless — audit
+   remaining `formatInTimeZone` call sites (`sessionCounts.ts`,
+   `useLazyMarkedDates.ts`, `DateUtils`) (§5). A shared `Intl`-based day-key
+   resolver fixes correctness, but note the Hermes lesson: keep it to **one**
+   `Intl` call per item, no table build.
 4. Remove the dev-only profiler (`src/libs/Statistics/profiling.ts`) once the
-   Statistics load is confirmed acceptable on device.
+   Statistics load is acceptable on device.
+
+Status on this branch:
+
+- `src/libs/Statistics/events.ts` — **reverted to baseline** (no change ships).
+- `__tests__/unit/libs/Statistics/events.test.ts` — **29/29 pass**.
+- `__tests__/unit/libs/Statistics/eventsCandidates.test.ts` — investigation suite,
+  **30/30 pass** (candidates a/b/c all match the oracle; (c) is correct, just slow
+  on device).
+- `scripts/perf/` — reproducible benchmark + profiler harness (dev-only).

--- a/STATS_PERF_REPORT.md
+++ b/STATS_PERF_REPORT.md
@@ -1,0 +1,326 @@
+# Statistics event-stream materialization — performance deep-dive
+
+**Scope:** `buildDrinkEvents` in `src/libs/Statistics/events.ts` — the function
+that turns raw Onyx drinking sessions into the flat `DrinkEvent[]` every
+Statistics chart reduces over. A cold Statistics open took ~5 s; an in-app
+profiler (`src/libs/Statistics/profiling.ts`) pinned the cost to this function
+(~5096 ms for 161 sessions → 717 events on device), entirely CPU — no I/O.
+
+A first optimization already landed on `claude/sleepy-satoshi-d9cb40`: the five
+per-timestamp `formatInTimeZone` (date-fns-tz) calls were collapsed into one
+cached `Intl.DateTimeFormat` + `formatToParts`, with ISO-week / day-of-week
+derived arithmetically. **That is the baseline this report measures against.**
+
+**TL;DR:** The per-timestamp `Intl` call is still ~60–66% of the pass. Resolving
+each timezone's UTC-offset transitions _once_ into a small table and then
+deriving every local field by pure integer arithmetic (candidate **c**) is
+**~2× faster on large datasets (up to ~4× on small/no-DST)**, allocates ~30%
+fewer GC cycles, is byte-identical across an exhaustive timezone sweep, and is in
+fact _more_ correct than date-fns-tz at DST boundaries. **Candidate (c) has been
+adopted into `events.ts`**; the public signature and `DrinkEvent` shape are
+unchanged and all existing tests pass.
+
+---
+
+## 1. Methodology
+
+- **Isolated micro-benchmarks**, not the in-app trace. The in-app number is
+  inflated 1–2 orders of magnitude by Hermes dev mode + React dev mode; it tells
+  us _where_ the cost is, not a clean ms figure. The harness calls
+  `buildDrinkEvents` directly on synthetic data with real `performance.now()`.
+- **Run outside Jest.** `jest.config.js` sets `fakeTimers.enableGlobally`, which
+  freezes `performance.now()` — useless for timing. The benchmark runs under
+  `ts-node` (`scripts/perf/`); Jest is used only for correctness.
+- **Datasets** (`scripts/perf/statsDataset.ts`): deterministic (seeded
+  mulberry32 PRNG), near-daily sessions over 1 / 3 / 5 years, 1–8 drink
+  timestamps per session, 1–6 drink types per timestamp, 30% v2-A object
+  entries. Sizes land near the 1k / 10k / 50k event targets:
+
+  | dataset | span | sessions | events |
+  | ------- | ---- | -------- | ------ |
+  | small   | 1 yr | 326      | 1,307  |
+  | medium  | 3 yr | 998      | 12,302 |
+  | large   | 5 yr | 1,785    | 48,320 |
+
+- **Timing:** warmup iterations then N timed iterations; report **median ms**
+  (± stdev). A fresh top-level `sessions` wrapper is passed each iteration so the
+  module-level identity cache in `buildDrinkEvents` never short-circuits real
+  work.
+- **Profiling:** node `--cpu-prof` (self-time attribution) plus a manual
+  per-segment `performance.now()` breakdown.
+- **GC:** `--trace-gc` in a separate process per candidate (reliable per-process
+  counts).
+- **Correctness oracle:** the platform's native `Intl` for wall-clock fields
+  (the exact engine the app runs on) and date-fns for ISO-week / DOW computed
+  from the civil date at noon. See §4 for why date-fns is _not_ used as the
+  wall-clock oracle.
+
+> **On-device caveat:** V8 (node) has a relatively fast `Intl`. Hermes' `Intl`
+> is comparatively slower vs. plain arithmetic, so eliminating the per-timestamp
+> `Intl` call should yield a **larger** relative win on device than the node
+> numbers below.
+
+Reproduce:
+
+```bash
+ln -s /Users/petr/code/Kiroku/node_modules node_modules   # worktrees only
+npx ts-node --project scripts/perf/tsconfig.json scripts/perf/statsEventsBench.ts
+npx ts-node --project scripts/perf/tsconfig.json scripts/perf/statsEventsBench.ts --segments
+node --expose-gc -r ts-node/register/transpile-only scripts/perf/statsEventsBench.ts --gc   # TS_NODE_PROJECT=scripts/perf/tsconfig.json
+npx jest __tests__/unit/libs/Statistics/eventsCandidates.test.ts
+```
+
+---
+
+## 2. Where the time goes (baseline hot-path)
+
+**Per-segment breakdown** (large dataset, instrumented):
+
+| segment                       | % of pass |
+| ----------------------------- | --------- |
+| `formatToParts` (Intl)        | **60.5%** |
+| `Date` alloc (ISO-week + DOW) | 11.2%     |
+| `events.push`                 | 7.5%      |
+| `normalizeEntry`              | 3.9%      |
+| string building               | 2.9%      |
+| (loop / iteration overhead)   | ~14%      |
+
+**`--cpu-prof` self-time** (baseline, 300× large, independent confirmation):
+
+| function                         | self-time |
+| -------------------------------- | --------- |
+| `resolveLocalParts` (incl. Intl) | **65.8%** |
+| `buildDrinkEvents` (per-event)   | 17.0%     |
+| garbage collector                | 7.0%      |
+| `isoWeekLabel` (2 `Date` allocs) | 6.4%      |
+
+Both methods agree: **timezone resolution dominates (~66–73%)** — the per-
+timestamp `Intl` call plus the `Date` allocations behind ISO-week/DOW (which also
+drive most of the GC). The per-event loop (`normalizeEntry` + SDU + `push`) is
+~17–20% and is the irreducible floor — no timezone trick removes it. This
+predicts the ceiling: an approach that fully eliminates per-timestamp timezone
+work caps out around **3–4×**, and lands at ~2× once the per-event floor
+dominates on large data.
+
+---
+
+## 3. Candidates & results
+
+All candidates keep the exact `buildDrinkEvents` signature and `DrinkEvent`
+output shape (`scripts/perf/statsCandidates.ts`).
+
+- **(a) Baseline** — cached `Intl` formatter, one `formatToParts` per timestamp,
+  ISO-week/DOW via `Date`. _(The already-landed optimization.)_
+- **(b) Day-bucket memo** — one `Intl` offset probe per distinct _local day_
+  (plus a cheap far-edge probe to detect intra-day DST transitions); same-day
+  timestamps derive the hour arithmetically; full per-timestamp probe only on
+  the ≤2 DST-transition days/year.
+- **(c) Offset-table arithmetic** — each zone's UTC-offset _transitions_ are
+  located once (a handful of `Intl` probes via coarse scan + binary search) into
+  a sorted table; every timestamp then resolves to all local fields (day, month,
+  hour, ISO week, DOW) by **pure integer arithmetic** — zero `Intl`, zero `Date`
+  allocation per timestamp.
+
+### Throughput — median ms (node v20, Europe/London, DST)
+
+| candidate           | small (1.3k) | medium (12.3k) | large (48.3k) |
+| ------------------- | ------------ | -------------- | ------------- |
+| (a) baseline        | 3.1          | 11.7           | 39.4          |
+| (b) day-bucket memo | 2.8          | 11.8           | 32.7          |
+| (c) offset-table    | **1.0**      | **5.8**        | **18.8**      |
+
+**Speedup vs baseline:**
+
+| candidate           | small | medium | large |
+| ------------------- | ----- | ------ | ----- |
+| (b) day-bucket memo | 1.10× | 0.99×  | 1.21× |
+| (c) offset-table    | 3.06× | 2.01×  | 2.10× |
+
+No-DST zone (Asia/Tokyo) — (c) does even better because the table is a single
+entry: **3.92× / 2.25× / 2.26×**.
+
+### GC pressure — collections over 200× large (`--trace-gc`, per-process)
+
+| candidate        | total GC | scavenge | major |
+| ---------------- | -------- | -------- | ----- |
+| (a) baseline     | 297      | 282      | 15    |
+| (b) day-bucket   | 196      | 178      | 18    |
+| (c) offset-table | 214      | 192      | 22    |
+
+The output array is identical across candidates (same retained size), so the
+differentiator is _transient_ allocation: the baseline allocates ~3 `Date`
+objects + a parts array + a fields object per timestamp; (c) drops the `Date`
+objects → **~28% fewer GC cycles**, i.e. fewer frame-drop opportunities on
+device.
+
+### Why (b) underperforms
+
+(b) only attacks the per-timestamp work, but (i) its per-day probe must be a
+_full_ (6-field) offset probe plus a transition-edge probe (2 probes/day), and
+(ii) the per-event floor (~17–20%) is untouched. Net: marginal and noisy
+(0.99–1.5×). Not worth its added complexity.
+
+### Maintainability notes
+
+- **(a):** simplest, ~25 lines of tz logic. Per-timestamp `Intl` is the cost.
+- **(b):** medium complexity (day-range cache + transition edge-probe) for a
+  marginal, noisy win. **Rejected.**
+- **(c):** +~120 lines (offset transition table: coarse scan, binary-search
+  transition pinning, table lookup, Hinnant civil-date math). More code, but
+  self-contained and covered by an exhaustive correctness suite kept in-repo.
+  One documented assumption: the transition scan stride (`SCAN_STEP_MS`, 8 days)
+  must be shorter than the gap between consecutive offset transitions in the
+  covered range — true for every IANA zone in the modern era (transitions are
+  months apart), and drink timestamps are recent.
+
+### Post-adoption confirmation
+
+Re-profiling the shipped `events.ts` after adopting (c): total self-time
+**~4.4 s vs ~11.4 s** (300× large) — `formatToParts` is gone from the hot path;
+`offsetSecondsAt` (the `Intl` probe) is now only 12.3% because it runs ~once per
+zone, and the per-event loop (37.3%) is the new top cost — exactly the predicted
+floor. The added range pre-scan (`drinkTimestampRange`) is ~5%.
+
+---
+
+## 4. Correctness
+
+Every candidate must pass the existing
+`__tests__/unit/libs/Statistics/events.test.ts` **unchanged** (29 tests — DST
+forward/backward in Europe/London, Tokyo cross-day, NY fallback, leap day,
+2020-W53 edge, DOW rotation). ✅ All green against the adopted implementation.
+
+A new suite `__tests__/unit/libs/Statistics/eventsCandidates.test.ts` (30 tests)
+exercises all three candidates against the oracle:
+
+- **Hard-timezone oracle sweep** — >10,000 samples per zone (7h11m stride across
+  2017–2026, deliberately off the hour/day grid), for **11 zones**: UTC,
+  Europe/London, America/New_York, Asia/Tokyo, **Asia/Kolkata (+5:30)**,
+  **Asia/Kathmandu (+5:45)**, **Australia/Sydney**, **Pacific/Auckland**
+  (southern-hemisphere DST), **Australia/Lord_Howe (30-minute DST)**,
+  **Pacific/Chatham (+12:45/+13:45)**, **America/Sao_Paulo** (DST abolished
+  2019). ✅
+- **Explicit DST-transition brackets** — ±1 s / ±1 min / ±1 h around each
+  spring-forward and fall-back instant, including Lord Howe's 30-minute jumps. ✅
+- **Pre-1970 instants** — moon landing, 1965, 1955, 1945, 1900 across UTC /
+  London / Kolkata / Tokyo (whole-_second_ offset handling covers LMT). ✅
+- **Cross-equality** — on a 4-year synthetic dataset (>1000 events) in
+  Europe/London, Australia/Lord_Howe, Asia/Kathmandu, Pacific/Auckland, (b) and
+  (c) reproduce the baseline event stream **byte-for-byte** (`toEqual`). ✅
+
+### Finding: date-fns-tz is wrong at the exact spring-forward instant
+
+The brief specified date-fns `formatInTimeZone` as the oracle. While building the
+sweep it surfaced a **date-fns-tz bug**: at the precise spring-forward second the
+clock jumps 01:00→02:00 local, so `2021-03-28 01:00:00 UTC` is `02:00 BST` in
+London. Native `Intl` (and therefore every candidate, including the shipped
+baseline) reports **hour 2**; date-fns-tz reports **hour 3**.
+
+```
+UTC 2021-03-28T01:00:00Z | date-fns-tz: 03:00 (WRONG) | native Intl: 02:00 | a/b/c: 2
+```
+
+Consequences:
+
+1. The oracle was switched to **native `Intl`** for wall-clock fields (the
+   on-device ground truth); ISO-week/DOW use date-fns from the civil date at
+   _noon_ (never a transition instant), keeping that check independent of the
+   candidates' own arithmetic.
+2. The Intl-based event builder (baseline and (c)) is **strictly more correct**
+   than the _original_ date-fns-tz code it replaced — a latent off-by-one-hour
+   bug at DST spring-forward existed in the pre-optimization Statistics path and
+   anywhere else that still calls `formatInTimeZone` (see §5). This is captured
+   by a dedicated regression test.
+
+---
+
+## 5. Cross-repo timezone audit
+
+`rg "formatInTimeZone|date-fns-tz|getTimezoneOffset|Intl.DateTimeFormat" src`
+plus review of Day Overview, SessionsCalendar, and shared date utilities. The
+same "date-fns-tz per item in a loop over a session/event collection" pattern
+recurs:
+
+| call site                                                                                  | pattern                            | heat        | notes                                                                             |
+| ------------------------------------------------------------------------------------------ | ---------------------------------- | ----------- | --------------------------------------------------------------------------------- |
+| `src/libs/Statistics/events.ts`                                                            | per **drink-timestamp**            | **hottest** | optimized here (candidate c)                                                      |
+| `src/libs/Statistics/sessionCounts.ts`                                                     | `formatInTimeZone` per **session** | warm        | same module; a _second_ tz pass over the same data                                |
+| `src/hooks/useLazyMarkedDates.ts`                                                          | `toZonedTime` per **session**      | warm        | powers the **Day Overview** + home calendar; over the loaded range (can be years) |
+| `src/libs/DrinkingSessionUtils.ts` `isDifferentDay`                                        | 2× `formatInTimeZone`              | cold        | one caller (Session Timezone settings screen), per-render                         |
+| `src/libs/DateUtils.ts` (`getLocalizedDateTime`, `getLocalizedDay`, `getZoneAbbreviation`) | `formatInTimeZone` wrappers        | cold-each   | single value per render, but widely used                                          |
+| `src/screens/Badges/BadgesContent.tsx`                                                     | `formatInTimeZone` in a `useMemo`  | cold        | once per mount                                                                    |
+
+Notable: `useLazyMarkedDates` was **already** hand-optimized for the same class
+of problem — its comment notes date-fns `format` is "~100× slower" on Hermes and
+dominated the day-overview mount ("77 months ≈ 2.3k `format` calls ≈ ~460 ms"),
+so they replaced it with raw `Date` getters. The remaining `toZonedTime`
+per-session call is the analogous next step.
+
+### Recommendation: extract a shared timezone resolver
+
+`sessionCounts.ts` and `useLazyMarkedDates.ts` only need _"given (ts, tz) → local
+day key"_ — exactly what candidate (c)'s offset table provides. A shared resolver
+(e.g. `@libs/Statistics/localTime` or a `DateUtils` helper) would be a DRY win
+_and_ a perf win across both Statistics and Day Overview, and would also fix the
+date-fns spring-forward bug in those paths. Sketch of the call-site change:
+
+```ts
+// sessionCounts.ts — today
+dateKey = formatInTimeZone(startMs, sessionTz, 'yyyy-MM-dd'); // 1 Intl / session
+// with a shared resolver
+dateKey = resolver.dayKey(startMs, sessionTz); // pure arithmetic
+```
+
+```ts
+// useLazyMarkedDates.ts — today
+const sessionDate = toZonedTime(session.start_time, tz); // 1 Intl / session
+const dayKey = toDateKey(sessionDate);
+// with a shared resolver
+const dayKey = resolver.dayKey(session.start_time, tz);
+```
+
+These are **per-session** (fewer items than per-drink-timestamp), so the absolute
+win is smaller than in `events.ts`, but it removes a second full timezone pass
+over the same data and unifies the (now bug-free) logic. Prototyped in
+`scripts/perf/statsCandidates.ts` (`offsetSecondsAt` / `partsFromOffset` /
+offset-table are the reusable primitives); migrating the two shipped call sites
+is left as a contained follow-up to keep this change's blast radius on `events.ts`
+alone (`useLazyMarkedDates` is a React-Compiler-sensitive hook).
+
+---
+
+## 6. Recommendation
+
+**Adopt candidate (c) — done.** It is the only candidate that meaningfully moves
+the ~60% per-timestamp `Intl` cost, delivering ~2× on large data (more on
+device), ~30% fewer GC cycles, byte-identical output validated across an
+exhaustive timezone sweep, and improved DST correctness. Risk is contained: the
+public API is unchanged, output is proven identical, and a permanent oracle suite
+guards it. The one assumption (offset-transition spacing ≥ scan stride) is safe
+for the app's data domain (recent timestamps, standard IANA zones).
+
+Status of the change on this branch:
+
+- `src/libs/Statistics/events.ts` — candidate (c) adopted; signature + shape
+  unchanged.
+- `__tests__/unit/libs/Statistics/events.test.ts` — unchanged, **29/29 pass**.
+- `__tests__/unit/libs/Statistics/eventsCandidates.test.ts` — new, **30/30 pass**
+  (full Statistics suite: 151/151).
+- `npm run typecheck-tsgo` clean · `./scripts/lint.sh` clean.
+- `scripts/perf/` — reproducible benchmark + profiler harness (dev-only, not
+  shipped).
+
+**Follow-ups (not in this change):**
+
+1. Extract the offset resolver into a shared util; migrate `sessionCounts.ts` and
+   `useLazyMarkedDates.ts` off `formatInTimeZone` / `toZonedTime` (§5).
+2. Audit remaining `formatInTimeZone` call sites for the spring-forward
+   off-by-one (§4) — anything still on date-fns-tz inherits the bug.
+3. Optional: persist/precompute the event stream or daily aggregates so cold
+   launches skip the recompute entirely. Feasibility: high (the stream is a pure
+   function of sessions + prefs); rough win: eliminates the build cost on cold
+   open at the price of a cache-invalidation story (sessions, timezone, weekStart,
+   drinkDefaults are all inputs). Worth it only if §6's compute time is still
+   user-visible after (c) — measure on device first.
+4. Remove the dev-only profiler (`src/libs/Statistics/profiling.ts`) once the
+   Statistics load is confirmed acceptable on device.

--- a/__tests__/unit/libs/Statistics/eventsCandidates.test.ts
+++ b/__tests__/unit/libs/Statistics/eventsCandidates.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Correctness gate for the `buildDrinkEvents` optimization candidates
+ * (see scripts/perf/statsCandidates.ts and STATS_PERF_REPORT.md).
+ *
+ * Each candidate must reproduce, byte-for-byte, the local wall-clock fields that
+ * date-fns-tz's `formatInTimeZone` yields — the reference oracle. We sweep a
+ * battery of hard timezones (half-hour / 45-min offsets, southern-hemisphere
+ * DST, the 30-minute-DST Lord Howe zone) and pre-1970 instants, then assert all
+ * three candidates agree with the oracle and with each other on a realistic
+ * synthetic dataset.
+ */
+import {formatInTimeZone} from 'date-fns-tz';
+import type {DrinksList} from '@src/types/onyx/Drinks';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {WeekStart} from '@libs/Statistics/types';
+import {
+  buildBaseline,
+  buildDayBucket,
+  buildOffsetTable,
+} from '../../../../scripts/perf/statsCandidates';
+import type {
+  BuildDrinkEvents,
+  DrinkDefaults,
+} from '../../../../scripts/perf/statsCandidates';
+import {
+  generateDataset,
+  DEFAULTS,
+  UNITS,
+} from '../../../../scripts/perf/statsDataset';
+
+const MON: WeekStart = 1;
+
+const CANDIDATES: Array<{name: string; fn: BuildDrinkEvents}> = [
+  {name: '(a) baseline', fn: buildBaseline},
+  {name: '(b) day-bucket', fn: buildDayBucket},
+  {name: '(c) offset-table', fn: buildOffsetTable},
+];
+
+type Oracle = {
+  localDay: string;
+  localMonth: string;
+  localHour: number;
+  localIsoWeek: string;
+  localDow: number;
+  isWeekend: boolean;
+};
+
+const nativeFormatters = new Map<string, Intl.DateTimeFormat>();
+function nativeFormatter(tz: string): Intl.DateTimeFormat {
+  let f = nativeFormatters.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      hourCycle: 'h23',
+    });
+    nativeFormatters.set(tz, f);
+  }
+  return f;
+}
+
+/**
+ * Reference oracle. Wall-clock fields (day / month / hour) come from the
+ * platform's native `Intl` — the exact engine the app runs on, and the ground
+ * truth at DST boundaries (date-fns-tz mis-reports the hour at the precise
+ * spring-forward instant; see the dedicated test below). ISO week / DOW are
+ * computed by date-fns from the civil date taken at NOON (never a transition
+ * instant), giving an implementation independent of the candidates' own
+ * day-count arithmetic.
+ */
+function oracle(ts: number, tz: string, weekStart: WeekStart): Oracle {
+  const fields: Record<string, string> = {};
+  for (const part of nativeFormatter(tz).formatToParts(ts)) {
+    fields[part.type] = part.value;
+  }
+  const localDay = `${fields.year}-${fields.month}-${fields.day}`;
+  const localMonth = `${fields.year}-${fields.month}`;
+  const localHour = Number(fields.hour) % 24;
+
+  const noonUtc = Date.UTC(
+    Number(fields.year),
+    Number(fields.month) - 1,
+    Number(fields.day),
+    12,
+  );
+  const localIsoWeek = formatInTimeZone(noonUtc, 'UTC', "RRRR-'W'II");
+  // date-fns 'i' → 1=Mon..7=Sun; calendarDow 0=Sun..6=Sat is (iso % 7).
+  const calendarDow = Number(formatInTimeZone(noonUtc, 'UTC', 'i')) % 7;
+  const localDow = (calendarDow - weekStart + 7) % 7;
+  const isWeekend = calendarDow === 0 || calendarDow === 6;
+  return {localDay, localMonth, localHour, localIsoWeek, localDow, isWeekend};
+}
+
+/** A one-drink session at `ts` in `tz`, so each candidate yields one event. */
+function singleEventSessions(
+  ts: number,
+  tz: SelectedTimezone,
+): UserDrinkingSessionsList {
+  const drinks: DrinksList = {[String(ts)]: {beer: 1}};
+  return {
+    u: {s: {start_time: ts, timezone: tz, drinks}},
+  };
+}
+
+/** Timezones spanning the hard cases called out in the perf brief. */
+const HARD_ZONES: string[] = [
+  'UTC',
+  'Europe/London', // EU DST
+  'America/New_York', // US DST
+  'Asia/Tokyo', // no DST, +9
+  'Asia/Kolkata', // +5:30, no DST
+  'Asia/Kathmandu', // +5:45, no DST
+  'Australia/Sydney', // southern-hemisphere DST
+  'Pacific/Auckland', // southern-hemisphere DST
+  'Australia/Lord_Howe', // +10:30 / +11:00 — 30-minute DST
+  'Pacific/Chatham', // +12:45 / +13:45
+  'America/Sao_Paulo', // southern DST (abolished 2019)
+];
+
+describe('buildDrinkEvents candidates — oracle sweep across hard timezones', () => {
+  // Sweep a multi-year window at a 7h11m stride (deliberately not aligned to
+  // the hour/day grid) so samples land on varied wall-clock times, then add
+  // explicit instants around DST transitions.
+  const STRIDE = 7 * 3600000 + 11 * 60000;
+  const START = Date.UTC(2017, 0, 1, 0, 0, 0);
+  const END = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+  it.each(HARD_ZONES)('matches the date-fns oracle across %s', zone => {
+    const tz = zone as SelectedTimezone;
+    let checked = 0;
+    for (let ts = START; ts < END; ts += STRIDE) {
+      const want = oracle(ts, zone, MON);
+      for (const {name, fn} of CANDIDATES) {
+        const [ev] = fn(singleEventSessions(ts, tz), UNITS, DEFAULTS, tz, MON);
+        if (
+          ev.localDay !== want.localDay ||
+          ev.localMonth !== want.localMonth ||
+          ev.localHour !== want.localHour ||
+          ev.localIsoWeek !== want.localIsoWeek ||
+          ev.localDow !== want.localDow ||
+          ev.isWeekend !== want.isWeekend
+        ) {
+          throw new Error(
+            `${name} mismatch in ${zone} at ts=${ts} (${new Date(
+              ts,
+            ).toISOString()})\n  got:  ${JSON.stringify({
+              localDay: ev.localDay,
+              localMonth: ev.localMonth,
+              localHour: ev.localHour,
+              localIsoWeek: ev.localIsoWeek,
+              localDow: ev.localDow,
+              isWeekend: ev.isWeekend,
+            })}\n  want: ${JSON.stringify(want)}`,
+          );
+        }
+      }
+      checked += 1;
+    }
+    expect(checked).toBeGreaterThan(10000);
+  });
+});
+
+describe('buildDrinkEvents candidates — explicit DST-transition instants', () => {
+  // Bracket each transition: ±1 min, ±1 h around the documented UTC instant.
+  type Probe = {zone: string; around: number; label: string};
+  const probes: Probe[] = [
+    {zone: 'Europe/London', around: Date.UTC(2024, 2, 31, 1), label: 'GMT→BST'},
+    {zone: 'Europe/London', around: Date.UTC(2024, 9, 27, 1), label: 'BST→GMT'},
+    {
+      zone: 'America/New_York',
+      around: Date.UTC(2024, 2, 10, 7),
+      label: 'EST→EDT',
+    },
+    {
+      zone: 'America/New_York',
+      around: Date.UTC(2024, 10, 3, 6),
+      label: 'EDT→EST',
+    },
+    {
+      zone: 'Australia/Sydney',
+      around: Date.UTC(2024, 3, 6, 16),
+      label: 'AEDT→AEST',
+    },
+    {
+      zone: 'Australia/Sydney',
+      around: Date.UTC(2024, 9, 5, 16),
+      label: 'AEST→AEDT',
+    },
+    {
+      zone: 'Pacific/Auckland',
+      around: Date.UTC(2024, 3, 6, 14),
+      label: 'NZDT→NZST',
+    },
+    {
+      zone: 'Australia/Lord_Howe',
+      around: Date.UTC(2024, 3, 6, 15, 30),
+      label: 'LHDT→LHST (30min)',
+    },
+    {
+      zone: 'Australia/Lord_Howe',
+      around: Date.UTC(2024, 9, 5, 16),
+      label: 'LHST→LHDT (30min)',
+    },
+  ];
+
+  const deltas = [
+    -3600000,
+    -60000,
+    -1000,
+    0,
+    1000,
+    60000,
+    3600000,
+    2 * 3600000,
+  ];
+
+  it.each(probes)(
+    '$zone $label brackets match the oracle',
+    ({zone, around}) => {
+      const tz = zone as SelectedTimezone;
+      for (const d of deltas) {
+        const ts = around + d;
+        const want = oracle(ts, zone, MON);
+        for (const {name, fn} of CANDIDATES) {
+          const [ev] = fn(
+            singleEventSessions(ts, tz),
+            UNITS,
+            DEFAULTS,
+            tz,
+            MON,
+          );
+          expect({
+            who: name,
+            localDay: ev.localDay,
+            localHour: ev.localHour,
+            localIsoWeek: ev.localIsoWeek,
+            localDow: ev.localDow,
+            isWeekend: ev.isWeekend,
+          }).toEqual({
+            who: name,
+            localDay: want.localDay,
+            localHour: want.localHour,
+            localIsoWeek: want.localIsoWeek,
+            localDow: want.localDow,
+            isWeekend: want.isWeekend,
+          });
+        }
+      }
+    },
+  );
+});
+
+describe('buildDrinkEvents candidates — pre-1970 timestamps', () => {
+  const preEpoch = [
+    Date.UTC(1969, 6, 20, 20, 17), // moon landing
+    Date.UTC(1965, 0, 1, 0, 30),
+    Date.UTC(1955, 11, 31, 23, 30),
+    Date.UTC(1945, 4, 8, 12),
+    Date.UTC(1900, 0, 1, 0, 0),
+  ];
+  const zones: string[] = [
+    'UTC',
+    'Europe/London',
+    'Asia/Kolkata',
+    'Asia/Tokyo',
+  ];
+
+  it.each(zones)('matches the oracle for pre-1970 instants in %s', zone => {
+    const tz = zone as SelectedTimezone;
+    for (const ts of preEpoch) {
+      const want = oracle(ts, zone, MON);
+      for (const {name, fn} of CANDIDATES) {
+        const [ev] = fn(singleEventSessions(ts, tz), UNITS, DEFAULTS, tz, MON);
+        expect({
+          who: name,
+          localDay: ev.localDay,
+          localMonth: ev.localMonth,
+          localHour: ev.localHour,
+        }).toEqual({
+          who: name,
+          localDay: want.localDay,
+          localMonth: want.localMonth,
+          localHour: want.localHour,
+        });
+      }
+    }
+  });
+});
+
+describe('finding: date-fns-tz mis-reports the spring-forward instant', () => {
+  // At the exact spring-forward second the clock jumps 01:00→02:00 local, so
+  // 01:00:00 UTC = 02:00 BST. Native Intl (and therefore every candidate)
+  // reports hour 2; date-fns-tz reports hour 3. This is why the Intl-based
+  // event builder is strictly MORE correct than the original date-fns-tz code.
+  const ts = Date.UTC(2021, 2, 28, 1); // 2021-03-28 01:00:00 UTC, London
+
+  it('native Intl and all candidates agree on hour 2', () => {
+    const tz = 'Europe/London' as SelectedTimezone;
+    const nativeHour = Number(
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: 'Europe/London',
+        hour: '2-digit',
+        hourCycle: 'h23',
+      }).format(ts),
+    );
+    expect(nativeHour).toBe(2);
+    for (const {fn} of CANDIDATES) {
+      const [ev] = fn(singleEventSessions(ts, tz), UNITS, DEFAULTS, tz, MON);
+      expect(ev.localHour).toBe(2);
+    }
+  });
+
+  it('date-fns-tz disagrees (reports hour 3) — documented bug', () => {
+    expect(Number(formatInTimeZone(ts, 'Europe/London', 'HH'))).toBe(3);
+  });
+});
+
+describe('buildDrinkEvents candidates — cross-equality on synthetic data', () => {
+  const zones: SelectedTimezone[] = [
+    'Europe/London',
+    'Australia/Lord_Howe',
+    'Asia/Kathmandu',
+    'Pacific/Auckland',
+  ] as SelectedTimezone[];
+
+  it.each(zones)(
+    'b and c reproduce the baseline event stream exactly (%s)',
+    zone => {
+      const ds = generateDataset({
+        years: 4,
+        sessionDensity: 0.7,
+        minTimestamps: 1,
+        maxTimestamps: 6,
+        minTypes: 1,
+        maxTypes: 4,
+        v2Fraction: 0.4,
+        timezone: zone,
+        seed: 42,
+      });
+      const defaults: DrinkDefaults = DEFAULTS;
+      const base = buildBaseline(ds.sessions, UNITS, defaults, zone, MON);
+      const b = buildDayBucket(ds.sessions, UNITS, defaults, zone, MON);
+      const c = buildOffsetTable(ds.sessions, UNITS, defaults, zone, MON);
+      expect(base.length).toBeGreaterThan(1000);
+      expect(b).toEqual(base);
+      expect(c).toEqual(base);
+    },
+  );
+});

--- a/scripts/perf/benchGlobals.ts
+++ b/scripts/perf/benchGlobals.ts
@@ -1,0 +1,14 @@
+/**
+ * Side-effect import that defines the React Native `__DEV__` global before any
+ * app source is loaded. `src/libs/Statistics/profiling.ts` references `__DEV__`
+ * at module-evaluation time; under ts-node (the benchmark runner) that global
+ * does not exist and would throw `ReferenceError`. Jest already injects
+ * `__DEV__`, so the nullish guard leaves it untouched there.
+ *
+ * Import this FIRST, before importing anything under `@libs`/`@src`.
+ */
+const g = globalThis as Record<string, unknown>;
+// eslint-disable-next-line no-underscore-dangle
+g.__DEV__ ??= false;
+
+export {};

--- a/scripts/perf/statsCandidates.ts
+++ b/scripts/perf/statsCandidates.ts
@@ -1,0 +1,640 @@
+/* eslint-disable no-bitwise */
+/**
+ * Benchmark + correctness candidates for `buildDrinkEvents`.
+ *
+ * This module is NOT shipped (it lives under `scripts/`) and is imported by
+ * both the ts-node benchmark (`statsEventsBench.ts`) and the jest correctness
+ * suite (`__tests__/unit/libs/Statistics/eventsCandidates.test.ts`). Every
+ * candidate keeps the exact public signature of `buildDrinkEvents` and emits
+ * the identical `DrinkEvent` shape, so they are drop-in comparable.
+ *
+ *   (a) baseline      — the shipped implementation (1 formatToParts / timestamp
+ *                       + Date-based ISO-week + DOW). Re-exported, not copied.
+ *   (b) day-bucket    — one Intl probe per distinct local day (plus a cheap
+ *                       transition probe); same-day timestamps derive the hour
+ *                       arithmetically. Full formatToParts only on the ≤2
+ *                       DST-transition days per year.
+ *   (c) offset-table  — per-zone offset-transition table built with a handful
+ *                       of Intl probes; every timestamp then resolves with pure
+ *                       integer arithmetic (zero Intl in steady state).
+ */
+import './benchGlobals';
+import buildBaselineImpl from '@libs/Statistics/events';
+import {sduFrom} from '@libs/Statistics/sdu';
+import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
+import type DrinkingSession from '@src/types/onyx/DrinkingSession';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+import type {DrinksToUnits} from '@src/types/onyx/Preferences';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {DrinkEvent, WeekStart} from '@libs/Statistics/types';
+
+type DrinkDefaults = Partial<Record<DrinkKey, {ml: number; abv: number}>>;
+
+type BuildDrinkEvents = (
+  sessions: UserDrinkingSessionsList | undefined,
+  drinksToUnits: DrinksToUnits | undefined,
+  drinkDefaults: DrinkDefaults | undefined,
+  timezone: SelectedTimezone,
+  weekStart: WeekStart,
+) => DrinkEvent[];
+
+// ───────────────────────────── shared internals ─────────────────────────────
+
+type NormalizedEntry = {count: number; volumeMl?: number; abv?: number};
+
+function normalizeEntry(raw: unknown): NormalizedEntry | null {
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw) || raw <= 0) {
+      return null;
+    }
+    return {count: raw};
+  }
+  if (raw && typeof raw === 'object') {
+    const obj = raw as {count?: unknown; volume_ml?: unknown; abv?: unknown};
+    const count =
+      typeof obj.count === 'number' &&
+      Number.isFinite(obj.count) &&
+      obj.count > 0
+        ? obj.count
+        : null;
+    if (count === null) {
+      return null;
+    }
+    const volumeMl =
+      typeof obj.volume_ml === 'number' && Number.isFinite(obj.volume_ml)
+        ? obj.volume_ml
+        : undefined;
+    const abv =
+      typeof obj.abv === 'number' && Number.isFinite(obj.abv)
+        ? obj.abv
+        : undefined;
+    return {count, volumeMl, abv};
+  }
+  return null;
+}
+
+function computeSdu(
+  entry: NormalizedEntry,
+  defaults: {ml: number; abv: number} | undefined,
+): number | undefined {
+  const ml = entry.volumeMl ?? defaults?.ml;
+  const abv = entry.abv ?? defaults?.abv;
+  if (ml === undefined || abv === undefined) {
+    return undefined;
+  }
+  return sduFrom(ml, abv) * entry.count;
+}
+
+// ─────────────────────── pure proleptic-Gregorian math ───────────────────────
+// Howard Hinnant's days<->civil algorithms. Operate on "days since 1970-01-01".
+
+/** Days since the Unix epoch for a Y/M/D (Gregorian). */
+function daysFromCivil(y: number, m: number, d: number): number {
+  const yy = y - (m <= 2 ? 1 : 0);
+  const era = Math.floor((yy >= 0 ? yy : yy - 399) / 400);
+  const yoe = yy - era * 400;
+  const doy = Math.floor((153 * (m + (m > 2 ? -3 : 9)) + 2) / 5) + d - 1;
+  const doe = yoe * 365 + Math.floor(yoe / 4) - Math.floor(yoe / 100) + doy;
+  return era * 146097 + doe - 719468;
+}
+
+/** Inverse of {@link daysFromCivil}: [year, month, day] from days since epoch. */
+function civilFromDays(z: number): [number, number, number] {
+  const zz = z + 719468;
+  const era = Math.floor((zz >= 0 ? zz : zz - 146096) / 146097);
+  const doe = zz - era * 146097;
+  const yoe = Math.floor(
+    (doe -
+      Math.floor(doe / 1460) +
+      Math.floor(doe / 36524) -
+      Math.floor(doe / 146096)) /
+      365,
+  );
+  const y = yoe + era * 400;
+  const doy = doe - (365 * yoe + Math.floor(yoe / 4) - Math.floor(yoe / 100));
+  const mp = Math.floor((5 * doy + 2) / 153);
+  const d = doy - Math.floor((153 * mp + 2) / 5) + 1;
+  const m = mp + (mp < 10 ? 3 : -9);
+  return [y + (m <= 2 ? 1 : 0), m, d];
+}
+
+const D2 = (n: number) => (n < 10 ? `0${n}` : String(n));
+
+/** ISO-8601 week label from a day-count, matching the baseline's output. */
+function isoWeekLabelFromDays(dayCount: number): string {
+  const calendarDow = ((((dayCount % 7) + 4) % 7) + 7) % 7; // 0=Sun..6=Sat
+  const dayFromMonday = (calendarDow + 6) % 7;
+  const thursdayDays = dayCount - dayFromMonday + 3;
+  const [isoYear] = civilFromDays(thursdayDays);
+  const jan4 = daysFromCivil(isoYear, 1, 4);
+  const jan4Dow = ((((jan4 % 7) + 4) % 7) + 7) % 7;
+  const firstOffset = (jan4Dow + 6) % 7;
+  const firstThursdayDays = jan4 - firstOffset + 3;
+  const week = 1 + Math.round((thursdayDays - firstThursdayDays) / 7);
+  return `${String(isoYear).padStart(4, '0')}-W${D2(week)}`;
+}
+
+type LocalParts = {
+  localDay: string;
+  localMonth: string;
+  localHour: number;
+  localIsoWeek: string;
+  calendarDow: number;
+};
+
+/** Build the per-day bundle (everything except the hour) from a day-count. */
+function bundleFromDayCount(dayCount: number): Omit<LocalParts, 'localHour'> {
+  const [y, m, d] = civilFromDays(dayCount);
+  const calendarDow = ((((dayCount % 7) + 4) % 7) + 7) % 7;
+  return {
+    localDay: `${String(y).padStart(4, '0')}-${D2(m)}-${D2(d)}`,
+    localMonth: `${String(y).padStart(4, '0')}-${D2(m)}`,
+    localIsoWeek: isoWeekLabelFromDays(dayCount),
+    calendarDow,
+  };
+}
+
+// One full `Intl` formatter per zone, used to probe offsets.
+const offsetFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getOffsetFormatter(tz: string): Intl.DateTimeFormat {
+  let f = offsetFormatters.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    });
+    offsetFormatters.set(tz, f);
+  }
+  return f;
+}
+
+/**
+ * Whole-second UTC offset for `ts` in `tz`, via one full Intl probe.
+ * `localWallSecond - utcSecond`. Robust for half-hour / 45-minute zones.
+ */
+function offsetSecondsAt(ts: number, tz: string): number {
+  const fields: Record<string, string> = {};
+  for (const part of getOffsetFormatter(tz).formatToParts(ts)) {
+    fields[part.type] = part.value;
+  }
+  const y = Number(fields.year);
+  const mo = Number(fields.month);
+  const d = Number(fields.day);
+  const h = Number(fields.hour) % 24;
+  const mi = Number(fields.minute);
+  const s = Number(fields.second);
+  const localWallSec = daysFromCivil(y, mo, d) * 86400 + h * 3600 + mi * 60 + s;
+  const utcSec = Math.floor(ts / 1000);
+  return localWallSec - utcSec;
+}
+
+/** Derive all local fields from a UTC `ts` and a known whole-second offset. */
+function partsFromOffset(ts: number, offsetSec: number): LocalParts {
+  const localMs = ts + offsetSec * 1000;
+  const dayCount = Math.floor(localMs / 86400000);
+  const secOfDay = Math.floor((localMs - dayCount * 86400000) / 1000);
+  const bundle = bundleFromDayCount(dayCount);
+  return {...bundle, localHour: Math.floor(secOfDay / 3600)};
+}
+
+// ───────────────────────────── (b) day-bucket ───────────────────────────────
+
+/**
+ * One Intl probe per distinct local day. On entering a new day we probe the
+ * offset, then probe the offset at the day's far edge: if they agree the whole
+ * local day shares one offset and same-day timestamps resolve by arithmetic; if
+ * they disagree (a DST-transition day, ≤2/year) we fall back to a per-timestamp
+ * full probe so the boundary stays exact.
+ */
+function makeDayBucketResolver() {
+  type Cache = {
+    tz: string;
+    dayStartUtc: number;
+    dayEndUtc: number;
+    offsetSec: number;
+    transitionDay: boolean;
+    bundle: Omit<LocalParts, 'localHour'>;
+  };
+  let cache: Cache | null = null;
+
+  return function resolve(ts: number, tz: string): LocalParts {
+    if (
+      cache &&
+      cache.tz === tz &&
+      ts >= cache.dayStartUtc &&
+      ts < cache.dayEndUtc
+    ) {
+      if (cache.transitionDay) {
+        return partsFromOffset(ts, offsetSecondsAt(ts, tz));
+      }
+      const localMs = ts + cache.offsetSec * 1000;
+      const dayCount = Math.floor(localMs / 86400000);
+      const secOfDay = Math.floor((localMs - dayCount * 86400000) / 1000);
+      return {...cache.bundle, localHour: Math.floor(secOfDay / 3600)};
+    }
+
+    const offsetSec = offsetSecondsAt(ts, tz);
+    const localMs = ts + offsetSec * 1000;
+    const dayCount = Math.floor(localMs / 86400000);
+    const dayStartUtc = dayCount * 86400000 - offsetSec * 1000;
+    const dayEndUtc = dayStartUtc + 86400000;
+    // Probe the far edge to detect an intra-day transition cheaply.
+    const offsetAtEnd = offsetSecondsAt(dayEndUtc - 1000, tz);
+    const transitionDay = offsetAtEnd !== offsetSec;
+    const bundle = bundleFromDayCount(dayCount);
+    cache = {
+      tz,
+      dayStartUtc,
+      dayEndUtc,
+      offsetSec,
+      transitionDay,
+      bundle,
+    };
+    if (transitionDay) {
+      return partsFromOffset(ts, offsetSecondsAt(ts, tz));
+    }
+    const secOfDay = Math.floor((localMs - dayCount * 86400000) / 1000);
+    return {...bundle, localHour: Math.floor(secOfDay / 3600)};
+  };
+}
+
+// ───────────────────────────── (c) offset-table ─────────────────────────────
+
+type OffsetTable = {
+  tz: string;
+  lo: number;
+  hi: number;
+  // Parallel sorted arrays: boundary[i] is the first UTC ms at which offset[i]
+  // applies; offset[i] holds until boundary[i+1].
+  boundary: number[];
+  offset: number[];
+};
+
+// Scan step for locating transitions. Must be shorter than the shortest gap
+// between two consecutive offset transitions for every zone we resolve. DST
+// dwell is ≥ ~4 months for the supported zones; 8 days is comfortably safe and
+// keeps the probe budget tiny (≈ range/8d Intl calls, once per zone).
+const SCAN_STEP_MS = 8 * 86400000;
+
+/** Binary-search the exact transition instant in (loTs, hiTs] to ms precision. */
+function findTransition(
+  loTs: number,
+  loOff: number,
+  hiTs: number,
+  tz: string,
+): {at: number; off: number} {
+  let lo = loTs;
+  let hi = hiTs;
+  while (hi - lo > 1) {
+    const mid = lo + Math.floor((hi - lo) / 2);
+    if (offsetSecondsAt(mid, tz) === loOff) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return {at: hi, off: offsetSecondsAt(hi, tz)};
+}
+
+function computeOffsetTable(tz: string, lo: number, hi: number): OffsetTable {
+  const boundary: number[] = [];
+  const offset: number[] = [];
+  let prevOff = offsetSecondsAt(lo, tz);
+  boundary.push(lo);
+  offset.push(prevOff);
+  let cursor = lo;
+  while (cursor < hi) {
+    const next = Math.min(cursor + SCAN_STEP_MS, hi);
+    const nextOff = offsetSecondsAt(next, tz);
+    if (nextOff !== prevOff) {
+      // A transition lies in (cursor, next]; pin it exactly, then continue
+      // from the transition (handles multiple transitions in one step too).
+      let segLo = cursor;
+      let segLoOff = prevOff;
+      // Loop in case the step straddles >1 transition.
+      for (;;) {
+        const t = findTransition(segLo, segLoOff, next, tz);
+        boundary.push(t.at);
+        offset.push(t.off);
+        prevOff = t.off;
+        segLo = t.at;
+        segLoOff = t.off;
+        if (offsetSecondsAt(next, tz) === t.off) {
+          break;
+        }
+      }
+    }
+    cursor = next;
+  }
+  return {tz, lo, hi, boundary, offset};
+}
+
+function offsetFromTable(table: OffsetTable, ts: number): number {
+  const {boundary, offset} = table;
+  // Binary search: last boundary <= ts.
+  let lo = 0;
+  let hi = boundary.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (boundary[mid] <= ts) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return offset[lo];
+}
+
+function makeOffsetTableResolver(globalLo: number, globalHi: number) {
+  const tables = new Map<string, OffsetTable>();
+  return function resolve(ts: number, tz: string): LocalParts {
+    let table = tables.get(tz);
+    if (!table) {
+      // Pad the range by one scan step so edge timestamps stay covered.
+      table = computeOffsetTable(
+        tz,
+        globalLo - SCAN_STEP_MS,
+        globalHi + SCAN_STEP_MS,
+      );
+      tables.set(tz, table);
+    }
+    return partsFromOffset(ts, offsetFromTable(table, ts));
+  };
+}
+
+// ─────────────────── generic builder shared by (b) and (c) ───────────────────
+
+type Resolver = (ts: number, tz: string) => LocalParts;
+
+function buildWithResolver(
+  sessions: UserDrinkingSessionsList | undefined,
+  drinksToUnits: DrinksToUnits | undefined,
+  drinkDefaults: DrinkDefaults | undefined,
+  timezone: SelectedTimezone,
+  weekStart: WeekStart,
+  makeResolver: () => Resolver,
+): DrinkEvent[] {
+  const events: DrinkEvent[] = [];
+  if (!sessions) {
+    return events;
+  }
+  const resolve = makeResolver();
+  for (const userId of Object.keys(sessions)) {
+    const userSessions = sessions[userId];
+    if (!userSessions) {
+      continue;
+    }
+    for (const sessionId of Object.keys(userSessions)) {
+      const session: DrinkingSession | undefined = userSessions[sessionId];
+      if (!session || session.ongoing === true) {
+        continue;
+      }
+      const startMs = Number(session.start_time);
+      if (!Number.isFinite(startMs)) {
+        continue;
+      }
+      const sessionTz = session.timezone ?? timezone;
+      const sessionDurationMin =
+        typeof session.end_time === 'number' &&
+        Number.isFinite(session.end_time)
+          ? (session.end_time - startMs) / 60000
+          : undefined;
+      const blackoutSession = session.blackout === true;
+      const drinks: DrinksList | undefined = session.drinks;
+      if (!drinks) {
+        continue;
+      }
+      for (const [tsKey, drinksAtTs] of Object.entries(drinks)) {
+        const ts = Number(tsKey);
+        if (!Number.isFinite(ts) || !drinksAtTs) {
+          continue;
+        }
+        let parts: LocalParts | null;
+        try {
+          parts = resolve(ts, sessionTz);
+        } catch {
+          continue;
+        }
+        if (!parts) {
+          continue;
+        }
+        const {localDay, localMonth, localHour, localIsoWeek, calendarDow} =
+          parts;
+        const localDow = (calendarDow - weekStart + 7) % 7;
+        const isWeekend = calendarDow === 0 || calendarDow === 6;
+        for (const drinkKeyRaw of Object.keys(drinksAtTs)) {
+          const drinkKey = drinkKeyRaw as DrinkKey;
+          const entry = normalizeEntry(
+            (drinksAtTs as Record<string, unknown>)[drinkKey],
+          );
+          if (!entry) {
+            continue;
+          }
+          const unitsPerDrink = drinksToUnits?.[drinkKey] ?? 0;
+          const units = entry.count * unitsPerDrink;
+          const sdu = computeSdu(entry, drinkDefaults?.[drinkKey]);
+          events.push({
+            userId,
+            sessionId,
+            ts,
+            localDay,
+            localIsoWeek,
+            localMonth,
+            localHour,
+            localDow,
+            isWeekend,
+            drinkKey,
+            count: entry.count,
+            units,
+            sdu,
+            blackoutSession,
+            sessionDurationMin,
+          });
+        }
+      }
+    }
+  }
+  return events;
+}
+
+/** Global min/max timestamp scan — feeds the (c) offset table range. */
+function tsRange(
+  sessions: UserDrinkingSessionsList | undefined,
+): [number, number] {
+  let lo = Number.POSITIVE_INFINITY;
+  let hi = Number.NEGATIVE_INFINITY;
+  if (!sessions) {
+    return [0, 0];
+  }
+  for (const userId of Object.keys(sessions)) {
+    const us = sessions[userId];
+    if (!us) {
+      continue;
+    }
+    for (const sid of Object.keys(us)) {
+      const drinks = us[sid]?.drinks;
+      if (!drinks) {
+        continue;
+      }
+      for (const k of Object.keys(drinks)) {
+        const ts = Number(k);
+        if (Number.isFinite(ts)) {
+          if (ts < lo) {
+            lo = ts;
+          }
+          if (ts > hi) {
+            hi = ts;
+          }
+        }
+      }
+    }
+  }
+  if (!Number.isFinite(lo)) {
+    return [0, 0];
+  }
+  return [lo, hi];
+}
+
+// ─────────────────── frozen original baseline (for the bench) ────────────────
+// A faithful copy of the pre-(c) shipped implementation: one cached
+// `formatToParts` per timestamp + Date-based ISO-week/DOW. Kept independent of
+// whatever ships in events.ts so the benchmark's "(a) baseline" column stays a
+// stable before/after reference even after a candidate is adopted.
+
+const frozenFormatters = new Map<string, Intl.DateTimeFormat>();
+function frozenFormatter(tz: string): Intl.DateTimeFormat {
+  let f = frozenFormatters.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      hourCycle: 'h23',
+    });
+    frozenFormatters.set(tz, f);
+  }
+  return f;
+}
+
+function frozenIsoWeekLabel(localMidnightUtc: number): string {
+  const thursday = new Date(localMidnightUtc);
+  const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
+  thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
+  const isoYear = thursday.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstOffset + 3);
+  const week =
+    1 +
+    Math.round((thursday.getTime() - firstThursday.getTime()) / 604_800_000);
+  return `${String(isoYear).padStart(4, '0')}-W${D2(week)}`;
+}
+
+function frozenResolver(): Resolver {
+  return function resolve(ts: number, tz: string): LocalParts {
+    const fields: Record<string, string> = {};
+    for (const part of frozenFormatter(tz).formatToParts(ts)) {
+      fields[part.type] = part.value;
+    }
+    const {year, month, day, hour} = fields;
+    const localMidnightUtc = Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+    );
+    return {
+      localDay: `${year}-${month}-${day}`,
+      localMonth: `${year}-${month}`,
+      localHour: Number(hour) % 24,
+      localIsoWeek: frozenIsoWeekLabel(localMidnightUtc),
+      calendarDow: new Date(localMidnightUtc).getUTCDay(),
+    };
+  };
+}
+
+const buildBaselineFrozen: BuildDrinkEvents = (
+  sessions,
+  drinksToUnits,
+  drinkDefaults,
+  timezone,
+  weekStart,
+) =>
+  buildWithResolver(
+    sessions,
+    drinksToUnits,
+    drinkDefaults,
+    timezone,
+    weekStart,
+    frozenResolver,
+  );
+
+// ───────────────────────────── public candidates ────────────────────────────
+
+// Tracks whatever ships in events.ts — the correctness suite validates this.
+const buildBaseline: BuildDrinkEvents = buildBaselineImpl;
+
+const buildDayBucket: BuildDrinkEvents = (
+  sessions,
+  drinksToUnits,
+  drinkDefaults,
+  timezone,
+  weekStart,
+) =>
+  buildWithResolver(
+    sessions,
+    drinksToUnits,
+    drinkDefaults,
+    timezone,
+    weekStart,
+    makeDayBucketResolver,
+  );
+
+const buildOffsetTable: BuildDrinkEvents = (
+  sessions,
+  drinksToUnits,
+  drinkDefaults,
+  timezone,
+  weekStart,
+) => {
+  const [lo, hi] = tsRange(sessions);
+  return buildWithResolver(
+    sessions,
+    drinksToUnits,
+    drinkDefaults,
+    timezone,
+    weekStart,
+    () => makeOffsetTableResolver(lo, hi),
+  );
+};
+
+type Candidate = {key: string; label: string; fn: BuildDrinkEvents};
+
+const CANDIDATES: Candidate[] = [
+  {key: 'a', label: '(a) baseline cached-formatter', fn: buildBaselineFrozen},
+  {key: 'b', label: '(b) day-bucket memo', fn: buildDayBucket},
+  {key: 'c', label: '(c) offset-table arithmetic', fn: buildOffsetTable},
+];
+
+export {
+  buildBaseline,
+  buildBaselineFrozen,
+  buildDayBucket,
+  buildOffsetTable,
+  CANDIDATES,
+  // exported for the benchmark's segment profiler / sanity checks
+  offsetSecondsAt,
+  partsFromOffset,
+  daysFromCivil,
+  civilFromDays,
+  isoWeekLabelFromDays,
+};
+export type {BuildDrinkEvents, Candidate, DrinkDefaults};

--- a/scripts/perf/statsCpuProfile.ts
+++ b/scripts/perf/statsCpuProfile.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+/**
+ * Drives one candidate hard so an external `--cpu-prof` capture has signal.
+ *
+ *   node --cpu-prof --cpu-prof-dir=/tmp/statsprof \
+ *     -r ts-node/register/transpile-only \
+ *     --project scripts/perf/tsconfig.json \
+ *     scripts/perf/statsCpuProfile.ts --candidate=a --loops=400
+ *
+ * (TS_NODE_PROJECT must point at scripts/perf/tsconfig.json.)
+ */
+import './benchGlobals';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {WeekStart} from '@libs/Statistics/types';
+import {
+  buildBaseline,
+  buildDayBucket,
+  buildOffsetTable,
+} from './statsCandidates';
+import type {BuildDrinkEvents} from './statsCandidates';
+import {standardDatasets, UNITS, DEFAULTS} from './statsDataset';
+
+const argv = process.argv.slice(2);
+const which = (
+  argv.find(a => a.startsWith('--candidate=')) ?? '--candidate=a'
+).split('=')[1];
+const loops = Number(
+  (argv.find(a => a.startsWith('--loops=')) ?? '--loops=400').split('=')[1],
+);
+const byKey: Record<string, BuildDrinkEvents> = {
+  a: buildBaseline,
+  b: buildDayBucket,
+  c: buildOffsetTable,
+};
+const fn = byKey[which] ?? buildBaseline;
+
+const ZONE = 'Europe/London' as SelectedTimezone;
+const MON: WeekStart = 1;
+const ds = standardDatasets(ZONE).large;
+
+let total = 0;
+for (let i = 0; i < loops; i++) {
+  const wrapped = {...ds.sessions};
+  total += fn(wrapped, UNITS, DEFAULTS, ZONE, MON).length;
+}
+console.log(
+  `candidate ${which}: ${loops} loops × ${ds.eventCount} events (sink=${total})`,
+);

--- a/scripts/perf/statsDataset.ts
+++ b/scripts/perf/statsDataset.ts
@@ -1,0 +1,202 @@
+/**
+ * Deterministic synthetic-dataset generator for the Statistics benchmarks.
+ * Produces realistic `UserDrinkingSessionsList` shapes: near-daily sessions
+ * over an N-year span, 1–8 drink timestamps per session, several drink types
+ * per timestamp. Seeded so every run is byte-for-byte reproducible.
+ */
+import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+import type {DrinksToUnits} from '@src/types/onyx/Preferences';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {DrinkDefaults} from './statsCandidates';
+
+/* eslint-disable no-bitwise, operator-assignment */
+/** mulberry32 — tiny, fast, deterministic PRNG. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+/* eslint-enable no-bitwise, operator-assignment */
+
+const DRINK_KEYS: DrinkKey[] = [
+  'small_beer',
+  'beer',
+  'cocktail',
+  'other',
+  'strong_shot',
+  'weak_shot',
+  'wine',
+];
+
+const UNITS: DrinksToUnits = {
+  small_beer: 0.5,
+  beer: 1,
+  cocktail: 1.5,
+  other: 1,
+  strong_shot: 1,
+  weak_shot: 0.5,
+  wine: 1.5,
+};
+
+const DEFAULTS: DrinkDefaults = {
+  small_beer: {ml: 330, abv: 0.05},
+  beer: {ml: 500, abv: 0.05},
+  cocktail: {ml: 250, abv: 0.1},
+  other: {ml: 200, abv: 0.1},
+  strong_shot: {ml: 40, abv: 0.4},
+  weak_shot: {ml: 40, abv: 0.2},
+  wine: {ml: 150, abv: 0.12},
+};
+
+type GenOptions = {
+  years: number;
+  /** Fraction of days that have a session (near-daily ≈ 0.85). */
+  sessionDensity: number;
+  /** Drink timestamps per session: minTimestamps..maxTimestamps, uniform. */
+  minTimestamps?: number;
+  maxTimestamps: number;
+  /** Distinct drink types per timestamp: minTypes..maxTypes, uniform. */
+  minTypes?: number;
+  maxTypes: number;
+  /** Probability an entry uses the v2-A object shape with overrides. */
+  v2Fraction: number;
+  timezone: SelectedTimezone;
+  seed: number;
+  /** End of the data window (defaults to a fixed date for reproducibility). */
+  endMs?: number;
+};
+
+type GenResult = {
+  sessions: UserDrinkingSessionsList;
+  sessionCount: number;
+  eventCount: number;
+  options: GenOptions;
+};
+
+const DAY = 86400000;
+const DEFAULT_END = Date.UTC(2025, 0, 1, 0, 0, 0); // fixed anchor
+
+function generateDataset(opts: GenOptions): GenResult {
+  const rand = mulberry32(opts.seed);
+  const end = opts.endMs ?? DEFAULT_END;
+  const totalDays = Math.round(opts.years * 365);
+  const start = end - totalDays * DAY;
+
+  const userSessions: Record<string, ReturnType<typeof makeSession>> = {};
+  let sessionCount = 0;
+  let eventCount = 0;
+
+  function makeSession(dayStart: number) {
+    // Session begins somewhere in the evening, runs 1–5h.
+    const startOffset = (16 + Math.floor(rand() * 7)) * 3600000; // 16:00–22:00
+    const startTime = dayStart + startOffset + Math.floor(rand() * 3600000);
+    const durationMin = 30 + Math.floor(rand() * 270);
+    const endTime = startTime + durationMin * 60000;
+    const minTs = opts.minTimestamps ?? 1;
+    const minTy = opts.minTypes ?? 1;
+    const nTs = minTs + Math.floor(rand() * (opts.maxTimestamps - minTs + 1));
+    // Keyed by stringified ms; cast to DrinksList at return (the runtime shape
+    // matches — DrinksList's numeric index is just string keys at runtime).
+    const drinks: Record<string, unknown> = {};
+    for (let i = 0; i < nTs; i++) {
+      const ts = startTime + Math.floor(rand() * (endTime - startTime) * 0.98);
+      const nTypes = minTy + Math.floor(rand() * (opts.maxTypes - minTy + 1));
+      const entry: Record<string, unknown> = {};
+      const used = new Set<number>();
+      for (let j = 0; j < nTypes; j++) {
+        let idx = Math.floor(rand() * DRINK_KEYS.length);
+        if (used.has(idx)) {
+          idx = (idx + 1) % DRINK_KEYS.length;
+        }
+        used.add(idx);
+        const key = DRINK_KEYS[idx];
+        const count = 1 + Math.floor(rand() * 4);
+        if (rand() < opts.v2Fraction) {
+          entry[key] = {
+            count,
+            volume_ml: 150 + Math.floor(rand() * 350),
+            abv: 0.04 + rand() * 0.1,
+          };
+        } else {
+          entry[key] = count;
+        }
+        eventCount += 1;
+      }
+      // Distinct ms keys; collisions are vanishingly unlikely but guarded.
+      drinks[String(ts + i)] = entry;
+    }
+    return {
+      start_time: startTime,
+      end_time: endTime,
+      timezone: opts.timezone,
+      blackout: rand() < 0.1,
+      drinks: drinks as unknown as DrinksList,
+    };
+  }
+
+  for (let d = 0; d < totalDays; d++) {
+    if (rand() > opts.sessionDensity) {
+      continue;
+    }
+    const dayStart = start + d * DAY;
+    const sid = `s${d}`;
+    userSessions[sid] = makeSession(dayStart);
+    sessionCount += 1;
+  }
+
+  const sessions = {user1: userSessions} as unknown as UserDrinkingSessionsList;
+  return {sessions, sessionCount, eventCount, options: opts};
+}
+
+/** The three canonical sizes, tuned to land near 1k / 10k / 50k events. */
+function standardDatasets(
+  timezone: SelectedTimezone = 'Europe/London' as SelectedTimezone,
+): Record<'small' | 'medium' | 'large', GenResult> {
+  return {
+    // ~1 year near-daily, ~1k events
+    small: generateDataset({
+      years: 1,
+      sessionDensity: 0.85,
+      minTimestamps: 1,
+      maxTimestamps: 3,
+      minTypes: 1,
+      maxTypes: 3,
+      v2Fraction: 0.3,
+      timezone,
+      seed: 1,
+    }),
+    // ~3 years near-daily, ~10k events
+    medium: generateDataset({
+      years: 3,
+      sessionDensity: 0.9,
+      minTimestamps: 1,
+      maxTimestamps: 6,
+      minTypes: 2,
+      maxTypes: 5,
+      v2Fraction: 0.3,
+      timezone,
+      seed: 2,
+    }),
+    // ~5 years near-daily, ~50k events
+    large: generateDataset({
+      years: 5,
+      sessionDensity: 0.98,
+      minTimestamps: 4,
+      maxTimestamps: 8,
+      minTypes: 3,
+      maxTypes: 6,
+      v2Fraction: 0.3,
+      timezone,
+      seed: 3,
+    }),
+  };
+}
+
+export {generateDataset, standardDatasets, UNITS, DEFAULTS, DRINK_KEYS};
+export type {GenOptions, GenResult};

--- a/scripts/perf/statsEventsBench.ts
+++ b/scripts/perf/statsEventsBench.ts
@@ -1,0 +1,419 @@
+/* eslint-disable no-console */
+/**
+ * Isolated micro-benchmark for `buildDrinkEvents` candidates. Runs OUTSIDE jest
+ * (jest's global fake timers freeze `performance.now`) via:
+ *
+ *   npx ts-node scripts/perf/statsEventsBench.ts
+ *
+ * Flags:
+ *   --iterations=N   timed iterations per candidate (default 25)
+ *   --warmup=N       warmup iterations (default 5)
+ *   --segments       run the baseline hot-path segment breakdown
+ *   --zone=Area/City dataset timezone (default Europe/London)
+ *
+ * The module-level last-call cache in the baseline is defeated by passing a
+ * fresh top-level `sessions` wrapper object each iteration (same inner data),
+ * so every iteration does real work.
+ */
+import './benchGlobals';
+import {performance, PerformanceObserver} from 'node:perf_hooks';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+import type {WeekStart} from '@libs/Statistics/types';
+import {CANDIDATES} from './statsCandidates';
+import type {Candidate} from './statsCandidates';
+import {standardDatasets, UNITS, DEFAULTS} from './statsDataset';
+import type {GenResult} from './statsDataset';
+
+const argv = process.argv.slice(2);
+function flag(name: string, dflt: string): string {
+  const hit = argv.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : dflt;
+}
+const ITER = Number(flag('iterations', '25'));
+const WARMUP = Number(flag('warmup', '5'));
+const ZONE = flag('zone', 'Europe/London') as SelectedTimezone;
+const RUN_SEGMENTS = argv.includes('--segments');
+const RUN_GC = argv.includes('--gc');
+
+const MON: WeekStart = 1;
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+function stdev(xs: number[]): number {
+  const m = mean(xs);
+  return Math.sqrt(mean(xs.map(x => (x - m) ** 2)));
+}
+
+/** Fresh top-level wrapper each call → defeats baseline's identity cache. */
+function rewrap(sessions: UserDrinkingSessionsList): UserDrinkingSessionsList {
+  return {...sessions};
+}
+
+function timeCandidate(
+  cand: Candidate,
+  ds: GenResult,
+): {median: number; mean: number; stdev: number; events: number} {
+  let events = 0;
+  for (let i = 0; i < WARMUP; i++) {
+    events = cand.fn(rewrap(ds.sessions), UNITS, DEFAULTS, ZONE, MON).length;
+  }
+  const samples: number[] = [];
+  for (let i = 0; i < ITER; i++) {
+    const wrapped = rewrap(ds.sessions);
+    const t0 = performance.now();
+    const out = cand.fn(wrapped, UNITS, DEFAULTS, ZONE, MON);
+    const t1 = performance.now();
+    samples.push(t1 - t0);
+    events = out.length;
+  }
+  return {
+    median: median(samples),
+    mean: mean(samples),
+    stdev: stdev(samples),
+    events,
+  };
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+function padL(s: string, n: number): string {
+  return s.length >= n ? s : ' '.repeat(n - s.length) + s;
+}
+
+function runMainTable(): void {
+  const datasets = standardDatasets(ZONE);
+  const sizes = ['small', 'medium', 'large'] as const;
+
+  console.log(`\nStatistics buildDrinkEvents benchmark`);
+  console.log(
+    `node ${process.version} · zone ${ZONE} · warmup ${WARMUP} · iterations ${ITER} (median ms)\n`,
+  );
+  for (const size of sizes) {
+    const ds = datasets[size];
+    console.log(
+      `${size.toUpperCase()}: ${ds.sessionCount} sessions → ${ds.eventCount} events`,
+    );
+  }
+  console.log('');
+
+  // Header
+  const col = 22;
+  const numc = 26;
+  let header = pad('candidate', col);
+  for (const size of sizes) {
+    const ds = datasets[size];
+    header += padL(`${size} (${(ds.eventCount / 1000).toFixed(1)}k ev)`, numc);
+  }
+  console.log(header);
+  console.log('-'.repeat(col + numc * sizes.length));
+
+  const table: Record<string, Record<string, number>> = {};
+  for (const cand of CANDIDATES) {
+    let row = pad(cand.label, col);
+    table[cand.key] = {};
+    for (const size of sizes) {
+      const r = timeCandidate(cand, datasets[size]);
+      table[cand.key][size] = r.median;
+      row += padL(`${r.median.toFixed(1)} ±${r.stdev.toFixed(1)}`, numc);
+    }
+    console.log(row);
+  }
+
+  // Speedup vs baseline
+  console.log('\nspeedup vs (a) baseline (median):');
+  let srow = pad('candidate', col);
+  for (const size of sizes) {
+    srow += padL(size, numc);
+  }
+  console.log(srow);
+  console.log('-'.repeat(col + numc * sizes.length));
+  for (const cand of CANDIDATES) {
+    let row = pad(cand.label, col);
+    for (const size of sizes) {
+      const base = table.a[size];
+      const x = base / table[cand.key][size];
+      row += padL(`${x.toFixed(2)}×`, numc);
+    }
+    console.log(row);
+  }
+  console.log('');
+}
+
+// ─────────────────────── baseline hot-path segment profile ──────────────────
+// Re-implements the baseline inline so each stage can be timed independently.
+// Mirrors src/libs/Statistics/events.ts exactly; for diagnosis only.
+
+function runSegments(): void {
+  const ds = standardDatasets(ZONE).large;
+  const sessions = ds.sessions;
+  console.log(
+    `\nSegment profile — LARGE (${ds.eventCount} events), zone ${ZONE}`,
+  );
+  console.log(`(sum over ${ITER} iterations, median per-iter ms)\n`);
+
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    hourCycle: 'h23',
+  });
+
+  type Acc = {
+    iterTotal: number[];
+    formatToParts: number[];
+    dateAlloc: number[];
+    stringBuild: number[];
+    normalize: number[];
+    push: number[];
+  };
+  const acc: Acc = {
+    iterTotal: [],
+    formatToParts: [],
+    dateAlloc: [],
+    stringBuild: [],
+    normalize: [],
+    push: [],
+  };
+
+  for (let it = 0; it < WARMUP + ITER; it++) {
+    let tFmt = 0;
+    let tDate = 0;
+    let tStr = 0;
+    let tNorm = 0;
+    let tPush = 0;
+    const events: unknown[] = [];
+    const iterStart = performance.now();
+
+    for (const userId of Object.keys(sessions)) {
+      const us = sessions[userId];
+      if (!us) {
+        continue;
+      }
+      for (const sid of Object.keys(us)) {
+        const session = us[sid];
+        if (!session || session.ongoing === true) {
+          continue;
+        }
+        const startMs = Number(session.start_time);
+        if (!Number.isFinite(startMs)) {
+          continue;
+        }
+        const drinks = session.drinks;
+        if (!drinks) {
+          continue;
+        }
+        for (const [tsKey, drinksAtTs] of Object.entries(drinks)) {
+          const ts = Number(tsKey);
+          if (!Number.isFinite(ts) || !drinksAtTs) {
+            continue;
+          }
+
+          // segment: formatToParts
+          let s = performance.now();
+          const fields: Record<string, string> = {};
+          for (const part of fmt.formatToParts(ts)) {
+            fields[part.type] = part.value;
+          }
+          tFmt += performance.now() - s;
+
+          const {year, month, day, hour} = fields;
+
+          // segment: Date allocations (ISO week + DOW)
+          s = performance.now();
+          const localMidnightUtc = Date.UTC(
+            Number(year),
+            Number(month) - 1,
+            Number(day),
+          );
+          const thursday = new Date(localMidnightUtc);
+          const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
+          thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
+          const isoYear = thursday.getUTCFullYear();
+          const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+          const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
+          firstThursday.setUTCDate(
+            firstThursday.getUTCDate() - firstOffset + 3,
+          );
+          const week =
+            1 +
+            Math.round(
+              (thursday.getTime() - firstThursday.getTime()) / 604_800_000,
+            );
+          const calendarDow = new Date(localMidnightUtc).getUTCDay();
+          tDate += performance.now() - s;
+
+          // segment: string building
+          s = performance.now();
+          const localDay = `${year}-${month}-${day}`;
+          const localMonth = `${year}-${month}`;
+          const localIsoWeek = `${String(isoYear).padStart(4, '0')}-W${String(
+            week,
+          ).padStart(2, '0')}`;
+          const localHour = Number(hour) % 24;
+          tStr += performance.now() - s;
+
+          const localDow = (calendarDow - 1 + 7) % 7;
+          const isWeekend = calendarDow === 0 || calendarDow === 6;
+
+          for (const drinkKeyRaw of Object.keys(drinksAtTs)) {
+            // segment: normalize
+            s = performance.now();
+            const raw = (drinksAtTs as Record<string, unknown>)[drinkKeyRaw];
+            let ok = false;
+            let count = 0;
+            if (typeof raw === 'number') {
+              ok = Number.isFinite(raw) && raw > 0;
+              count = raw;
+            } else if (raw && typeof raw === 'object') {
+              const o = raw as {count?: unknown};
+              ok =
+                typeof o.count === 'number' &&
+                Number.isFinite(o.count) &&
+                o.count > 0;
+              count = ok ? (o.count as number) : 0;
+            }
+            tNorm += performance.now() - s;
+            if (!ok) {
+              continue;
+            }
+
+            // segment: push
+            s = performance.now();
+            events.push({
+              userId,
+              sessionId: sid,
+              ts,
+              localDay,
+              localIsoWeek,
+              localMonth,
+              localHour,
+              localDow,
+              isWeekend,
+              drinkKey: drinkKeyRaw,
+              count,
+              units: count,
+              blackoutSession: session.blackout === true,
+            });
+            tPush += performance.now() - s;
+          }
+        }
+      }
+    }
+
+    const iterTotal = performance.now() - iterStart;
+    if (it >= WARMUP) {
+      acc.iterTotal.push(iterTotal);
+      acc.formatToParts.push(tFmt);
+      acc.dateAlloc.push(tDate);
+      acc.stringBuild.push(tStr);
+      acc.normalize.push(tNorm);
+      acc.push.push(tPush);
+    }
+  }
+
+  const rows: Array<[string, number[]]> = [
+    ['formatToParts', acc.formatToParts],
+    ['Date alloc (ISO-week + DOW)', acc.dateAlloc],
+    ['string building', acc.stringBuild],
+    ['normalizeEntry', acc.normalize],
+    ['events.push', acc.push],
+  ];
+  const total = median(acc.iterTotal);
+  console.log(
+    `${pad('segment', 32)}${padL('median ms', 14)}${padL('% of pass', 12)}`,
+  );
+  console.log('-'.repeat(58));
+  for (const [name, xs] of rows) {
+    const m = median(xs);
+    console.log(
+      `${pad(name, 32)}${padL(m.toFixed(2), 14)}${padL(`${((m / total) * 100).toFixed(1)}%`, 12)}`,
+    );
+  }
+  console.log('-'.repeat(58));
+  console.log(
+    `${pad('full pass (instrumented)', 32)}${padL(total.toFixed(2), 14)}`,
+  );
+  console.log(
+    `\nNote: per-segment performance.now() adds overhead, inflating the\n` +
+      `instrumented total vs the clean benchmark; use the ratios, not the absolutes.\n`,
+  );
+}
+
+// ───────────────────────── GC-pressure measurement ──────────────────────────
+// Total GC pause time + collection count over a fixed loop count. A proxy for
+// transient-allocation pressure — the on-device cost that shows up as jank.
+// Run with: node --expose-gc -r ts-node/register/transpile-only ... --gc
+
+const tick = () =>
+  new Promise<void>(res => {
+    setTimeout(res, 0);
+  });
+
+async function runGc(): Promise<void> {
+  const ds = standardDatasets(ZONE).large;
+  const LOOPS = Number(flag('loops', '120'));
+  console.log(`\nGC pressure — LARGE (${ds.eventCount} events), zone ${ZONE}`);
+  console.log(`(${LOOPS} loops per candidate)\n`);
+  console.log(
+    `${pad('candidate', 32)}${padL('GC count', 12)}${padL('GC time ms', 14)}${padL(
+      'ms/loop',
+      12,
+    )}`,
+  );
+  console.log('-'.repeat(70));
+
+  const gc = (globalThis as {gc?: () => void}).gc;
+  for (const cand of CANDIDATES) {
+    let gcCount = 0;
+    let gcTime = 0;
+    const obs = new PerformanceObserver(list => {
+      for (const e of list.getEntries()) {
+        gcCount += 1;
+        gcTime += e.duration;
+      }
+    });
+    obs.observe({entryTypes: ['gc'], buffered: true});
+    if (gc) {
+      gc();
+    }
+    let sink = 0;
+    for (let i = 0; i < LOOPS; i++) {
+      sink += cand.fn({...ds.sessions}, UNITS, DEFAULTS, ZONE, MON).length;
+    }
+    await tick(); // let queued GC entries flush before reading
+    obs.disconnect();
+    if (sink <= 0) {
+      throw new Error('benchmark produced no events');
+    }
+    console.log(
+      `${pad(cand.label, 32)}${padL(String(gcCount), 12)}${padL(
+        gcTime.toFixed(1),
+        14,
+      )}${padL((gcTime / LOOPS).toFixed(3), 12)}`,
+    );
+  }
+  console.log(
+    `\n(Run under \`node --expose-gc\` for accurate, deterministic GC counts.)\n`,
+  );
+}
+
+if (RUN_SEGMENTS) {
+  runSegments();
+} else if (RUN_GC) {
+  runGc().catch((e: unknown) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+} else {
+  runMainTable();
+}

--- a/scripts/perf/tsconfig.json
+++ b/scripts/perf/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": false,
+    "baseUrl": "../../",
+    "types": ["node"],
+    "paths": {
+      "@assets/*": ["assets/*"],
+      "@components/*": ["src/components/*"],
+      "@context/*": ["src/context/*"],
+      "@database/*": ["src/database/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@libs/*": ["src/libs/*"],
+      "@navigation/*": ["src/libs/Navigation/*"],
+      "@screens/*": ["src/screens/*"],
+      "@src/*": ["src/*"],
+      "@storage/*": ["src/storage/*"],
+      "@styles/*": ["src/styles/*"],
+      "@utils/*": ["src/utils/*"],
+      "@userActions/*": ["src/libs/actions/*"]
+    }
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "require": ["tsconfig-paths/register"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -78,28 +78,15 @@ function computeSdu(
   return sduFrom(ml, abv) * entry.count;
 }
 
-/* ── Timezone resolution ──────────────────────────────────────────────────
- *
- * Per-drink timezone resolution dominated the event-stream build: a single
- * `Intl` `formatToParts` per timestamp was ~60% of the pass, and the `Date`
- * allocations behind ISO-week / day-of-week added ~11% more plus the bulk of
- * the GC pressure. Instead, we resolve each session timezone's UTC-offset
- * *transitions* ONCE — a handful of `Intl` probes per zone — into a sorted
- * table, then derive every local field (day, month, hour, ISO week,
- * day-of-week) by pure integer arithmetic with zero `Intl` and zero `Date`
- * allocation per timestamp.
- *
- * This is byte-identical to the formatter path across an exhaustive timezone
- * sweep — half-hour (+5:30) and 45-minute (+5:45) offsets, southern-hemisphere
- * DST, Lord Howe's 30-minute DST, and pre-1970 instants — verified against the
- * native `Intl` oracle in __tests__/unit/libs/Statistics/eventsCandidates.test.ts.
+/**
+ * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
+ * expensive part of timezone resolution, so we build it once and reuse it for
+ * every timestamp in that zone — in practice a single zone per user.
  */
+const localPartsFormatters = new Map<string, Intl.DateTimeFormat>();
 
-/** One full `Intl` formatter per zone, used only to probe offsets. */
-const offsetFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = offsetFormatters.get(timeZone);
+function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = localPartsFormatters.get(timeZone);
   if (!formatter) {
     formatter = new Intl.DateTimeFormat('en-US', {
       timeZone,
@@ -107,67 +94,30 @@ function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
       hourCycle: 'h23',
     });
-    offsetFormatters.set(timeZone, formatter);
+    localPartsFormatters.set(timeZone, formatter);
   }
   return formatter;
 }
 
-// Howard Hinnant's proleptic-Gregorian day<->civil algorithms, operating on
-// "days since 1970-01-01". Pure integer math — no `Date` allocation.
-
-function daysFromCivil(y: number, m: number, d: number): number {
-  const yy = y - (m <= 2 ? 1 : 0);
-  const era = Math.floor((yy >= 0 ? yy : yy - 399) / 400);
-  const yoe = yy - era * 400;
-  const doy = Math.floor((153 * (m + (m > 2 ? -3 : 9)) + 2) / 5) + d - 1;
-  const doe = yoe * 365 + Math.floor(yoe / 4) - Math.floor(yoe / 100) + doy;
-  return era * 146097 + doe - 719468;
-}
-
-function civilFromDays(z: number): [number, number, number] {
-  const zz = z + 719468;
-  const era = Math.floor((zz >= 0 ? zz : zz - 146096) / 146097);
-  const doe = zz - era * 146097;
-  const yoe = Math.floor(
-    (doe -
-      Math.floor(doe / 1460) +
-      Math.floor(doe / 36524) -
-      Math.floor(doe / 146096)) /
-      365,
-  );
-  const y = yoe + era * 400;
-  const doy = doe - (365 * yoe + Math.floor(yoe / 4) - Math.floor(yoe / 100));
-  const mp = Math.floor((5 * doy + 2) / 153);
-  const d = doy - Math.floor((153 * mp + 2) / 5) + 1;
-  const m = mp + (mp < 10 ? 3 : -9);
-  return [y + (m <= 2 ? 1 : 0), m, d];
-}
-
-const pad2 = (n: number): string => (n < 10 ? `0${n}` : String(n));
-const pad4 = (n: number): string => String(n).padStart(4, '0');
-
-/** 0=Sunday..6=Saturday for a day-count (1970-01-01 was a Thursday). */
-const dowFromDays = (dayCount: number): number =>
-  ((((dayCount % 7) + 4) % 7) + 7) % 7;
-
 /**
- * ISO 8601 week label (`RRRR-'W'II`) from a day-count. The week-numbering year
- * and week can both differ from the calendar year at the Dec/Jan boundary —
- * e.g. 2021-01-01 belongs to 2020-W53.
+ * ISO 8601 week label (`RRRR-'W'II`) for a UTC-midnight stamp of a local wall
+ * day. The week-numbering year and week can both differ from the calendar year
+ * at the Dec/Jan boundary — e.g. 2021-01-01 belongs to 2020-W53.
  */
-function isoWeekLabelFromDays(dayCount: number): string {
-  const dayFromMonday = (dowFromDays(dayCount) + 6) % 7;
-  const thursday = dayCount - dayFromMonday + 3;
-  const [isoYear] = civilFromDays(thursday);
-  const jan4 = daysFromCivil(isoYear, 1, 4);
-  const firstOffset = (dowFromDays(jan4) + 6) % 7;
-  const firstThursday = jan4 - firstOffset + 3;
-  const week = 1 + Math.round((thursday - firstThursday) / 7);
-  return `${pad4(isoYear)}-W${pad2(week)}`;
+function isoWeekLabel(localMidnightUtc: number): string {
+  const thursday = new Date(localMidnightUtc);
+  const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
+  thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
+  const isoYear = thursday.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstOffset + 3);
+  const week =
+    1 +
+    Math.round((thursday.getTime() - firstThursday.getTime()) / 604_800_000);
+  return `${String(isoYear).padStart(4, '0')}-W${String(week).padStart(2, '0')}`;
 }
 
 type LocalParts = {
@@ -180,157 +130,35 @@ type LocalParts = {
 };
 
 /**
- * Whole-second UTC offset for `ts` in `timeZone`, via one full `Intl` probe:
- * `localWallSecond - utcSecond`. Whole seconds (not minutes) keep half-hour,
- * 45-minute and pre-1970 sub-minute (LMT) offsets exact. Throws on an invalid
- * timezone (the `Intl` constructor does) — the caller skips.
+ * Resolve a timestamp's local wall-clock fields with a single cached
+ * `formatToParts` call, then derive day-of-week and ISO week arithmetically.
+ * Replaces five per-timestamp `formatInTimeZone` calls — the dominant cost of
+ * building the event stream. Throws only on an invalid timezone (the caller
+ * skips); returns `null` if the formatter omits a field, which no supported
+ * runtime does.
  */
-function offsetSecondsAt(ts: number, timeZone: string): number {
+function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
   const fields: Record<string, string> = {};
-  for (const part of getOffsetFormatter(timeZone).formatToParts(ts)) {
+  for (const part of getLocalPartsFormatter(timeZone).formatToParts(ts)) {
     fields[part.type] = part.value;
   }
-  const localWallSec =
-    daysFromCivil(
-      Number(fields.year),
-      Number(fields.month),
-      Number(fields.day),
-    ) *
-      86400 +
-    (Number(fields.hour) % 24) * 3600 +
-    Number(fields.minute) * 60 +
-    Number(fields.second);
-  return localWallSec - Math.floor(ts / 1000);
-}
-
-/** Derive all local fields from a UTC `ts` and a known whole-second offset. */
-function partsFromOffset(ts: number, offsetSec: number): LocalParts {
-  const localMs = ts + offsetSec * 1000;
-  const dayCount = Math.floor(localMs / 86400000);
-  const secOfDay = Math.floor((localMs - dayCount * 86400000) / 1000);
-  const [y, m, d] = civilFromDays(dayCount);
+  const {year, month, day, hour} = fields;
+  if (!year || !month || !day || !hour) {
+    return null;
+  }
+  const localMidnightUtc = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+  );
   return {
-    localDay: `${pad4(y)}-${pad2(m)}-${pad2(d)}`,
-    localMonth: `${pad4(y)}-${pad2(m)}`,
-    localHour: Math.floor(secOfDay / 3600),
-    localIsoWeek: isoWeekLabelFromDays(dayCount),
-    calendarDow: dowFromDays(dayCount),
+    localDay: `${year}-${month}-${day}`,
+    localMonth: `${year}-${month}`,
+    // `% 24` folds the "24" some ICU builds emit for midnight back to 0.
+    localHour: Number(hour) % 24,
+    localIsoWeek: isoWeekLabel(localMidnightUtc),
+    calendarDow: new Date(localMidnightUtc).getUTCDay(),
   };
-}
-
-/**
- * Per-zone offset-transition table. `boundary[i]` is the first UTC ms at which
- * `offset[i]` (whole seconds) applies; it holds until `boundary[i+1]`.
- */
-type OffsetTable = {boundary: number[]; offset: number[]};
-
-/**
- * Scan stride for locating offset transitions. Must be shorter than the gap
- * between any two consecutive transitions in the covered range — drink
- * timestamps are recent, where every IANA zone keeps transitions months apart,
- * so 8 days carries a wide safety margin while keeping the probe budget tiny
- * (≈ range / 8d `Intl` calls, once per zone).
- */
-const SCAN_STEP_MS = 8 * 86400000;
-
-/** Binary-search the exact transition instant in (loTs, hiTs] to ms precision. */
-function findTransition(
-  loTs: number,
-  loOff: number,
-  hiTs: number,
-  timeZone: string,
-): {at: number; off: number} {
-  let lo = loTs;
-  let hi = hiTs;
-  while (hi - lo > 1) {
-    const mid = lo + Math.floor((hi - lo) / 2);
-    if (offsetSecondsAt(mid, timeZone) === loOff) {
-      lo = mid;
-    } else {
-      hi = mid;
-    }
-  }
-  return {at: hi, off: offsetSecondsAt(hi, timeZone)};
-}
-
-function buildOffsetTable(
-  timeZone: string,
-  lo: number,
-  hi: number,
-): OffsetTable {
-  const boundary: number[] = [lo];
-  let prevOff = offsetSecondsAt(lo, timeZone);
-  const offset: number[] = [prevOff];
-  let cursor = lo;
-  while (cursor < hi) {
-    const next = Math.min(cursor + SCAN_STEP_MS, hi);
-    if (offsetSecondsAt(next, timeZone) !== prevOff) {
-      // One or more transitions lie in (cursor, next]; pin each exactly.
-      let segLo = cursor;
-      let segLoOff = prevOff;
-      for (;;) {
-        const t = findTransition(segLo, segLoOff, next, timeZone);
-        boundary.push(t.at);
-        offset.push(t.off);
-        prevOff = t.off;
-        segLo = t.at;
-        segLoOff = t.off;
-        if (offsetSecondsAt(next, timeZone) === t.off) {
-          break;
-        }
-      }
-    }
-    cursor = next;
-  }
-  return {boundary, offset};
-}
-
-/** Offset for `ts`: the entry of the last boundary <= ts (binary search). */
-function offsetFromTable(table: OffsetTable, ts: number): number {
-  const {boundary, offset} = table;
-  let lo = 0;
-  let hi = boundary.length - 1;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    if (boundary[mid] <= ts) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return offset[lo];
-}
-
-/** Global min/max drink timestamp — bounds each zone's offset table. */
-function drinkTimestampRange(
-  sessions: UserDrinkingSessionsList,
-): [number, number] {
-  let lo = Number.POSITIVE_INFINITY;
-  let hi = Number.NEGATIVE_INFINITY;
-  for (const userId of Object.keys(sessions)) {
-    const userSessions = sessions[userId];
-    if (!userSessions) {
-      continue;
-    }
-    for (const sessionId of Object.keys(userSessions)) {
-      const drinks = userSessions[sessionId]?.drinks;
-      if (!drinks) {
-        continue;
-      }
-      for (const tsKey of Object.keys(drinks)) {
-        const ts = Number(tsKey);
-        if (Number.isFinite(ts)) {
-          if (ts < lo) {
-            lo = ts;
-          }
-          if (ts > hi) {
-            hi = ts;
-          }
-        }
-      }
-    }
-  }
-  return Number.isFinite(lo) ? [lo, hi] : [0, 0];
 }
 
 /**
@@ -398,24 +226,6 @@ function buildDrinkEvents(
     return events;
   }
 
-  // Build each session timezone's offset table lazily over the data's span, so
-  // every per-drink resolution below is pure arithmetic. Most users have a
-  // single zone, so this is a handful of `Intl` probes for the whole pass.
-  const [rangeLo, rangeHi] = drinkTimestampRange(sessions);
-  const offsetTables = new Map<string, OffsetTable>();
-  const resolveParts = (ts: number, tz: string): LocalParts => {
-    let table = offsetTables.get(tz);
-    if (!table) {
-      table = buildOffsetTable(
-        tz,
-        rangeLo - SCAN_STEP_MS,
-        rangeHi + SCAN_STEP_MS,
-      );
-      offsetTables.set(tz, table);
-    }
-    return partsFromOffset(ts, offsetFromTable(table, ts));
-  };
-
   for (const userId of Object.keys(sessions)) {
     const userSessions = sessions[userId];
     if (!userSessions) {
@@ -450,10 +260,13 @@ function buildDrinkEvents(
         if (!drinksAtTs) {
           continue;
         }
-        let parts: LocalParts;
+        let parts: LocalParts | null;
         try {
-          parts = resolveParts(ts, sessionTz);
+          parts = resolveLocalParts(ts, sessionTz);
         } catch {
+          continue;
+        }
+        if (!parts) {
           continue;
         }
         const {localDay, localMonth, localHour, localIsoWeek, calendarDow} =

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -78,15 +78,28 @@ function computeSdu(
   return sduFrom(ml, abv) * entry.count;
 }
 
-/**
- * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
- * expensive part of timezone resolution, so we build it once and reuse it for
- * every timestamp in that zone — in practice a single zone per user.
+/* ── Timezone resolution ──────────────────────────────────────────────────
+ *
+ * Per-drink timezone resolution dominated the event-stream build: a single
+ * `Intl` `formatToParts` per timestamp was ~60% of the pass, and the `Date`
+ * allocations behind ISO-week / day-of-week added ~11% more plus the bulk of
+ * the GC pressure. Instead, we resolve each session timezone's UTC-offset
+ * *transitions* ONCE — a handful of `Intl` probes per zone — into a sorted
+ * table, then derive every local field (day, month, hour, ISO week,
+ * day-of-week) by pure integer arithmetic with zero `Intl` and zero `Date`
+ * allocation per timestamp.
+ *
+ * This is byte-identical to the formatter path across an exhaustive timezone
+ * sweep — half-hour (+5:30) and 45-minute (+5:45) offsets, southern-hemisphere
+ * DST, Lord Howe's 30-minute DST, and pre-1970 instants — verified against the
+ * native `Intl` oracle in __tests__/unit/libs/Statistics/eventsCandidates.test.ts.
  */
-const localPartsFormatters = new Map<string, Intl.DateTimeFormat>();
 
-function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = localPartsFormatters.get(timeZone);
+/** One full `Intl` formatter per zone, used only to probe offsets. */
+const offsetFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = offsetFormatters.get(timeZone);
   if (!formatter) {
     formatter = new Intl.DateTimeFormat('en-US', {
       timeZone,
@@ -94,30 +107,67 @@ function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
       hourCycle: 'h23',
     });
-    localPartsFormatters.set(timeZone, formatter);
+    offsetFormatters.set(timeZone, formatter);
   }
   return formatter;
 }
 
+// Howard Hinnant's proleptic-Gregorian day<->civil algorithms, operating on
+// "days since 1970-01-01". Pure integer math — no `Date` allocation.
+
+function daysFromCivil(y: number, m: number, d: number): number {
+  const yy = y - (m <= 2 ? 1 : 0);
+  const era = Math.floor((yy >= 0 ? yy : yy - 399) / 400);
+  const yoe = yy - era * 400;
+  const doy = Math.floor((153 * (m + (m > 2 ? -3 : 9)) + 2) / 5) + d - 1;
+  const doe = yoe * 365 + Math.floor(yoe / 4) - Math.floor(yoe / 100) + doy;
+  return era * 146097 + doe - 719468;
+}
+
+function civilFromDays(z: number): [number, number, number] {
+  const zz = z + 719468;
+  const era = Math.floor((zz >= 0 ? zz : zz - 146096) / 146097);
+  const doe = zz - era * 146097;
+  const yoe = Math.floor(
+    (doe -
+      Math.floor(doe / 1460) +
+      Math.floor(doe / 36524) -
+      Math.floor(doe / 146096)) /
+      365,
+  );
+  const y = yoe + era * 400;
+  const doy = doe - (365 * yoe + Math.floor(yoe / 4) - Math.floor(yoe / 100));
+  const mp = Math.floor((5 * doy + 2) / 153);
+  const d = doy - Math.floor((153 * mp + 2) / 5) + 1;
+  const m = mp + (mp < 10 ? 3 : -9);
+  return [y + (m <= 2 ? 1 : 0), m, d];
+}
+
+const pad2 = (n: number): string => (n < 10 ? `0${n}` : String(n));
+const pad4 = (n: number): string => String(n).padStart(4, '0');
+
+/** 0=Sunday..6=Saturday for a day-count (1970-01-01 was a Thursday). */
+const dowFromDays = (dayCount: number): number =>
+  ((((dayCount % 7) + 4) % 7) + 7) % 7;
+
 /**
- * ISO 8601 week label (`RRRR-'W'II`) for a UTC-midnight stamp of a local wall
- * day. The week-numbering year and week can both differ from the calendar year
- * at the Dec/Jan boundary — e.g. 2021-01-01 belongs to 2020-W53.
+ * ISO 8601 week label (`RRRR-'W'II`) from a day-count. The week-numbering year
+ * and week can both differ from the calendar year at the Dec/Jan boundary —
+ * e.g. 2021-01-01 belongs to 2020-W53.
  */
-function isoWeekLabel(localMidnightUtc: number): string {
-  const thursday = new Date(localMidnightUtc);
-  const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
-  thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
-  const isoYear = thursday.getUTCFullYear();
-  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
-  const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
-  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstOffset + 3);
-  const week =
-    1 +
-    Math.round((thursday.getTime() - firstThursday.getTime()) / 604_800_000);
-  return `${String(isoYear).padStart(4, '0')}-W${String(week).padStart(2, '0')}`;
+function isoWeekLabelFromDays(dayCount: number): string {
+  const dayFromMonday = (dowFromDays(dayCount) + 6) % 7;
+  const thursday = dayCount - dayFromMonday + 3;
+  const [isoYear] = civilFromDays(thursday);
+  const jan4 = daysFromCivil(isoYear, 1, 4);
+  const firstOffset = (dowFromDays(jan4) + 6) % 7;
+  const firstThursday = jan4 - firstOffset + 3;
+  const week = 1 + Math.round((thursday - firstThursday) / 7);
+  return `${pad4(isoYear)}-W${pad2(week)}`;
 }
 
 type LocalParts = {
@@ -130,35 +180,157 @@ type LocalParts = {
 };
 
 /**
- * Resolve a timestamp's local wall-clock fields with a single cached
- * `formatToParts` call, then derive day-of-week and ISO week arithmetically.
- * Replaces five per-timestamp `formatInTimeZone` calls — the dominant cost of
- * building the event stream. Throws only on an invalid timezone (the caller
- * skips); returns `null` if the formatter omits a field, which no supported
- * runtime does.
+ * Whole-second UTC offset for `ts` in `timeZone`, via one full `Intl` probe:
+ * `localWallSecond - utcSecond`. Whole seconds (not minutes) keep half-hour,
+ * 45-minute and pre-1970 sub-minute (LMT) offsets exact. Throws on an invalid
+ * timezone (the `Intl` constructor does) — the caller skips.
  */
-function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
+function offsetSecondsAt(ts: number, timeZone: string): number {
   const fields: Record<string, string> = {};
-  for (const part of getLocalPartsFormatter(timeZone).formatToParts(ts)) {
+  for (const part of getOffsetFormatter(timeZone).formatToParts(ts)) {
     fields[part.type] = part.value;
   }
-  const {year, month, day, hour} = fields;
-  if (!year || !month || !day || !hour) {
-    return null;
-  }
-  const localMidnightUtc = Date.UTC(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-  );
+  const localWallSec =
+    daysFromCivil(
+      Number(fields.year),
+      Number(fields.month),
+      Number(fields.day),
+    ) *
+      86400 +
+    (Number(fields.hour) % 24) * 3600 +
+    Number(fields.minute) * 60 +
+    Number(fields.second);
+  return localWallSec - Math.floor(ts / 1000);
+}
+
+/** Derive all local fields from a UTC `ts` and a known whole-second offset. */
+function partsFromOffset(ts: number, offsetSec: number): LocalParts {
+  const localMs = ts + offsetSec * 1000;
+  const dayCount = Math.floor(localMs / 86400000);
+  const secOfDay = Math.floor((localMs - dayCount * 86400000) / 1000);
+  const [y, m, d] = civilFromDays(dayCount);
   return {
-    localDay: `${year}-${month}-${day}`,
-    localMonth: `${year}-${month}`,
-    // `% 24` folds the "24" some ICU builds emit for midnight back to 0.
-    localHour: Number(hour) % 24,
-    localIsoWeek: isoWeekLabel(localMidnightUtc),
-    calendarDow: new Date(localMidnightUtc).getUTCDay(),
+    localDay: `${pad4(y)}-${pad2(m)}-${pad2(d)}`,
+    localMonth: `${pad4(y)}-${pad2(m)}`,
+    localHour: Math.floor(secOfDay / 3600),
+    localIsoWeek: isoWeekLabelFromDays(dayCount),
+    calendarDow: dowFromDays(dayCount),
   };
+}
+
+/**
+ * Per-zone offset-transition table. `boundary[i]` is the first UTC ms at which
+ * `offset[i]` (whole seconds) applies; it holds until `boundary[i+1]`.
+ */
+type OffsetTable = {boundary: number[]; offset: number[]};
+
+/**
+ * Scan stride for locating offset transitions. Must be shorter than the gap
+ * between any two consecutive transitions in the covered range — drink
+ * timestamps are recent, where every IANA zone keeps transitions months apart,
+ * so 8 days carries a wide safety margin while keeping the probe budget tiny
+ * (≈ range / 8d `Intl` calls, once per zone).
+ */
+const SCAN_STEP_MS = 8 * 86400000;
+
+/** Binary-search the exact transition instant in (loTs, hiTs] to ms precision. */
+function findTransition(
+  loTs: number,
+  loOff: number,
+  hiTs: number,
+  timeZone: string,
+): {at: number; off: number} {
+  let lo = loTs;
+  let hi = hiTs;
+  while (hi - lo > 1) {
+    const mid = lo + Math.floor((hi - lo) / 2);
+    if (offsetSecondsAt(mid, timeZone) === loOff) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return {at: hi, off: offsetSecondsAt(hi, timeZone)};
+}
+
+function buildOffsetTable(
+  timeZone: string,
+  lo: number,
+  hi: number,
+): OffsetTable {
+  const boundary: number[] = [lo];
+  let prevOff = offsetSecondsAt(lo, timeZone);
+  const offset: number[] = [prevOff];
+  let cursor = lo;
+  while (cursor < hi) {
+    const next = Math.min(cursor + SCAN_STEP_MS, hi);
+    if (offsetSecondsAt(next, timeZone) !== prevOff) {
+      // One or more transitions lie in (cursor, next]; pin each exactly.
+      let segLo = cursor;
+      let segLoOff = prevOff;
+      for (;;) {
+        const t = findTransition(segLo, segLoOff, next, timeZone);
+        boundary.push(t.at);
+        offset.push(t.off);
+        prevOff = t.off;
+        segLo = t.at;
+        segLoOff = t.off;
+        if (offsetSecondsAt(next, timeZone) === t.off) {
+          break;
+        }
+      }
+    }
+    cursor = next;
+  }
+  return {boundary, offset};
+}
+
+/** Offset for `ts`: the entry of the last boundary <= ts (binary search). */
+function offsetFromTable(table: OffsetTable, ts: number): number {
+  const {boundary, offset} = table;
+  let lo = 0;
+  let hi = boundary.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (boundary[mid] <= ts) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return offset[lo];
+}
+
+/** Global min/max drink timestamp — bounds each zone's offset table. */
+function drinkTimestampRange(
+  sessions: UserDrinkingSessionsList,
+): [number, number] {
+  let lo = Number.POSITIVE_INFINITY;
+  let hi = Number.NEGATIVE_INFINITY;
+  for (const userId of Object.keys(sessions)) {
+    const userSessions = sessions[userId];
+    if (!userSessions) {
+      continue;
+    }
+    for (const sessionId of Object.keys(userSessions)) {
+      const drinks = userSessions[sessionId]?.drinks;
+      if (!drinks) {
+        continue;
+      }
+      for (const tsKey of Object.keys(drinks)) {
+        const ts = Number(tsKey);
+        if (Number.isFinite(ts)) {
+          if (ts < lo) {
+            lo = ts;
+          }
+          if (ts > hi) {
+            hi = ts;
+          }
+        }
+      }
+    }
+  }
+  return Number.isFinite(lo) ? [lo, hi] : [0, 0];
 }
 
 /**
@@ -226,6 +398,24 @@ function buildDrinkEvents(
     return events;
   }
 
+  // Build each session timezone's offset table lazily over the data's span, so
+  // every per-drink resolution below is pure arithmetic. Most users have a
+  // single zone, so this is a handful of `Intl` probes for the whole pass.
+  const [rangeLo, rangeHi] = drinkTimestampRange(sessions);
+  const offsetTables = new Map<string, OffsetTable>();
+  const resolveParts = (ts: number, tz: string): LocalParts => {
+    let table = offsetTables.get(tz);
+    if (!table) {
+      table = buildOffsetTable(
+        tz,
+        rangeLo - SCAN_STEP_MS,
+        rangeHi + SCAN_STEP_MS,
+      );
+      offsetTables.set(tz, table);
+    }
+    return partsFromOffset(ts, offsetFromTable(table, ts));
+  };
+
   for (const userId of Object.keys(sessions)) {
     const userSessions = sessions[userId];
     if (!userSessions) {
@@ -260,13 +450,10 @@ function buildDrinkEvents(
         if (!drinksAtTs) {
           continue;
         }
-        let parts: LocalParts | null;
+        let parts: LocalParts;
         try {
-          parts = resolveLocalParts(ts, sessionTz);
+          parts = resolveParts(ts, sessionTz);
         } catch {
-          continue;
-        }
-        if (!parts) {
           continue;
         }
         const {localDay, localMonth, localHour, localIsoWeek, calendarDow} =


### PR DESCRIPTION
## Outcome: investigation only — no `events.ts` change ships

Deep-dive into `buildDrinkEvents` cold-open cost. A candidate optimization
(per-zone offset table + arithmetic) tested **~2× faster in node** but was
**device-tested and reverted** — it is **~3.5× slower on Hermes**:

| build | `buildDrinkEvents` | dataset |
|-------|--------------------|---------|
| master (baseline, 1× `formatToParts`) | **1039 ms** | 163 sessions → 724 events |
| candidate c (offset-table) | **3703 ms** | same |

### Why node misled
- Hermes `Intl` is ~1000× slower than V8's; cold-open cost is ~linear in the
  **number of `Intl` calls** (~2–3 ms each on device).
- The offset-table trades "1 `Intl` call per timestamp" for "many `Intl` calls to
  build a transition table" (coarse scan + binary search). Free on V8, the
  bottleneck on Hermes — and its cost scales with the **data time-span**, not the
  event count, so a small real dataset (724 events) over several years did *more*
  `Intl` work than the baseline.

### What ships here
- `src/libs/Statistics/events.ts` — **reverted to baseline** (no behavior change).
- `scripts/perf/` — reproducible benchmark + profiler harness (dev-only).
- `__tests__/unit/libs/Statistics/eventsCandidates.test.ts` — oracle correctness
  suite (11 hard zones, DST brackets, pre-1970). Also documents a real
  **date-fns-tz spring-forward off-by-one** bug.
- `STATS_PERF_REPORT.md` — full write-up + device result.

### Real next steps (separate sessions)
1. **Chart bundle (~2 s)** — the "chart bundle parsed" gate is ~2000 ms on both
   builds, the single biggest cold-open cost.
2. **Persist precomputed local fields** — compute `localDay`/`localHour`/… once at
   drink-log time and store them, so `buildDrinkEvents` does zero `Intl` on cold
   open (eliminates the 1039 ms). The genuine `events.ts` win.

**Reviewer note:** merge this only if you want the harness + investigation record
in the tree; otherwise it can be closed without losing any shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)