### PR TITLE
fix(calendar): align compact skeleton arrows with real chevrons

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1672,7 +1672,11 @@ const styles = (theme: ThemeColors) =>
       alignItems: 'center',
       justifyContent: 'space-between',
       marginTop: 6,
-      paddingHorizontal: 20,
+      // Centre the 10px arrow placeholders on the real chevrons: the library
+      // pads the header by 10 and the arrow touchable by another 10, then our
+      // `ArrowIcon` adds `p1` (4) before its 20px glyph — so each arrow centre
+      // sits 34px from the edge (10+10+4+10). 34 − half the placeholder = 29.
+      paddingHorizontal: 29,
       minHeight: 48,
     },
 


### PR DESCRIPTION
## Summary

The compact calendar loading skeleton (Home / Profile) draws month-nav
arrow placeholders that sat **~9px further toward the edges** than the
real `react-native-calendars` chevrons. On the skeleton→calendar
handover the arrows visibly jumped inward.

This **Approach A** of two: nudge the placeholders inward so their
centres land exactly on the real chevron centres.

### The geometry

The real arrow centre sits **34px from each edge**:

| layer | px |
|---|---|
| library header `paddingLeft/Right` | 10 |
| library arrow touchable `padding` | 10 |
| our `ArrowIcon` `p1` padding | 4 |
| half of the 20px (`iconSizeNormal`) glyph | 10 |
| **total** | **34** |

The 10px-wide placeholder centred at 34 ⇒ left edge at 29, so
`paddingHorizontal` changes `20 → 29`. Header height (`marginTop:6` +
`minHeight:48`) is unchanged, so the vertical handover stays quiet.

## Alternative

This is one of a pair. The sibling PR **removes** the skeleton arrows
entirely instead of repositioning them. Exactly one of the two should be
merged; the other closed.

## Test plan

- [ ] Open Home / Profile and observe the brief calendar skeleton — arrows
      no longer shift horizontally when the real grid swaps in.
- [ ] Light + dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)