### PR TITLE
refactor(realtime): cut profile writes over to kiroku-api

### DIFF
--- a/src/components/UploadImage.tsx
+++ b/src/components/UploadImage.tsx
@@ -29,7 +29,7 @@ function UploadImageComponent({
   isProfilePicture = false,
   containerStyles,
 }: UploadImageComponentProps) {
-  const {auth, db, storage} = useFirebase();
+  const {auth, storage} = useFirebase();
   const styles = useThemeStyles();
   const user = auth.currentUser;
   const [imageSource, setImageSource] = useState<string | null>(null);
@@ -173,13 +173,7 @@ function UploadImageComponent({
           setSuccess,
         ); // Wait for the promise to resolve
         if (isProfilePicture) {
-          await Profile.updateProfileInfo(
-            pathToUpload,
-            user,
-            auth,
-            db,
-            storage,
-          );
+          await Profile.updateProfileInfo(pathToUpload, user, auth, storage);
         }
       } catch (error) {
         setImageSource(null);
@@ -191,7 +185,7 @@ function UploadImageComponent({
     };
 
     handleUpload(imageSource);
-  }, [auth, db, isProfilePicture, storage, user, pathToUpload, imageSource]);
+  }, [auth, isProfilePicture, storage, user, pathToUpload, imageSource]);
 
   return (
     <View

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -83,6 +83,18 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/privacy/friend',
   },
+  [WRITE_COMMANDS.UPDATE_DISPLAY_NAME]: {
+    method: 'post',
+    path: '/v1/profile/display-name',
+  },
+  [WRITE_COMMANDS.UPDATE_LEGAL_NAME]: {
+    method: 'post',
+    path: '/v1/profile/name',
+  },
+  [WRITE_COMMANDS.UPDATE_PROFILE_PHOTO]: {
+    method: 'post',
+    path: '/v1/profile/photo',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/UpdateDisplayNameParams.ts
+++ b/src/libs/API/parameters/UpdateDisplayNameParams.ts
@@ -1,5 +1,4 @@
 type UpdateDisplayNameParams = {
-  firstName: string;
-  lastName: string;
+  displayName: string;
 };
 export default UpdateDisplayNameParams;

--- a/src/libs/API/parameters/UpdateLegalNameParams.ts
+++ b/src/libs/API/parameters/UpdateLegalNameParams.ts
@@ -1,6 +1,6 @@
 type UpdateLegalNameParams = {
-  legalFirstName: string;
-  legalLastName: string;
+  firstName: string;
+  lastName: string;
 };
 
 export default UpdateLegalNameParams;

--- a/src/libs/API/parameters/UpdateProfilePhotoParams.ts
+++ b/src/libs/API/parameters/UpdateProfilePhotoParams.ts
@@ -1,0 +1,5 @@
+type UpdateProfilePhotoParams = {
+  photoURL: string;
+};
+
+export default UpdateProfilePhotoParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -25,4 +25,5 @@ export type {default as UpdateSelectedTimezoneParams} from './UpdateSelectedTime
 export type {default as UpdateThemeParams} from './UpdateThemeParams';
 export type {default as SetHideFromAllFriendsParams} from './SetHideFromAllFriendsParams';
 export type {default as SetFriendDataHiddenParams} from './SetFriendDataHiddenParams';
+export type {default as UpdateProfilePhotoParams} from './UpdateProfilePhotoParams';
 // export type {default as UpdateUserAvatarParams} from './UpdateUserAvatarParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -41,6 +41,7 @@ const WRITE_COMMANDS = {
   PURGE_SESSION_LOCATIONS: 'PurgeSessionLocations',
   SET_HIDE_FROM_ALL_FRIENDS: 'SetHideFromAllFriends',
   SET_FRIEND_DATA_HIDDEN: 'SetFriendDataHidden',
+  UPDATE_PROFILE_PHOTO: 'UpdateProfilePhoto',
   // ...
 } as const;
 
@@ -81,6 +82,7 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.PURGE_SESSION_LOCATIONS]: EmptyObject;
   [WRITE_COMMANDS.SET_HIDE_FROM_ALL_FRIENDS]: Parameters.SetHideFromAllFriendsParams;
   [WRITE_COMMANDS.SET_FRIEND_DATA_HIDDEN]: Parameters.SetFriendDataHiddenParams;
+  [WRITE_COMMANDS.UPDATE_PROFILE_PHOTO]: Parameters.UpdateProfilePhotoParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/Profile.ts
+++ b/src/libs/actions/Profile.ts
@@ -1,10 +1,12 @@
 import type {Database} from 'firebase/database';
