### PR TITLE
perf(statistics): cache tz offset per month to cut Intl off the cold path

### DIFF
--- a/__tests__/unit/libs/Statistics/localParts.test.ts
+++ b/__tests__/unit/libs/Statistics/localParts.test.ts
@@ -1,0 +1,144 @@
+import {isoWeekLabel, resolveLocalParts} from '@libs/Statistics/localParts';
+import type {LocalParts} from '@libs/Statistics/localParts';
+
+/**
+ * Independent reference: the straightforward "one `Intl.formatToParts` per
+ * timestamp" resolution that `resolveLocalParts` replaced with a cached-offset
+ * derivation. These must stay byte-identical — especially at DST transition
+ * instants, where an off-by-one in the offset cache would surface.
+ */
+function referenceLocalParts(ts: number, timeZone: string): LocalParts {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    hourCycle: 'h23',
+  });
+  const fields: Record<string, string> = {};
+  for (const part of formatter.formatToParts(ts)) {
+    fields[part.type] = part.value;
+  }
+  const {year, month, day, hour} = fields;
+  const localMidnightUtc = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+  );
+  return {
+    localDay: `${year}-${month}-${day}`,
+    localMonth: `${year}-${month}`,
+    localHour: Number(hour) % 24,
+    localIsoWeek: isoWeekLabel(localMidnightUtc),
+    calendarDow: new Date(localMidnightUtc).getUTCDay(),
+  };
+}
+
+const ZONES = [
+  'UTC',
+  'America/New_York', // -5 / -4 DST
+  'Europe/London', // +0 / +1 DST
+  'Asia/Tokyo', // +9, no DST
+  'Asia/Kathmandu', // +5:45, no DST (sub-hour offset)
+  'Australia/Lord_Howe', // +10:30 / +11 (30-minute DST)
+];
+
+const HOUR = 3_600_000;
+
+describe('resolveLocalParts — byte-identical to a fresh Intl resolution', () => {
+  it.each(ZONES)('matches the reference across a 3-year sweep (%s)', zone => {
+    // Every 12h from 2023-01-01 to 2026-01-01 exercises both DST halves, both
+    // transition months, leap day, and the cache's constant-month fast path.
+    const start = Date.UTC(2023, 0, 1);
+    const end = Date.UTC(2026, 0, 1);
+    for (let ts = start; ts < end; ts += 12 * HOUR) {
+      expect(resolveLocalParts(ts, zone)).toEqual(
+        referenceLocalParts(ts, zone),
+      );
+    }
+  });
+});
+
+describe('resolveLocalParts — exact DST transition instants', () => {
+  // Dense ±2h minute-by-minute sweep straddling each jump: the offset flips
+  // mid-window, so this is the strongest guard on the cached-offset path.
+  const transitions: Array<{zone: string; instant: number; label: string}> = [
+    {
+      zone: 'America/New_York',
+      instant: Date.UTC(2024, 2, 10, 7),
+      label: 'NY spring-forward',
+    },
+    {
+      zone: 'America/New_York',
+      instant: Date.UTC(2024, 10, 3, 6),
+      label: 'NY fall-back',
+    },
+    {
+      zone: 'Europe/London',
+      instant: Date.UTC(2024, 2, 31, 1),
+      label: 'London spring-forward',
+    },
+    {
+      zone: 'Europe/London',
+      instant: Date.UTC(2024, 9, 27, 1),
+      label: 'London fall-back',
+    },
+    {
+      zone: 'Australia/Lord_Howe',
+      instant: Date.UTC(2024, 3, 6, 15, 30),
+      label: 'Lord Howe fall-back',
+    },
+  ];
+
+  it.each(transitions)('is exact within ±2h of $label', ({zone, instant}) => {
+    for (let ts = instant - 2 * HOUR; ts <= instant + 2 * HOUR; ts += 60_000) {
+      expect(resolveLocalParts(ts, zone)).toEqual(
+        referenceLocalParts(ts, zone),
+      );
+    }
+  });
+
+  it('returns distinct local hours either side of NY spring-forward', () => {
+    const jump = Date.UTC(2024, 2, 10, 7); // 02:00 EST -> 03:00 EDT
+    // One minute before the jump is 01:59 EST; the jump instant is 03:00 EDT.
+    expect(
+      resolveLocalParts(jump - 60_000, 'America/New_York')?.localHour,
+    ).toBe(1);
+    expect(resolveLocalParts(jump, 'America/New_York')?.localHour).toBe(3);
+  });
+});
+
+describe('resolveLocalParts — cache behaviour within a month', () => {
+  it('resolves many timestamps in one constant-offset month correctly', () => {
+    // July has no transition in NY; every stamp must use the same -4h offset.
+    for (let day = 1; day <= 28; day++) {
+      const ts = Date.UTC(2024, 6, day, 17, 30); // 13:30 EDT
+      expect(resolveLocalParts(ts, 'America/New_York')).toEqual(
+        referenceLocalParts(ts, 'America/New_York'),
+      );
+    }
+  });
+
+  it('handles a transition month queried both before and after the jump', () => {
+    const before = Date.UTC(2024, 2, 1, 12); // March, pre-spring-forward
+    const after = Date.UTC(2024, 2, 20, 12); // March, post-spring-forward
+    expect(resolveLocalParts(before, 'America/New_York')).toEqual(
+      referenceLocalParts(before, 'America/New_York'),
+    );
+    expect(resolveLocalParts(after, 'America/New_York')).toEqual(
+      referenceLocalParts(after, 'America/New_York'),
+    );
+    // Same wall hour (07:00 -> different offsets give different local hours)
+    expect(resolveLocalParts(before, 'America/New_York')?.localHour).toBe(7); // 12:00 UTC = 07:00 EST
+    expect(resolveLocalParts(after, 'America/New_York')?.localHour).toBe(8); // 12:00 UTC = 08:00 EDT
+  });
+});
+
+describe('resolveLocalParts — invalid timezone', () => {
+  it('throws so the caller can skip the timestamp', () => {
+    expect(() =>
+      resolveLocalParts(Date.UTC(2024, 0, 1), 'Not/AZone'),
+    ).toThrow();
+  });
+});

