### PR TITLE
perf(statistics): speed up the Statistics cold open

### DIFF
--- a/__tests__/unit/components/Charts/KpiCard.test.tsx
+++ b/__tests__/unit/components/Charts/KpiCard.test.tsx
@@ -20,10 +20,11 @@ jest.mock('@components/Pressable', () => {
   };
 });
 
-// Sparkline composes BaseChart → CartesianChart → Skia. Stub it.
-jest.mock('@components/Charts/Sparkline', () => ({
+// Sparkline composes BaseChart → CartesianChart → Skia. Stub it. KpiCard pulls
+// it in lazily from the component file (not the barrel), so mock that path.
+jest.mock('@components/Charts/Sparkline/Sparkline', () => ({
   __esModule: true,
-  Sparkline: () => null,
+  default: () => null,
 }));
 
 describe('KpiCard', () => {

--- a/src/components/Charts/KpiCard/KpiCard.tsx
+++ b/src/components/Charts/KpiCard/KpiCard.tsx
@@ -1,11 +1,20 @@
+import {Suspense, lazy} from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
 import {PressableWithFeedback} from '@components/Pressable';
 import {ChartSkeleton} from '@components/Charts/ChartSkeleton';
-import {Sparkline} from '@components/Charts/Sparkline';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {ChartDatum} from '@libs/Statistics';
+
+// Lazy so the hero sparkline's chart stack (Sparkline → BaseChart →
+// victory-native + @shopify/react-native-skia, ~2 s to evaluate on Hermes) is
+// pulled off the Statistics first-paint critical path: the KPI numbers, bars,
+// and distribution paint immediately, then the sparkline streams in behind a
+// fixed-height skeleton. Only the hero KpiCard passes `sparkline`, so this is
+// the single Skia/victory dependency the default Overview tab would otherwise
+// drag onto the cold-open path.
+const Sparkline = lazy(() => import('@components/Charts/Sparkline/Sparkline'));
 
 type KpiCardTone = 'neutral' | 'supportive' | 'celebratory';
 
@@ -146,11 +155,13 @@ function KpiCard({
       ) : null}
       {sparkline && sparkline.length > 0 ? (
         <View style={styles.mt2}>
-          <Sparkline
-            data={sparkline}
-            accessibilityLabel={`${label} trend`}
-            height={28}
-          />
+          <Suspense fallback={<ChartSkeleton variant="line" height={28} />}>
+            <Sparkline
+              data={sparkline}
+              accessibilityLabel={`${label} trend`}
+              height={28}
+            />
+          </Suspense>
         </View>
       ) : null}
     </View>

--- a/src/hooks/useIdlePrefetch.ts
+++ b/src/hooks/useIdlePrefetch.ts
@@ -1,0 +1,31 @@
+import {useEffect} from 'react';
+import {InteractionManager} from 'react-native';
+
+/**
+ * Warm heavy module graphs off the critical path. Once the app is idle — after
+ * the current interactions / entry animations settle — each prefetcher runs
+ * exactly once. Fire-and-forget; if the host unmounts before the idle callback
+ * fires, the scheduled work is cancelled.
+ *
+ * Pass a stable (module-level) `prefetchers` array; a fresh array identity
+ * re-schedules the warm, so don't build it inline in render.
+ */
+function useIdlePrefetch(prefetchers: ReadonlyArray<() => unknown>): void {
+  useEffect(() => {
+    let cancelled = false;
+    const handle = InteractionManager.runAfterInteractions(() => {
+      if (cancelled) {
+        return;
+      }
+      for (const prefetch of prefetchers) {
+        prefetch();
+      }
+    });
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
+  }, [prefetchers]);
+}
+
+export default useIdlePrefetch;

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -35,6 +35,8 @@ import * as ApiUtils from '@libs/ApiUtils';
 import kirokuPusherAuthorizer from '@libs/Pusher/kirokuAuthorizer';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useIdlePrefetch from '@hooks/useIdlePrefetch';
+import prefetchStatisticsBundle from '@screens/Statistics/prefetchStatisticsBundle';
 import {useFirebase} from '@context/global/FirebaseContext';
 import OnboardingGuard from '@libs/Navigation/guards/OnboardingGuard';
 import TermsReConsentGuard from '@libs/Navigation/guards/TermsReConsentGuard';
@@ -130,6 +132,10 @@ const modalScreenListeners = {
     Modal.willAlertModalBecomeVisible(false);
   },
 };
+
+// Module graphs warmed once the authenticated app is idle, so the first open
+// of these screens is a cache hit instead of a cold parse on the critical path.
+const IDLE_PREFETCHERS = [prefetchStatisticsBundle];
 
 function AuthScreensContent() {
   const styles = useThemeStyles();
@@ -288,6 +294,11 @@ function AuthScreensContent() {
     // Rule disabled because this effect is only for component did mount & will component unmount lifecycle event
     // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
   }, []);
+
+  // Warm heavy screen bundles (the Statistics chart graph) once the app is
+  // idle, so their first open is a cache hit rather than a cold parse on the
+  // navigation critical path.
+  useIdlePrefetch(IDLE_PREFETCHERS);
 
   // const CentralPaneScreenOptions = {
   //   headerShown: false,

--- a/src/screens/Statistics/StatisticsTabs.tsx
+++ b/src/screens/Statistics/StatisticsTabs.tsx
@@ -1,5 +1,5 @@
 import type {TupleToUnion} from 'type-fest';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {Suspense, lazy, useCallback, useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {SceneMap, TabBar, TabView} from 'react-native-tab-view';
 import type {
@@ -14,10 +14,17 @@ import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import type {TranslationPaths} from '@src/languages/types';
-import BreakdownTab from './tabs/BreakdownTab';
 import OverviewTab from './tabs/OverviewTab';
-import PatternsTab from './tabs/PatternsTab';
-import TrendsTab from './tabs/TrendsTab';
+
+// Overview is the default tab, so it stays statically imported and paints on
+// mount. The other three each pull a distinct slice of the Skia/victory chart
+// stack; loading them lazily keeps their modules out of the screen's first
+// dynamic-import parse (the ~2 s "chart bundle parsed" gate) and defers each
+// to the moment its tab is first activated, behind the same placeholder the
+// TabView already shows for not-yet-rendered tabs.
+const TrendsTab = lazy(() => import('./tabs/TrendsTab'));
+const PatternsTab = lazy(() => import('./tabs/PatternsTab'));
+const BreakdownTab = lazy(() => import('./tabs/BreakdownTab'));
 
 // Tab order is locked per STATISTICS_V2.md and issue #582.
 const ROUTE_KEYS = ['overview', 'trends', 'patterns', 'breakdown'] as const;
@@ -35,11 +42,35 @@ const LABEL_KEYS: Record<RouteKey, TranslationPaths> = {
   breakdown: 'statistics.tabs.breakdown.label',
 };
 
+function TrendsScene() {
+  return (
+    <Suspense fallback={<TabLazyPlaceholder />}>
+      <TrendsTab />
+    </Suspense>
+  );
+}
+
+function PatternsScene() {
+  return (
+    <Suspense fallback={<TabLazyPlaceholder />}>
+      <PatternsTab />
+    </Suspense>
+  );
+}
+
+function BreakdownScene() {
+  return (
+    <Suspense fallback={<TabLazyPlaceholder />}>
+      <BreakdownTab />
+    </Suspense>
+  );
+}
+
 const renderScene = SceneMap({
   overview: OverviewTab,
-  trends: TrendsTab,
-  patterns: PatternsTab,
-  breakdown: BreakdownTab,
+  trends: TrendsScene,
+  patterns: PatternsScene,
+  breakdown: BreakdownScene,
 });
 
 const styles = StyleSheet.create({
@@ -81,13 +112,14 @@ function renderTabLabel({
   return <Text style={[styles.tabBarLabel, {color}]}>{route.title}</Text>;
 }
 
-function renderLazyPlaceholder(): React.ReactNode {
-  // First mount of an inactive tab: paint a generic tab-shell skeleton so the
-  // user sees structure for the 200–400ms it takes the tab's actual render +
-  // deferred compute to land. Every lazy tab (Trends/Patterns/Breakdown) leads
-  // with the filter toolbar followed by chart cards, so mirror that shape.
-  // Per-chart skeletons take over once the tab mounts; this is just the bridge
-  // between "tap" and "mount".
+// First mount of an inactive tab: paint a generic tab-shell skeleton so the
+// user sees structure for the 200–400ms it takes the tab's actual render +
+// deferred compute to land. Every lazy tab (Trends/Patterns/Breakdown) leads
+// with the filter toolbar followed by chart cards, so mirror that shape.
+// Per-chart skeletons take over once the tab mounts; this is the bridge between
+// "tap" and "mount" — used both as the TabView placeholder and as the Suspense
+// fallback while the tab's lazily-imported chart module is parsing.
+function TabLazyPlaceholder(): React.ReactNode {
   return (
     <View style={styles.lazyPlaceholder}>
       <StatsFilterToolbarSkeleton />
@@ -98,6 +130,10 @@ function renderLazyPlaceholder(): React.ReactNode {
       </View>
     </View>
   );
+}
+
+function renderLazyPlaceholder(): React.ReactNode {
+  return <TabLazyPlaceholder />;
 }
 
 const COMMON_OPTIONS: TabDescriptor<TabRoute> = {

--- a/src/screens/Statistics/prefetchStatisticsBundle.ts
+++ b/src/screens/Statistics/prefetchStatisticsBundle.ts
@@ -1,0 +1,15 @@
+/**
+ * Eagerly evaluate the Statistics chart-tab module so the first open of the
+ * Statistics tab is a cache hit instead of a ~1.5s cold parse of
+ * `react-native-tab-view` + the chart graph. The specifier matches
+ * `StatisticsScreen`'s `import('./StatisticsTabs')`, so Metro evaluates the
+ * module once and the open reuses it.
+ *
+ * Fire-and-forget: a single-bundle dynamic import only rejects if the module
+ * itself throws, in which case the on-open parse simply runs as before.
+ */
+function prefetchStatisticsBundle(): Promise<unknown> {
+  return import('./StatisticsTabs').catch(() => undefined);
+}
+
+export default prefetchStatisticsBundle;


### PR DESCRIPTION
### Details

The Statistics screen had a slow cold open. Two changes here attack it; both only change *when* work happens, not what renders.

**1. Defer the chart stack off the first-paint critical path**

`import('./StatisticsTabs')` eagerly evaluated the whole 4-tab chart graph on the Hermes JS thread before any content could paint. `TabView`'s `lazy` prop only defers tab *rendering*, not module *parsing*, so all four tabs were parsed up front — and even the default Overview tab dragged in `victory-native` + Skia via its hero `KpiCard → Sparkline`.

- **`StatisticsTabs.tsx`** — `Trends`/`Patterns`/`Breakdown` are now `React.lazy` + `Suspense`, reusing the existing tab-shell placeholder as the fallback. `Overview` stays static so it paints on mount; each heavy tab's chart module parses only when its tab is first activated.
- **`KpiCard.tsx`** — the hero `Sparkline` is `React.lazy`-loaded behind a fixed-height `line` skeleton, moving the single Skia/victory dependency on the Overview path off first paint. `BarList`/`DistributionBar`/`ChartCard` are pure RN Views, so the Overview first-paint subtree is now Skia/victory-free.
- **`KpiCard.test.tsx`** — point the Sparkline stub at the new direct-file import path.

**2. Warm the chart bundle at app idle**

Even deferred, opening Statistics still pays a ~1.5s `react-native-tab-view` + chart-graph parse (Statistics is the app's only tab-view consumer, so that module evaluates cold on first open).

- **`AuthScreens.tsx`** — pre-parse `StatisticsTabs` once from the authenticated app root, deferred past the entry animations via `InteractionManager`. The specifier resolves to the same module file as the screen's `import('./StatisticsTabs')`, so Metro evaluates it once and the open becomes a cache hit. Trade-off: the chart graph (tab-view + Overview shell) is parsed for every authenticated user even if they never open Statistics; `victory`/Skia stay lazy (pulled only when a chart actually mounts).

> Note: this branch originally also added a `buildDrinkEvents` Intl offset-cache, but master's `b8981d296` (persist per-drink local-time fields at write time) supersedes it. On merge, `events.ts` was resolved to master's version and the offset-cache dropped.

⚠️ **Perf wins need on-device confirmation** via the `[StatsProfile]` cold-open trace (Hermes; node/V8 numbers are misleading for this app). With the app idle for a moment before opening Statistics, the `chart bundle parsed` delta should collapse.

### Tests

1. Cold-launch the app, let it sit idle a few seconds, then open Statistics. Verify (via `[StatsProfile]`) the `chart bundle parsed` delta collapses to a cache hit.
2. Watch the home screen after boot for a one-time hitch when the warm fires (the chart parse blocks the JS thread once); confirm it isn't disruptive.
3. Verify the Overview tab paints KPIs / bars / distribution first, then the hero sparkline fills in behind its skeleton with no layout jump.
4. Tap into Trends, Patterns, Breakdown — verify each renders its charts correctly.
5. Verify stats numbers are unchanged vs. before.

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed — the dynamic `import()` resolves from the local Metro/Hermes bundle.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Navigate to Statistics; verify Overview content appears (KPI tiles, bar list, distribution bar, hero sparkline).
2. Open Trends, Patterns and Breakdown and verify charts render with no blank state or crash.
3. From a cold launch, confirm the screen reaches content faster than before, with no visual regressions and unchanged numbers.

- [ ] Verify that no errors appear in the JS console

### Automated checks

- prettier / `./scripts/lint.sh` / `typecheck-tsgo` / `react-compiler-compliance-check` — all clean
- Jest: `KpiCard.test.tsx` and all Statistics suites pass on the merged tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)