### PR TITLE
refactor(realtime): cut user-status read + presence write over to kiroku-api

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -705,7 +705,6 @@
 "src/components/SelectionList/types.ts"	"@typescript-eslint/no-duplicate-type-constituents"	1
 "src/components/Skeletons/ItemListSkeletonView.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	2
 "src/components/StartSessionButtonAndPopover.tsx"	"react-hooks/set-state-in-effect"	1
-"src/components/StartSessionButtonAndPopover.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
 "src/components/Switch.tsx"	"react-hooks/refs"	1
 "src/components/TermsScreenContent.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
 "src/components/TextInput/BaseTextInput/index.native.tsx"	"react-hooks/refs"	5

--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -26,7 +26,6 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {DrinkingSessionType} from '@src/types/onyx';
 import Log from '@libs/Log';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import DateUtils from '@libs/DateUtils';
 import Navigation from '@libs/Navigation/Navigation';
@@ -66,7 +65,6 @@ function StartSessionButtonAndPopover(
   const {auth, db} = useFirebase();
   const {translate} = useLocalize();
   const user = auth.currentUser;
-  const {userStatusData} = useDatabaseData();
   const userData = useCurrentUserData();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
   const [startSession] = useOnyx(ONYXKEYS.START_SESSION_GLOBAL_CREATE);
@@ -246,7 +244,7 @@ function StartSessionButtonAndPopover(
       text: translate(DSUtils.getSessionTypeTitle(sessionType)),
     });
 
