### PR TITLE
feat(navigation): Day Overview fades in from center like calendar

### DIFF
--- a/src/NAVIGATORS.ts
+++ b/src/NAVIGATORS.ts
@@ -10,4 +10,5 @@ export default {
   FULL_SCREEN_NAVIGATOR: 'FullScreenNavigator',
   ONBOARDING_MODAL_NAVIGATOR: 'OnboardingModalNavigator',
   SESSIONS_CALENDAR_NAVIGATOR: 'SessionsCalendarNavigator',
+  DAY_OVERVIEW_NAVIGATOR: 'DayOverviewNavigator',
 } as const;

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -24,7 +24,6 @@ const SCREENS = {
 
   RIGHT_MODAL: {
     BADGES: 'Badges',
-    DAY_OVERVIEW: 'DayOverview',
     DRINKING_SESSION: 'DrinkingSession',
     SETTINGS: 'Settings',
     PROFILE: 'Profile',

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -6,6 +6,7 @@ import {format} from 'date-fns';
 import lodashDebounce from 'lodash/debounce';
 import Text from '@components/Text';
 import DrinkingSessionOverview from '@components/DrinkingSessionOverview';
+import SwipeBackGestureDetector from '@components/SwipeBackGestureDetector';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -87,6 +88,9 @@ type DayOverviewListViewProps = {
   /** When true, each session tile shows its edit affordance. Driven by the
    *  day-overview screen's Edit/Done header toggle (self only). */
   isEditModeOn?: boolean;
+  /** Dismisses the day-overview modal on a rightward swipe. Omitted in the
+   *  embedded (compact calendar) usages where there's no modal to dismiss. */
+  onSwipeBack?: () => void;
 };
 
 /**
@@ -111,6 +115,7 @@ function DayOverviewListView({
   onVisibleDayChange,
   isReadOnly,
   isEditModeOn,
+  onSwipeBack,
 }: DayOverviewListViewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -389,20 +394,22 @@ function DayOverviewListView({
   const initialScrollIndex = targetIndex ?? Math.max(0, items.length - 1);
 
   return (
-    <FlashList
-      ref={listRef}
-      data={items}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      initialScrollIndex={initialScrollIndex}
-      contentContainerStyle={contentContainerStyle}
-      showsVerticalScrollIndicator
-      ListHeaderComponent={listHeader}
-      ListEmptyComponent={listEmpty}
-      onScrollBeginDrag={onScrollBeginDrag}
-      onViewableItemsChanged={onViewableItemsChanged}
-      viewabilityConfig={VIEWABILITY_CONFIG}
-    />
+    <SwipeBackGestureDetector onSwipeBack={onSwipeBack}>
+      <FlashList
+        ref={listRef}
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={initialScrollIndex}
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={listEmpty}
+        onScrollBeginDrag={onScrollBeginDrag}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={VIEWABILITY_CONFIG}
+      />
+    </SwipeBackGestureDetector>
   );
 }
 

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -1,7 +1,5 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
 import {ActivityIndicator, View} from 'react-native';
-import {Gesture, GestureDetector} from 'react-native-gesture-handler';
-import {runOnJS} from 'react-native-reanimated';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef} from '@shopify/flash-list';
 import {format, parseISO, startOfDay} from 'date-fns';
@@ -10,6 +8,7 @@ import type {DateData} from 'react-native-calendars';
 import {LocaleConfig} from 'react-native-calendars';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
+import SwipeBackGestureDetector from '@components/SwipeBackGestureDetector';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
@@ -412,69 +411,35 @@ function SessionsCalendarWeekListView({
       ? targetIndex
       : Math.max(0, items.length - 1);
 
-  // Side-swipe-right → dismiss the fullscreen view. The Pan gesture only
-  // activates on a clear horizontal drift, and fails the moment a vertical
-  // drift takes the lead, so the FlashList's vertical scroll wins every
-  // intra-list pan. `enabled` keeps the gesture inert when no handler is
-  // wired up (e.g. a future reuse of this view outside the modal stack).
-  const swipeBackGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .enabled(!!onSwipeBack)
-        // Only positive translation (rightward swipe) should be a candidate;
-        // we leave a generous failOffset on the left so dragging the
-        // scrollbar / horizontal day-row never accidentally trips it.
-        .activeOffsetX(20)
-        .failOffsetY([-20, 20])
-        .onEnd(e => {
-          'worklet';
-
-          const SWIPE_THRESHOLD = 80;
-          const VELOCITY_THRESHOLD = 500;
-          if (!onSwipeBack) {
-            return;
-          }
-          if (
-            e.translationX > SWIPE_THRESHOLD ||
-            e.velocityX > VELOCITY_THRESHOLD
-          ) {
-            runOnJS(onSwipeBack)();
-          }
-        }),
-    [onSwipeBack],
-  );
-
   return (
-    <GestureDetector gesture={swipeBackGesture}>
-      <View style={styles.flex1}>
-        <View style={styles.sessionsCalendarDayNamesRow}>
-          {dayNames.map((name, idx) => (
-            <View
-              // eslint-disable-next-line react/no-array-index-key
-              key={`day-name-${idx}`}
-              style={styles.sessionsCalendarDayNameCell}>
-              <Text style={styles.sessionsCalendarDayNameText}>{name}</Text>
-            </View>
-          ))}
-        </View>
-        <View style={styles.flex1}>
-          <FlashList
-            ref={listRef}
-            data={items}
-            renderItem={renderItem}
-            keyExtractor={keyExtractor}
-            stickyHeaderIndices={stickyHeaderIndices}
-            initialScrollIndex={initialScrollIndex}
-            contentContainerStyle={contentContainerStyle}
-            showsVerticalScrollIndicator
-            ListHeaderComponent={listHeader}
-            onScrollBeginDrag={onScrollBeginDrag}
-            onViewableItemsChanged={onViewableItemsChanged}
-            viewabilityConfig={VIEWABILITY_CONFIG}
-          />
-        </View>
+    <SwipeBackGestureDetector onSwipeBack={onSwipeBack}>
+      <View style={styles.sessionsCalendarDayNamesRow}>
+        {dayNames.map((name, idx) => (
+          <View
+            // eslint-disable-next-line react/no-array-index-key
+            key={`day-name-${idx}`}
+            style={styles.sessionsCalendarDayNameCell}>
+            <Text style={styles.sessionsCalendarDayNameText}>{name}</Text>
+          </View>
+        ))}
       </View>
-    </GestureDetector>
+      <View style={styles.flex1}>
+        <FlashList
+          ref={listRef}
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          stickyHeaderIndices={stickyHeaderIndices}
+          initialScrollIndex={initialScrollIndex}
+          contentContainerStyle={contentContainerStyle}
+          showsVerticalScrollIndicator
+          ListHeaderComponent={listHeader}
+          onScrollBeginDrag={onScrollBeginDrag}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={VIEWABILITY_CONFIG}
+        />
+      </View>
+    </SwipeBackGestureDetector>
   );
 }
 

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -210,6 +210,7 @@ function SessionsCalendar({
         onVisibleDayChange={onVisibleDayChange}
         isReadOnly={isReadOnly}
         isEditModeOn={isEditModeOn}
+        onSwipeBack={Navigation.goBack}
       />
     );
   }

--- a/src/components/SwipeBackGestureDetector.tsx
+++ b/src/components/SwipeBackGestureDetector.tsx
@@ -1,0 +1,72 @@
+import React, {useMemo} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import {View} from 'react-native';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {runOnJS} from 'react-native-reanimated';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+// A rightward swipe past this distance (px) — or faster than the velocity
+// threshold — dismisses. Tuned alongside `activeOffsetX`/`failOffsetY` so the
+// gesture coexists with a vertically-scrolling list underneath.
+const SWIPE_DISTANCE_THRESHOLD = 80;
+const SWIPE_VELOCITY_THRESHOLD = 500;
+
+type SwipeBackGestureDetectorProps = {
+  /** Invoked when the user completes a rightward swipe. When omitted the gesture
+   *  stays inert, so the wrapped content behaves normally. */
+  onSwipeBack?: () => void;
+
+  /** Style for the gesture's host view. Defaults to filling the parent. */
+  style?: StyleProp<ViewStyle>;
+
+  children: React.ReactNode;
+};
+
+/**
+ * Wraps content in a horizontal swipe-right-to-dismiss gesture.
+ *
+ * The Pan only activates on a clear horizontal drift and fails the moment a
+ * vertical drift takes the lead, so a `FlashList`/`ScrollView` underneath keeps
+ * every vertical pan. Shared by the fullscreen calendar and the day-overview
+ * scroll so both transparent-modal screens dismiss the same way.
+ */
+function SwipeBackGestureDetector({
+  onSwipeBack,
+  style,
+  children,
+}: SwipeBackGestureDetectorProps) {
+  const styles = useThemeStyles();
+  const swipeBackGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(!!onSwipeBack)
+        // Only a rightward drag is a candidate; the generous left failOffset
+        // keeps horizontal day-rows / the scrollbar from tripping it.
+        .activeOffsetX(20)
+        .failOffsetY([-20, 20])
+        .onEnd(e => {
+          'worklet';
+
+          if (!onSwipeBack) {
+            return;
+          }
+          if (
+            e.translationX > SWIPE_DISTANCE_THRESHOLD ||
+            e.velocityX > SWIPE_VELOCITY_THRESHOLD
+          ) {
+            runOnJS(onSwipeBack)();
+          }
+        }),
+    [onSwipeBack],
+  );
+
+  return (
+    <GestureDetector gesture={swipeBackGesture}>
+      <View style={style ?? styles.flex1}>{children}</View>
+    </GestureDetector>
+  );
+}
+
+SwipeBackGestureDetector.displayName = 'SwipeBackGestureDetector';
+
+export default SwipeBackGestureDetector;

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -48,7 +48,10 @@ import BottomTabNavigator from './Navigators/BottomTabNavigator';
 // import LeftModalNavigator from './Navigators/LeftModalNavigator';
 import OnboardingModalNavigator from './Navigators/OnboardingModalNavigator';
 import RightModalNavigator from './Navigators/RightModalNavigator';
