### PR TITLE
feat(calendar): route day-tile taps by surface

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -34,8 +34,9 @@ const ROUTES = {
   BADGES: 'badges',
 
   DAY_OVERVIEW: {
-    route: 'day-overview/:date',
-    getRoute: (date: DateString) => `day-overview/${date}` as const,
+    route: 'day-overview/:userID/:date',
+    getRoute: (userID: UserID, date: DateString) =>
+      `day-overview/${userID}/${date}` as const,
   },
 
   DRINKING_SESSION: {

--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -160,12 +160,13 @@ function DrinkingSessionOverview({
         />
       ) : (
         isEditModeOn && (
-          <Button
-            large
-            style={styles.bgTransparent}
-            icon={KirokuIcons.Edit}
+          <PressableWithFeedback
+            accessibilityLabel={translate('common.edit')}
+            accessibilityRole={CONST.ROLE.BUTTON}
             onPress={onNavigateToEditSession}
-          />
+            style={styles.p2}>
+            <Icon src={KirokuIcons.Edit} fill={theme.icon} />
+          </PressableWithFeedback>
         )
       )}
     </PressableWithFeedback>

--- a/src/components/HeaderWithBackButton/index.tsx
+++ b/src/components/HeaderWithBackButton/index.tsx
@@ -29,6 +29,7 @@ function HeaderWithBackButton({
   onThreeDotsButtonPress = () => {},
   avatar,
   shouldShowBackButton = true,
+  shouldAlignTitleStart = false,
   shouldShowBorderBottom = false,
   shouldShowCloseButton = false,
   shouldShowDownloadButton = false,
@@ -96,13 +97,18 @@ function HeaderWithBackButton({
           titleColor ? StyleUtils.getTextColorStyle(titleColor) : {},
           isCentralPaneSettings && styles.textHeadlineH2,
         ]}
-        containerStyles={styles.justifyContentEnd}
+        // Default end-alignment parks the title by the right-side actions;
+        // `shouldAlignTitleStart` keeps it next to the back button instead.
+        containerStyles={
+          shouldAlignTitleStart ? undefined : styles.justifyContentEnd
+        }
       />
     );
   }, [
     StyleUtils,
     isCentralPaneSettings,
     progressBarPercentage,
+    shouldAlignTitleStart,
     styles.flexGrow1,
     styles.headerProgressBar,
     styles.headerProgressBarContainer,

--- a/src/components/HeaderWithBackButton/types.ts
+++ b/src/components/HeaderWithBackButton/types.ts
@@ -83,6 +83,10 @@ type HeaderWithBackButtonProps = Partial<ChildrenProps> & {
   /** Whether we should show a back button */
   shouldShowBackButton?: boolean;
 
+  /** Align the title to the start (next to the back button) instead of the
+   *  default end alignment. */
+  shouldAlignTitleStart?: boolean;
+
   /** Single execution function to prevent concurrent navigation actions */
   singleExecution?: <T extends unknown[]>(action: Action<T>) => Action<T>;
 

--- a/src/components/SessionsCalendar/DayDrillDownSheet.tsx
+++ b/src/components/SessionsCalendar/DayDrillDownSheet.tsx
@@ -17,7 +17,7 @@ import CONST from '@src/CONST';
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 
-type FriendDayDrillDownSheetProps = {
+type DayDrillDownSheetProps = {
   /** Whether the modal is visible */
   isVisible: boolean;
 
@@ -27,20 +27,26 @@ type FriendDayDrillDownSheetProps = {
   /** The selected day, or null when no day is selected */
   date: DateString | null;
 
-  /** The viewed friend's drinking session data */
+  /** The viewed user's drinking session data */
   drinkingSessionData: DrinkingSessionList | null | undefined;
 
-  /** The viewed friend's preferences, used for color/unit computation */
+  /** The viewed user's preferences, used for color/unit computation */
   preferences: Preferences;
+
+  /** When true, the session tiles are interactive: tapping a tile opens its
+   *  summary and an edit button is shown. When false (viewing another user's
+   *  history) the tiles are read-only. */
+  canEdit: boolean;
 };
 
-function FriendDayDrillDownSheet({
+function DayDrillDownSheet({
   isVisible,
   onClose,
   date,
   drinkingSessionData,
   preferences,
-}: FriendDayDrillDownSheetProps) {
+  canEdit,
+}: DayDrillDownSheetProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
   const {translate} = useLocalize();
@@ -101,8 +107,8 @@ function FriendDayDrillDownSheet({
               <DrinkingSessionOverview
                 sessionId={item.sessionId}
                 session={item.session}
-                isEditModeOn={false}
-                readOnly
+                isEditModeOn={canEdit}
+                readOnly={!canEdit}
                 preferences={preferences}
               />
             )}
@@ -116,6 +122,6 @@ function FriendDayDrillDownSheet({
   );
 }
 
-FriendDayDrillDownSheet.displayName = 'FriendDayDrillDownSheet';
+DayDrillDownSheet.displayName = 'DayDrillDownSheet';
 
-export default FriendDayDrillDownSheet;
+export default DayDrillDownSheet;

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -84,6 +84,9 @@ type DayOverviewListViewProps = {
    *  history). Also suppresses the "last viewed day" persistence so browsing a
    *  friend's days doesn't repoint the current user's own compact calendar. */
   isReadOnly?: boolean;
+  /** When true, each session tile shows its edit affordance. Driven by the
+   *  day-overview screen's Edit/Done header toggle (self only). */
+  isEditModeOn?: boolean;
 };
 
 /**
@@ -107,6 +110,7 @@ function DayOverviewListView({
   onInitialScrollReady,
   onVisibleDayChange,
   isReadOnly,
+  isEditModeOn,
 }: DayOverviewListViewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -320,7 +324,7 @@ function DayOverviewListView({
         <DrinkingSessionOverview
           sessionId={item.entry.sessionId}
           session={item.entry.session}
-          isEditModeOn={false}
+          isEditModeOn={isEditModeOn ?? false}
           readOnly={isReadOnly}
           preferences={preferences}
         />
@@ -329,6 +333,7 @@ function DayOverviewListView({
     [
       preferences,
       isReadOnly,
+      isEditModeOn,
       translate,
       styles.sessionsCalendarMonthLabel,
       styles.sessionsCalendarMonthLabelText,

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -80,6 +80,10 @@ type DayOverviewListViewProps = {
   /** Debounced report of the center-most visible day as the user scrolls — the
    *  screen uses it to open the add-session picker on the viewed month. */
   onVisibleDayChange?: (day: DateString) => void;
+  /** Render the session tiles non-interactively (viewing another user's
+   *  history). Also suppresses the "last viewed day" persistence so browsing a
+   *  friend's days doesn't repoint the current user's own compact calendar. */
+  isReadOnly?: boolean;
 };
 
 /**
@@ -102,6 +106,7 @@ function DayOverviewListView({
   initialDay,
   onInitialScrollReady,
   onVisibleDayChange,
+  isReadOnly,
 }: DayOverviewListViewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -233,10 +238,14 @@ function DayOverviewListView({
   const recordVisibleDay = useMemo(
     () =>
       lodashDebounce((day: DateString) => {
-        App.setLastViewedCalendarDate(day);
+        // Read-only (friend) browsing must not repoint the current user's own
+        // compact calendar, which restores from this NVP.
+        if (!isReadOnly) {
+          App.setLastViewedCalendarDate(day);
+        }
         onVisibleDayChange?.(day);
       }, LAST_VIEWED_DEBOUNCE_MS),
-    [onVisibleDayChange],
+    [onVisibleDayChange, isReadOnly],
   );
   useEffect(() => () => recordVisibleDay.cancel(), [recordVisibleDay]);
 
@@ -312,12 +321,14 @@ function DayOverviewListView({
           sessionId={item.entry.sessionId}
           session={item.entry.session}
           isEditModeOn={false}
+          readOnly={isReadOnly}
           preferences={preferences}
         />
       );
     },
     [
       preferences,
+      isReadOnly,
       translate,
       styles.sessionsCalendarMonthLabel,
       styles.sessionsCalendarMonthLabelText,

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -11,7 +11,6 @@ import {getPreviousMonth, getNextMonth} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import {computeLoadTarget} from '@libs/SessionsCalendarUtils';
 import CONST from '@src/CONST';
-import {useFirebase} from '@context/global/FirebaseContext';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import type {DateString, Timestamp} from '@src/types/onyx/OnyxCommon';
@@ -42,15 +41,14 @@ function SessionsCalendar({
   drinkingSessionData,
   preferences,
   isFetchingOlderMonths,
-  onForeignDayPress,
+  onDayDrillDown,
+  isReadOnly,
   mode = 'compact',
   initialMonthYear,
   initialDay,
   onVisibleDayChange,
   onInitialScrollReady,
 }: SessionsCalendarProps) {
-  const {auth} = useFirebase();
-  const user = auth.currentUser;
   const {
     markedDates,
     unitsMap,
@@ -180,15 +178,17 @@ function SessionsCalendar({
 
   const onDayPress = useCallback(
     (dateData: DateData) => {
-      if (userID !== user?.uid) {
-        onForeignDayPress?.(dateData.dateString as DateString);
+      const date = dateData.dateString as DateString;
+      // The infinite (fullscreen) calendar opens a drill-down sheet on the host
+      // screen; the compact calendar navigates to the day-overview scroll. The
+      // scroll route carries `userID`, so it works for self and friends alike.
+      if (mode === 'fullscreen') {
+        onDayDrillDown?.(date);
         return;
       }
-      Navigation.navigate(
-        ROUTES.DAY_OVERVIEW.getRoute(dateData.dateString as DateString),
-      );
+      Navigation.navigate(ROUTES.DAY_OVERVIEW.getRoute(userID, date));
     },
-    [userID, user?.uid, onForeignDayPress],
+    [mode, userID, onDayDrillDown],
   );
 
   if (isLoading) {
@@ -207,6 +207,7 @@ function SessionsCalendar({
         initialDay={initialDay}
         onInitialScrollReady={onInitialScrollReady}
         onVisibleDayChange={onVisibleDayChange}
+        isReadOnly={isReadOnly}
       />
     );
   }

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -43,6 +43,7 @@ function SessionsCalendar({
   isFetchingOlderMonths,
   onDayDrillDown,
   isReadOnly,
+  isEditModeOn,
   mode = 'compact',
   initialMonthYear,
   initialDay,
@@ -208,6 +209,7 @@ function SessionsCalendar({
         onInitialScrollReady={onInitialScrollReady}
         onVisibleDayChange={onVisibleDayChange}
         isReadOnly={isReadOnly}
+        isEditModeOn={isEditModeOn}
       />
     );
   }

--- a/src/components/SessionsCalendar/types.ts
+++ b/src/components/SessionsCalendar/types.ts
@@ -34,6 +34,10 @@ type SessionsCalendarProps = {
    *  doesn't repoint the current user's own compact calendar. */
   isReadOnly?: boolean;
 
+  /** dayList-only. When true, each session tile shows an edit affordance
+   *  (driven by the day-overview screen's Edit/Done header toggle). */
+  isEditModeOn?: boolean;
+
   /**
    * Rendering mode:
    * - `compact` (default): fixed-size single-month `Calendar` with arrow

--- a/src/components/SessionsCalendar/types.ts
+++ b/src/components/SessionsCalendar/types.ts
@@ -24,10 +24,15 @@ type SessionsCalendarProps = {
    *  being fetched after a back-nav past the loaded window edge. */
   isFetchingOlderMonths?: boolean;
 
-  /** Fires when a day is tapped while viewing another user's calendar (the
-   *  self case navigates to the day overview instead). Lets the parent open a
-   *  read-only drill-down. Omit to keep foreign-day taps inert. */
-  onForeignDayPress?: (date: DateString) => void;
+  /** Fullscreen-only. Fires when a day is tapped in the infinite calendar so
+   *  the host screen can open the day drill-down sheet. In `compact` mode taps
+   *  navigate to the day-overview scroll instead. */
+  onDayDrillDown?: (date: DateString) => void;
+
+  /** dayList-only. Render the session tiles non-interactively (viewing another
+   *  user's history). Also suppresses the "last viewed day" persistence so it
+   *  doesn't repoint the current user's own compact calendar. */
+  isReadOnly?: boolean;
 
   /**
    * Rendering mode:

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -16,7 +16,7 @@ import type SCREENS from '@src/SCREENS';
 import type {Route as Routes} from '@src/ROUTES';
 import type {DrinkingSessionId} from '@src/types/onyx';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
-import type {DateString} from '@src/types/onyx/OnyxCommon';
+import type {DateString, UserID} from '@src/types/onyx/OnyxCommon';
 
 type NavigationRef = NavigationContainerRefWithCurrent<RootStackParamList>;
 
@@ -74,6 +74,7 @@ type BadgesNavigatorParamList = {
 
 type DayOverviewNavigatorParamList = {
   [SCREENS.DAY_OVERVIEW.ROOT]: {
+    userID: UserID;
     date: DateString;
   };
 };

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -31,7 +31,6 @@ import DateSelectorModal from '@components/DateSelectorModal';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {PressableWithFeedback} from '@components/Pressable';
-import Button from '@components/Button';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import useTheme from '@hooks/useTheme';
@@ -54,6 +53,15 @@ const internalStyles = StyleSheet.create({
     position: 'absolute',
     right: 20,
     bottom: 20,
+  },
+  // Round brand button in the header — the Edit/Done toggle. Background color
+  // is applied inline since it comes from the (per-render) theme.
+  editToggle: {
+    width: 36,
+    height: 36,
+    borderRadius: 999,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -88,7 +96,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const {isOnline} = useUserConnection();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
-  const {textLight} = useTheme();
+  const theme = useTheme();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
   const isSelf = user?.uid === userID;
@@ -190,15 +198,27 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
         onBackButtonPress={Navigation.goBack}
         customRightButton={
           isSelf ? (
-            <Button
-              small
-              style={styles.bgTransparent}
-              textStyles={styles.link}
-              text={
-                editMode ? translate('common.done') : translate('common.edit')
-              }
+            <PressableWithFeedback
+              accessibilityLabel={translate(
+                editMode ? 'common.done' : 'common.edit',
+              )}
+              accessibilityRole={CONST.ROLE.BUTTON}
               onPress={() => setEditMode(prev => !prev)}
-            />
+              style={[
+                internalStyles.editToggle,
+                {
+                  backgroundColor: editMode
+                    ? theme.successPressed
+                    : theme.appColor,
+                },
+              ]}>
+              <Icon
+                src={editMode ? KirokuIcons.Checkmark : KirokuIcons.Edit}
+                fill={theme.textOnBrand}
+                width={18}
+                height={18}
+              />
+            </PressableWithFeedback>
           ) : undefined
         }
       />
@@ -241,7 +261,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
             style={[styles.floatingActionButton, internalStyles.fab]}>
             <Icon
               src={KirokuIcons.Plus}
-              fill={textLight}
+              fill={theme.textLight}
               width={variables.iconSizeNormal}
               height={variables.iconSizeNormal}
             />

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -14,6 +14,9 @@ import Navigation from '@libs/Navigation/Navigation';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useFetchData from '@hooks/useFetchData';
+import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
+import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import {dateStringToDate, dateToDateData} from '@libs/DataHandling';
 import * as App from '@userActions/App';
 import * as DS from '@userActions/DrinkingSession';
@@ -55,6 +58,10 @@ const internalStyles = StyleSheet.create({
 
 function noop() {}
 
+// Non-windowed keys to fetch for a friend (their session data is fetched
+// separately via `useDrinkingSessionsFetch`). Mirrors `SessionsCalendarScreen`.
+const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
+
 // Module-level so React Compiler skips it — the `try/finally` it needs bails
 // the compiler, and that would regress the screen's compilation.
 async function createSessionForDay(
@@ -76,16 +83,40 @@ async function createSessionForDay(
 }
 
 function DayOverviewScreen({route}: DayOverviewScreenProps) {
-  const {date} = route.params;
+  const {userID, date} = route.params;
   const {isOnline} = useUserConnection();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const {textLight} = useTheme();
   const {auth, db} = useFirebase();
   const user = auth.currentUser;
+  const isSelf = user?.uid === userID;
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
-  const {preferences, userData, isFetchingOlderMonths} = useDatabaseData();
-  const drinkingSessionData = useCurrentUserDrinkingSessions();
+
+  // Self reads the current user's sessions from the dedicated hook; a friend's
+  // data is fetched on demand (same self/other gating as
+  // `SessionsCalendarScreen`). The non-needed hook is invoked with an empty
+  // `userID`, which both hooks treat as a no-op.
+  const ownData = useDatabaseData();
+  const currentUserSessions = useCurrentUserDrinkingSessions();
+  const {data: friendFetchedData, isLoading: isFriendFetchLoading} =
+    useFetchData(isSelf ? '' : userID, FRIEND_FETCH_KEYS);
+  const {
+    data: friendSessionData,
+    isLoading: isFriendSessionsLoading,
+    isFetchingOlderMonths: friendFetchingOlder,
+  } = useDrinkingSessionsFetch(isSelf ? '' : userID);
+
+  const drinkingSessionData = isSelf ? currentUserSessions : friendSessionData;
+  const preferences = isSelf
+    ? ownData.preferences
+    : friendFetchedData?.preferences;
+  const isFetchingOlderMonths = isSelf
+    ? ownData.isFetchingOlderMonths
+    : friendFetchingOlder;
+  // Timezone is only read by the self-only add-session flow, so the current
+  // user's own data is always the right source here.
+  const userData = ownData.userData;
 
   // Hold the list invisible (skeleton on top) until it has scrolled to the
   // focused day. With no `date` (shouldn't happen via the calendar) we never
@@ -135,7 +166,13 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
     return <FullScreenLoadingIndicator loadingText={loadingText} />;
   }
 
-  const isReady = !!user && !!preferences && drinkingSessionData !== undefined;
+  const isFriendLoading =
+    !isSelf && (isFriendFetchLoading || isFriendSessionsLoading);
+  const isReady =
+    !!user &&
+    !!preferences &&
+    drinkingSessionData !== undefined &&
+    !isFriendLoading;
   const showSkeleton = !didScreenTransitionEnd || !isReady || !isScrollReady;
 
   return (
@@ -155,7 +192,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
               !isScrollReady && internalStyles.hidden,
             ]}>
             <SessionsCalendar
-              userID={user.uid}
+              userID={userID}
               visibleDate={placeholderVisibleDate}
               onDateChange={noop}
               drinkingSessionData={drinkingSessionData}
@@ -165,6 +202,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
               initialDay={date}
               onInitialScrollReady={onInitialScrollReady}
               onVisibleDayChange={setVisibleDay}
+              isReadOnly={!isSelf}
             />
           </View>
         )}
@@ -173,7 +211,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
             <DayOverviewSkeleton />
           </View>
         )}
-        {!showSkeleton && (
+        {!showSkeleton && isSelf && (
           <PressableWithFeedback
             accessibilityLabel={translate(
               'dayOverviewScreen.addSessionExplained',
@@ -190,17 +228,19 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
           </PressableWithFeedback>
         )}
       </View>
-      <DateSelectorModal
-        mode="single"
-        isVisible={isDatePickerVisible}
-        title={translate('dayOverviewScreen.selectSessionDate')}
-        initialDate={visibleDay ? dateStringToDate(visibleDay) : new Date()}
-        maxDate={endOfToday()}
-        applyText={translate('common.confirm')}
-        cancelText={translate('common.cancel')}
-        onApply={onPickDate}
-        onCancel={() => setIsDatePickerVisible(false)}
-      />
+      {isSelf && (
+        <DateSelectorModal
+          mode="single"
+          isVisible={isDatePickerVisible}
+          title={translate('dayOverviewScreen.selectSessionDate')}
+          initialDate={visibleDay ? dateStringToDate(visibleDay) : new Date()}
+          maxDate={endOfToday()}
+          applyText={translate('common.confirm')}
+          cancelText={translate('common.cancel')}
+          onApply={onPickDate}
+          onCancel={() => setIsDatePickerVisible(false)}
+        />
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -31,6 +31,7 @@ import DateSelectorModal from '@components/DateSelectorModal';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {PressableWithFeedback} from '@components/Pressable';
+import Button from '@components/Button';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import useTheme from '@hooks/useTheme';
@@ -134,6 +135,11 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
 
   const [isDatePickerVisible, setIsDatePickerVisible] = useState(false);
 
+  // Edit mode reveals a per-session edit affordance on every tile (self only).
+  // Toggled from the header; persists across the edit round-trip so the user
+  // can edit several sessions in a row.
+  const [editMode, setEditMode] = useState(false);
+
   // The day the user is currently looking at — opens the add-session picker on
   // the viewed month. Seeded with the focused day, updated as the user scrolls.
   const [visibleDay, setVisibleDay] = useState<DateString | undefined>(date);
@@ -182,6 +188,19 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
       <HeaderWithBackButton
         title={translate('calendar.fullscreenTitle')}
         onBackButtonPress={Navigation.goBack}
+        customRightButton={
+          isSelf ? (
+            <Button
+              small
+              style={styles.bgTransparent}
+              textStyles={styles.link}
+              text={
+                editMode ? translate('common.done') : translate('common.edit')
+              }
+              onPress={() => setEditMode(prev => !prev)}
+            />
+          ) : undefined
+        }
       />
       <View style={styles.flex1}>
         {isReady && didScreenTransitionEnd && (
@@ -203,6 +222,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
               onInitialScrollReady={onInitialScrollReady}
               onVisibleDayChange={setVisibleDay}
               isReadOnly={!isSelf}
+              isEditModeOn={editMode}
             />
           </View>
         )}

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -196,6 +196,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
       <HeaderWithBackButton
         title={translate('calendar.fullscreenTitle')}
         onBackButtonPress={Navigation.goBack}
+        shouldAlignTitleStart
         customRightButton={
           isSelf ? (
             <PressableWithFeedback

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -23,7 +23,7 @@ import {getCommonFriendsCount} from '@libs/FriendUtils';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {DrinkingSessionArray} from '@src/types/onyx';
-import type {DateString, UserList} from '@src/types/onyx/OnyxCommon';
+import type {UserList} from '@src/types/onyx/OnyxCommon';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
@@ -45,7 +45,6 @@ import ManageFriendPopover from '@components/ManageFriendPopover';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
-import FriendDayDrillDownSheet from './FriendDayDrillDownSheet';
 
 type ProfileScreenProps = StackScreenProps<
   ProfileNavigatorParamList,
@@ -108,7 +107,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const [unitsConsumed, setUnitsConsumed] = useState(0);
   const [manageFriendModalVisible, setManageFriendModalVisible] =
     useState(false);
-  const [drillDownDate, setDrillDownDate] = useState<DateString | null>(null);
   const userData = fetchedData?.userData;
   const preferences = fetchedData?.preferences;
   const profileData = userData?.profile;
@@ -269,7 +267,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
               drinkingSessionData={drinkingSessionData}
               preferences={preferences}
               isFetchingOlderMonths={isFetchingOlderMonths}
-              onForeignDayPress={setDrillDownDate}
             />
           ) : (
             <SessionsCalendarCompactSkeleton />
@@ -289,13 +286,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
         isVisible={manageFriendModalVisible}
         onClose={() => setManageFriendModalVisible(false)}
         friendId={userID}
-      />
-      <FriendDayDrillDownSheet
-        isVisible={!!drillDownDate}
-        onClose={() => setDrillDownDate(null)}
-        date={drillDownDate}
-        drinkingSessionData={drinkingSessionData}
-        preferences={preferences}
       />
     </ScreenWrapper>
   );

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -4,6 +4,7 @@ import type {StackScreenProps} from '@react-navigation/stack';
 import type {DateData} from 'react-native-calendars';
 import SessionsCalendar from '@components/SessionsCalendar';
 import SessionsCalendarSkeleton from '@components/SessionsCalendar/SessionsCalendarSkeleton';
+import DayDrillDownSheet from '@components/SessionsCalendar/DayDrillDownSheet';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -19,6 +20,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {SessionsCalendarNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 
 type SessionsCalendarScreenProps = StackScreenProps<
@@ -81,6 +83,12 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
     dateToDateData(new Date()),
   );
 
+  // The day whose drill-down sheet is open, or null when closed. Tapping a day
+  // in the infinite calendar opens the sheet; for self it's editable (tap a
+  // session → summary, edit button → edit), for friends it's read-only. Kept
+  // mounted across the edit round-trip so it reopens on back with live data.
+  const [drillDownDate, setDrillDownDate] = useState<DateString | null>(null);
+
   // Hold the calendar invisible until the WeekListView has applied its
   // initial scroll, so the user never sees a "latest at bottom → target"
   // jump on open. With no `monthYear` (e.g. deep-link), we never wait.
@@ -125,6 +133,7 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
               mode="fullscreen"
               initialMonthYear={monthYear}
               onInitialScrollReady={onInitialScrollReady}
+              onDayDrillDown={setDrillDownDate}
             />
           </View>
         )}
@@ -134,6 +143,16 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
           </View>
         )}
       </View>
+      {preferences && (
+        <DayDrillDownSheet
+          isVisible={!!drillDownDate}
+          onClose={() => setDrillDownDate(null)}
+          date={drillDownDate}
+          drinkingSessionData={drinkingSessionData}
+          preferences={preferences}
+          canEdit={isSelf}
+        />
+      )}
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
### Details

Reworks calendar day-tile tap behavior so the destination depends on the **surface** the tap happens on, not on whose calendar it is. Previously the infinite (fullscreen) calendar opened the **day-overview scroll** on tap — but that scroll is itself an infinite list, so reaching/editing a session meant scrolling into a second infinite scroll. Friend calendars were inconsistent (compact opened a drill-down, fullscreen did nothing).

New rule:

| Surface | Self | Other |
| --- | --- | --- |
| **Compact** (Home / Profile) | day-overview scroll *(unchanged)* | day-overview scroll, **read-only** |
| **Infinite** (fullscreen) | drill-down sheet, **editable** (row → summary, Edit → edit) | drill-down sheet, **read-only** |

Editing a session from the infinite calendar is now a two-tap flow: tap the day → drill-down opens → tap **Edit**.

What changed:
- `DAY_OVERVIEW` route carries `userID`; the day-overview scroll renders another user's history **read-only** (non-interactive session tiles, add-session FAB/date-picker hidden for non-self, friend data fetched with the same self/other gating as the fullscreen calendar). It also suppresses the "last viewed day" persistence when read-only so browsing a friend doesn't repoint your own compact calendar.
- The drill-down sheet is generalized (`FriendDayDrillDownSheet` → `components/SessionsCalendar/DayDrillDownSheet` with a `canEdit` flag) and hosted by the infinite-calendar screen. It's kept mounted across the edit round-trip so it reopens on back with live Onyx data.
- The tap decision is centralized in `SessionsCalendar` (`mode === 'fullscreen'` → open sheet via `onDayDrillDown`; otherwise navigate to the day-overview scroll with `userID`). Profile's inline drill-down is removed.

Reviewer notes:
- **Modal-over-navigation layering**: the sheet stays mounted under the pushed edit/summary route ("approach (a)"). Worth a close look on device — if a bottom-docked `Modal` misbehaves under the pushed screen, the fallback is dismiss-on-navigate + reopen-on-focus.
- The friend **day-overview scroll** is a new surface; its lazy older-month widening reuses the same fetch infra the friend fullscreen calendar already uses.
- The `DAY_OVERVIEW` deeplink path changed (`day-overview/:date` → `day-overview/:userID/:date`).
- No new user-facing strings (reused existing `common.*` / `dayOverviewScreen.*` keys).

Local checks: `prettier`, `typecheck-tsgo`, seatbelt lint, and React Compiler compliance all pass.

### Tests

1. **Self, compact (Home & Profile)** — tap a day → the day-overview scroll opens (unchanged).
2. **Self, infinite** — from the Home compact calendar tap the month header → infinite calendar. Tap a day → drill-down sheet listing that day's sessions with **Edit** buttons.
   1. Tap a session row → its summary opens.
   2. Tap **Edit** → edit screen; change units and save → back lands on the infinite calendar with the sheet still open showing updated units.
   3. Delete the session from the edit screen → back → the sheet shows the day without it (empty state if it was the last one).
3. **Other, compact (friend Profile)** — tap a day → the day-overview scroll opens **read-only**; session tiles are **not** tappable; no add-session FAB.
4. **Other, infinite** — from a friend's Profile compact calendar tap the month header → friend infinite calendar. Tap a day → **read-only** drill-down (no Edit button, tiles not tappable).
5. Browse a friend's day-overview scroll, go back, then open your own Home calendar — verify the month shown on your own compact calendar did **not** change.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline. Open the self infinite calendar and tap a day → the drill-down sheet still shows already-loaded sessions.
- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Repeat the **Tests** steps above on Staging across iOS and Android.
2. Confirm the `feat(calendar)` behavior matrix holds for both your own and a friend's calendar.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I wrote clear testing steps that cover the changes made in this PR
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [ ] I verified there are no console errors

### Screenshots/Videos

<details>
<summary>Android</summary>

</details>

<details>
<summary>iOS</summary>

</details>