### PR TITLE
refactor(realtime): cut feedback & bug writes over to kiroku-api

### DIFF
--- a/src/database/feedback.ts
+++ b/src/database/feedback.ts
@@ -1,56 +1,9 @@
 import type {Database} from 'firebase/database';
-import {child, push, ref, update} from 'firebase/database';
-import type {FeedbackList, Feedback, Bug, BugList} from '@src/types/onyx';
-import type {FormOnyxValues} from '@components/Form/types';
-import type ONYXKEYS from '@src/ONYXKEYS';
+import {ref, update} from 'firebase/database';
 import DBPATHS from '@src/DBPATHS';
 
 const feedbackItemRef = DBPATHS.FEEDBACK_FEEDBACK_ID;
 const bugItemRef = DBPATHS.BUGS_BUG_ID;
-
-/** Submit feedback into the database
- *
- * @description Each feedback has its own unique ID that gets created upon pushing the data into the database. The function also automatically creates a timestamp corresponding to the time when the feedback was submitted.
- *
- * @param db The database object
- * @param userID The user ID
- * @param values The feedback form values
- * @returns An empty promise
- *
- *  */
-async function submitFeedback(
-  db: Database,
-  userID: string | undefined,
-  values: FormOnyxValues<typeof ONYXKEYS.FORMS.FEEDBACK_FORM>,
-): Promise<void> {
-  if (!userID) {
-    throw new Error(
-      'The application failed to retrieve the user ID from the authentication context',
-    );
-  }
-
-  const timestampNow = new Date().getTime();
-  const newFeedback: Feedback = {
-    submit_time: timestampNow,
-    text: values.text,
-    user_id: userID,
-  };
-
-  // Create a new feedback id
-  const newFeedbackKey = push(child(ref(db), DBPATHS.FEEDBACK)).key;
-  if (!newFeedbackKey) {
-    throw new Error(
-      'The application failed to create a new feedback object in the database',
-    );
-  }
-
-  // Create the updates object
-  const updates: FeedbackList = {};
-  updates[feedbackItemRef.getRoute(newFeedbackKey)] = newFeedback;
-
-  // Submit the feedback
-  await update(ref(db), updates);
-}
 
 /**
  * Remove a feedback item from the database
@@ -67,48 +20,6 @@ async function removeFeedback(
   await update(ref(db), updates);
 }
 
-/** Submit a bug report into the database
- *
- * @param db The database object
- * @param userID The user ID
- * @param bugDescription The bug description
- * @returns An empty promise
- *
- *  */
-async function reportABug(
-  db: Database,
-  userID: string | undefined,
-  bugDescription: string,
-): Promise<void> {
-  if (!userID) {
-    throw new Error(
-      'The application failed to retrieve the user ID from the authentication context',
-    );
-  }
-
-  const timestampNow = new Date().getTime();
-  const newBug: Bug = {
-    submit_time: timestampNow,
-    text: bugDescription,
-    user_id: userID,
-  };
-
-  // Create a new bug id
-  const newBugKey = push(child(ref(db), DBPATHS.BUGS)).key;
-  if (!newBugKey) {
-    throw new Error(
-      'The application failed to create a new bug object in the database',
-    );
-  }
-
-  // Create the updates object
-  const updates: BugList = {};
-  updates[bugItemRef.getRoute(newBugKey)] = newBug;
-
-  // Submit the bug
-  await update(ref(db), updates);
-}
-
 /**
  * Remove a bug item from the database
  *
@@ -121,4 +32,4 @@ async function removeBug(db: Database, bugKey: string): Promise<void> {
   await update(ref(db), updates);
 }
 
-export {submitFeedback, removeFeedback, reportABug, removeBug};
+export {removeFeedback, removeBug};

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -83,6 +83,14 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/privacy/friend',
   },
+  [WRITE_COMMANDS.SUBMIT_FEEDBACK]: {
+    method: 'post',
+    path: '/v1/feedback',
+  },
+  [WRITE_COMMANDS.REPORT_BUG]: {
+    method: 'post',
+    path: '/v1/feedback/bug',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/ReportBugParams.ts
+++ b/src/libs/API/parameters/ReportBugParams.ts
@@ -1,0 +1,5 @@
+type ReportBugParams = {
+  text: string;
+};
+
+export default ReportBugParams;

--- a/src/libs/API/parameters/SubmitFeedbackParams.ts
+++ b/src/libs/API/parameters/SubmitFeedbackParams.ts
@@ -1,0 +1,5 @@
+type SubmitFeedbackParams = {
+  text: string;
+};
+
+export default SubmitFeedbackParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -25,4 +25,6 @@ export type {default as UpdateSelectedTimezoneParams} from './UpdateSelectedTime
 export type {default as UpdateThemeParams} from './UpdateThemeParams';
 export type {default as SetHideFromAllFriendsParams} from './SetHideFromAllFriendsParams';
 export type {default as SetFriendDataHiddenParams} from './SetFriendDataHiddenParams';
+export type {default as SubmitFeedbackParams} from './SubmitFeedbackParams';
+export type {default as ReportBugParams} from './ReportBugParams';
 // export type {default as UpdateUserAvatarParams} from './UpdateUserAvatarParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -41,6 +41,8 @@ const WRITE_COMMANDS = {
   PURGE_SESSION_LOCATIONS: 'PurgeSessionLocations',
   SET_HIDE_FROM_ALL_FRIENDS: 'SetHideFromAllFriends',
   SET_FRIEND_DATA_HIDDEN: 'SetFriendDataHidden',
+  SUBMIT_FEEDBACK: 'SubmitFeedback',
+  REPORT_BUG: 'ReportBug',
   // ...
 } as const;
 
@@ -81,6 +83,8 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.PURGE_SESSION_LOCATIONS]: EmptyObject;
   [WRITE_COMMANDS.SET_HIDE_FROM_ALL_FRIENDS]: Parameters.SetHideFromAllFriendsParams;
   [WRITE_COMMANDS.SET_FRIEND_DATA_HIDDEN]: Parameters.SetFriendDataHiddenParams;
+  [WRITE_COMMANDS.SUBMIT_FEEDBACK]: Parameters.SubmitFeedbackParams;
+  [WRITE_COMMANDS.REPORT_BUG]: Parameters.ReportBugParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/Feedback.ts
+++ b/src/libs/actions/Feedback.ts
@@ -1,0 +1,21 @@
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+
+/**
+ * Feedback + bug-report writes, cut over from direct Firebase RTDB writes
+ * (`src/database/feedback.ts`) to kiroku-api `API.write` calls. The server owns
+ * the generated id, `submit_time`, and `user_id` (derived from the caller's
+ * Firebase ID token), so callers pass only the free-text body. The feedback/bug
+ * collections are admin-only and fetched on demand, so the server route's
+ * `onyxData` is empty — there is nothing to optimistically write.
+ */
+
+function submitFeedback(text: string) {
+  API.write(WRITE_COMMANDS.SUBMIT_FEEDBACK, {text});
+}
+
+function reportABug(text: string) {
+  API.write(WRITE_COMMANDS.REPORT_BUG, {text});
+}
+
+export {submitFeedback, reportABug};

