### PR TITLE
refactor(realtime): cut preferences reads off the Firebase listener

### DIFF
--- a/__tests__/unit/useDrinkEvents.test.ts
+++ b/__tests__/unit/useDrinkEvents.test.ts
@@ -6,6 +6,7 @@ import {useOnyx} from 'react-native-onyx';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Statistics from '@libs/actions/Statistics';
 import useDrinkEvents from '@hooks/useStatistics/useDrinkEvents';
 import type {Preferences, UserData} from '@src/types/onyx';
@@ -30,6 +31,11 @@ jest.mock('@hooks/useCurrentUserData', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('@hooks/useCurrentUserPreferences', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 // The hook delegates persistence of precomputed time fields to this action.
 jest.mock('@libs/actions/Statistics', () => ({
   __esModule: true,
@@ -40,6 +46,7 @@ const mockedUseOnyx = jest.mocked(useOnyx);
 const mockedUseFirebase = jest.mocked(useFirebase);
 const mockedUseDatabaseData = jest.mocked(useDatabaseData);
 const mockedUseCurrentUserData = jest.mocked(useCurrentUserData);
+const mockedUseCurrentUserPreferences = jest.mocked(useCurrentUserPreferences);
 
 function makePreferences(): Preferences {
   return {
@@ -83,8 +90,8 @@ function setContexts(
   preferences: Preferences | undefined = makePreferences(),
   userData: UserData | undefined = makeUserData(),
 ): void {
+  mockedUseCurrentUserPreferences.mockReturnValue(preferences);
   mockedUseDatabaseData.mockReturnValue({
-    preferences,
     isFetchingOlderMonths: false,
   });
   mockedUseCurrentUserData.mockReturnValue(userData ?? {});
@@ -239,8 +246,8 @@ describe('useDrinkEvents', () => {
   });
 
   test('missing preferences still produces events (units default to 0)', () => {
+    mockedUseCurrentUserPreferences.mockReturnValue(undefined);
     mockedUseDatabaseData.mockReturnValue({
-      preferences: undefined,
       isFetchingOlderMonths: false,
     });
     mockedUseCurrentUserData.mockReturnValue(makeUserData());

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -151,6 +151,10 @@ const ONYXKEYS = {
   //   // This can be either "light", "dark" or "system"
   PREFERRED_THEME: 'preferredTheme',
 
+  /** The signed-in user's preferences object, hydrated from `app/open`
+   *  (kiroku-api) and kept in sync via the preferences write + `/v1/updates`. */
+  PREFERENCES: 'preferences',
+
   //   // Information about the onyx updates IDs that were received from the server
   ONYX_UPDATES_FROM_SERVER: 'onyxUpdatesFromServer',
 
@@ -336,6 +340,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.IS_BETA]: boolean;
   [ONYXKEYS.HAS_CHECKED_AUTO_LOGIN]: boolean;
   [ONYXKEYS.PREFERRED_THEME]: ValueOf<typeof CONST.THEME>;
+  [ONYXKEYS.PREFERENCES]: OnyxTypes.Preferences;
   [ONYXKEYS.ONYX_UPDATES_FROM_SERVER]: OnyxTypes.OnyxUpdatesFromServer;
   [ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT]: number;
   [ONYXKEYS.LAST_VISITED_PATH]: string | undefined;

--- a/src/components/Buttons/SessionDrinksInputWindow.tsx
+++ b/src/components/Buttons/SessionDrinksInputWindow.tsx
@@ -14,7 +14,7 @@ import {
   isLightHex,
 } from '@libs/SessionColorPalettes';
 import {PressableWithoutFeedback} from '@components/Pressable';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Log from '@libs/Log';
 import CONST from '@src/CONST';
 
@@ -37,7 +37,7 @@ function SessionDrinksInputWindow({
   const styles = useThemeStyles();
   const theme = useTheme();
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const palette = useResolvedPalette(preferences);
   const isClassicPalette =
     getPaletteIdFromColors(palette) === DEFAULT_PALETTE_ID;

--- a/src/components/DrinkTypesView.tsx
+++ b/src/components/DrinkTypesView.tsx
@@ -6,7 +6,7 @@ import DrinkData from '@libs/DrinkData';
 import * as DS from '@userActions/DrinkingSession';
 import * as SessionLocations from '@userActions/SessionLocations';
 import {findDrinkNameTranslationKey} from '@libs/DataHandling';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import CONST from '@src/CONST';
 import useTheme from '@hooks/useTheme';
 import * as KirokuIcons from './Icon/KirokuIcons';
@@ -22,7 +22,7 @@ type DrinkTypesViewProps = {
 
 function DrinkTypesView({session}: DrinkTypesViewProps) {
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const styles = useThemeStyles();
   const theme = useTheme();
 

--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -7,7 +7,7 @@ import DrinkData from '@libs/DrinkData';
 import {resolvePalette} from '@libs/SessionColorPalettes';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import * as DS from '@userActions/DrinkingSession';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import CONST from '@src/CONST';
@@ -30,7 +30,7 @@ function DrinkingSessionOverview({
   readOnly = false,
   preferences: preferencesProp,
 }: DrinkingSessionOverviewProps) {
-  const {preferences: ownPreferences} = useDatabaseData();
+  const ownPreferences = useCurrentUserPreferences();
   const preferences = preferencesProp ?? ownPreferences;
   const {translate} = useLocalize();
   const theme = useTheme();

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -9,7 +9,7 @@ import DrinkTypesView from '@components/DrinkTypesView';
 import SessionDetailsWindow from '@components/SessionDetailsWindow';
 import FillerView from '@components/FillerView';
 import CONST from '@src/CONST';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -38,7 +38,7 @@ function DrinkingSessionWindow({
   const user = auth.currentUser;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const sessionRef = useRef<DrinkingSession | undefined>(session);
   // Session details
   const [totalUnits, setTotalUnits] = useState<number>(0);

--- a/src/components/LocationTaggingPrompt.tsx
+++ b/src/components/LocationTaggingPrompt.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Alert} from 'react-native';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import * as Preferences from '@userActions/Preferences';
 import checkPermission from '@libs/Permissions/checkPermission';
@@ -18,7 +18,7 @@ import ConfirmModal from './ConfirmModal';
  */
 function LocationTaggingPrompt() {
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
 
   const [dismissed, setDismissed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -1,11 +1,10 @@
 // DatabaseDataContext.tsx
 import type {ReactNode} from 'react';
 import React, {createContext, useContext, useEffect, useMemo} from 'react';
-import Onyx from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import type {
   Config,
   DataVisibility,
-  Preferences,
   UnconfirmedDays,
   UserData,
   UserStatus,
@@ -14,12 +13,10 @@ import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import useListenToData from '@hooks/useListenToData';
 import setCrashReportingCollectionEnabled from '@libs/setCrashReportingCollectionEnabled';
 import ONYXKEYS from '@src/ONYXKEYS';
-import CONST from '@src/CONST';
 import {useFirebase} from './FirebaseContext';
 
 type DatabaseDataContextType = {
   userStatusData?: UserStatus;
-  preferences?: Preferences;
   unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
   /** Owner-controlled visibility of the current user's drinking data to
@@ -60,7 +57,6 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const dataTypes: FetchDataKeys = [
     'config',
     'userStatusData',
-    'preferences',
     'unconfirmedDays',
     'userData',
     'dataVisibility',
@@ -68,10 +64,11 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
 
   const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
 
+  const [preferences] = useOnyx(ONYXKEYS.PREFERENCES);
+
   const value = useMemo(
     () => ({
       userStatusData: data.userStatusData,
-      preferences: data.preferences,
       unconfirmedDays: data.unconfirmedDays,
       userData: data.userData,
       dataVisibility: data.dataVisibility,
@@ -81,23 +78,19 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
     [data, isFetchingOlderMonths],
   );
 
-  // Sync theme preference from Firebase to Onyx when preferences are loaded
-  // This ensures the app theme is consistent with the user's saved preference
+  // Apply the crash-reporting opt-out from the user's preferences (server is the
+  // source of truth via `app/open`, so it survives reinstall) to the native
+  // collectors. Absent ⇒ enabled (the legitimate-interest opt-out default);
+  // gating against the build flag and the web no-op live in the util.
+  // Crashlytics persists this across restarts.
   useEffect(() => {
-    if (data.preferences === undefined) {
+    if (preferences === undefined) {
       return;
     }
-    const theme = data.preferences?.theme ?? CONST.THEME.DEFAULT;
-    // eslint-disable-next-line rulesdir/prefer-actions-set-data
-    Onyx.set(ONYXKEYS.PREFERRED_THEME, theme);
-    // Apply the crash-reporting opt-out from Firebase (source of truth, so it
-    // survives reinstall) to the native collectors. Absent ⇒ enabled (the
-    // legitimate-interest opt-out default); gating against the build flag and
-    // the web no-op live in the util. Crashlytics persists this across restarts.
     setCrashReportingCollectionEnabled(
-      data.preferences?.crash_reporting_enabled !== false,
+      preferences.crash_reporting_enabled !== false,
     );
-  }, [data.preferences]);
+  }, [preferences]);
 
   // Monitor local data for changes - TODO rewrite this later
   // useEffect(() => {

--- a/src/hooks/useCurrentUserPreferences.ts
+++ b/src/hooks/useCurrentUserPreferences.ts
@@ -1,0 +1,19 @@
+import {useOnyx} from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Preferences} from '@src/types/onyx';
+
+/**
+ * The signed-in user's preferences, sourced from Onyx `PREFERENCES` — hydrated
+ * by `app/open` and kept in sync via the preferences write `onyxData` + Pusher /
+ * `/v1/updates` (kiroku-api), not a Firebase listener.
+ *
+ * Returns `undefined` only while the key is still resolving, matching the old
+ * listener semantics consumers expect (`preferences === undefined` means "not
+ * loaded yet").
+ */
+function useCurrentUserPreferences(): Preferences | undefined {
+  const [preferences] = useOnyx(ONYXKEYS.PREFERENCES);
+  return preferences;
+}
+
+export default useCurrentUserPreferences;

--- a/src/hooks/useResolvedPalette.ts
+++ b/src/hooks/useResolvedPalette.ts
@@ -1,4 +1,4 @@
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {resolvePalette} from '@libs/SessionColorPalettes';
 import type {Preferences, SessionColorPalette} from '@src/types/onyx';
 
@@ -16,7 +16,7 @@ import type {Preferences, SessionColorPalette} from '@src/types/onyx';
 function useResolvedPalette(
   viewedUserPreferences: Preferences | undefined,
 ): SessionColorPalette {
-  const {preferences: ownPreferences} = useDatabaseData();
+  const ownPreferences = useCurrentUserPreferences();
   const useOwn = ownPreferences?.use_own_palette_for_others === true;
   const source = useOwn
     ? ownPreferences?.session_color_palette

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -7,6 +7,7 @@ import Statistics from '@libs/actions/Statistics';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
@@ -56,7 +57,8 @@ function resolveWeekStart(label: string | undefined): WeekStart {
  */
 function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
   const {auth} = useFirebase();
-  const {preferences, isFetchingOlderMonths} = useDatabaseData();
+  const {isFetchingOlderMonths} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const userData = useCurrentUserData();
   const [allSessions, allSessionsMeta] = useOnyx(
     ONYXKEYS.CACHED_DRINKING_SESSIONS,

--- a/src/hooks/useStatistics/useOverviewTabData.ts
+++ b/src/hooks/useStatistics/useOverviewTabData.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useStatsContext from '@hooks/useStatsContext';
 import {buildOverviewModel} from '@libs/Statistics/overview';
 import type {
@@ -45,7 +45,7 @@ type OverviewTabData = {
 function useOverviewTabData(): OverviewTabData {
   const {events, isLoading} = useDrinkEvents();
   const {range, comparisonRange} = useStatsContext();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const thresholds = useMemo(
     () => preferences?.units_to_colors ?? DEFAULT_THRESHOLDS,
     [preferences?.units_to_colors],

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -36,6 +36,7 @@ import kirokuPusherAuthorizer from '@libs/Pusher/kirokuAuthorizer';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useIdlePrefetch from '@hooks/useIdlePrefetch';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import prefetchStatisticsBundle from '@screens/Statistics/prefetchStatisticsBundle';
 import {useFirebase} from '@context/global/FirebaseContext';
 import OnboardingGuard from '@libs/Navigation/guards/OnboardingGuard';
@@ -162,7 +163,8 @@ function AuthScreensContent() {
   // splash hides only once these two fields have arrived from the live
   // listener — matches HomeScreen's own render gate so the user sees the
   // splash continuously until real content can paint.
-  const {userData, preferences} = useDatabaseData();
+  const {userData} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const {setIsAuthDataReady} = useSplashScreenStateContext();
   useEffect(() => {
     if (userData === undefined || preferences === undefined) {

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -13,6 +13,7 @@ import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import Navigation from '@libs/Navigation/Navigation';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useFetchData from '@hooks/useFetchData';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
@@ -107,6 +108,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   // `SessionsCalendarScreen`). The non-needed hook is invoked with an empty
   // `userID`, which both hooks treat as a no-op.
   const ownData = useDatabaseData();
+  const ownPreferences = useCurrentUserPreferences();
   const currentUserSessions = useCurrentUserDrinkingSessions();
   const {data: friendFetchedData, isLoading: isFriendFetchLoading} =
     useFetchData(isSelf ? '' : userID, FRIEND_FETCH_KEYS);
@@ -117,9 +119,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   } = useDrinkingSessionsFetch(isSelf ? '' : userID);
 
   const drinkingSessionData = isSelf ? currentUserSessions : friendSessionData;
-  const preferences = isSelf
-    ? ownData.preferences
-    : friendFetchedData?.preferences;
+  const preferences = isSelf ? ownPreferences : friendFetchedData?.preferences;
   const isFetchingOlderMonths = isSelf
     ? ownData.isFetchingOlderMonths
     : friendFetchingOlder;

--- a/src/screens/DrinkingSession/SessionSummaryScreen.tsx
+++ b/src/screens/DrinkingSession/SessionSummaryScreen.tsx
@@ -9,7 +9,7 @@ import {resolvePalette} from '@libs/SessionColorPalettes';
 import useLocalize from '@hooks/useLocalize';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {DrinkingSession} from '@src/types/onyx';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import type {StackScreenProps} from '@react-navigation/stack';
 import CONST from '@src/CONST';
@@ -58,7 +58,7 @@ type SessionSummaryScreenProps = StackScreenProps<
 
 function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
   const {sessionId} = route.params;
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const drinkingSessionData = useCurrentUserDrinkingSessions();
   const {translate} = useLocalize();
   const styles = useThemeStyles();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -39,6 +39,7 @@ import Timing from '@userActions/Timing';
 import ScrollView from '@components/ScrollView';
 import useLocalize from '@hooks/useLocalize';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import Text from '@components/Text';
 import BottomTabBar from '@libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar';
@@ -66,7 +67,8 @@ function HomeScreen({route}: HomeScreenProps) {
   const [lastViewedCalendarDate] = useOnyx(
     ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE,
   );
-  const {preferences, userData, isFetchingOlderMonths} = useDatabaseData();
+  const {userData, isFetchingOlderMonths} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const drinkingSessionData = useCurrentUserDrinkingSessions();
   const [localVisibleDate, setLocalVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -12,6 +12,7 @@ import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useFetchData from '@hooks/useFetchData';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -57,6 +58,7 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
   const styles = useThemeStyles();
 
   const ownData = useDatabaseData();
+  const ownPreferences = useCurrentUserPreferences();
   const currentUserSessions = useCurrentUserDrinkingSessions();
   const {data: friendFetchedData, isLoading: isFriendFetchLoading} =
     useFetchData(isSelf ? '' : userID, FRIEND_FETCH_KEYS);
@@ -70,7 +72,7 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
     ? currentUserSessions
     : friendSessionData;
   const preferences: Preferences | undefined = isSelf
-    ? ownData.preferences
+    ? ownPreferences
     : friendFetchedData?.preferences;
   const isFetchingOlderMonths = isSelf
     ? ownData.isFetchingOlderMonths

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Alert, View} from 'react-native';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -57,7 +57,7 @@ function ColorPaletteScreen() {
   const StyleUtils = useStyleUtils();
   const theme = useTheme();
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const [pendingPaletteId, setPendingPaletteId] = useState<PaletteId | null>(
     null,
   );

--- a/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
+++ b/src/screens/Settings/Preferences/DrinksToUnitsScreen.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Alert, View} from 'react-native';
 import {getDefaultPreferences} from '@userActions/User';
 import type {DrinksToUnits} from '@src/types/onyx';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
 import isEqual from 'lodash/isEqual';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -34,7 +34,7 @@ type PreferencesSliderConfig = NumericSliderProps & {
 function DrinksToUnitsScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const initialValues = useRef(preferences?.drinks_to_units);
   const [saving, setSaving] = useState<boolean>(false);
   const [currentValues, setCurrentValues] = useState<DrinksToUnits>(

--- a/src/screens/Settings/Preferences/PreferencesScreen.tsx
+++ b/src/screens/Settings/Preferences/PreferencesScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useMemo} from 'react';
 import {BackHandler} from 'react-native';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
@@ -50,7 +50,7 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
   const {translate, preferredLocale} = useLocalize();
   const styles = useThemeStyles();
   const {singleExecution} = useSingleExecution();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const waitForNavigate = useWaitForNavigation();
 
   // const handleFirstDayOfWeekToggle = (value: boolean) => {

--- a/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
+++ b/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Alert, View} from 'react-native';
 import {getDefaultPreferences} from '@userActions/User';
 import type {UnitsToColors} from '@src/types/onyx';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
 import isEqual from 'lodash/isEqual';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -34,7 +34,7 @@ type PreferencesSliderConfig = NumericSliderProps & {
 function UnitsToColorsScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const initialValues = useRef(preferences?.units_to_colors);
   const [saving, setSaving] = useState<boolean>(false);
   const [currentValues, setCurrentValues] = useState<UnitsToColors>(

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {Alert, BackHandler, View} from 'react-native';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -22,7 +23,8 @@ import requestPermission from '@libs/Permissions/requestPermission';
 function PrivacyScreen() {
   const {translate} = useLocalize();
   const styles = useThemeStyles();
-  const {preferences, dataVisibility} = useDatabaseData();
+  const {dataVisibility} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const {auth} = useFirebase();
   const user = auth.currentUser;
 

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -8,7 +8,7 @@ import {HourPolar} from '@components/Charts/HourPolar';
 import {ChartCard} from '@components/Charts/ChartCard';
 import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import useStatsContext from '@hooks/useStatsContext';
 import {useAggregate, useDrinkEvents} from '@hooks/useStatistics';
@@ -120,7 +120,7 @@ function formatDurationMin(minutes: number): string {
 
 function PatternsTab() {
   const {range, drinkTypeFilter, userIds} = useStatsContext();
-  const {preferences} = useDatabaseData();
+  const preferences = useCurrentUserPreferences();
   const {events, isLoading} = useDrinkEvents(
     userIds.length > 0 ? [...userIds] : undefined,
   );


### PR DESCRIPTION
## Summary

Part of read epic #809 (strangler-fig migration off direct Firebase RTDB reads). Cuts the **signed-in user's preferences** off the Firebase listener in `DatabaseDataContext` and onto an Onyx top-level key (`PREFERENCES`), read through a small new hook `useCurrentUserPreferences` — mirroring the existing `useCurrentUserDrinkingSessions` precedent.

## ⚠️ DO NOT MERGE — runtime-blocked on kiroku-api

This change is **correct as written but only works at runtime once the paired kiroku-api PR is deployed.** That server PR adds the `"preferences"` top-level Onyx key and hydrates it from `app/open`, the preferences write, and provisioning. Until it is **merged + device-verified**, the `PREFERENCES` key is never populated and preferences-dependent UI would render empty.

**Merge order:** kiroku-api PR first (merged + device-verified) → then this PR.

## What changed

- **`ONYXKEYS.ts`** — new top-level key `PREFERENCES: 'preferences'` + type mapping `OnyxTypes.Preferences`. The string value matches the kiroku-api key exactly so the two repos agree.
- **New hook `useCurrentUserPreferences`** — `useOnyx(ONYXKEYS.PREFERENCES)`, returns `undefined` while the key is still resolving (same "not loaded yet" semantics consumers relied on from the old listener).
- **~19 self-preferences consumers repointed** off `useDatabaseData().preferences` to the new hook (screens, components, hooks, stats). For consumers that destructured other fields too, only `preferences` moved; the rest stays on `useDatabaseData()`.
- **`AuthScreens`** — the `setIsAuthDataReady` splash gate now sources `preferences` from the new hook; gate still flips once `userData` + `preferences` are both defined, with the existing safety timeout intact.
- **`DatabaseDataContext`** — removed `'preferences'` from the listener `dataTypes`, the context type, and the context value. Removed the now-redundant `Onyx.set(PREFERRED_THEME)` sync (the server sets `PREFERRED_THEME` directly via `app/open`/write). `setCrashReportingCollectionEnabled` is retained, now driven off the new `PREFERENCES` Onyx key.
- **`useDrinkEvents` unit test** — updated to mock the new hook instead of the removed context field.

## Out of scope (left untouched)

The **cross-user / friend** preferences path (`useFetchData` / `useDrinkingSessionsFetch`) is a separate #809 slice and is **not** touched: `ProfileScreen`, the friend half of `SessionsCalendarScreen` / `DayOverviewScreen` (`friendFetchedData?.preferences`), and `FriendDayDrillDownSheet`. Other listeners (`config`, `userStatusData`, `unconfirmedDays`, `userData`, `dataVisibility`) and `ConfigContext` are unchanged.

## Test plan

- [x] `npx prettier --write` on changed files
- [x] `npm run lint-changed` — clean
- [x] `npm run typecheck-tsgo` — clean
- [x] `npm run react-compiler-compliance-check check-changed` — passes
- [x] `__tests__/unit/useDrinkEvents.test.ts` — 14/14 pass
- [ ] **Device verification (post kiroku-api deploy):** units/colors/palette, first-day-of-week, statistics, privacy crash-reporting toggle, and the boot splash → home gate all behave identically to today once `PREFERENCES` hydrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