-import {ref, update} from 'firebase/database';
 import type {FirebaseStorage} from 'firebase/storage';
 import {ref as StorageRef, getDownloadURL} from 'firebase/storage';
 import type {Auth, User} from 'firebase/auth';
 import {updateProfile} from 'firebase/auth';
 import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import type {ProfileList, UserStatusList} from '@src/types/onyx';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import DBPATHS from '@src/DBPATHS';
@@ -97,29 +99,22 @@ async function fetchUserStatuses(
 }
 
 /**
- * Using the Firebase realtime database instance, the user UID, and the full name of the
- * profile picture path, set the name of the file to a new path.
+ * Persist a user's new profile photo URL via kiroku-api. The optimistic Onyx
+ * update mirrors the server's `onyxData`. Should be called after the picture
+ * has been uploaded to storage.
  *
- * @description
- * Should be called together with uploading of the picture to the storage.
- *
- * @param db The Firebase realtime database instance.
  * @param userID User UID.
- * @param photoURL Name of the new file, including the suffix (e.g., profile_picture.jpg)
- * @returns Promise with the full path to the image
- *
- * @example
- * await setProfilePictureURL(db, 'test-user-id', 'profile_picture.jpg');
+ * @param photoURL The download URL of the uploaded profile picture.
  */
-async function setProfilePictureURL(
-  db: Database,
-  userID: string,
-  photoURL: string,
-): Promise<void> {
-  const updates: Record<string, string> = {};
-  const photoUrlPath = DBPATHS.USERS_USER_ID_PROFILE_PHOTO_URL.getRoute(userID);
-  updates[photoUrlPath] = photoURL;
-  await update(ref(db), updates);
+function setProfilePictureURL(userID: string, photoURL: string): void {
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {[userID]: {profile: {photo_url: photoURL}}},
+    },
+  ];
+  API.write(WRITE_COMMANDS.UPDATE_PROFILE_PHOTO, {photoURL}, {optimisticData});
 }
 
 /**
@@ -128,7 +123,6 @@ async function setProfilePictureURL(
  * @param pathToUpload - The path to the file to upload.
  * @param user - The user object.
  * @param auth - The authentication object.
- * @param db - The database object.
  * @param storage - The Firebase storage object.
  * @returns A promise that resolves when the profile information is updated.
  */
@@ -136,14 +130,13 @@ async function updateProfileInfo(
   pathToUpload: string,
   user: User | null,
   auth: Auth,
-  db: Database,
   storage: FirebaseStorage,
 ): Promise<void> {
   if (!user || !auth.currentUser) {
     return;
   }
   const downloadURL = await getDownloadURL(StorageRef(storage, pathToUpload));
-  await setProfilePictureURL(db, user.uid, downloadURL);
+  setProfilePictureURL(user.uid, downloadURL);
   await updateProfile(auth.currentUser, {photoURL: downloadURL});
 }
 

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -45,6 +45,8 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
 import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import PusherUtils from '@libs/PusherUtils';
 import * as Pusher from '@libs/Pusher/pusher';
 import * as OnyxUpdates from '@userActions/OnyxUpdates';
@@ -362,91 +364,64 @@ async function sendVerifyEmailLink(
 }
 
 /**
- * Change a display name for a user both in the realtime database,
- *  and in the authentication system.
+ * Change a user's display name via kiroku-api, keeping the Firebase Auth
+ * profile in sync. The server owns the nickname-index rebuild; the optimistic
+ * Onyx update mirrors the server's `onyxData`.
  *
- * @param db Database to change the display name in
  * @param user User to change the display name for
- * @param oldDisplayName The old display name
  * @param newDisplayName The new display name
- * @returns An empty promise
  */
-async function changeDisplayName(
-  db: Database,
-  user: User | null,
-  oldDisplayName: string | undefined,
-  newDisplayName: string,
-): Promise<void> {
+function changeDisplayName(user: User | null, newDisplayName: string): void {
   if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
-  }
-  if (!oldDisplayName) {
-    throw new Error(
-      'Could not identify the old display name. Try reloading the app.',
-    );
-  }
-  const userID = user.uid;
-  const nicknameRef = DBPATHS.NICKNAME_TO_ID_NICKNAME_KEY_USER_ID;
-  const displayNameRef = DBPATHS.USERS_USER_ID_PROFILE_DISPLAY_NAME;
-
-  const currentDisplayName = await readDataOnce<string>(
-    db,
-    displayNameRef.getRoute(userID),
-  );
-  if (currentDisplayName === newDisplayName) {
     return;
   }
-
-  // Derive the keys to remove from the name currently stored in the database
-  // (not the caller-supplied old name), so renames never leave stale tokens.
-  const oldKeys = getNicknameKeys(currentDisplayName ?? oldDisplayName);
-  const newKeys = getNicknameKeys(newDisplayName);
-  const newKeySet = new Set(newKeys);
-
-  const updates: Record<string, string | null> = {};
-  oldKeys
-    .filter(key => !newKeySet.has(key))
-    .forEach(key => {
-      updates[nicknameRef.getRoute(key, userID)] = null;
-    });
-  newKeys.forEach(key => {
-    updates[nicknameRef.getRoute(key, userID)] = newDisplayName;
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {[user.uid]: {profile: {display_name: newDisplayName}}},
+    },
+  ];
+  API.write(
+    WRITE_COMMANDS.UPDATE_DISPLAY_NAME,
+    {displayName: newDisplayName},
+    {optimisticData},
+  );
+  updateProfile(user, {displayName: newDisplayName}).catch(() => {
+    // Auth profile sync is best-effort; the server write is authoritative.
   });
-  updates[displayNameRef.getRoute(userID)] = newDisplayName;
-
-  // TODO possibly rewrite these into a transaction
-  await update(ref(db), updates);
-  await updateProfile(user, {displayName: newDisplayName});
 }
 
 /**
- * Change a user name for a user.
+ * Change a user's first/last name via kiroku-api. The optimistic Onyx update
+ * mirrors the server's `onyxData`.
  *
- * @param db Database to change the display name in
- * @param user User to change the display name for
+ * @param user User to change the name for
  * @param firstName The new first name
  * @param lastName The new last name
- * @returns An empty promise
  */
