### PR TITLE
refactor(realtime): cut userData reads off the Firebase listener (+ drop dead unconfirmedDays)

### DIFF
--- a/__tests__/unit/useOnboardingFlow.test.ts
+++ b/__tests__/unit/useOnboardingFlow.test.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 import {renderHook} from '@testing-library/react-native';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useOnboardingFlow from '@hooks/useOnboardingFlow';
 import CONFIG from '@src/CONFIG';
 import ROUTES from '@src/ROUTES';
@@ -14,8 +16,14 @@ jest.mock('@context/global/DatabaseDataContext', () => ({
   useDatabaseData: jest.fn(),
 }));
 
+jest.mock('@hooks/useCurrentUserData', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockedUseFirebase = jest.mocked(useFirebase);
 const mockedUseDatabaseData = jest.mocked(useDatabaseData);
+const mockedUseCurrentUserData = jest.mocked(useCurrentUserData);
 
 const TEST_UID = 'user-123';
 
@@ -25,11 +33,13 @@ function setAuth(uid: string | undefined): void {
   } as unknown as ReturnType<typeof useFirebase>);
 }
 
+// `userData` now comes from `useCurrentUserData` (Onyx), which returns {} (not
+// undefined) while not hydrated; `config` still comes from `useDatabaseData`.
 function setUserData(userData: UserData | undefined, config?: Config): void {
   mockedUseDatabaseData.mockReturnValue({
-    userData,
     config,
   } as unknown as ReturnType<typeof useDatabaseData>);
+  mockedUseCurrentUserData.mockReturnValue(userData ?? {});
 }
 
 function makeUserData(overrides: Partial<UserData> = {}): UserData {

--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -18,7 +18,7 @@ import {View} from 'react-native';
 import FlatList from '@components/FlatList';
 import {PressableWithFeedback} from '@components/Pressable';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import UserOverview from './UserOverview';
 
@@ -52,7 +52,7 @@ function UserListComponent({
 }: UserListProps) {
   const {db} = useFirebase();
   const styles = useThemeStyles();
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const {translate} = useLocalize();
   // Partial list of users for initial display and dynamic updates
   const [displayUserArray, setDisplayUserArray] = useState<UserArray>([]);

--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -16,6 +16,7 @@ import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import * as App from '@userActions/App';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import usePrevious from '@hooks/usePrevious';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -65,7 +66,8 @@ function StartSessionButtonAndPopover(
   const {auth, db} = useFirebase();
   const {translate} = useLocalize();
   const user = auth.currentUser;
-  const {userData, userStatusData} = useDatabaseData();
+  const {userStatusData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
   const [startSession] = useOnyx(ONYXKEYS.START_SESSION_GLOBAL_CREATE);
   const [isCreateMenuActive, setIsCreateMenuActive] = useState(false);

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -2,12 +2,7 @@
 import type {ReactNode} from 'react';
 import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import {useOnyx} from 'react-native-onyx';
-import type {
-  Config,
-  UnconfirmedDays,
-  UserData,
-  UserStatus,
-} from '@src/types/onyx';
+import type {Config, UserStatus} from '@src/types/onyx';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import useListenToData from '@hooks/useListenToData';
 import setCrashReportingCollectionEnabled from '@libs/setCrashReportingCollectionEnabled';
@@ -16,8 +11,6 @@ import {useFirebase} from './FirebaseContext';
 
 type DatabaseDataContextType = {
   userStatusData?: UserStatus;
-  unconfirmedDays?: UnconfirmedDays;
-  userData?: UserData;
   /** Global app configuration, including the terms re-consent signal. */
   config?: Config;
   /** Legacy windowed-listener flag. Always `false` now that the signed-in
@@ -50,12 +43,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const user = auth.currentUser;
   const userID = user ? user.uid : '';
 
-  const dataTypes: FetchDataKeys = [
-    'config',
-    'userStatusData',
-    'unconfirmedDays',
-    'userData',
-  ];
+  const dataTypes: FetchDataKeys = ['config', 'userStatusData'];
 
   const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
 
@@ -64,8 +52,6 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const value = useMemo(
     () => ({
       userStatusData: data.userStatusData,
-      unconfirmedDays: data.unconfirmedDays,
-      userData: data.userData,
       config: data.config,
       isFetchingOlderMonths,
     }),
@@ -85,17 +71,6 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
       preferences.crash_reporting_enabled !== false,
     );
   }, [preferences]);
-
-  // Monitor local data for changes - TODO rewrite this later
-  // useEffect(() => {
-  //   Object.entries(data).forEach(([key, value]) => {
-  //     if (key === 'userData') {
-  //       Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-  //         [userID]: value as UserData,
-  //       });
-  //     }
-  //   });
-  // }, [data.userData]);
 
   return (
     <DatabaseDataContext.Provider value={value}>

--- a/src/hooks/useFetchData/index.ts
+++ b/src/hooks/useFetchData/index.ts
@@ -107,7 +107,6 @@ const useFetchData = (
       userStatusData: data.userStatusData,
       drinkingSessionData: data.drinkingSessionData,
       preferences: data.preferences,
-      unconfirmedDays: data.unconfirmedDays,
       userData: data.userData,
     },
     isLoading,

--- a/src/hooks/useFetchData/types.ts
+++ b/src/hooks/useFetchData/types.ts
@@ -3,7 +3,6 @@ import type {
   DataVisibility,
   DrinkingSessionList,
   Preferences,
-  UnconfirmedDays,
   UserData,
   UserStatus,
 } from '@src/types/onyx';
@@ -17,7 +16,6 @@ type FetchData = {
   userStatusData?: UserStatus;
   drinkingSessionData?: DrinkingSessionList;
   preferences?: Preferences;
-  unconfirmedDays?: UnconfirmedDays;
   userData?: UserData;
   dataVisibility?: DataVisibility;
 };

--- a/src/hooks/useFetchData/utils.ts
+++ b/src/hooks/useFetchData/utils.ts
@@ -22,9 +22,6 @@ function fetchDataKeyToDbPath(key: FetchDataKey, userID?: UserID) {
     case 'preferences':
       path = DBPATHS.USER_PREFERENCES_USER_ID.getRoute(id);
       break;
-    case 'unconfirmedDays':
-      path = DBPATHS.USER_UNCONFIRMED_DAYS_USER_ID.getRoute(id);
-      break;
     case 'userData':
       path = DBPATHS.USERS_USER_ID.getRoute(id);
       break;

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -1,12 +1,14 @@
 import {useMemo} from 'react';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {
   getOnboardingLastVisitedPath,
   hasAcceptedCurrentTerms,
   hasCompletedOnboarding,
   isLegacyGrandfatheredUser,
 } from '@libs/OnboardingSelectors';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import CONFIG from '@src/CONFIG';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
@@ -31,7 +33,12 @@ type OnboardingFlowState = {
 function useOnboardingFlow(): OnboardingFlowState {
   const {auth} = useFirebase();
   const userID = auth?.currentUser?.uid;
-  const {userData, config} = useDatabaseData();
+  const {config} = useDatabaseData();
+  // `useCurrentUserData` returns {} (truthy) while loading / after the Onyx
+  // record is wiped on account close; the readiness gate and selectors below
+  // expect `undefined` to mean "not loaded yet", so map empty → undefined.
+  const currentUserData = useCurrentUserData();
+  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
 
   return useMemo<OnboardingFlowState>(() => {
     const skipOnboarding = CONFIG.SKIP_ONBOARDING;

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -23,10 +23,8 @@ import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 // import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
-import {
-  DatabaseDataProvider,
-  useDatabaseData,
-} from '@context/global/DatabaseDataContext';
+import {DatabaseDataProvider} from '@context/global/DatabaseDataContext';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import {useSplashScreenStateContext} from '@context/global/SplashScreenStateContext';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {FirebaseApp, getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
@@ -36,6 +34,7 @@ import kirokuPusherAuthorizer from '@libs/Pusher/kirokuAuthorizer';
 import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useIdlePrefetch from '@hooks/useIdlePrefetch';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import prefetchStatisticsBundle from '@screens/Statistics/prefetchStatisticsBundle';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -163,7 +162,10 @@ function AuthScreensContent() {
   // splash hides only once these two fields have arrived from the live
   // listener — matches HomeScreen's own render gate so the user sees the
   // splash continuously until real content can paint.
-  const {userData} = useDatabaseData();
+  // `useCurrentUserData` returns {} (truthy) while loading; the auth-ready gate
+  // below must treat the empty object as "not loaded", so map empty → undefined.
+  const currentUserData = useCurrentUserData();
+  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
   const preferences = useCurrentUserPreferences();
   const {setIsAuthDataReady} = useSplashScreenStateContext();
   useEffect(() => {

--- a/src/libs/Navigation/guards/TermsReConsentGuard.tsx
+++ b/src/libs/Navigation/guards/TermsReConsentGuard.tsx
@@ -4,12 +4,14 @@ import SafeAreaConsumer from '@components/SafeAreaConsumer';
 import TermsScreenContent from '@components/TermsScreenContent';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import * as Onboarding from '@userActions/Onboarding';
 import {
   hasAcceptedCurrentTerms,
   hasCompletedOnboarding,
 } from '@libs/OnboardingSelectors';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import CONST from '@src/CONST';
 import {View} from 'react-native';
 
@@ -22,7 +24,11 @@ import {View} from 'react-native';
 function TermsReConsentGuard() {
   const {auth, db} = useFirebase();
   const {translate} = useLocalize();
-  const {userData, config} = useDatabaseData();
+  const {config} = useDatabaseData();
+  // `useCurrentUserData` returns {} (truthy) while loading; the selectors below
+  // expect `undefined` to mean "not loaded yet", so map empty → undefined.
+  const currentUserData = useCurrentUserData();
+  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
 
   const shouldPrompt = useMemo(() => {
     if (!auth?.currentUser) {

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -12,6 +12,7 @@ import type {DateString} from '@src/types/onyx/OnyxCommon';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import Navigation from '@libs/Navigation/Navigation';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -125,7 +126,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
     : friendFetchingOlder;
   // Timezone is only read by the self-only add-session flow, so the current
   // user's own data is always the right source here.
-  const userData = ownData.userData;
+  const userData = useCurrentUserData();
 
   // Hold the list invisible (skeleton on top) until it has scrolled to the
   // focused day. With no `date` (shouldn't happen via the calendar) we never

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -38,6 +38,7 @@ import * as Session from '@userActions/Session';
 import Timing from '@userActions/Timing';
 import ScrollView from '@components/ScrollView';
 import useLocalize from '@hooks/useLocalize';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -46,6 +47,7 @@ import BottomTabBar from '@libs/Navigation/AppNavigator/createCustomBottomTabNav
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import Button from '@components/Button';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import {HomeHeaderSkeleton, StatOverviewSkeleton} from './HomeScreenSkeleton';
@@ -67,7 +69,11 @@ function HomeScreen({route}: HomeScreenProps) {
   const [lastViewedCalendarDate] = useOnyx(
     ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE,
   );
-  const {userData, isFetchingOlderMonths} = useDatabaseData();
+  const {isFetchingOlderMonths} = useDatabaseData();
+  // `useCurrentUserData` returns {} (truthy) while loading; the readiness gates
+  // and header below treat `undefined` as "not loaded", so map empty → undefined.
+  const currentUserData = useCurrentUserData();
+  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
   const preferences = useCurrentUserPreferences();
   const drinkingSessionData = useCurrentUserDrinkingSessions();
   const [localVisibleDate, setLocalVisibleDate] = useState<DateData>(

--- a/src/screens/Onboarding/DisplayNameScreen.tsx
+++ b/src/screens/Onboarding/DisplayNameScreen.tsx
@@ -8,7 +8,7 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import OnboardingScreenLayout from '@components/OnboardingScreenLayout';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -33,7 +33,7 @@ function DisplayNameScreen({}: DisplayNameScreenProps) {
   const {translate} = useLocalize();
   const {db, auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const currentDisplayName = userData?.profile?.display_name ?? '';
   const [isSaving, setIsSaving] = useState(false);
   const [serverErrorMessage, setServerErrorMessage] = useState('');

--- a/src/screens/Settings/Account/AccountScreen.tsx
+++ b/src/screens/Settings/Account/AccountScreen.tsx
@@ -4,7 +4,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItemGroup from '@components/MenuItemGroup';
 import ScreenWrapper from '@components/ScreenWrapper';
 import Section from '@components/Section';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useLocalize from '@hooks/useLocalize';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -35,7 +35,7 @@ function AccountScreen({route}: AccountScreenProps) {
   const {auth} = useFirebase();
   const user = auth.currentUser;
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const profileData = userData?.profile;
 
   const hasEmailProvider = (user?.providerData ?? []).some(

--- a/src/screens/Settings/Account/DisplayNameScreen.tsx
+++ b/src/screens/Settings/Account/DisplayNameScreen.tsx
@@ -20,7 +20,7 @@ import INPUT_IDS from '@src/types/form/DisplayNameForm';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {changeDisplayName} from '@userActions/User';
 
@@ -35,7 +35,7 @@ function DisplayNameScreen({route}: DisplayNameScreenProps) {
   const {translate} = useLocalize();
   const {auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const profileData = userData?.profile;
 
   const currentUserDetails = {

--- a/src/screens/Settings/Account/TimezoneInitialScreen.tsx
+++ b/src/screens/Settings/Account/TimezoneInitialScreen.tsx
@@ -14,7 +14,7 @@ import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as User from '@userActions/User';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
@@ -30,7 +30,7 @@ type TimezoneInitialScreenProps = StackScreenProps<
 function TimezoneInitialScreen({route}: TimezoneInitialScreenProps) {
   const styles = useThemeStyles();
   const {db, auth} = useFirebase();
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const timezone: Timezone = userData?.timezone ?? CONST.DEFAULT_TIME_ZONE;
 
   const {translate} = useLocalize();

--- a/src/screens/Settings/Account/TimezoneSelectScreen.tsx
+++ b/src/screens/Settings/Account/TimezoneSelectScreen.tsx
@@ -13,7 +13,7 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import TimezoneSelect from '@components/TimezoneSelect';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import CONST from '@src/CONST';
 import ERRORS from '@src/ERRORS';
 
@@ -26,7 +26,7 @@ type TimezoneSelectScreenProps = StackScreenProps<
 function TimezoneSelectScreen({route}: TimezoneSelectScreenProps) {
   const {translate} = useLocalize();
   const {db, auth} = useFirebase();
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const timezone = userData?.timezone ?? CONST.DEFAULT_TIME_ZONE;
   const [isLoading, setIsLoading] = useState(false);
 

--- a/src/screens/Settings/Account/UserNameScreen.tsx
+++ b/src/screens/Settings/Account/UserNameScreen.tsx
@@ -20,7 +20,7 @@ import type {StackScreenProps} from '@react-navigation/stack';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import {useFirebase} from '@context/global/FirebaseContext';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {changeUserName} from '@userActions/User';
 
 type UserNameScreenProps = StackScreenProps<
@@ -34,7 +34,7 @@ function UserNameScreen({route}: UserNameScreenProps) {
   const {translate} = useLocalize();
   const {auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const profileData = userData?.profile;
 
   const currentUserDetails = {

--- a/src/screens/Settings/DeleteAccountScreen.tsx
+++ b/src/screens/Settings/DeleteAccountScreen.tsx
@@ -23,7 +23,8 @@ import type SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/CloseAccountForm';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import {useFirebase} from '@context/global/FirebaseContext';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import ERRORS from '@src/ERRORS';
 
 type DeleteAccountScreenProps = StackScreenProps<
@@ -36,7 +37,10 @@ function DeleteAccountScreen({route}: DeleteAccountScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const {db, auth} = useFirebase();
-  const {userData} = useDatabaseData();
+  const currentUserData = useCurrentUserData();
+  // `useCurrentUserData` returns {} (truthy) while loading; closeAccount guards
+  // on `!userData` then dereferences `userData.profile`, so map empty → undefined.
+  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
 
   const currentUser = auth?.currentUser;
   const providerId =

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -40,7 +40,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useFirebase} from '@context/global/FirebaseContext';
 import UserOffline from '@components/UserOfflineModal';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import {useOnyx} from 'react-native-onyx';
 import * as UserUtils from '@libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -69,7 +69,7 @@ function SettingsScreen() {
   const network = useNetwork();
   const {auth} = useFirebase();
   const styles = useThemeStyles();
-  const {userData} = useDatabaseData();
+  const userData = useCurrentUserData();
   const {isExecuting, singleExecution} = useSingleExecution();
   const waitForNavigate = useWaitForNavigation();
   const popoverAnchor = useRef(null);
@@ -77,7 +77,7 @@ function SettingsScreen() {
   const activeCentralPaneRoute = useActiveCentralPaneRoute();
   const [isLoading, setIsLoading] = useState(false);
   const [loadingText, setLoadingText] = useState('');
-  const userIsAdmin = userData && userData.role === 'admin';
+  const userIsAdmin = userData?.role === 'admin';
   const [privateData] = useOnyx(ONYXKEYS.USER_PRIVATE_DATA);
   const supporter = UserUtils.getCurrentUserSupporterStatus(privateData);
   // Hidden entirely in production builds until v1.1 launch clears Apple's


### PR DESCRIPTION
## Summary

Part of read epic #809 (migrate reads off Firebase listeners → Onyx). **Client-only; no server changes.**

- **userData reads → Onyx.** Repoint all 15 self-`userData` consumers from `useDatabaseData().userData` (Firebase listener) to the existing `useCurrentUserData()` hook, which reads `ONYXKEYS.USER_DATA_LIST[uid]` (hydrated by kiroku-api `app/open` + Pusher / `/v1/updates`). `userData` is then dropped from `DatabaseDataContext`.
- **Loading-semantics audit.** `useCurrentUserData()` returns `{}` (an empty, **truthy** object) while loading, whereas the old listener returned `undefined`. Consumers that only read fields with optional-chaining + fallbacks swap directly. Consumers with real loading guards — `HomeScreen`, the `AuthScreens` auth-ready/splash gate, `TermsReConsentGuard`, `useOnboardingFlow`, `DeleteAccountScreen` — map the empty object back to `undefined` (`isEmptyObject(x) ? undefined : x`) so their existing `=== undefined` / `!userData` logic and the selector signatures are preserved unchanged.
- **Drop dead `unconfirmedDays` listener.** Nothing consumed it. Removed end-to-end from `DatabaseDataContext` and the `useFetchData` plumbing (`index.ts`, `types.ts`, `utils.ts`). Left in place: the `DBPATHS` entry, `types/onyx/UnconfirmedDays`, and the account-close null-out in `User.ts`.

`config` and `userStatusData` are the only listeners remaining on `DatabaseDataContext` after this PR (separate slices, separate cutovers). `dataVisibility` was retired by its own cutover that has since merged to master; **this branch is rebased on top of it**, and the `DatabaseDataContext` change here is the union of both removals.

### Consumers repointed
HomeScreen, DayOverviewScreen, SettingsScreen, DeleteAccountScreen, AccountScreen, TimezoneInitialScreen, TimezoneSelectScreen, UserNameScreen, DisplayNameScreen (Settings + Onboarding), StartSessionButtonAndPopover, Social/UserListComponent, TermsReConsentGuard, useOnboardingFlow, AuthScreens.

## Test plan

- [x] `npx prettier --write` on changed files (clean)
- [x] `npm run typecheck-tsgo` (clean)
- [x] `npm run react-compiler-compliance-check check-changed` (passed, 19 files)
- [x] `npm run lint-changed` (clean)
- [x] Rebased onto latest master (dataVisibility cutover + 0.3.14-49); re-ran all gates green
- [x] Device verification: cold start shows splash until real userData loads (auth-ready gate doesn't flip on `{}`); home header/skeleton swap correct; settings/profile/timezone screens render current user fields; account deletion does not flash the T&C re-consent modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)