### PR TITLE
fix(calendar): drop nav-arrow placeholders from compact skeleton

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarCompactSkeleton.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarCompactSkeleton.tsx
@@ -25,10 +25,12 @@ function getWeekRowCount(date: Date): number {
  * `useLazyMarkedDates` indexing — is deferred past the navigation slide.
  *
  * Mirrors `SessionsCalendarView`'s react-native-calendars geometry so the swap
- * is visually quiet: the `componentBG` body, the month-header row (nav arrows
- * flanking a centered month-year title, `marginTop:6`, ~48px tall from the
- * library's arrow padding), the borderless day-name strip (`marginTop:7`), and
- * the variable-height 7×N day grid. Sibling to the fullscreen
+ * is visually quiet: the `componentBG` body, the month-header row (just a
+ * centered month-year title — the real nav arrows are intentionally omitted
+ * from the skeleton, but the row keeps its `marginTop:6` and ~48px height from
+ * the library's arrow padding so the handover doesn't jolt vertically), the
+ * borderless day-name strip (`marginTop:7`), and the variable-height 7×N day
+ * grid. Sibling to the fullscreen
  * `SessionsCalendarSkeleton`; cells stay static (`animate={false}`) on this
  * dense grid for the same anti-jank reason.
  */
@@ -50,9 +52,7 @@ function SessionsCalendarCompactSkeleton() {
       ]}
       testID="SessionsCalendarCompactSkeleton">
       <View style={styles.sessionsCalendarCompactSkeletonHeader}>
-        <Skeleton width={10} height={18} radius={3} animate={false} />
         <Skeleton width={78} height={18} radius={3} animate={false} />
-        <Skeleton width={10} height={18} radius={3} animate={false} />
       </View>
       <View style={styles.sessionsCalendarCompactSkeletonDayNamesRow}>
         {DAY_COLUMNS.map(col => (

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1664,15 +1664,16 @@ const styles = (theme: ThemeColors) =>
     // Compact-calendar loading skeleton (`SessionsCalendarCompactSkeleton`).
     // These mirror react-native-calendars' compact header geometry so the
     // skeleton→calendar handover doesn't shift layout. The library's month-row
-    // (`header`) is `marginTop:6` with nav arrows padded out to ~48px tall, and
+    // (`header`) is `marginTop:6` and ~48px tall (its nav-arrow padding), and
     // its day-name strip (`week`/`dayHeader`) sits `marginTop:7` with no
-    // separator rule — unlike the fullscreen `sessionsCalendarDayNamesRow`.
+    // separator rule — unlike the fullscreen `sessionsCalendarDayNamesRow`. The
+    // skeleton omits the arrow placeholders, so the month title is centered and
+    // the row height alone reproduces the real arrows' vertical footprint.
     sessionsCalendarCompactSkeletonHeader: {
       flexDirection: 'row',
       alignItems: 'center',
-      justifyContent: 'space-between',
+      justifyContent: 'center',
       marginTop: 6,
-      paddingHorizontal: 20,
       minHeight: 48,
     },
 


### PR DESCRIPTION
## Summary

The compact calendar loading skeleton (Home / Profile) draws month-nav
arrow placeholders that never lined up with the real
`react-native-calendars` chevrons (the placeholders sat ~9px further
toward the edges), so they read as a flicker on the skeleton→calendar
handover.

This **Approach B** of two: drop the arrow placeholders entirely and
center the month-year title. The header keeps its `marginTop:6` +
`minHeight:48`, so the real arrows' vertical footprint is preserved and
the swap stays quiet — only the (mismatched) arrow shapes go away.

## Alternative

This is one of a pair. The sibling PR **repositions** the skeleton
arrows to land exactly on the real chevrons instead of removing them.
Exactly one of the two should be merged; the other closed.

## Test plan

- [ ] Open Home / Profile and observe the brief calendar skeleton — no
      arrow shapes, month title centered, no horizontal/vertical jump
      when the real grid swaps in.
- [ ] Light + dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)