-async function changeUserName(
-  db: Database,
+function changeUserName(
   user: User | null,
   firstName: string,
   lastName: string,
-): Promise<void> {
+): void {
   if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
+    return;
   }
-
-  const userID = user.uid;
-  const firstNameRef = DBPATHS.USERS_USER_ID_PROFILE_FIRST_NAME;
-  const lastNameRef = DBPATHS.USERS_USER_ID_PROFILE_LAST_NAME;
-
-  const updates: Record<string, string> = {};
-  updates[firstNameRef.getRoute(userID)] = firstName;
-  updates[lastNameRef.getRoute(userID)] = lastName;
-
-  await update(ref(db), updates);
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {
+        [user.uid]: {profile: {first_name: firstName, last_name: lastName}},
+      },
+    },
+  ];
+  API.write(
+    WRITE_COMMANDS.UPDATE_LEGAL_NAME,
+    {firstName, lastName},
+    {optimisticData},
+  );
 }
 
 /**

--- a/src/screens/Settings/Account/DisplayNameScreen.tsx
+++ b/src/screens/Settings/Account/DisplayNameScreen.tsx
@@ -13,7 +13,6 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import * as ValidationUtils from '@libs/ValidationUtils';
-import * as App from '@userActions/App';
 import Navigation from '@libs/Navigation/Navigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -24,7 +23,6 @@ import type SCREENS from '@src/SCREENS';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {changeDisplayName} from '@userActions/User';
-import ERRORS from '@src/ERRORS';
 
 type DisplayNameScreenProps = StackScreenProps<
   SettingsNavigatorParamList,
@@ -35,43 +33,24 @@ type DisplayNameScreenProps = StackScreenProps<
 function DisplayNameScreen({route}: DisplayNameScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
+  const {auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const {userData} = useDatabaseData();
   const profileData = userData?.profile;
-  const [isLoadingName, setIsLoadingName] = React.useState(false);
 
   const currentUserDetails = {
     displayName: profileData?.display_name,
   };
 
   /**
-   * Submit form to update user's display
+   * Submit form to update user's display name. Fire-and-forget: the optimistic
+   * Onyx update lands immediately, so we navigate back without awaiting.
    */
   const updateDisplayName = (
     values: FormOnyxValues<typeof ONYXKEYS.FORMS.DISPLAY_NAME_FORM>,
   ) => {
-    (async () => {
-      const newDisplayName = values.displayName.trim();
-      try {
-        setIsLoadingName(true);
-        await App.setLoadingText(
-          translate('displayNameScreen.updatingDisplayName'),
-        );
-        await changeDisplayName(
-          db,
-          auth.currentUser,
-          profileData?.display_name,
-          newDisplayName,
-        );
-      } catch (error) {
-        ErrorUtils.raiseAppError(ERRORS.USER.NICKNAME_UPDATE_FAILED, error);
-      } finally {
-        Navigation.goBack();
-        App.setLoadingText(null);
-        setIsLoadingName(false);
-      }
-    })();
+    changeDisplayName(auth.currentUser, values.displayName.trim());
+    Navigation.goBack();
   };
 
   const validate = (
@@ -100,7 +79,7 @@ function DisplayNameScreen({route}: DisplayNameScreenProps) {
         title={translate('displayNameScreen.headerTitle')}
         onBackButtonPress={() => Navigation.goBack()}
       />
-      {!!loadingText || isLoadingName ? (
+      {loadingText ? (
         <FullScreenLoadingIndicator
           style={[styles.flex1]}
           loadingText={loadingText}

--- a/src/screens/Settings/Account/UserNameScreen.tsx
+++ b/src/screens/Settings/Account/UserNameScreen.tsx
@@ -13,7 +13,6 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import * as ValidationUtils from '@libs/ValidationUtils';
-import * as App from '@userActions/App';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import INPUT_IDS from '@src/types/form/UserNameForm';
@@ -23,7 +22,6 @@ import type SCREENS from '@src/SCREENS';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {changeUserName} from '@userActions/User';
-import ERRORS from '@src/ERRORS';
 
 type UserNameScreenProps = StackScreenProps<
   SettingsNavigatorParamList,
@@ -34,11 +32,10 @@ type UserNameScreenProps = StackScreenProps<
 function UserNameScreen({route}: UserNameScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
+  const {auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const {userData} = useDatabaseData();
   const profileData = userData?.profile;
-  const [isLoadingName, setIsLoadingName] = React.useState(false);
 
   const currentUserDetails = {
     firstName: profileData?.first_name,
@@ -48,22 +45,12 @@ function UserNameScreen({route}: UserNameScreenProps) {
   const updateUserName = (
     values: FormOnyxValues<typeof ONYXKEYS.FORMS.USER_NAME_FORM>,
   ) => {
-    (async () => {
-      const newFirstName = values.firstName.trim();
-      const newLastName = values.lastName.trim();
-
-      try {
-        setIsLoadingName(true);
-        await App.setLoadingText(translate('userNameScreen.updatingUserName'));
-        await changeUserName(db, auth.currentUser, newFirstName, newLastName);
-        Navigation.goBack();
-      } catch (error) {
-        ErrorUtils.raiseAppError(ERRORS.USER.USERNAME_UPDATE_FAILED, error);
-      } finally {
-        setIsLoadingName(false);
-        await App.setLoadingText(null);
-      }
-    })();
+    changeUserName(
+      auth.currentUser,
+      values.firstName.trim(),
+      values.lastName.trim(),
+    );
+    Navigation.goBack();
   };
 
   const validate = (
@@ -149,7 +136,7 @@ function UserNameScreen({route}: UserNameScreenProps) {
         title={translate('userNameScreen.headerTitle')}
         onBackButtonPress={() => Navigation.goBack()}
       />
-      {!!loadingText || isLoadingName ? (
+      {loadingText ? (
         <FullScreenLoadingIndicator
           style={[styles.flex1]}
           loadingText={loadingText}


### PR DESCRIPTION
## Summary
Writes-only slice of the realtime strangler-fig migration (epic #778): the three **profile writes** are cut off direct Firebase RTDB `update()` calls and onto offline-first `API.write` calls against kiroku-api. Firebase **read** listeners are intentionally left untouched (read cutover is a separate epic).

- `changeDisplayName` → `POST /v1/profile/display-name` (`UPDATE_DISPLAY_NAME`), body `{ displayName }`. The server owns the `nickname_to_id` search-index rebuild.
- `changeUserName` → `POST /v1/profile/name` (`UPDATE_LEGAL_NAME`), body `{ firstName, lastName }`.
- profile photo (`setProfilePictureURL` / `updateProfileInfo`) → `POST /v1/profile/photo` (new `UPDATE_PROFILE_PHOTO`), body `{ photoURL }`.

Each call's `optimisticData` mirrors the server route's `onyxData` (a `USER_DATA_LIST[uid].profile` merge). The Firebase **Auth** `updateProfile()` sync (display name + photo) is preserved — that is an Auth call, not an RTDB write. Call sites are converted from await-then-navigate to fire-and-forget (mirrors `Preferences.updateTheme`).

## Changes
- `libs/API/types.ts`: add `UPDATE_PROFILE_PHOTO` command + param mapping; reuse the already-declared `UPDATE_DISPLAY_NAME` / `UPDATE_LEGAL_NAME`.
- `libs/API/parameters`: new `UpdateProfilePhotoParams`; fix `UpdateDisplayNameParams` / `UpdateLegalNameParams` field names to match the server bodies.
- `libs/API/kirokuRoutes.ts`: map the three commands to their `POST /v1/profile/*` routes.
- `libs/actions/User.ts`, `libs/actions/Profile.ts`: rewrite the three writers to `API.write` and drop the now-unused `db` argument.
- `DisplayNameScreen`, `UserNameScreen`, `UploadImage`: fire-and-forget call sites.

## Test plan
- [ ] **Device verification of the realtime write transport** — this cutover is merge-gated on it; do not merge until verified.
- [ ] Change display name → persists; server-side `nickname_to_id` search index updates; Firebase Auth `displayName` synced.
- [ ] Change first / last name → persists.
- [ ] Upload profile picture → `photo_url` persists; Firebase Auth `photoURL` synced.
- [x] `typecheck`, `lint-changed`, and the React Compiler compliance check pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)