### PR TITLE
fix(preferences): relabel color cutoffs to Light/Moderate

### DIFF
--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -44,33 +44,36 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 
 ## Glossary (canonical terms)
 
-| English                   | Czech (canonical)                                 | Do NOT use     |
-| ------------------------- | ------------------------------------------------- | -------------- |
-| session                   | **relace**                                        | sezení         |
-| drinking session          | **alkoholová relace**                             | relace pití    |
-| live (session)            | **živá** (relace)                                 |                |
-| edit / past (session)     | **zpětná** (relace)                               |                |
-| unit / units              | **jednotka / jednotky / jednotek**                |                |
-| drink / drinks (beverage) | **drink / drinky** (gen sg drinku, gen pl drinků) | nápoj / nápoje |
-| beer                      | **pivo**                                          |                |
-| small beer                | **malé pivo**                                     |                |
-| wine                      | **víno**                                          |                |
-| weak shot                 | **malý panák**                                    |                |
-| strong shot               | **velký panák**                                   |                |
-| cocktail                  | **koktejl**                                       |                |
-| other (drink type)        | **ostatní**                                       |                |
-| statistics / stats        | **statistiky**                                    |                |
-| calendar                  | **kalendář**                                      |                |
-| profile                   | **profil**                                        |                |
-| friend / friends          | **přítel / přátelé**                              |                |
-| friend request            | **žádost o přátelství** (short: "žádost")         |                |
-| supporter (role)          | **podporovatel**                                  |                |
-| badge / badges            | **odznaky**                                       |                |
-| sober                     | **bez pití**                                      |                |
-| alcohol-free day(s)       | **dny bez alkoholu**                              |                |
-| quiet day(s)              | **klidné dny**                                    |                |
-| blackout                  | **výpadek paměti**                                |                |
-| streak (alcohol-free)     | **série** (dnů bez alkoholu)                      |                |
+| English                     | Czech (canonical)                                 | Do NOT use     |
+| --------------------------- | ------------------------------------------------- | -------------- |
+| session                     | **relace**                                        | sezení         |
+| drinking session            | **alkoholová relace**                             | relace pití    |
+| live (session)              | **živá** (relace)                                 |                |
+| edit / past (session)       | **zpětná** (relace)                               |                |
+| unit / units                | **jednotka / jednotky / jednotek**                |                |
+| drink / drinks (beverage)   | **drink / drinky** (gen sg drinku, gen pl drinků) | nápoj / nápoje |
+| beer                        | **pivo**                                          |                |
+| small beer                  | **malé pivo**                                     |                |
+| wine                        | **víno**                                          |                |
+| weak shot                   | **malý panák**                                    |                |
+| strong shot                 | **velký panák**                                   |                |
+| cocktail                    | **koktejl**                                       |                |
+| other (drink type)          | **ostatní**                                       |                |
+| statistics / stats          | **statistiky**                                    |                |
+| calendar                    | **kalendář**                                      |                |
+| profile                     | **profil**                                        |                |
+| friend / friends            | **přítel / přátelé**                              |                |
+| friend request              | **žádost o přátelství** (short: "žádost")         |                |
+| supporter (role)            | **podporovatel**                                  |                |
+| badge / badges              | **odznaky**                                       |                |
+| sober                       | **bez pití**                                      |                |
+| alcohol-free day(s)         | **dny bez alkoholu**                              |                |
+| quiet day(s)                | **klidné dny**                                    |                |
+| blackout                    | **výpadek paměti**                                |                |
+| streak (alcohol-free)       | **série** (dnů bez alkoholu)                      |                |
+| session intensity: light    | **mírná** (relace)                                | lehká          |
+| session intensity: moderate | **střední** (relace)                              |                |
+| session intensity: heavy    | **těžká** (relace)                                | silná, náročná |
 
 ## Do-not-translate (keep verbatim)
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -340,8 +340,8 @@ export default {
     other: 'Ostatní',
   },
   units: {
-    yellow: 'Žlutá',
-    orange: 'Oranžová',
+    light: 'Lehká',
+    moderate: 'Střední',
   },
   timePeriods: {
     never: 'Nikdy',
@@ -586,7 +586,7 @@ export default {
   unitsToColorsScreen: {
     title: 'Jednotky na barvy',
     description:
-      'Nastavte hraniční body, při kterých se mění barvy relace; tyto body představují maximální hodnotu, do které zůstane relace v dané barvě',
+      'Nastavte maximální počet jednotek pro lehkou a střední relaci. Cokoli nad tím už je těžká relace.',
   },
   colorPaletteScreen: {
     title: 'Barvy relací',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -340,7 +340,7 @@ export default {
     other: 'Ostatní',
   },
   units: {
-    light: 'Lehká',
+    light: 'Mírná',
     moderate: 'Střední',
   },
   timePeriods: {
@@ -586,7 +586,7 @@ export default {
   unitsToColorsScreen: {
     title: 'Jednotky na barvy',
     description:
-      'Nastavte maximální počet jednotek pro lehkou a střední relaci. Cokoli nad tím už je těžká relace.',
+      'Nastavte maximální počet jednotek pro mírnou a střední relaci. Cokoli nad tím už je těžká relace.',
   },
   colorPaletteScreen: {
     title: 'Barvy relací',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -338,8 +338,8 @@ export default {
     other: 'Other',
   },
   units: {
-    yellow: 'Yellow',
-    orange: 'Orange',
+    light: 'Light',
+    moderate: 'Moderate',
   },
   timePeriods: {
     never: 'Never',
@@ -581,7 +581,7 @@ export default {
   unitsToColorsScreen: {
     title: 'Units to Colors',
     description:
-      'Set cutoff points where session colors change; each is the maximum value up to which the session retains that color',
+      'Set the maximum units for a Light and a Moderate session. Anything above becomes Heavy.',
   },
   colorPaletteScreen: {
     title: 'Session colors',

--- a/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
+++ b/src/screens/Settings/Preferences/UnitsToColorsScreen.tsx
@@ -81,12 +81,12 @@ function UnitsToColorsScreen() {
   const unitsToColorsMenuItems = useMemo(() => {
     const unitsHelperData: MenuItemProps[] = [
       {
-        title: translate('units.yellow'),
+        title: translate('units.light'),
         key: 'yellow',
         currentValue: currentValues.yellow,
       },
       {
-        title: translate('units.orange'),
+        title: translate('units.moderate'),
         key: 'orange',
         currentValue: currentValues.orange,
       },


### PR DESCRIPTION
## Summary

- The **Units to Colors** preferences screen asked users to set cutoffs for **"Yellow"** and **"Orange"**. That wording is misleading now that session colors come from selectable palettes — the labels named raw colors, not what the cutoffs actually mean.
- Relabel the two cutoffs to **"Light"** and **"Moderate"**, mirroring the intensity terminology already used in the Statistics → Overview "Days by intensity" distribution (Light / Moderate / Heavy).
- Reword the screen description to: _"Set the maximum units for a Light and a Moderate session. Anything above becomes Heavy."_
- **No data-model or backend change**: the underlying `units_to_colors` keys (`yellow`/`orange`) and the color palette mapping are untouched — only the displayed labels and the `en.ts`/`cs_cz.ts` translation strings changed.

## Test plan

- [x] `npm run typecheck-tsgo` — clean
- [x] `__tests__/unit/Translate.test.ts` + `TranslationContext.test.ts` — pass (key parity + Czech context intact)
- [x] `npm run lint-changed` — clean
- [x] `npm run react-compiler-compliance-check check-changed` — pass
- [ ] Manually open Settings → Preferences → Units to Colors and confirm the two rows read "Light"/"Moderate" and the slider still saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)