### PR TITLE
perf(statistics): persist per-drink local time fields to cut Intl off the cold path

### DIFF
--- a/__tests__/unit/libs/Statistics/sessionTimeParts.test.ts
+++ b/__tests__/unit/libs/Statistics/sessionTimeParts.test.ts
@@ -1,0 +1,277 @@
+import buildDrinkEvents from '@libs/Statistics/events';
+import type {DrinkDefaults} from '@libs/Statistics/events';
+import {
+  buildSessionTimeParts,
+  buildTimePartsPatchFromEvents,
+  isStoredLocalParts,
+} from '@libs/Statistics/sessionTimeParts';
+import type {WeekStart} from '@libs/Statistics/types';
+import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
+import type DrinkingSession from '@src/types/onyx/DrinkingSession';
+import type {
+  SessionTimeParts,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx/DrinkingSession';
+import type {DrinksToUnits} from '@src/types/onyx/Preferences';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+
+const UTC = 'UTC' as SelectedTimezone;
+const LONDON = 'Europe/London' as SelectedTimezone;
+const TOKYO = 'Asia/Tokyo' as SelectedTimezone;
+
+const UNITS: DrinksToUnits = {
+  small_beer: 0.5,
+  beer: 1,
+  cocktail: 1.5,
+  other: 1,
+  strong_shot: 1,
+  weak_shot: 0.5,
+  wine: 1.5,
+};
+
+const DEFAULTS: DrinkDefaults = {
+  beer: {ml: 500, abv: 0.05},
+  wine: {ml: 150, abv: 0.12},
+};
+
+const MON: WeekStart = 1;
+
+function makeDrinks(
+  rows: Array<[ts: number, entries: Partial<Record<DrinkKey, number>>]>,
+): DrinksList {
+  const out: DrinksList = {};
+  for (const [ts, entries] of rows) {
+    out[ts] = entries;
+  }
+  return out;
+}
+
+/** Fresh single-user/single-session wrapper (defeats the module-level memo). */
+function oneSession(
+  session: Partial<DrinkingSession>,
+): UserDrinkingSessionsList {
+  return {u1: {s1: {start_time: session.start_time ?? 0, ...session}}};
+}
+
+describe('isStoredLocalParts', () => {
+  it('accepts a well-formed entry', () => {
+    expect(
+      isStoredLocalParts({d: '2024-01-15', h: 11, w: '2024-W03', dow: 1}),
+    ).toBe(true);
+  });
+
+  it('rejects wrong field types, nullish, and non-objects', () => {
+    expect(isStoredLocalParts({d: 1, h: 11, w: '2024-W03', dow: 1})).toBe(
+      false,
+    );
+    expect(isStoredLocalParts({d: '2024-01-15', h: '11', w: 'x', dow: 1})).toBe(
+      false,
+    );
+    expect(isStoredLocalParts({d: '2024-01-15', h: 11, w: '2024-W03'})).toBe(
+      false,
+    );
+    expect(isStoredLocalParts(null)).toBe(false);
+    expect(isStoredLocalParts('nope')).toBe(false);
+  });
+});
+
+describe('buildSessionTimeParts', () => {
+  it('stores d/h/w/dow per timestamp in the given timezone', () => {
+    // 2024-01-15 23:30 UTC → 2024-01-16 08:30 in Tokyo (UTC+9).
+    const ts = Date.UTC(2024, 0, 15, 23, 30);
+    const parts = buildSessionTimeParts(makeDrinks([[ts, {beer: 1}]]), TOKYO);
+    expect(parts).toEqual({
+      tz: TOKYO,
+      byTs: {[ts]: {d: '2024-01-16', h: 8, w: '2024-W03', dow: 2}},
+    });
+  });
+
+  it('returns undefined when there are no drinks', () => {
+    expect(buildSessionTimeParts(undefined, UTC)).toBeUndefined();
+    expect(buildSessionTimeParts({}, UTC)).toBeUndefined();
+  });
+
+  it('skips non-finite timestamp keys but keeps the finite ones', () => {
+    const good = Date.UTC(2024, 0, 15, 11);
+    const drinks: DrinksList = {
+      NaN: {beer: 1},
+      [good]: {beer: 1},
+    };
+    const parts = buildSessionTimeParts(drinks, UTC);
+    expect(Object.keys(parts?.byTs ?? {})).toEqual([String(good)]);
+  });
+});
+
+/**
+ * The strongest correctness guarantee: events built from stored fields must be
+ * byte-identical to events built by recomputing from the raw stamp, because the
+ * write path and the read-path fallback share one resolver.
+ */
+describe('buildDrinkEvents — stored parts match the recompute path', () => {
+  const cases: Array<[label: string, tz: SelectedTimezone, ts: number]> = [
+    ['UTC midday', UTC, Date.UTC(2024, 0, 15, 11)],
+    ['Tokyo cross-day', TOKYO, Date.UTC(2024, 0, 15, 23, 30)],
+    // London spring-forward instant: 01:00Z = 02:00 BST (date-fns-tz says 03:00).
+    ['London spring-forward', LONDON, Date.UTC(2021, 2, 28, 1, 0, 0)],
+    // ISO-week boundary: 2021-01-01 belongs to 2020-W53.
+    ['ISO week edge', UTC, Date.UTC(2021, 0, 1, 12)],
+    // Leap day.
+    ['leap day', UTC, Date.UTC(2024, 1, 29, 14)],
+  ];
+
+  it.each(cases)('%s', (_label, tz, ts) => {
+    const drinks = makeDrinks([[ts, {beer: 2, wine: 1}]]);
+    const withoutParts = buildDrinkEvents(
+      oneSession({start_time: ts, end_time: ts, timezone: tz, drinks}),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    const parts = buildSessionTimeParts(drinks, tz);
+    const withParts = buildDrinkEvents(
+      oneSession({
+        start_time: ts,
+        end_time: ts,
+        timezone: tz,
+        drinks,
+        drinksTimeParts: parts,
+      }),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    expect(withParts).toEqual(withoutParts);
+    expect(withParts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildDrinkEvents — stored-parts trust + tz guard', () => {
+  const ts = Date.UTC(2024, 0, 15, 11);
+  const drinks = makeDrinks([[ts, {beer: 1}]]);
+  // Deliberately wrong stored fields, to observe whether the read path uses them.
+  const bogus: SessionTimeParts = {
+    tz: UTC,
+    byTs: {[ts]: {d: '1999-12-31', h: 5, w: '1999-W52', dow: 4}},
+  };
+
+  it('uses stored fields verbatim when the tz tag matches the session tz', () => {
+    const events = buildDrinkEvents(
+      oneSession({
+        start_time: ts,
+        timezone: UTC,
+        drinks,
+        drinksTimeParts: bogus,
+      }),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    expect(events[0].localDay).toBe('1999-12-31');
+    expect(events[0].localMonth).toBe('1999-12'); // derived from stored day
+    expect(events[0].localHour).toBe(5);
+    expect(events[0].localIsoWeek).toBe('1999-W52');
+  });
+
+  it('ignores stored fields (recomputes) when the tz tag does not match', () => {
+    const events = buildDrinkEvents(
+      // Session is UTC, but the stored map is tagged Tokyo → distrusted.
+      oneSession({
+        start_time: ts,
+        timezone: UTC,
+        drinks,
+        drinksTimeParts: {...bogus, tz: TOKYO},
+      }),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    expect(events[0].localDay).toBe('2024-01-15');
+    expect(events[0].localHour).toBe(11);
+  });
+
+  it('falls back per timestamp when a stored entry is corrupt', () => {
+    const events = buildDrinkEvents(
+      oneSession({
+        start_time: ts,
+        timezone: UTC,
+        drinks,
+        drinksTimeParts: {
+          tz: UTC,
+          byTs: {[ts]: {d: 123} as never},
+        },
+      }),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    expect(events[0].localDay).toBe('2024-01-15');
+    expect(events[0].localHour).toBe(11);
+  });
+});
+
+describe('buildTimePartsPatchFromEvents — backfill round-trip', () => {
+  // Sunday in Tokyo with weekStart=Monday exercises the dow rotation inverse.
+  const ts = Date.UTC(2024, 0, 14, 3, 0); // 2024-01-14 12:00 in Tokyo (Sunday)
+  const drinks = makeDrinks([[ts, {beer: 1, wine: 2}]]);
+
+  function freshSessions(parts?: SessionTimeParts): UserDrinkingSessionsList {
+    return oneSession({
+      start_time: ts,
+      end_time: ts,
+      timezone: TOKYO,
+      drinks,
+      drinksTimeParts: parts,
+    });
+  }
+
+  it('reconstructs a patch whose stored parts reproduce the events exactly', () => {
+    const base = freshSessions();
+    const events = buildDrinkEvents(base, UNITS, DEFAULTS, UTC, MON);
+
+    const patch = buildTimePartsPatchFromEvents(events, base, UTC, MON);
+    expect(patch).not.toBeNull();
+    const reconstructed = patch?.u1?.s1?.drinksTimeParts;
+    expect(reconstructed?.tz).toBe(TOKYO);
+
+    // Feed the reconstructed parts back through events: must match byte-for-byte.
+    const afterBackfill = buildDrinkEvents(
+      freshSessions(reconstructed),
+      UNITS,
+      DEFAULTS,
+      UTC,
+      MON,
+    );
+    expect(afterBackfill).toEqual(events);
+    // It also matches what the write path would have produced directly.
+    expect(reconstructed).toEqual(buildSessionTimeParts(drinks, TOKYO));
+  });
+
+  it('returns null once every session already has valid parts (converges)', () => {
+    const withParts = freshSessions(buildSessionTimeParts(drinks, TOKYO));
+    const events = buildDrinkEvents(withParts, UNITS, DEFAULTS, UTC, MON);
+    expect(
+      buildTimePartsPatchFromEvents(events, withParts, UTC, MON),
+    ).toBeNull();
+  });
+
+  it('re-tags when the existing parts were computed under a different tz', () => {
+    const stale = freshSessions({
+      tz: LONDON,
+      byTs: {[ts]: {d: '1999-12-31', h: 5, w: '1999-W52', dow: 4}},
+    });
+    const events = buildDrinkEvents(stale, UNITS, DEFAULTS, UTC, MON);
+    const patch = buildTimePartsPatchFromEvents(events, stale, UTC, MON);
+    expect(patch?.u1?.s1?.drinksTimeParts.tz).toBe(TOKYO);
+  });
+
+  it('returns null for an empty event list', () => {
+    expect(
+      buildTimePartsPatchFromEvents([], freshSessions(), UTC, MON),
+    ).toBeNull();
+  });
+});

--- a/__tests__/unit/useDrinkEvents.test.ts
+++ b/__tests__/unit/useDrinkEvents.test.ts
@@ -6,6 +6,7 @@ import {useOnyx} from 'react-native-onyx';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import Statistics from '@libs/actions/Statistics';
 import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
 import type {Preferences, UserData} from '@src/types/onyx';
 import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
@@ -27,6 +28,12 @@ jest.mock('@context/global/DatabaseDataContext', () => ({
 jest.mock('@hooks/useCurrentUserData', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+// The hook delegates persistence of precomputed time fields to this action.
+jest.mock('@libs/actions/Statistics', () => ({
+  __esModule: true,
+  default: {setFilters: jest.fn(), backfillSessionTimeParts: jest.fn()},
 }));
 
 const mockedUseOnyx = jest.mocked(useOnyx);
@@ -270,13 +277,26 @@ describe('useDrinkEvents', () => {
 
   test('cancels deferred work on unmount mid-flight', () => {
     const cancel = jest.fn();
-    runAfterSpy.mockImplementation(
-      () => ({cancel, then: () => {}}) as never,
-    );
+    runAfterSpy.mockImplementation(() => ({cancel, then: () => {}}) as never);
 
     const {unmount} = renderHook(() => useDrinkEvents(['u1']));
     unmount();
 
     expect(cancel).toHaveBeenCalled();
+  });
+
+  test('delegates a time-parts backfill for the computed events', () => {
+    const sessions = makeSessions();
+    setOnyx(sessions, 'loaded');
+
+    renderHook(() => useDrinkEvents(['u1']));
+
+    const backfill = jest.mocked(Statistics.backfillSessionTimeParts);
+    expect(backfill).toHaveBeenCalledTimes(1);
+    const [events, passedSessions, tz, weekStart] = backfill.mock.calls[0];
+    expect(events.length).toBeGreaterThan(0);
+    expect(passedSessions).toBe(sessions);
+    expect(tz).toBe('Africa/Abidjan');
+    expect(weekStart).toBe(1);
   });
 });

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -4,6 +4,7 @@ import {useOnyx} from 'react-native-onyx';
 import {buildDrinkEvents} from '@libs/Statistics';
 import type {DrinkEvent, WeekStart} from '@libs/Statistics';
 import {markStatsPhase} from '@libs/Statistics/profiling';
+import Statistics from '@libs/actions/Statistics';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
@@ -92,6 +93,18 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
       setAllEvents(next);
       setIsCompiled(true);
       markStatsPhase('first events ready', {events: next.length});
+
+      // Persist the local fields any session was just forced to recompute, so
+      // the next cold open reads them with zero `Intl`. Reconstructed from the
+      // events above (no extra `Intl`); the merge re-fires this effect, which
+      // then reads the stored fields and produces an empty patch — so it
+      // converges in one step and never loops.
+      Statistics.backfillSessionTimeParts(
+        next,
+        allSessions,
+        timezone,
+        weekStart,
+      );
     });
     return () => {
       cancelled = true;

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -3,8 +3,11 @@ import type DrinkingSession from '@src/types/onyx/DrinkingSession';
 import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
 import type {DrinksToUnits} from '@src/types/onyx/Preferences';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import type {LocalParts} from './localParts';
+import {resolveLocalParts} from './localParts';
 import {logBuildDrinkEvents} from './profiling';
 import {sduFrom} from './sdu';
+import {isStoredLocalParts} from './sessionTimeParts';
 import type {DrinkEvent, WeekStart} from './types';
 
 /**
@@ -79,86 +82,27 @@ function computeSdu(
 }
 
 /**
- * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
- * expensive part of timezone resolution, so we build it once and reuse it for
- * every timestamp in that zone — in practice a single zone per user.
+ * Resolve a timestamp's local fields, preferring values stored on the session
+ * at write time (zero `Intl`). `stored` is one entry of `session.drinksTimeParts.byTs`,
+ * already gated on a matching timezone by the caller; on a missing or corrupt
+ * entry we recompute from the raw stamp so a partial map is never wrong. The
+ * month is derived from the day string (a free slice — not stored separately).
  */
-const localPartsFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = localPartsFormatters.get(timeZone);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      hourCycle: 'h23',
-    });
-    localPartsFormatters.set(timeZone, formatter);
+function localPartsFor(
+  ts: number,
+  sessionTz: string,
+  stored: unknown,
+): LocalParts | null {
+  if (isStoredLocalParts(stored)) {
+    return {
+      localDay: stored.d,
+      localMonth: stored.d.slice(0, 7),
+      localHour: stored.h,
+      localIsoWeek: stored.w,
+      calendarDow: stored.dow,
+    };
   }
-  return formatter;
-}
-
-/**
- * ISO 8601 week label (`RRRR-'W'II`) for a UTC-midnight stamp of a local wall
- * day. The week-numbering year and week can both differ from the calendar year
- * at the Dec/Jan boundary — e.g. 2021-01-01 belongs to 2020-W53.
- */
-function isoWeekLabel(localMidnightUtc: number): string {
-  const thursday = new Date(localMidnightUtc);
-  const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
-  thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
-  const isoYear = thursday.getUTCFullYear();
-  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
-  const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
-  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstOffset + 3);
-  const week =
-    1 +
-    Math.round((thursday.getTime() - firstThursday.getTime()) / 604_800_000);
-  return `${String(isoYear).padStart(4, '0')}-W${String(week).padStart(2, '0')}`;
-}
-
-type LocalParts = {
-  localDay: string;
-  localMonth: string;
-  localHour: number;
-  localIsoWeek: string;
-  /** Calendar day of week, 0=Sunday..6=Saturday (weekStart-independent). */
-  calendarDow: number;
-};
-
-/**
- * Resolve a timestamp's local wall-clock fields with a single cached
- * `formatToParts` call, then derive day-of-week and ISO week arithmetically.
- * Replaces five per-timestamp `formatInTimeZone` calls — the dominant cost of
- * building the event stream. Throws only on an invalid timezone (the caller
- * skips); returns `null` if the formatter omits a field, which no supported
- * runtime does.
- */
-function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
-  const fields: Record<string, string> = {};
-  for (const part of getLocalPartsFormatter(timeZone).formatToParts(ts)) {
-    fields[part.type] = part.value;
-  }
-  const {year, month, day, hour} = fields;
-  if (!year || !month || !day || !hour) {
-    return null;
-  }
-  const localMidnightUtc = Date.UTC(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-  );
-  return {
-    localDay: `${year}-${month}-${day}`,
-    localMonth: `${year}-${month}`,
-    // `% 24` folds the "24" some ICU builds emit for midnight back to 0.
-    localHour: Number(hour) % 24,
-    localIsoWeek: isoWeekLabel(localMidnightUtc),
-    calendarDow: new Date(localMidnightUtc).getUTCDay(),
-  };
+  return resolveLocalParts(ts, sessionTz);
 }
 
 /**
@@ -251,6 +195,13 @@ function buildDrinkEvents(
       if (!drinks) {
         continue;
       }
+      // Stored fields are trusted only when they were computed under the
+      // session's current timezone; on a mismatch every timestamp falls back to
+      // recomputing, so a stale tag can never serve a wrong value.
+      const storedByTs =
+        session.drinksTimeParts?.tz === sessionTz
+          ? session.drinksTimeParts.byTs
+          : undefined;
       sessionCount += 1;
       for (const [tsKey, drinksAtTs] of Object.entries(drinks)) {
         const ts = Number(tsKey);
@@ -262,7 +213,7 @@ function buildDrinkEvents(
         }
         let parts: LocalParts | null;
         try {
-          parts = resolveLocalParts(ts, sessionTz);
+          parts = localPartsFor(ts, sessionTz, storedByTs?.[ts]);
         } catch {
           continue;
         }

--- a/src/libs/Statistics/localParts.ts
+++ b/src/libs/Statistics/localParts.ts
@@ -1,0 +1,108 @@
+/**
+ * Resolve a UTC instant's local wall-clock fields in a given timezone using a
+ * single cached `Intl.DateTimeFormat.formatToParts` call, then derive ISO week
+ * and calendar day-of-week arithmetically.
+ *
+ * This is the *one* place the app turns `(timestamp, timezone)` into local
+ * calendar fields, shared by:
+ *  - `buildDrinkEvents` (read path, as a fallback when stored fields are absent)
+ *  - `buildSessionTimeParts` (write path, when a session is saved)
+ *
+ * Sharing it guarantees the value persisted at write time and the value
+ * recomputed on the fly are byte-identical — there is no second implementation
+ * to drift. Native `Intl` (not `date-fns-tz`) is used deliberately: `date-fns-tz`
+ * is off-by-one-hour at the exact spring-forward instant, whereas `Intl` matches
+ * the engine the app runs on.
+ *
+ * On Hermes each `formatToParts` call is ~2-3 ms, so the write path pays this
+ * once per drink timestamp while the user is interacting, and the cold read path
+ * pays nothing once the fields are stored.
+ */
+
+/**
+ * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
+ * expensive part of timezone resolution, so we build it once and reuse it for
+ * every timestamp in that zone — in practice a single zone per user.
+ */
+const localPartsFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = localPartsFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      hourCycle: 'h23',
+    });
+    localPartsFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * ISO 8601 week label (`RRRR-'W'II`) for a UTC-midnight stamp of a local wall
+ * day. The week-numbering year and week can both differ from the calendar year
+ * at the Dec/Jan boundary — e.g. 2021-01-01 belongs to 2020-W53.
+ */
+function isoWeekLabel(localMidnightUtc: number): string {
+  const thursday = new Date(localMidnightUtc);
+  const dayFromMonday = (thursday.getUTCDay() + 6) % 7;
+  thursday.setUTCDate(thursday.getUTCDate() - dayFromMonday + 3);
+  const isoYear = thursday.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstOffset = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstOffset + 3);
+  const week =
+    1 +
+    Math.round((thursday.getTime() - firstThursday.getTime()) / 604_800_000);
+  return `${String(isoYear).padStart(4, '0')}-W${String(week).padStart(2, '0')}`;
+}
+
+type LocalParts = {
+  /** `yyyy-MM-dd` in the target timezone. */
+  localDay: string;
+  /** `yyyy-MM` in the target timezone. */
+  localMonth: string;
+  /** 0..23 in the target timezone. */
+  localHour: number;
+  /** ISO-8601 week label `RRRR-Www` in the target timezone. */
+  localIsoWeek: string;
+  /** Calendar day of week, 0=Sunday..6=Saturday (weekStart-independent). */
+  calendarDow: number;
+};
+
+/**
+ * Resolve a timestamp's local wall-clock fields with a single cached
+ * `formatToParts` call, then derive day-of-week and ISO week arithmetically.
+ * Throws only on an invalid timezone (the caller skips); returns `null` if the
+ * formatter omits a field, which no supported runtime does.
+ */
+function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
+  const fields: Record<string, string> = {};
+  for (const part of getLocalPartsFormatter(timeZone).formatToParts(ts)) {
+    fields[part.type] = part.value;
+  }
+  const {year, month, day, hour} = fields;
+  if (!year || !month || !day || !hour) {
+    return null;
+  }
+  const localMidnightUtc = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+  );
+  return {
+    localDay: `${year}-${month}-${day}`,
+    localMonth: `${year}-${month}`,
+    // `% 24` folds the "24" some ICU builds emit for midnight back to 0.
+    localHour: Number(hour) % 24,
+    localIsoWeek: isoWeekLabel(localMidnightUtc),
+    calendarDow: new Date(localMidnightUtc).getUTCDay(),
+  };
+}
+
+export {resolveLocalParts, isoWeekLabel};
+export type {LocalParts};

--- a/src/libs/Statistics/sessionTimeParts.ts
+++ b/src/libs/Statistics/sessionTimeParts.ts
@@ -1,0 +1,134 @@
+import type {DrinksList} from '@src/types/onyx/Drinks';
+import type {
+  SessionTimeParts,
+  StoredLocalParts,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx/DrinkingSession';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+import {resolveLocalParts} from './localParts';
+import type {DrinkEvent, WeekStart} from './types';
+
+/**
+ * Runtime guard for a stored entry. Onyx persistence has produced corrupt
+ * values in the wild (e.g. `NaN` keys), so the read path validates a stored
+ * entry's shape before trusting it and falls back to recomputing on failure.
+ */
+function isStoredLocalParts(value: unknown): value is StoredLocalParts {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.d === 'string' &&
+    typeof candidate.h === 'number' &&
+    typeof candidate.w === 'string' &&
+    typeof candidate.dow === 'number'
+  );
+}
+
+/**
+ * Write path: compute the precomputed local fields for every drink timestamp in
+ * a session, in timezone `tz`. One `Intl` call per timestamp — paid while the
+ * user is saving, never on the Statistics cold path.
+ *
+ * Returns `undefined` when there is nothing worth storing (no drinks, or no
+ * timestamp resolved), so callers can skip writing an empty map.
+ */
+function buildSessionTimeParts(
+  drinks: DrinksList | undefined,
+  tz: string,
+): SessionTimeParts | undefined {
+  if (!drinks) {
+    return undefined;
+  }
+  const byTs: Record<number, StoredLocalParts> = {};
+  let stored = false;
+  for (const tsKey of Object.keys(drinks)) {
+    const ts = Number(tsKey);
+    if (!Number.isFinite(ts)) {
+      continue;
+    }
+    let parts;
+    try {
+      parts = resolveLocalParts(ts, tz);
+    } catch {
+      continue;
+    }
+    if (!parts) {
+      continue;
+    }
+    byTs[ts] = {
+      d: parts.localDay,
+      h: parts.localHour,
+      w: parts.localIsoWeek,
+      dow: parts.calendarDow,
+    };
+    stored = true;
+  }
+  return stored ? {tz, byTs} : undefined;
+}
+
+/** A deep-partial merge patch for `CACHED_DRINKING_SESSIONS`. */
+type TimePartsPatch = Record<
+  UserID,
+  Record<string, {drinksTimeParts: SessionTimeParts}>
+>;
+
+/**
+ * Backfill path: reconstruct the stored fields from an already-materialised
+ * `DrinkEvent[]` — **zero** `Intl` work, since every field bar the absolute
+ * day-of-week is carried verbatim on the event, and `calendarDow` inverts the
+ * weekStart rotation (`localDow = (calendarDow - weekStart + 7) % 7`).
+ *
+ * Only sessions whose stored parts are absent or computed under a different
+ * timezone are included, so a steady state produces an empty patch and the
+ * caller's merge converges (no rewrite loop). The `tz` tag is derived exactly
+ * as the read path derives it, so a backfilled session is immediately trusted.
+ *
+ * Returns `null` when nothing needs backfilling.
+ */
+function buildTimePartsPatchFromEvents(
+  events: DrinkEvent[],
+  sessions: UserDrinkingSessionsList | undefined,
+  defaultTimezone: string,
+  weekStart: WeekStart,
+): TimePartsPatch | null {
+  if (events.length === 0 || !sessions) {
+    return null;
+  }
+  const patch: TimePartsPatch = {};
+  for (const event of events) {
+    const session = sessions[event.userId]?.[event.sessionId];
+    if (!session) {
+      continue;
+    }
+    const sessionTz = session.timezone ?? defaultTimezone;
+    if (session.drinksTimeParts?.tz === sessionTz) {
+      continue;
+    }
+    let userPatch = patch[event.userId];
+    if (!userPatch) {
+      userPatch = {};
+      patch[event.userId] = userPatch;
+    }
+    let sessionPatch = userPatch[event.sessionId];
+    if (!sessionPatch) {
+      sessionPatch = {drinksTimeParts: {tz: sessionTz, byTs: {}}};
+      userPatch[event.sessionId] = sessionPatch;
+    }
+    sessionPatch.drinksTimeParts.byTs[event.ts] = {
+      d: event.localDay,
+      h: event.localHour,
+      w: event.localIsoWeek,
+      dow: (event.localDow + weekStart) % 7,
+    };
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
+export {
+  buildSessionTimeParts,
+  buildTimePartsPatchFromEvents,
+  isStoredLocalParts,
+};
+export type {TimePartsPatch};

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -26,6 +26,7 @@ import {generateDatabaseKey} from '@database/baseFunctions';
 import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
+import {buildSessionTimeParts} from '@libs/Statistics/sessionTimeParts';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import type {OnyxKey} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -287,6 +288,20 @@ async function startLiveDrinkingSession(
  * @param sesisonKey ID of the session to edit (can be null in case of finishing the session)
  * @returnsPromise void.
  *  */
+/**
+ * Attach precomputed per-drink local calendar fields (`drinksTimeParts`) to a
+ * finalised session so the Statistics cold path reads them with zero `Intl`
+ * work. Computed here — at the single save chokepoint, while the user is
+ * already interacting — over the session's final timezone and drink timestamps,
+ * which is why it transparently picks up timezone changes and date shifts.
+ * Returns the session unchanged when there is nothing to store.
+ */
+function withSessionTimeParts(session: DrinkingSession): DrinkingSession {
+  const sessionTz = session.timezone ?? CONST.DEFAULT_TIME_ZONE.selected;
+  const drinksTimeParts = buildSessionTimeParts(session.drinks, sessionTz);
+  return drinksTimeParts ? {...session, drinksTimeParts} : session;
+}
+
 async function saveDrinkingSessionData(
   userID: string,
   newSessionData: DrinkingSession,
@@ -294,6 +309,7 @@ async function saveDrinkingSessionData(
   onyxKey: OnyxKey,
   sessionIsLive?: boolean,
 ): Promise<void> {
+  const sessionToPersist = withSessionTimeParts(newSessionData);
   // The server upserts the session, owns the `earliest_session_at` floor
   // (recomputing it when an edit moves the previously-earliest session later),
   // and — when `sessionIsLive` — updates the user's live status. The optimistic
@@ -303,14 +319,14 @@ async function saveDrinkingSessionData(
     WRITE_COMMANDS.UPDATE_SESSION,
     {
       sessionId: sessionKey,
-      session: newSessionData,
+      session: sessionToPersist,
       sessionIsLive: !!sessionIsLive,
     },
     {
       optimisticData: sessionUpsertOptimisticData(
         userID,
         sessionKey,
-        newSessionData,
+        sessionToPersist,
       ),
     },
   );

--- a/src/libs/actions/Statistics.ts
+++ b/src/libs/actions/Statistics.ts
@@ -1,6 +1,9 @@
 import Onyx from 'react-native-onyx';
+import {buildTimePartsPatchFromEvents} from '@libs/Statistics/sessionTimeParts';
+import type {DrinkEvent, WeekStart} from '@libs/Statistics';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {StatisticsFilters} from '@src/types/onyx';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
 
 /**
  * Merge a patch into the persisted Statistics filter state. The provider
@@ -12,4 +15,29 @@ function setFilters(patch: Partial<StatisticsFilters>): void {
   Onyx.merge(ONYXKEYS.STATISTICS_FILTERS, patch);
 }
 
-export default {setFilters};
+/**
+ * Persist the precomputed per-drink local time fields that `buildDrinkEvents`
+ * had to recompute this pass, so the next cold open reads them with zero `Intl`.
+ * The patch is reconstructed from the already-materialised events (no extra
+ * `Intl`); it covers only sessions whose stored fields are absent or stale, so
+ * a steady state is a no-op and the triggering subscription converges in one
+ * step rather than looping.
+ */
+function backfillSessionTimeParts(
+  events: DrinkEvent[],
+  sessions: UserDrinkingSessionsList | undefined,
+  defaultTimezone: string,
+  weekStart: WeekStart,
+): void {
+  const patch = buildTimePartsPatchFromEvents(
+    events,
+    sessions,
+    defaultTimezone,
+    weekStart,
+  );
+  if (patch) {
+    Onyx.merge(ONYXKEYS.CACHED_DRINKING_SESSIONS, patch);
+  }
+}
+
+export default {setFilters, backfillSessionTimeParts};

--- a/src/types/onyx/DrinkingSession.ts
+++ b/src/types/onyx/DrinkingSession.ts
@@ -28,6 +28,41 @@ type AddDrinksOptions =
 /** Options denoting how drinks should be removed */
 type RemoveDrinksOptions = 'removeFromLatest' | 'removeFromEarliest';
 
+/**
+ * Per-drink-timestamp local calendar fields, precomputed once in the session's
+ * timezone so the Statistics cold path reads them with zero `Intl` work. Keys
+ * are intentionally terse — this is a persisted, network-synced wire format and
+ * a heavy user can accumulate thousands of timestamps.
+ *
+ * `localMonth` is intentionally not stored: it is `localDay.slice(0, 7)`, a free
+ * string slice at read time.
+ */
+type StoredLocalParts = {
+  /** `localDay` — `yyyy-MM-dd` in the session timezone. */
+  d: string;
+  /** `localHour` — 0..23 in the session timezone. */
+  h: number;
+  /** `localIsoWeek` — ISO-8601 week label `RRRR-Www` in the session timezone. */
+  w: string;
+  /** Calendar day of week, 0=Sunday..6=Saturday (weekStart-independent). */
+  dow: number;
+};
+
+/**
+ * Precomputed local fields for every drink timestamp in a session.
+ *
+ * `tz` records the timezone the fields were computed under. The read path only
+ * trusts `byTs` when `tz` matches the session's current timezone; on a mismatch
+ * (or for any timestamp missing from `byTs`) it recomputes from the raw stamp,
+ * so a stale or partial map can never serve a wrong value — only a slower one.
+ */
+type SessionTimeParts = {
+  /** IANA timezone these parts were computed under. */
+  tz: string;
+  /** Keyed by the same ms-timestamp keys as `DrinkingSession.drinks`. */
+  byTs: Record<Timestamp, StoredLocalParts>;
+};
+
 /** A drinking session unique identifier */
 type DrinkingSessionId = string;
 
@@ -50,6 +85,13 @@ type DrinkingSession = {
 
   /** The drinks recorded during the session */
   drinks?: DrinksList;
+
+  /**
+   * Precomputed local calendar fields per drink timestamp, in the session's
+   * timezone. Maintained on save (`saveDrinkingSessionData`) and backfilled
+   * lazily; absence is fine — the Statistics read path recomputes from `drinks`.
+   */
+  drinksTimeParts?: SessionTimeParts;
 
   /** Whether or not the user had a blackout during the session */
   blackout?: boolean;
@@ -81,5 +123,7 @@ export type {
   DrinkingSessionList,
   DrinkingSessionType,
   RemoveDrinksOptions,
+  SessionTimeParts,
+  StoredLocalParts,
   UserDrinkingSessionsList,
 };

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -13,6 +13,8 @@ import type {
   DrinkingSessionArray,
   DrinkingSessionList,
   DrinkingSessionType,
+  SessionTimeParts,
+  StoredLocalParts,
   UserDrinkingSessionsList,
 } from './DrinkingSession';
 import type Feedback from './Feedback';
@@ -133,6 +135,8 @@ export type {
   SessionLocations,
   SessionPlaceholder,
   SessionPlaceholderList,
+  SessionTimeParts,
+  StoredLocalParts,
   RangePreset,
   StartSession,
   StatisticsFilters,


### PR DESCRIPTION
### Details

`buildDrinkEvents` (`src/libs/Statistics/events.ts`) — the function every Statistics chart reduces over — called `Intl.DateTimeFormat.formatToParts` **once per drink timestamp** to resolve each session's local calendar fields. On Hermes each `Intl` call costs ~2-3ms (vs ~0.003ms on V8), so a cold Statistics open spent ~1s in pure `Intl` for a modest real dataset (163 sessions → 724 events). A prior in-function optimization (per-zone offset-transition table) was tried and **reverted** — it was ~2x faster on node but ~3.5x **slower** on Hermes (see PR #884 / `STATS_PERF_REPORT.md`), because its table-build `Intl` probes dominate on Hermes.

This PR takes the real fix: **eliminate `Intl` from the cold path entirely** by precomputing the per-drink local fields once, when a session is saved, and persisting them. On a cold open `buildDrinkEvents` reads stored values with **zero `Intl`**.

**Stored shape.** Each session gains an optional `drinksTimeParts: { tz, byTs }` (`src/types/onyx/DrinkingSession.ts`), where `byTs` maps each drink timestamp → `{ d, h, w, dow }` (local day, hour, ISO week, **absolute** calendar day-of-week). `localMonth` is a free `d.slice(0,7)` at read; the day-of-week is stored absolute and rotated by `weekStart` at read time, so changing week-start never requires a rewrite. `tz` records the timezone the fields were computed under.

**Read path** (`events.ts`) trusts `byTs` only when `tz` matches the session's current timezone, and validates each entry's shape; on any mismatch, gap, or corrupt entry it recomputes from the raw stamp. A stale or partial map therefore can never serve a *wrong* value — only a slower one. This also keeps it correct during rollout (sessions without stored fields just recompute).

**Write path** enriches at the single `saveDrinkingSessionData` chokepoint (covers both live-session finalize and edit saves). Because it computes from the session's *final* timezone and timestamps, it transparently picks up timezone changes and date shifts. The server stores the session verbatim, so the fields sync across devices.

**Backfill** for existing/legacy/friends' sessions is lazy: `Statistics.backfillSessionTimeParts` reconstructs the stored fields from the already-materialised `DrinkEvent[]` (**zero** extra `Intl` — `calendarDow` inverts the weekStart rotation) and merges them into the cache. It only patches sessions lacking valid parts, so it converges in one step and never loops. Client-local (not pushed to the server en masse), so it stays cheap and offline-friendly; the server copy fills in naturally as sessions are edited.

**Correctness note.** The single write-time resolution uses native `Intl` (not `date-fns-tz`), which is off-by-one-hour at the exact spring-forward instant. A shared resolver (`src/libs/Statistics/localParts.ts`) guarantees the write path and read-path fallback are one implementation, so stored and recomputed values can't diverge.

Net effect: an existing user's *first* cold open still pays one fallback `Intl` pass (parts don't exist yet), the backfill persists them off the critical path, and **every subsequent cold open reads stored fields with zero `Intl`**.

### Tests

Unit tests prove the read path is byte-identical whether reading stored fields or recomputing.

1. `npx jest __tests__/unit/libs/Statistics/sessionTimeParts.test.ts` — 17 tests: stored-vs-recompute byte-identity across UTC, Tokyo cross-day, London spring-forward instant, the 2020-W53 ISO edge, and leap day; tz-guard fallback (mismatched/corrupt stored values are ignored); backfill round-trip + convergence.
2. `npx jest __tests__/unit/libs/Statistics/events.test.ts` — existing 29 tests unchanged and green.
3. `npx jest __tests__/unit/useDrinkEvents.test.ts` — hook delegates the backfill to the `Statistics` action with the computed events.
4. `npm run typecheck-tsgo`, `./scripts/lint.sh <changed>`, and `react-compiler-compliance-check check-changed` all pass.

- [ ] Verify that no errors appear in the JS console

### Offline tests

The feature is offline-first: stored fields are persisted in Onyx and survive cold opens with no network; the backfill is a local Onyx merge. Sessions without stored fields recompute on the fly, so Statistics works identically offline whether or not the fields are present.

### QA Steps

1. Open the Statistics tab and confirm all charts/KPIs render the same values as before this change.
2. Add or edit a drinking session, save it, then reopen Statistics — values for that session are unchanged.
3. Change a session's timezone (Session Timezone settings) or shift its date, save, reopen Statistics — the session's day/hour/week buckets reflect the new timezone/date correctly.
4. **Perf (Hermes only):** with the dev profiler, do a cold Statistics open, then a **second** cold open. The `[StatsProfile] buildDrinkEvents Xms` line should drop toward ~0 on the second open (the first open backfills). Node timings are not meaningful here.

- [ ] Verify that no errors appear in the JS console

### Notes for reviewer

- No new UI / copy / localization — pure data/perf change.
- On-device perf verification (the `[StatsProfile]` trace dropping toward ~0 on the second cold open) is the one thing the unit tests can't cover; please confirm on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)