--- a/src/libs/Statistics/localParts.ts
+++ b/src/libs/Statistics/localParts.ts
@@ -1,7 +1,6 @@
 /**
- * Resolve a UTC instant's local wall-clock fields in a given timezone using a
- * single cached `Intl.DateTimeFormat.formatToParts` call, then derive ISO week
- * and calendar day-of-week arithmetically.
+ * Resolve a UTC instant's local wall-clock fields in a given timezone, then
+ * derive ISO week and calendar day-of-week arithmetically.
  *
  * This is the *one* place the app turns `(timestamp, timezone)` into local
  * calendar fields, shared by:
@@ -10,24 +9,33 @@
  *
  * Sharing it guarantees the value persisted at write time and the value
  * recomputed on the fly are byte-identical — there is no second implementation
- * to drift. Native `Intl` (not `date-fns-tz`) is used deliberately: `date-fns-tz`
- * is off-by-one-hour at the exact spring-forward instant, whereas `Intl` matches
- * the engine the app runs on.
+ * to drift. Native `Intl` (not `date-fns-tz`) is the source of truth for the
+ * UTC offset: `date-fns-tz` is off-by-one-hour at the exact spring-forward
+ * instant, whereas `Intl` matches the engine the app runs on.
  *
- * On Hermes each `formatToParts` call is ~2-3 ms, so the write path pays this
- * once per drink timestamp while the user is interacting, and the cold read path
- * pays nothing once the fields are stored.
+ * On Hermes each `Intl.formatToParts` call is ~1-3 ms, and the cold read path
+ * can face hundreds of timestamps with no stored fields at once (a fresh
+ * install's whole history). So we never format per field: we use `Intl` only to
+ * learn the timezone's *UTC offset*, cache that offset per (timezone, UTC
+ * month), and compute every calendar field with plain `Date.UTC` arithmetic.
+ * A timezone's offset changes at most once inside a calendar month (DST
+ * transitions are months apart), so two probes at a month's edges decide it:
+ * equal offsets ⇒ one offset serves the entire month with zero further `Intl`;
+ * unequal ⇒ the rare transition month, where each timestamp is probed directly
+ * (still exact). The cache is keyed by UTC month, so it is shared across every
+ * session and drink regardless of how the timestamps are distributed.
  */
 
 /**
  * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
- * expensive part of timezone resolution, so we build it once and reuse it for
- * every timestamp in that zone — in practice a single zone per user.
+ * expensive part, so we build it once and reuse it for every offset probe in
+ * that zone. Minute and second precision are included so sub-hour offsets
+ * (e.g. UTC+5:45, UTC+10:30) resolve exactly.
  */
-const localPartsFormatters = new Map<string, Intl.DateTimeFormat>();
+const offsetFormatters = new Map<string, Intl.DateTimeFormat>();
 
