### PR TITLE
fix(metro): raise dev-server heap to 8GB to prevent OOM crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "prettier --write .",
     "prettier-changed": "prettier --experimental-cli --no-cache --write --ignore-unknown $(git diff --diff-filter=AMR --name-only origin/main HEAD)",
     "prettier-watch": "onchange \"**/*.{js,ts,tsx}\" -- prettier --write --ignore-unknown {{changed}}",
-    "start": "react-native start",
+    "start": "NODE_OPTIONS=--max_old_space_size=8192 react-native start",
     "symbolicate:android": "npx metro-symbolicate android/app/build/generated/sourcemaps/react/release/index.android.bundle.map",
     "symbolicate:ios": "npx metro-symbolicate main.jsbundle.map",
     "symbolicate-release:ios": "scripts/release-profile.ts --platform=ios",


### PR DESCRIPTION
## Summary

- Metro (the dev bundler, running in Node) hits Node's default ~2GB old-space cap during long dev sessions and crashes with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.
- This was observed after a ~3.2h session while the Statistics screen was loading: the on-device error triggered Metro's `/symbolicate` endpoint, whose source-map parsing is memory-heavy and tipped the already-bloated process over the edge.
- Raise the `start` script's heap to 8GB via `NODE_OPTIONS`, matching the cap already used by `typecheck` and `lint`.

This is a dev-tooling fix only — Metro never runs in production, so end users are unaffected.

## Notes

- This raises the ceiling; it does not remove a leak. If the Statistics screen turns out to throw in a render loop, that's a symbolication storm worth fixing separately.
- Separately worth aligning local Node with the pinned `.nvmrc` (20.19.4) — the crash ran under Homebrew node 24.2.0.

## Test plan

- [ ] `npm run kill-metro && npm start` — Metro boots normally
- [ ] Confirm `node` process for Metro starts with `--max_old_space_size=8192`