-    const session = userStatusData?.latest_session;
+    const session = ongoingSessionData;
     let ongoingItems: PopoverMenuItem[] = [];
 
     if (session?.ongoing && session.type) {
@@ -285,7 +283,7 @@ function StartSessionButtonAndPopover(
 
     return [ongoingItems, staticItems];
   }, [
-    userStatusData,
+    ongoingSessionData,
     userData?.timezone?.selected,
     hideCreateMenu,
     navigateToSessionType,

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -2,7 +2,7 @@
 import type {ReactNode} from 'react';
 import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import {useOnyx} from 'react-native-onyx';
-import type {Config, UserStatus} from '@src/types/onyx';
+import type {Config} from '@src/types/onyx';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import useListenToData from '@hooks/useListenToData';
 import setCrashReportingCollectionEnabled from '@libs/setCrashReportingCollectionEnabled';
@@ -10,7 +10,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {useFirebase} from './FirebaseContext';
 
 type DatabaseDataContextType = {
-  userStatusData?: UserStatus;
   /** Global app configuration, including the terms re-consent signal. */
   config?: Config;
   /** Legacy windowed-listener flag. Always `false` now that the signed-in
@@ -43,7 +42,7 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const user = auth.currentUser;
   const userID = user ? user.uid : '';
 
-  const dataTypes: FetchDataKeys = ['config', 'userStatusData'];
+  const dataTypes: FetchDataKeys = ['config'];
 
   const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
 
@@ -51,7 +50,6 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
 
   const value = useMemo(
     () => ({
-      userStatusData: data.userStatusData,
       config: data.config,
       isFetchingOlderMonths,
     }),

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -120,6 +120,10 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/profile/photo',
   },
+  [WRITE_COMMANDS.SYNC_USER_STATUS]: {
+    method: 'post',
+    path: '/v1/status/sync',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/SyncUserStatusParams.ts
+++ b/src/libs/API/parameters/SyncUserStatusParams.ts
@@ -1,0 +1,7 @@
+import type {EmptyObject} from '@src/types/utils/EmptyObject';
+
+/** Presence heartbeat: the server recomputes `user_status/$uid` from the
+ *  caller's own sessions, so no client-supplied data is sent. */
+type SyncUserStatusParams = EmptyObject;
+
+export default SyncUserStatusParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -30,4 +30,5 @@ export type {default as ReportBugParams} from './ReportBugParams';
 export type {default as RemoveFeedbackParams} from './RemoveFeedbackParams';
 export type {default as RemoveBugParams} from './RemoveBugParams';
 export type {default as UpdateProfilePhotoParams} from './UpdateProfilePhotoParams';
+export type {default as SyncUserStatusParams} from './SyncUserStatusParams';
 // export type {default as UpdateUserAvatarParams} from './UpdateUserAvatarParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -46,6 +46,7 @@ const WRITE_COMMANDS = {
   REMOVE_FEEDBACK: 'RemoveFeedback',
   REMOVE_BUG: 'RemoveBug',
   UPDATE_PROFILE_PHOTO: 'UpdateProfilePhoto',
+  SYNC_USER_STATUS: 'SyncUserStatus',
   // ...
 } as const;
 
@@ -91,6 +92,7 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.REMOVE_FEEDBACK]: Parameters.RemoveFeedbackParams;
   [WRITE_COMMANDS.REMOVE_BUG]: Parameters.RemoveBugParams;
   [WRITE_COMMANDS.UPDATE_PROFILE_PHOTO]: Parameters.UpdateProfilePhotoParams;
+  [WRITE_COMMANDS.SYNC_USER_STATUS]: Parameters.SyncUserStatusParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -213,6 +213,15 @@ async function deleteUserData(
   await update(ref(db), updates);
 }
 
+/**
+ * Presence heartbeat: ask the server to recompute the current user's
+ * `user_status` from their own sessions. No client-supplied data is sent and
+ * the server emits no `onyxData` (user_status has no top-level Onyx key).
+ */
+function syncUserStatus() {
+  API.write(WRITE_COMMANDS.SYNC_USER_STATUS, {});
+}
+
 /** Reauthentificate a user using the User object and a password
  * Necessary before important operations such as deleting a user
  * or changing a password.
@@ -919,6 +928,7 @@ export {
   sendVerifyEmailLink,
   setAppUpdateDismissed,
   setUsername,
+  syncUserStatus,
   updateAutomaticTimezone,
   updatePassword,
   userExistsInDatabase,

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -2,7 +2,6 @@ import type {Database} from 'firebase/database';
 import {update, ref, get} from 'firebase/database';
 import type {
   AppSettings,
-  DrinkingSessionList,
   FriendRequestList,
   NicknameToId,
   OnyxUpdatesFromServer,
@@ -12,7 +11,6 @@ import type {
   ReasonForLeaving,
   ReasonForLeavingId,
   UserData,
-  UserStatus,
 } from '@src/types/onyx';
 import type {Timestamp, UserID, UserList} from '@src/types/onyx/OnyxCommon';
 import type {Auth, AuthCredential, User, UserCredential} from 'firebase/auth';
@@ -36,7 +34,6 @@ import {getOAuthCredential} from '@libs/OAuthCredential';
 import DBPATHS from '@src/DBPATHS';
 import {readDataOnce} from '@database/baseFunctions';
 import type {FirebaseUpdates} from '@database/updates';
-import {getLastStartedSessionId} from '@libs/DataHandling';
 import * as Localize from '@libs/Localize';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {validateAppVersion} from '@libs/Validation';
@@ -213,27 +210,6 @@ async function deleteUserData(
       updates[friendRequestsRef.getRoute(friendRequestId, userID)] = null;
     });
   }
-  await update(ref(db), updates);
-}
-
-async function synchronizeUserStatus(
-  db: Database,
-  userID: string,
-  drinkingSessions: DrinkingSessionList | undefined,
-): Promise<void> {
-  const latestSessionId = getLastStartedSessionId(drinkingSessions) ?? null;
-  const latestSession =
-    drinkingSessions && latestSessionId
-      ? drinkingSessions[latestSessionId]
-      : null;
-  const newUserStatus: UserStatus = {
-    last_online: new Date().getTime(),
-    latest_session: latestSession,
-    latest_session_id: latestSessionId,
-  };
-  const userStatusRef = DBPATHS.USER_STATUS_USER_ID;
-  const updates: Record<string, UserStatus> = {};
-  updates[userStatusRef.getRoute(userID)] = newUserStatus;
   await update(ref(db), updates);
 }
 
@@ -943,7 +919,6 @@ export {
   sendVerifyEmailLink,
   setAppUpdateDismissed,
   setUsername,
-  synchronizeUserStatus,
   updateAutomaticTimezone,
   updatePassword,
   userExistsInDatabase,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -10,7 +10,6 @@ import {
 } from '@libs/DataHandling';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import UserOffline from '@components/UserOfflineModal';
-import {synchronizeUserStatus} from '@userActions/User';
 import {useFirebase} from '@context/global/FirebaseContext';
 import ProfileImage from '@components/ProfileImage';
 import {SupporterBadgeForUser} from '@components/SupporterBadge';
@@ -33,7 +32,8 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import * as App from '@userActions/App';
-import * as ErrorUtils from '@libs/ErrorUtils';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import * as Session from '@userActions/Session';
 import Timing from '@userActions/Timing';
 import ScrollView from '@components/ScrollView';
@@ -46,7 +46,6 @@ import Text from '@components/Text';
 import BottomTabBar from '@libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ERRORS from '@src/ERRORS';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import Button from '@components/Button';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
@@ -60,7 +59,7 @@ type HomeScreenProps = StackScreenProps<
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function HomeScreen({route}: HomeScreenProps) {
   const styles = useThemeStyles();
-  const {auth, db, storage} = useFirebase();
+  const {auth, storage} = useFirebase();
   const {translate} = useLocalize();
   const user = auth.currentUser;
   const {isOnline} = useUserConnection();
@@ -150,17 +149,14 @@ function HomeScreen({route}: HomeScreenProps) {
 
   useFocusEffect(
     React.useCallback(() => {
-      // Update user status on home screen focus
+      // Presence heartbeat on home focus: the server recomputes user_status
+      // from the caller's own sessions, so no client-supplied data is sent.
       if (!user || !userData || !preferences) {
         return;
       }
 
-      try {
-        synchronizeUserStatus(db, user.uid, drinkingSessionData);
-      } catch (error) {
-        ErrorUtils.raiseAppError(ERRORS.USER.STATUS_UPDATE_FAILED, error);
-      }
-    }, [db, user, userData, preferences, drinkingSessionData]),
+      API.write(WRITE_COMMANDS.SYNC_USER_STATUS, {});
+    }, [user, userData, preferences]),
   );
 
   // Fire the "home is ready" side effects exactly once, when all the initial

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from '@libs/DataHandling';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import UserOffline from '@components/UserOfflineModal';
+import {syncUserStatus} from '@userActions/User';
 import {useFirebase} from '@context/global/FirebaseContext';
 import ProfileImage from '@components/ProfileImage';
 import {SupporterBadgeForUser} from '@components/SupporterBadge';
@@ -32,8 +33,6 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import * as App from '@userActions/App';
-import * as API from '@libs/API';
-import {WRITE_COMMANDS} from '@libs/API/types';
 import * as Session from '@userActions/Session';
 import Timing from '@userActions/Timing';
 import ScrollView from '@components/ScrollView';
@@ -155,7 +154,7 @@ function HomeScreen({route}: HomeScreenProps) {
         return;
       }
 
-      API.write(WRITE_COMMANDS.SYNC_USER_STATUS, {});
+      syncUserStatus();
     }, [user, userData, preferences]),
   );
 


### PR DESCRIPTION
## Summary

Client-only cutover that retires the current user's **`user_status` Firebase listener** (read epic #809) and moves the redundant **presence-sync RTDB write** onto kiroku-api (write epic #778). The server endpoint already existed; this PR wires the app to it.

- **Read swap** — `StartSessionButtonAndPopover` now derives the ongoing session from the cross-device `ONGOING_SESSION_DATA` Onyx key (already in scope, hydrated via `CACHED_DRINKING_SESSIONS` → `syncLocalLiveSessionData` post-#824) instead of `useDatabaseData().userStatusData.latest_session`. Same shape (`DrinkingSession`), so the ongoing-session menu item renders identically.
- **Write cutover** — the home-focus presence heartbeat now calls `API.write(SYNC_USER_STATUS, {})` (`POST /v1/status/sync`) via a new `syncUserStatus` action. The server recomputes `{ last_online, latest_session, latest_session_id }` from the caller's own sessions; no client-supplied data, empty `onyxData`.
- **Cleanup** — deleted `synchronizeUserStatus` (and its now-unused imports) from `User.ts`, and removed the `userStatusData` listener from `DatabaseDataContext` (`dataTypes`, context type, value, import).

The cross-user friend-status path (`UserListComponent` / `UserOverview` / `DisplayPriority`, which read a friend's status from a separate fetch) is untouched.

### New write command
- `WRITE_COMMANDS.SYNC_USER_STATUS` + `WriteCommandParameters` entry (empty params)
- `SyncUserStatusParams` param file + `parameters/index.ts` export
- `kirokuRoutes.ts`: `{ method: 'post', path: '/v1/status/sync' }`

## Test plan
- [ ] On device, open Home: a `POST /v1/status/sync` fires on focus and `user_status/$uid` updates server-side.
- [ ] Start a live session, return to Home, open the FAB popover: the **ongoing session** menu item renders with the correct type + start time, and that type is excluded from the "start new session" list.
- [ ] With no ongoing session, the FAB popover shows only the static session types.
- [ ] Cross-device: an ongoing session started on device A surfaces the ongoing menu item on device B.

Refs #809 (read), #778 (write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)