-function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = localPartsFormatters.get(timeZone);
+function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = offsetFormatters.get(timeZone);
   if (!formatter) {
     formatter = new Intl.DateTimeFormat('en-US', {
       timeZone,
@@ -35,11 +43,74 @@ function getLocalPartsFormatter(timeZone: string): Intl.DateTimeFormat {
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
       hourCycle: 'h23',
     });
-    localPartsFormatters.set(timeZone, formatter);
+    offsetFormatters.set(timeZone, formatter);
   }
   return formatter;
+}
+
+/**
+ * The UTC offset (ms) that applies to `ts` in `timeZone`, via a single `Intl`
+ * call. Derived as `wallClock - ts`: the formatter yields the local wall clock,
+ * and the difference is the offset. Rounded to the nearest minute because the
+ * formatter drops sub-second precision while every real-world offset is a whole
+ * number of minutes. Throws on an invalid timezone (formatter construction) —
+ * the caller skips that timestamp.
+ */
+function probeOffsetMs(ts: number, timeZone: string): number {
+  const fields: Record<string, string> = {};
+  for (const part of getOffsetFormatter(timeZone).formatToParts(ts)) {
+    fields[part.type] = part.value;
+  }
+  const wallUtc = Date.UTC(
+    Number(fields.year),
+    Number(fields.month) - 1,
+    Number(fields.day),
+    Number(fields.hour) % 24,
+    Number(fields.minute),
+    Number(fields.second),
+  );
+  return Math.round((wallUtc - ts) / 60_000) * 60_000;
+}
+
+/** Per timezone: the resolved offset for each seen UTC month. */
+type MonthOffset = number | 'mixed';
+const monthOffsetCache = new Map<string, Map<number, MonthOffset>>();
+
+/** UTC-midnight of the first day of a `year*12 + monthZeroBased` index. */
+function monthStartUtc(monthIndex: number): number {
+  return Date.UTC(Math.floor(monthIndex / 12), monthIndex % 12, 1);
+}
+
+/**
+ * The UTC offset (ms) for `ts` in `timeZone`, memoised per UTC month. The first
+ * timestamp in a month pays two `Intl` probes (month start and end); if they
+ * agree the offset is constant all month and every later timestamp that month
+ * is free. A `'mixed'` month (a DST transition lies inside it) probes each
+ * timestamp directly, so the result stays exact at the transition instant.
+ */
+function getTzOffsetMs(ts: number, timeZone: string): number {
+  const at = new Date(ts);
+  const monthIndex = at.getUTCFullYear() * 12 + at.getUTCMonth();
+  let byMonth = monthOffsetCache.get(timeZone);
+  if (!byMonth) {
+    byMonth = new Map();
+    monthOffsetCache.set(timeZone, byMonth);
+  }
+  let cell = byMonth.get(monthIndex);
+  if (cell === undefined) {
+    const startOffset = probeOffsetMs(monthStartUtc(monthIndex), timeZone);
+    const endOffset = probeOffsetMs(
+      monthStartUtc(monthIndex + 1) - 1,
+      timeZone,
+    );
+    cell = startOffset === endOffset ? startOffset : 'mixed';
+    byMonth.set(monthIndex, cell);
+  }
+  return cell === 'mixed' ? probeOffsetMs(ts, timeZone) : cell;
 }
 
 /**
@@ -75,30 +146,24 @@ type LocalParts = {
 };
 
 /**
- * Resolve a timestamp's local wall-clock fields with a single cached
- * `formatToParts` call, then derive day-of-week and ISO week arithmetically.
- * Throws only on an invalid timezone (the caller skips); returns `null` if the
- * formatter omits a field, which no supported runtime does.
+ * Resolve a timestamp's local wall-clock fields. The timezone's UTC offset
+ * (cached per month) maps the instant onto a local wall clock, and every field
+ * is then `Date.UTC` arithmetic — no per-field formatting. Throws only on an
+ * invalid timezone (the caller skips).
  */
 function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