-import {SessionsCalendarModalStackNavigator} from './ModalStackNavigators';
+import {
+  DayOverviewModalStackNavigator,
+  SessionsCalendarModalStackNavigator,
+} from './ModalStackNavigators';
 // import WelcomeVideoModalNavigator from './Navigators/WelcomeVideoModalNavigator';
 
 // eslint-disable-next-line rulesdir/no-negated-variables
@@ -334,6 +337,12 @@ function AuthScreensContent() {
           name={NAVIGATORS.SESSIONS_CALENDAR_NAVIGATOR}
           options={screenOptions.sessionsCalendarNavigator}
           component={SessionsCalendarModalStackNavigator}
+        />
+        <RootStack.Screen
+          name={NAVIGATORS.DAY_OVERVIEW_NAVIGATOR}
+          options={screenOptions.dayOverviewNavigator}
+          component={DayOverviewModalStackNavigator}
+          listeners={modalScreenListeners}
         />
         {/* <RootStack.Screen
           name={NAVIGATORS.FULL_SCREEN_NAVIGATOR}

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -81,9 +81,15 @@ const BadgesModalStackNavigator =
 
 const DayOverviewModalStackNavigator =
   createModalStackNavigator<DayOverviewNavigatorParamList>({
-    [SCREENS.DAY_OVERVIEW.ROOT]: () =>
-      require<ReactComponentModule>('@screens/DayOverview/DayOverviewScreen')
-        .default,
+    [SCREENS.DAY_OVERVIEW.ROOT]: {
+      getComponent: () =>
+        require<ReactComponentModule>('@screens/DayOverview/DayOverviewScreen')
+          .default,
+      // The screen owns a horizontal swipe-back gesture (SwipeBackGestureDetector
+      // in DayOverviewListView). Disable the stack's own swipe-back so the two
+      // don't race on iOS — our gesture works on both platforms.
+      options: {gestureEnabled: false},
+    },
   });
 
 const DrinkingSessionModalStackNavigator =

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -61,10 +61,6 @@ function RightModalNavigator({navigation}: RightModalNavigatorProps) {
           component={ModalStackNavigators.BadgesModalStackNavigator}
         />
         <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.DAY_OVERVIEW}
-          component={ModalStackNavigators.DayOverviewModalStackNavigator}
-        />
-        <Stack.Screen
           name={SCREENS.RIGHT_MODAL.DRINKING_SESSION}
           component={ModalStackNavigators.DrinkingSessionModalStackNavigator}
         />

--- a/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
+++ b/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
@@ -96,6 +96,23 @@ const getRootNavigatorScreenOptions: GetRootNavigatorScreenOptions = (
     },
   };
 
+  // Shared "lift in from the center" transparent modal: the card fades and
+  // scales in (see sessionsCalendarCardStyleInterpolator) over the screen
+  // beneath it. Both calendar drill-downs — the fullscreen calendar and the
+  // day-overview scroll — use it so they look and behave identically.
+  // `gestureResponseDistance` stays at the platform default so the edge
+  // swipe-back doesn't fight the content's vertical scroll; each screen adds a
+  // content-level SwipeBackGestureDetector for full-width swipe-to-dismiss.
+  const centerModalScreenOptions: StackNavigationOptions = {
+    ...commonScreenOptions,
+    cardStyleInterpolator: sessionsCalendarCardStyleInterpolator,
+    presentation: 'transparentModal',
+    cardOverlayEnabled: false,
+    cardStyle: {backgroundColor: 'transparent'},
+    gestureEnabled: true,
+    gestureDirection: 'horizontal',
+  };
+
   return {
     // Function form so React Navigation re-evaluates gestureEnabled when the
     // nested stack state changes. Root-level swipe-back is enabled only when
@@ -129,32 +146,11 @@ const getRootNavigatorScreenOptions: GetRootNavigatorScreenOptions = (
         position: 'fixed' as ViewStyle['position'],
       },
     }),
-    // Fullscreen sessions calendar — transparent modal so the prior screen
-    // (Home or Profile) stays visible underneath while the calendar fades
-    // and scales in. Standard left-edge swipe-right dismisses; we leave
-    // `gestureResponseDistance` at the platform default to avoid
-    // competing with the FlashList's vertical scroll handler.
-    sessionsCalendarNavigator: {
-      ...commonScreenOptions,
-      cardStyleInterpolator: sessionsCalendarCardStyleInterpolator,
-      presentation: 'transparentModal',
-      cardOverlayEnabled: false,
-      cardStyle: {backgroundColor: 'transparent'},
-      gestureEnabled: true,
-      gestureDirection: 'horizontal',
-    },
-    // Day overview (drinking-sessions list for a tapped day) reuses the
-    // fullscreen calendar's fade-and-scale entrance so both calendar
-    // drill-downs lift in from the center rather than sliding from the right.
-    dayOverviewNavigator: {
-      ...commonScreenOptions,
-      cardStyleInterpolator: sessionsCalendarCardStyleInterpolator,
-      presentation: 'transparentModal',
-      cardOverlayEnabled: false,
-      cardStyle: {backgroundColor: 'transparent'},
-      gestureEnabled: true,
-      gestureDirection: 'horizontal',
-    },
+    // Fullscreen sessions calendar and day-overview scroll share the same
+    // center-lift modal (see centerModalScreenOptions) so the two calendar
+    // drill-downs feel identical.
+    sessionsCalendarNavigator: centerModalScreenOptions,
+    dayOverviewNavigator: centerModalScreenOptions,
     leftModalNavigator: {
       ...commonScreenOptions,
       cardStyleInterpolator: props =>

--- a/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
+++ b/src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx
@@ -29,6 +29,7 @@ type ScreenOptions = {
   rightModalNavigator: DynamicScreenOptions;
   onboardingModalNavigator: GetOnboardingModalNavigatorOptions;
   sessionsCalendarNavigator: StackNavigationOptions;
+  dayOverviewNavigator: StackNavigationOptions;
   leftModalNavigator: StackNavigationOptions;
   homeScreen: StackNavigationOptions;
   fullScreen: StackNavigationOptions;
@@ -134,6 +135,18 @@ const getRootNavigatorScreenOptions: GetRootNavigatorScreenOptions = (
     // `gestureResponseDistance` at the platform default to avoid
     // competing with the FlashList's vertical scroll handler.
     sessionsCalendarNavigator: {
+      ...commonScreenOptions,
+      cardStyleInterpolator: sessionsCalendarCardStyleInterpolator,
+      presentation: 'transparentModal',
+      cardOverlayEnabled: false,
+      cardStyle: {backgroundColor: 'transparent'},
+      gestureEnabled: true,
+      gestureDirection: 'horizontal',
+    },
+    // Day overview (drinking-sessions list for a tapped day) reuses the
+    // fullscreen calendar's fade-and-scale entrance so both calendar
+    // drill-downs lift in from the center rather than sliding from the right.
+    dayOverviewNavigator: {
       ...commonScreenOptions,
       cardStyleInterpolator: sessionsCalendarCardStyleInterpolator,
       presentation: 'transparentModal',

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -64,13 +64,6 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
             [SCREENS.BADGES.ROOT]: ROUTES.BADGES,
           },
         },
-        [SCREENS.RIGHT_MODAL.DAY_OVERVIEW]: {
-          screens: {
-            [SCREENS.DAY_OVERVIEW.ROOT]: {
-              path: ROUTES.DAY_OVERVIEW.route,
-            },
-          },
-        },
         [SCREENS.RIGHT_MODAL.DRINKING_SESSION]: {
           screens: {
             [SCREENS.DRINKING_SESSION.ROOT]: {
@@ -228,6 +221,14 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
       screens: {
         [SCREENS.SESSIONS_CALENDAR.FULLSCREEN]: {
           path: ROUTES.SESSIONS_CALENDAR_FULLSCREEN.route,
+        },
+      },
+    },
+
+    [NAVIGATORS.DAY_OVERVIEW_NAVIGATOR]: {
+      screens: {
+        [SCREENS.DAY_OVERVIEW.ROOT]: {
+          path: ROUTES.DAY_OVERVIEW.route,
         },
       },
     },

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -171,8 +171,6 @@ type StatisticsNavigatorParamList = {
 type RightModalNavigatorParamList = {
   [SCREENS.RIGHT_MODAL.BADGES]: NavigatorScreenParams<BadgesNavigatorParamList>;
   [SCREENS.RIGHT_MODAL
-    .DAY_OVERVIEW]: NavigatorScreenParams<DayOverviewNavigatorParamList>;
-  [SCREENS.RIGHT_MODAL
     .DRINKING_SESSION]: NavigatorScreenParams<DrinkingSessionNavigatorParamList>;
   [SCREENS.RIGHT_MODAL
     .PROFILE]: NavigatorScreenParams<ProfileNavigatorParamList>;
@@ -240,6 +238,7 @@ type AuthScreensParamList = CentralPaneScreensParamList &
     [NAVIGATORS.LEFT_MODAL_NAVIGATOR]: NavigatorScreenParams<LeftModalNavigatorParamList>;
     [NAVIGATORS.RIGHT_MODAL_NAVIGATOR]: NavigatorScreenParams<RightModalNavigatorParamList>;
     [NAVIGATORS.SESSIONS_CALENDAR_NAVIGATOR]: NavigatorScreenParams<SessionsCalendarNavigatorParamList>;
+    [NAVIGATORS.DAY_OVERVIEW_NAVIGATOR]: NavigatorScreenParams<DayOverviewNavigatorParamList>;
     [NAVIGATORS.ONBOARDING_MODAL_NAVIGATOR]: NavigatorScreenParams<OnboardingModalNavigatorParamList>;
     // [NAVIGATORS.FULL_SCREEN_NAVIGATOR]: NavigatorScreenParams<FullScreenNavigatorParamList>;
   };


### PR DESCRIPTION
### Details

When tapping the home calendar's month header, the fullscreen "infinite scroll" calendar **fades and scales in from the center**. Tapping a day tile, however, opened the Day Overview (drinking-sessions list for that day) with a **slide-from-the-right** transition. This PR makes the Day Overview use the same center fade-scale entrance, for consistency between the two calendar drill-downs.

**Why it couldn't be changed in place:** the slide-from-right is the root-level entrance of the shared `RightModalNavigator`, common to all seven RHP screens (Settings, Profile, Statistics, …). The fullscreen calendar avoids it by living in its **own** root navigator (`SESSIONS_CALENDAR_NAVIGATOR`) with a custom fade+scale interpolator.

**Approach:** give the Day Overview its own root navigator (`DAY_OVERVIEW_NAVIGATOR`), mirroring `SESSIONS_CALENDAR_NAVIGATOR`, and reuse the calendar's `sessionsCalendarCardStyleInterpolator`. The route builder and every `Navigation.navigate(ROUTES.DAY_OVERVIEW…)` call site are unchanged — React Navigation resolves the route through the linking config regardless of host navigator.

Files:
- `src/NAVIGATORS.ts` — new `DAY_OVERVIEW_NAVIGATOR` constant
- `src/SCREENS.ts` — removed obsolete `RIGHT_MODAL.DAY_OVERVIEW`
- `src/libs/Navigation/types.ts` — moved param list from the RHP to the root navigator
- `src/libs/Navigation/AppNavigator/getRootNavigatorScreenOptions.tsx` — `dayOverviewNavigator` options reusing the fade+scale interpolator
- `src/libs/Navigation/AppNavigator/AuthScreens.tsx` — mounted the root screen (keeps `modalScreenListeners` so modal-visibility state is preserved)
- `src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx` — removed the Day Overview screen
- `src/libs/Navigation/linkingConfig/config.ts` — moved the `day-overview/:date` deep-link entry

**Back-path note for reviewers:** moving Day Overview out of the RHP flips which branch `SessionSummaryScreen.onBackPress` takes (the RHP stack now holds only the Drinking Session, so `getLastScreenName(true)` no longer returns `DAY_OVERVIEW.ROOT`). The end state is preserved: it now falls into `dismissModal()`, which `StackActions.pop()`s the RHP off the root stack and reveals `DAY_OVERVIEW_NAVIGATOR` sitting directly beneath it. The user still returns to the Day Overview list with scroll position intact.

### Tests

1. From Home, tap a **day tile** in the calendar → verify the Day Overview **fades and scales in from the center** (previously slid in from the right).
2. From Home, tap the calendar **month header** → verify the fullscreen calendar still fades+scales in (unchanged).
3. In the Day Overview, tap a session → the Drinking Session summary slides in from the right → press **back** → verify you return to the **Day Overview list** (same scroll position), not Home.
4. Press **back** from the Day Overview → verify you return to Home with a fade+scale-out.
5. Open the fullscreen calendar → tap a day tile → verify the Day Overview fades+scales in on top; back returns to the calendar.
6. Tap the **+ FAB** in the Day Overview → pick a date → verify a new session is created and the edit screen opens.
7. Deep-link to `day-overview/<date>` → verify the screen still resolves and opens.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, then open the Day Overview → verify the offline modal (`UserOffline`) still appears (gating is unchanged).
- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Repeat **Tests** steps 1–7 on both iOS and Android.
2. Pay special attention to step 3 (session summary → back returns to Day Overview) and step 5 (calendar → day overview cross-navigator transition).
- [ ] Verify that no errors appear in the JS console

### Verification status

- Static checks pass locally: `prettier` (formatted), `typecheck-tsgo` (clean), `lint.sh` on changed files (no errors), `react-compiler-compliance-check` (7 files pass).
- **Not yet run on a device/simulator** — the actual animation and the flows above still need a manual iOS/Android pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)