--- a/src/screens/Settings/FeedbackScreen.tsx
+++ b/src/screens/Settings/FeedbackScreen.tsx
@@ -1,12 +1,10 @@
-import React, {useCallback} from 'react';
+import {useCallback} from 'react';
 import {View} from 'react-native';
-import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import * as ErrorUtils from '@libs/ErrorUtils';
 import * as ValidationUtils from '@libs/ValidationUtils';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type {FormOnyxValues} from '@src/components/Form/types';
@@ -21,9 +19,7 @@ import CONST from '@src/CONST';
 import TextInput from '@components/TextInput';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type SCREENS from '@src/SCREENS';
-import {submitFeedback} from '@database/feedback';
-import {useFirebase} from '@context/global/FirebaseContext';
-import ERRORS from '@src/ERRORS';
+import {submitFeedback} from '@libs/actions/Feedback';
 
 type FeedbackScreenProps = StackScreenProps<
   SettingsNavigatorParamList,
@@ -34,25 +30,12 @@ type FeedbackScreenProps = StackScreenProps<
 function FeedbackScreen({route}: FeedbackScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
-  const userID = auth.currentUser?.uid;
-
-  const [isLoading, setIsLoading] = React.useState(false);
 
   const onSubmit = (
     values: FormOnyxValues<typeof ONYXKEYS.FORMS.FEEDBACK_FORM>,
   ) => {
-    (async () => {
-      try {
-        setIsLoading(true);
-        await submitFeedback(db, userID, values);
-        Navigation.goBack();
-      } catch (error) {
-        ErrorUtils.raiseAppError(ERRORS.USER.FEEDBACK_SUBMISSION_FAILED, error);
-      } finally {
-        setIsLoading(false);
-      }
-    })();
+    submitFeedback(values.text);
+    Navigation.goBack();
   };
 
   const validate = useCallback(
@@ -72,35 +55,28 @@ function FeedbackScreen({route}: FeedbackScreenProps) {
         shouldShowBackButton
         onBackButtonPress={Navigation.goBack}
       />
-      {isLoading ? (
-        <FullscreenLoadingIndicator
-          style={[styles.flex1]}
-          loadingText={translate('feedbackScreen.sending')}
-        />
-      ) : (
-        <FormProvider
-          formID={ONYXKEYS.FORMS.FEEDBACK_FORM}
-          validate={validate}
-          onSubmit={onSubmit}
-          submitButtonText={translate('feedbackScreen.submit')}
-          style={[styles.flexGrow1, styles.mh5]}>
-          <View style={[styles.flexGrow1]}>
-            <Text>{translate('feedbackScreen.prompt')}</Text>
-            <InputWrapper
-              InputComponent={TextInput}
-              inputID={INPUT_IDS.TEXT}
-              autoGrowHeight
-              maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-              label={translate('feedbackScreen.enterFeedback')}
-              aria-label={translate('feedbackScreen.enterFeedback')}
-              role={CONST.ROLE.PRESENTATION}
-              maxLength={CONST.DESCRIPTION_LIMIT}
-              spellCheck={false}
-              containerStyles={[styles.mt5]}
-            />
-          </View>
-        </FormProvider>
-      )}
+      <FormProvider
+        formID={ONYXKEYS.FORMS.FEEDBACK_FORM}
+        validate={validate}
+        onSubmit={onSubmit}
+        submitButtonText={translate('feedbackScreen.submit')}
+        style={[styles.flexGrow1, styles.mh5]}>
+        <View style={[styles.flexGrow1]}>
+          <Text>{translate('feedbackScreen.prompt')}</Text>
+          <InputWrapper
+            InputComponent={TextInput}
+            inputID={INPUT_IDS.TEXT}
+            autoGrowHeight
+            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+            label={translate('feedbackScreen.enterFeedback')}
+            aria-label={translate('feedbackScreen.enterFeedback')}
+            role={CONST.ROLE.PRESENTATION}
+            maxLength={CONST.DESCRIPTION_LIMIT}
+            spellCheck={false}
+            containerStyles={[styles.mt5]}
+          />
+        </View>
+      </FormProvider>
     </ScreenWrapper>
   );
 }

--- a/src/screens/Settings/ReportBugScreen.tsx
+++ b/src/screens/Settings/ReportBugScreen.tsx
@@ -1,12 +1,10 @@
-import React, {useCallback} from 'react';
+import {useCallback} from 'react';
 import {View} from 'react-native';
-import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import * as ErrorUtils from '@libs/ErrorUtils';
 import * as ValidationUtils from '@libs/ValidationUtils';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type {FormOnyxValues} from '@src/components/Form/types';
@@ -21,9 +19,7 @@ import CONST from '@src/CONST';
 import TextInput from '@components/TextInput';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type SCREENS from '@src/SCREENS';
-import {reportABug} from '@database/feedback';
-import {useFirebase} from '@context/global/FirebaseContext';
-import ERRORS from '@src/ERRORS';
+import {reportABug} from '@libs/actions/Feedback';
 
 type ReportBugScreenProps = StackScreenProps<
   SettingsNavigatorParamList,
@@ -34,25 +30,12 @@ type ReportBugScreenProps = StackScreenProps<
 function ReportBugScreen({route}: ReportBugScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
-  const userID = auth.currentUser?.uid;
-
-  const [isLoading, setIsLoading] = React.useState(false);
 
   const onSubmit = (
     values: FormOnyxValues<typeof ONYXKEYS.FORMS.REPORT_BUG_FORM>,
   ) => {
-    (async () => {
-      try {
-        setIsLoading(true);
-        await reportABug(db, userID, values.text);
-        Navigation.goBack();
-      } catch (error) {
-        ErrorUtils.raiseAppError(ERRORS.USER.BUG_SUBMISSION_FAILED, error);
-      } finally {
-        setIsLoading(false);
-      }
-    })();
+    reportABug(values.text);
+    Navigation.goBack();
   };
 
   const validate = useCallback(
@@ -72,35 +55,28 @@ function ReportBugScreen({route}: ReportBugScreenProps) {
         shouldShowBackButton
         onBackButtonPress={Navigation.goBack}
       />
-      {isLoading ? (
-        <FullscreenLoadingIndicator
-          style={[styles.flex1]}
-          loadingText={translate('reportBugScreen.sending')}
-        />
-      ) : (
-        <FormProvider
-          formID={ONYXKEYS.FORMS.REPORT_BUG_FORM}
-          validate={validate}
-          onSubmit={onSubmit}
-          submitButtonText={translate('reportBugScreen.submit')}
-          style={[styles.flexGrow1, styles.mh5]}>
-          <View style={[styles.flexGrow1]}>
-            <Text>{translate('reportBugScreen.prompt')}</Text>
-            <InputWrapper
-              InputComponent={TextInput}
-              inputID={INPUT_IDS.TEXT}
-              autoGrowHeight
-              maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-              label={translate('reportBugScreen.describeBug')}
-              aria-label={translate('reportBugScreen.describeBug')}
-              role={CONST.ROLE.PRESENTATION}
-              maxLength={CONST.DESCRIPTION_LIMIT}
-              spellCheck={false}
-              containerStyles={[styles.mt5]}
-            />
-          </View>
-        </FormProvider>
-      )}
+      <FormProvider
+        formID={ONYXKEYS.FORMS.REPORT_BUG_FORM}
+        validate={validate}
+        onSubmit={onSubmit}
+        submitButtonText={translate('reportBugScreen.submit')}
+        style={[styles.flexGrow1, styles.mh5]}>
+        <View style={[styles.flexGrow1]}>
+          <Text>{translate('reportBugScreen.prompt')}</Text>
+          <InputWrapper
+            InputComponent={TextInput}
+            inputID={INPUT_IDS.TEXT}
+            autoGrowHeight
+            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+            label={translate('reportBugScreen.describeBug')}
+            aria-label={translate('reportBugScreen.describeBug')}
+            role={CONST.ROLE.PRESENTATION}
+            maxLength={CONST.DESCRIPTION_LIMIT}
+            spellCheck={false}
+            containerStyles={[styles.mt5]}
+          />
+        </View>
+      </FormProvider>
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## Summary
Cuts the **feedback + bug-report writes** off direct Firebase RTDB and onto the offline-first `API.write` pattern against kiroku-api. Part of the strangler-fig migration (epic #778); tracked by #902.

- `submitFeedback` → `API.write(SUBMIT_FEEDBACK)` → `POST /v1/feedback`
- `reportABug` → `API.write(REPORT_BUG)` → `POST /v1/feedback/bug`
- New action file `src/libs/actions/Feedback.ts` (Friends.ts shape). Callers pass only `text`; the server owns id/`submit_time`/`user_id` (from the caller's Firebase ID token). Server `onyxData` is empty, so **no optimistic data**.
- `FeedbackScreen` / `ReportBugScreen` updated to call the new actions. Because `API.write` is fire-and-forget (offline-first), the handlers are now straight-line `submit → goBack` — the old `await` + `try/finally` + `FullscreenLoadingIndicator` scaffolding is removed (per the migration convention and the React Compiler gotcha; submission errors now flow through the offline request queue, consistent with the other migrated writes). The success path (navigate back) is preserved.

## ⚠️ Deviation from the original task — admin removes are NOT dead code
The task assumed `removeFeedback` / `removeBug` had no client call sites and should be deleted along with `src/database/feedback.ts`. **That is not the case.** They are still imported and used by the live in-app admin screens `SeeFeedbackScreen` / `SeeBugsScreen` (routes `settings/admin/feedback` and `settings/admin/bugs`), which also read the `FEEDBACK` / `BUGS` collections via RTDB listeners. Deleting them would break the build.

So instead:
- `src/database/feedback.ts` is **trimmed** to just `removeFeedback` / `removeBug` (not deleted).
- The admin removes stay on RTDB. Their reads are a separate read-cutover slice (#809), and read listeners are never removed during a write cutover.
- The kiroku-api remove endpoints exist (`requireAdmin`-gated) but take the id as a **URL path param**, which the client `kirokuRoutes` / `HttpUtils` pipeline doesn't support yet — so migrating them is genuine follow-up work, captured in #902.

## Notes
- Shared-infra edits (`API/types.ts`, `kirokuRoutes.ts`, `parameters/index.ts`) are append-only to stay merge-trivial with the sibling cutover PRs.
- No Onyx `Feedback`/`Bug` collection plumbing was removed — still referenced by the admin screens.
- ⛔ **Do not merge** — merge-gated on device verification of the realtime transport.

## Test plan
- [ ] Device: submit feedback → lands in RTDB `feedback/$id` with server-generated id/submit_time/user_id; screen navigates back.
- [ ] Device: report a bug → lands in RTDB `bugs/$id`; screen navigates back.
- [ ] Offline: submit while offline → request queues and replays on reconnect.
- [ ] Admin `SeeFeedbackScreen` / `SeeBugsScreen` still list items and the delete (✕) button still works (unchanged RTDB path).
- [x] `npm run typecheck-tsgo`, `lint-changed`, `react-compiler-compliance-check check-changed` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)