-  const fields: Record<string, string> = {};
-  for (const part of getLocalPartsFormatter(timeZone).formatToParts(ts)) {
-    fields[part.type] = part.value;
-  }
-  const {year, month, day, hour} = fields;
-  if (!year || !month || !day || !hour) {
-    return null;
-  }
-  const localMidnightUtc = Date.UTC(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-  );
+  const wall = new Date(ts + getTzOffsetMs(ts, timeZone));
+  const year = wall.getUTCFullYear();
+  const month = wall.getUTCMonth() + 1;
+  const day = wall.getUTCDate();
+  const yyyy = String(year).padStart(4, '0');
+  const mm = String(month).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  const localMidnightUtc = Date.UTC(year, month - 1, day);
   return {
-    localDay: `${year}-${month}-${day}`,
-    localMonth: `${year}-${month}`,
-    // `% 24` folds the "24" some ICU builds emit for midnight back to 0.
-    localHour: Number(hour) % 24,
+    localDay: `${yyyy}-${mm}-${dd}`,
+    localMonth: `${yyyy}-${mm}`,
+    localHour: wall.getUTCHours(),
     localIsoWeek: isoWeekLabel(localMidnightUtc),
     calendarDow: new Date(localMidnightUtc).getUTCDay(),
   };


### PR DESCRIPTION
### Details

The Statistics cold path materialises per-drink local calendar fields via one `Intl.formatToParts` per drink timestamp whenever a session has no stored `drinksTimeParts`. The write path (compute-at-save) and the post-first-read backfill keep repeat opens at ~0ms, but the **first open of un-backfilled history** — fresh install, new device, or a timezone change — pays the full cost for every event at once. Profiled at **~950ms for ~711 events** on Hermes (≈1.34ms/`formatToParts`; `Intl` is ~1000x slower on Hermes than V8).

This rewrites `resolveLocalParts` to stop formatting per field. It uses `Intl` only to learn the timezone's **UTC offset**, caches that offset per `(timezone, UTC month)`, and derives every calendar field (`localDay`, `localMonth`, `localHour`, `localIsoWeek`, `calendarDow`) with plain `Date.UTC` arithmetic. A timezone's offset changes at most once inside a calendar month (DST transitions are months apart), so two edge probes decide the whole month; a `'mixed'` month (a transition lies inside it) falls back to a direct per-timestamp probe and stays exact at the jump instant. `resolveLocalParts` is the single source of truth for both read and write paths, so both benefit and cannot drift.

**Why it's a robust win:** the offset cache is shared across all sessions/drinks, so the reduction is *density-independent* — it does not depend on how many drinks each session has (a session/day-scoped cache would collapse to ~1x on sparse data).

Measured through the real `buildDrinkEvents` (711 events, no stored parts), `America/New_York`:

| drinks/session | `formatToParts` calls | reduction | est. time @1.34ms |
| --- | --- | --- | --- |
| ~12 | 156 | 4.6x | ~209ms |
| ~5 | 199 | 3.6x | ~267ms |
| ~2 | 207 | 3.4x | ~277ms |
| 1 | 170 | 4.2x | ~228ms |

Baseline is 711 calls (~953ms) in every case → ~950ms drops to ~210–280ms.

**Correctness:** output is byte-identical to the previous resolution. New `localParts.test.ts` asserts equality against a fresh `Intl` reference across a 3-year, 12-hourly sweep in 6 zones (incl. `Asia/Kathmandu` +5:45 and `Australia/Lord_Howe` 30-min DST), plus minute-by-minute sweeps straddling spring-forward / fall-back instants, plus the transition-month-queried-both-sides and invalid-timezone-throws cases. The existing `events.test.ts` DST/ISO-week/leap-day cases continue to pass unchanged.

> [!IMPORTANT]
> **The wall-clock win still needs on-device confirmation.** The numbers above are `formatToParts` call counts (node-valid) extrapolated by the known ~1.34ms/call device cost — node/V8 `Intl` timing does not match Hermes, so I did not benchmark wall-clock here. To confirm: restore the dev profiler (`git show f9be08043` / cherry-pick), cold-open Statistics on an account with un-backfilled history, read the `[StatsProfile] ... buildDrinkEvents` line, then revert it.

### Tests

1. `TZ=utc npm test -- __tests__/unit/libs/Statistics` → all Statistics suites pass (173 tests), incl. the new `localParts.test.ts`.
2. `npm run typecheck` passes.
3. Device verification (pending, see note above): cold-open Statistics on un-backfilled history and confirm the `buildDrinkEvents` phase drops from ~950ms to ~250ms; confirm charts render identical values (the change is byte-identical, so no visual change is expected).

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changes — `resolveLocalParts` is a pure local computation. Statistics works offline exactly as before.

### QA Steps

1. On a device/account with drinking-session history that predates the `drinksTimeParts` feature (or after a fresh install), open the Statistics screen.
2. Verify all tabs (Overview, Trends, Patterns, Breakdown) show the same numbers as before this change.
3. Verify the first open paints data noticeably faster; subsequent opens remain instant.

- [ ] Verify that no errors appear in the JS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)