### PR TITLE
chore(errors): remove orphaned PRIVACY_UPDATE_FAILED

### DIFF
--- a/src/ERRORS.ts
+++ b/src/ERRORS.ts
@@ -72,7 +72,6 @@ const ERRORS = {
     FRIEND_REQUEST_ACCEPT_FAILED: 'user/friend-request-accept-failed',
     FRIEND_REQUEST_REJECT_FAILED: 'user/friend-request-reject-failed',
     NICKNAME_UPDATE_FAILED: 'user/nickname-update-failed',
-    PRIVACY_UPDATE_FAILED: 'user/privacy-update-failed',
     STATUS_UPDATE_FAILED: 'user/status-update-failed',
     THEME_UPDATE_FAILED: 'user/theme-update-failed',
     TIMEZONE_UPDATE_FAILED: 'user/timezone-update-failed',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1739,11 +1739,6 @@ export default {
         message:
           'Při aktualizaci přezdívky došlo k chybě. Zkuste to prosím znovu.',
       },
-      privacyUpdateFailed: {
-        title: 'Nepodařilo se aktualizovat soukromí',
-        message:
-          'Při aktualizaci nastavení soukromí došlo k chybě. Zkuste to prosím znovu.',
-      },
       statusUpdateFailed: {
         title: 'Nepodařilo se aktualizovat stav',
         message: 'Při aktualizaci stavu došlo k chybě. Zkuste to prosím znovu.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1749,11 +1749,6 @@ export default {
         title: 'Nickname Update Failed',
         message: 'There was an error updating your nickname. Please try again.',
       },
-      privacyUpdateFailed: {
-        title: 'Privacy Update Failed',
-        message:
-          'There was an error updating your privacy settings. Please try again.',
-      },
       statusUpdateFailed: {
         title: 'Status Update Failed',
         message: 'There was an error updating your status. Please try again.',

--- a/src/libs/Errors/ERROR_MAPPING.ts
+++ b/src/libs/Errors/ERROR_MAPPING.ts
@@ -60,7 +60,6 @@ const ERROR_MAPPING: ErrorMapping = {
   [ERRORS.USER.FRIEND_REQUEST_REJECT_FAILED]:
     'errors.user.friendRequestRejectFailed',
   [ERRORS.USER.NICKNAME_UPDATE_FAILED]: 'errors.user.nicknameUpdateFailed',
-  [ERRORS.USER.PRIVACY_UPDATE_FAILED]: 'errors.user.privacyUpdateFailed',
   [ERRORS.USER.STATUS_UPDATE_FAILED]: 'errors.user.statusUpdateFailed',
   [ERRORS.USER.THEME_UPDATE_FAILED]: 'errors.user.themeUpdateFailed',
   [ERRORS.USER.TIMEZONE_UPDATE_FAILED]: 'errors.user.timezoneUpdateFailed',


### PR DESCRIPTION
## Summary

[PR #900](https://github.com/PetrCala/Kiroku/pull/900) cut privacy writes over to kiroku-api, rewiring `ManageFriendPopover`'s `handleToggleHidden` to a straight-line fire-and-forget `Privacy.setFriendDataHidden` call and deleting `src/database/privacy.ts`. That removed the **only** raiser of `ERRORS.USER.PRIVACY_UPDATE_FAILED`, leaving the error constant and its downstream config dead.

This PR removes the now-orphaned config:

- `src/ERRORS.ts` — the `PRIVACY_UPDATE_FAILED: 'user/privacy-update-failed'` constant.
- `src/libs/Errors/ERROR_MAPPING.ts` — the `[ERRORS.USER.PRIVACY_UPDATE_FAILED] → 'errors.user.privacyUpdateFailed'` mapping.
- `src/languages/en.ts` + `src/languages/cs_cz.ts` — the `errors.user.privacyUpdateFailed` translation block (both locales, kept in sync).

No call sites reference the constant anymore (verified by grep). Pure deletion, 12 lines.

## Test plan

- [x] `grep` for `PRIVACY_UPDATE_FAILED` / `privacyUpdateFailed` / `privacy-update-failed` — zero references remain
- [x] `npx prettier --check` on the four files — clean
- [x] `npm run lint-changed` — exit 0
- [x] `npm run typecheck-tsgo` — exit 0 (this is what enforces the ERROR_MAPPING → en translation-path link)
- [x] `npm run test -- TranslationContext` and `Translate.test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)