### PR TITLE
refactor(realtime): cut config reads off Firebase via global Pusher broadcast

### DIFF
--- a/__tests__/unit/useOnboardingFlow.test.ts
+++ b/__tests__/unit/useOnboardingFlow.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 import {renderHook} from '@testing-library/react-native';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import {useConfig} from '@context/global/ConfigContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useOnboardingFlow from '@hooks/useOnboardingFlow';
@@ -12,8 +12,8 @@ jest.mock('@context/global/FirebaseContext', () => ({
   useFirebase: jest.fn(),
 }));
 
-jest.mock('@context/global/DatabaseDataContext', () => ({
-  useDatabaseData: jest.fn(),
+jest.mock('@context/global/ConfigContext', () => ({
+  useConfig: jest.fn(),
 }));
 
 jest.mock('@hooks/useCurrentUserData', () => ({
@@ -22,7 +22,7 @@ jest.mock('@hooks/useCurrentUserData', () => ({
 }));
 
 const mockedUseFirebase = jest.mocked(useFirebase);
-const mockedUseDatabaseData = jest.mocked(useDatabaseData);
+const mockedUseConfig = jest.mocked(useConfig);
 const mockedUseCurrentUserData = jest.mocked(useCurrentUserData);
 
 const TEST_UID = 'user-123';
@@ -33,12 +33,10 @@ function setAuth(uid: string | undefined): void {
   } as unknown as ReturnType<typeof useFirebase>);
 }
 
-// `userData` now comes from `useCurrentUserData` (Onyx), which returns {} (not
-// undefined) while not hydrated; `config` still comes from `useDatabaseData`.
+// `userData` comes from `useCurrentUserData` (Onyx), which returns {} (not
+// undefined) while not hydrated; `config` comes from `useConfig` (Onyx-backed).
 function setUserData(userData: UserData | undefined, config?: Config): void {
-  mockedUseDatabaseData.mockReturnValue({
-    config,
-  } as unknown as ReturnType<typeof useDatabaseData>);
+  mockedUseConfig.mockReturnValue({config});
   mockedUseCurrentUserData.mockReturnValue(userData ?? {});
 }
 

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -717,8 +717,6 @@
 "src/components/Tooltip/PopoverAnchorTooltip.tsx"	"react-hooks/refs"	7
 "src/components/UploadImage.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	2
 "src/components/createOnyxContext.tsx"	"@typescript-eslint/no-unnecessary-type-assertion"	1
-"src/context/global/ConfigContext.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
-"src/context/global/DatabaseDataContext.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
 "src/context/global/SplashScreenStateContext.tsx"	"rulesdir/context-provider-split-values"	1
 "src/context/global/UserConnectionContext.tsx"	"arrow-body-style"	1
 "src/hooks/useDebouncedState.ts"	"react-hooks/refs"	2

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -841,6 +841,9 @@ const CONST = {
   PUSHER: {
     // kiroku-api authorizes/publishes to plain `private-user-<uid>` channels.
     PRIVATE_USER_CHANNEL_PREFIX: 'private-user-',
+    // Public (unauthenticated) channel carrying global app-config broadcasts.
+    CONFIG_CHANNEL: 'config',
+    CONFIG_UPDATE_EVENT: 'configUpdate',
   },
   REASON_FOR_LEAVING: {
     DB_KEY_LENGTH: 32,

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -160,6 +160,12 @@ const ONYXKEYS = {
    *  visible (grandfathered default). */
   DATA_VISIBILITY: 'dataVisibility',
 
+  /** Global app configuration (version gating, maintenance, terms-update
+   *  timestamp). Hydrated from `app/open` (kiroku-api) and kept live via the
+   *  public `config` Pusher broadcast — global + last-write-wins, so it bypasses
+   *  the per-user OnyxUpdates gap-detection pipeline. */
+  CONFIG: 'config',
+
   //   // Information about the onyx updates IDs that were received from the server
   ONYX_UPDATES_FROM_SERVER: 'onyxUpdatesFromServer',
 
@@ -347,6 +353,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.PREFERRED_THEME]: ValueOf<typeof CONST.THEME>;
   [ONYXKEYS.PREFERENCES]: OnyxTypes.Preferences;
   [ONYXKEYS.DATA_VISIBILITY]: OnyxTypes.DataVisibility;
+  [ONYXKEYS.CONFIG]: OnyxTypes.Config;
   [ONYXKEYS.ONYX_UPDATES_FROM_SERVER]: OnyxTypes.OnyxUpdatesFromServer;
   [ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT]: number;
   [ONYXKEYS.LAST_VISITED_PATH]: string | undefined;

--- a/src/context/global/ConfigContext.tsx
+++ b/src/context/global/ConfigContext.tsx
@@ -1,9 +1,9 @@
 // ConfigContext.tsx
 import type {ReactNode} from 'react';
 import React, {createContext, useContext, useMemo} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import type {Config} from '@src/types/onyx';
-import type {FetchDataKeys} from '@hooks/useFetchData/types';
-import useListenToData from '@hooks/useListenToData';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 type ConfigContextType = {
   config?: Config;
@@ -24,15 +24,15 @@ type ConfigProviderProps = {
 };
 
 function ConfigProvider({children}: ConfigProviderProps) {
-  const dataTypes: FetchDataKeys = ['config'];
-
-  const {data} = useListenToData(dataTypes);
+  // Global app config is hydrated from `app/open` (kiroku-api) and kept live via
+  // the public `config` Pusher broadcast (subscribed at boot in AuthScreens).
+  const [config] = useOnyx(ONYXKEYS.CONFIG);
 
   const value = useMemo(
     () => ({
-      config: data.config,
+      config,
     }),
-    [data],
+    [config],
   );
   return (
     <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>

--- a/src/context/global/DatabaseDataContext.tsx
+++ b/src/context/global/DatabaseDataContext.tsx
@@ -2,7 +2,6 @@
 import type {ReactNode} from 'react';
 import React, {createContext, useContext, useEffect, useMemo} from 'react';
 import {useOnyx} from 'react-native-onyx';
-import type {Config} from '@src/types/onyx';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import useListenToData from '@hooks/useListenToData';
 import setCrashReportingCollectionEnabled from '@libs/setCrashReportingCollectionEnabled';
@@ -10,8 +9,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {useFirebase} from './FirebaseContext';
 
 type DatabaseDataContextType = {
-  /** Global app configuration, including the terms re-consent signal. */
-  config?: Config;
   /** Legacy windowed-listener flag. Always `false` now that the signed-in
    *  user's sessions are read in full from Onyx `cachedDrinkingSessions`
    *  (the Firebase session listener was removed); kept until the calendar's
@@ -42,18 +39,22 @@ function DatabaseDataProvider({children}: DatabaseDataProviderProps) {
   const user = auth.currentUser;
   const userID = user ? user.uid : '';
 
-  const dataTypes: FetchDataKeys = ['config'];
+  // Every realtime read has migrated off the Firebase listener to Onyx
+  // (hydrated via `app/open` + kiroku-api updates), so no node keys remain. The
+  // `useListenToData` / `useFetchData` / `baseFunctions` listener infra is now
+  // dead and slated for the #809 final-teardown follow-up. `isFetchingOlderMonths`
+  // is retained until the calendar's older-months loading UI is cleaned up.
+  const dataTypes: FetchDataKeys = [];
 
-  const {data, isFetchingOlderMonths} = useListenToData(dataTypes, userID);
+  const {isFetchingOlderMonths} = useListenToData(dataTypes, userID);
 
   const [preferences] = useOnyx(ONYXKEYS.PREFERENCES);
 
   const value = useMemo(
     () => ({
-      config: data.config,
       isFetchingOlderMonths,
     }),
-    [data, isFetchingOlderMonths],
+    [isFetchingOlderMonths],
   );
 
   // Apply the crash-reporting opt-out from the user's preferences (server is the

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import {useConfig} from '@context/global/ConfigContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import {
@@ -33,7 +33,7 @@ type OnboardingFlowState = {
 function useOnboardingFlow(): OnboardingFlowState {
   const {auth} = useFirebase();
   const userID = auth?.currentUser?.uid;
-  const {config} = useDatabaseData();
+  const {config} = useConfig();
   // `useCurrentUserData` returns {} (truthy) while loading / after the Onyx
   // record is wiped on account close; the readiness gate and selectors below
   // expect `undefined` to mean "not loaded yet", so map empty → undefined.

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -231,6 +231,9 @@ function AuthScreensContent() {
       authEndpoint: `${ApiUtils.getKirokuApiRoot()}/v1/pusher/auth`,
     }).then(() => {
       User.subscribeToUserEvents();
+      // Global app config broadcasts on a public channel (no per-user auth), but
+      // co-locating the subscription here keeps all Pusher wiring at boot.
+      User.subscribeToConfigEvents();
     });
 
     // Hydrate the signed-in user's data and seed the realtime `lastUpdateID`

--- a/src/libs/Navigation/guards/TermsReConsentGuard.tsx
+++ b/src/libs/Navigation/guards/TermsReConsentGuard.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo} from 'react';
 import Modal from '@components/Modal';
 import SafeAreaConsumer from '@components/SafeAreaConsumer';
 import TermsScreenContent from '@components/TermsScreenContent';
-import {useDatabaseData} from '@context/global/DatabaseDataContext';
+import {useConfig} from '@context/global/ConfigContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
@@ -24,7 +24,7 @@ import {View} from 'react-native';
 function TermsReConsentGuard() {
   const {auth, db} = useFirebase();
   const {translate} = useLocalize();
-  const {config} = useDatabaseData();
+  const {config} = useConfig();
   // `useCurrentUserData` returns {} (truthy) while loading; the selectors below
   // expect `undefined` to mean "not loaded yet", so map empty → undefined.
   const currentUserData = useCurrentUserData();

--- a/src/libs/PusherUtils.ts
+++ b/src/libs/PusherUtils.ts
@@ -71,8 +71,45 @@ function subscribeToPrivateUserChannelEvent(
   ).catch(onSubscriptionFailed);
 }
 
+/**
+ * Abstraction around subscribing to a public Pusher channel event. Unlike
+ * `subscribeToPrivateUserChannelEvent`, the channel name carries no
+ * `private-`/`presence-` prefix, so Pusher subscribes without hitting the auth
+ * endpoint — used for global broadcasts (e.g. app config) that aren't scoped to
+ * a single user, hence there's no reconnect-callback coupling either.
+ */
+function subscribeToPublicChannelEvent<TEventData>(
+  channelName: string,
+  eventName: string,
+  onEvent: (eventData: TEventData) => void,
+) {
+  function onEventPush(eventData: TEventData) {
+    Log.info(
+      `[Pusher] Handled ${eventName} event on public channel ${channelName}`,
+      false,
+      eventData as Record<string, unknown>,
+    );
+    onEvent(eventData);
+  }
+
+  function onSubscriptionFailed(error: Error) {
+    Log.hmmm('[Pusher] Failed to subscribe to public channel', {
+      error,
+      channelName,
+      eventName,
+    });
+  }
+
+  Pusher.subscribe(
+    channelName,
+    eventName,
+    onEventPush as (data: unknown) => void,
+  ).catch(onSubscriptionFailed);
+}
+
 export default {
   subscribeToPrivateUserChannelEvent,
+  subscribeToPublicChannelEvent,
   subscribeToMultiEvent,
   triggerMultiEventHandler,
 };

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -924,7 +924,9 @@ function subscribeToConfigEvents() {
   PusherUtils.subscribeToPublicChannelEvent<Config>(
     CONST.PUSHER.CONFIG_CHANNEL,
     CONST.PUSHER.CONFIG_UPDATE_EVENT,
-    config => Onyx.set(ONYXKEYS.CONFIG, config),
+    config => {
+      Onyx.set(ONYXKEYS.CONFIG, config);
+    },
   );
 }
 

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -2,6 +2,7 @@ import type {Database} from 'firebase/database';
 import {update, ref, get} from 'firebase/database';
 import type {
   AppSettings,
+  Config,
   FriendRequestList,
   NicknameToId,
   OnyxUpdatesFromServer,
@@ -911,8 +912,25 @@ function subscribeToUserEvents() {
   );
 }
 
+/**
+ * Subscribe to global app-config broadcasts. kiroku-api publishes the full
+ * `Config` object on the public `config` channel (event `configUpdate`). Config
+ * is global + last-write-wins, so we idempotently overwrite the Onyx key on each
+ * push rather than routing it through the per-user OnyxUpdates gap-detection
+ * pipeline (that's only for `private-user-<uid>`). `app/open` seeds the baseline;
+ * this keeps it live.
+ */
+function subscribeToConfigEvents() {
+  PusherUtils.subscribeToPublicChannelEvent<Config>(
+    CONST.PUSHER.CONFIG_CHANNEL,
+    CONST.PUSHER.CONFIG_UPDATE_EVENT,
+    config => Onyx.set(ONYXKEYS.CONFIG, config),
+  );
+}
+
 export {
   subscribeToUserEvents,
+  subscribeToConfigEvents,
   changeDisplayName,
   changeUserName,
   deleteUserData,


### PR DESCRIPTION
## Summary

Final read listener of the **off-Firebase read epic #809**: the global app `config` (version gating, maintenance, terms-update timestamp). Previously read via Firebase RTDB listeners in **both** `ConfigContext` and `DatabaseDataContext` (`useListenToData(['config'])`). Now read from Onyx, hydrated by kiroku-api `app/open` and kept live via a **public** Pusher broadcast.

- New Onyx key `CONFIG: 'config'` (`OnyxTypes.Config`).
- `PusherUtils.subscribeToPublicChannelEvent(channelName, eventName, onEvent)` — mirrors `subscribeToPrivateUserChannelEvent` but for unauthenticated public channels (no `private-`/`presence-` prefix ⇒ Pusher skips the auth endpoint; no reconnect-callback coupling).
- `User.subscribeToConfigEvents()` subscribes to channel `config` / event `configUpdate` and idempotently `Onyx.set(ONYXKEYS.CONFIG, payload)` on each broadcast. Config is global + last-write-wins, so it deliberately **bypasses** the per-user OnyxUpdates gap-detection pipeline (that's for `private-user-<uid>`). Wired at boot in `AuthScreens` next to `subscribeToUserEvents()`.
- `ConfigProvider` now reads `useOnyx(ONYXKEYS.CONFIG)` instead of the Firebase listener; `useConfig()` API unchanged, so `Kiroku.tsx` (`validateAppVersion` + maintenance) needs no change.
- Repointed the two `config` consumers off `useDatabaseData()` onto `useConfig()`: `TermsReConsentGuard` and `useOnboardingFlow` (their `userData` now comes from `useCurrentUserData`, landed by the userData cutover — `useDatabaseData` is no longer imported in either).
- Removed `config` from `DatabaseDataContext` (`dataTypes`, type, value, import).

## ⚠️ Runtime-blocked — DO NOT MERGE yet

The code is correct as written but only works at **runtime** once the **paired kiroku-api PR** is deployed (it hydrates the `CONFIG` Onyx key at `app/open` and broadcasts on the public `config` channel, event `configUpdate`). Merge only after that PR is merged **and** the change is device-verified. Hand back for verification.

## Epic #809: this completes the read cutovers — teardown now ready

Rebased onto current `master` after the other read cutovers (`preferences`, `userData`, `dataVisibility`, `userStatus`, `unconfirmedDays`) all merged. With `config` removed, **`DatabaseDataContext` now has zero `dataTypes`** — `useListenToData(dataTypes, userID)` is called with an empty array purely to retain `isFetchingOlderMonths` (kept until the calendar older-months UI cleanup). The `useListenToData` / `useFetchData` / `DatabaseDataContext` / `baseFunctions` Firebase-listener infra is therefore **dead** and ready for the #809 final-teardown chip. Scope here is kept tight — no listener infra deleted in this PR.

## Test plan

- [ ] Deploy paired kiroku-api PR (config hydration at `app/open` + `config`/`configUpdate` broadcast).
- [ ] On device: verify `config` populates after sign-in (version gating + maintenance modal behave as before).
- [ ] Push a `configUpdate` broadcast and confirm the app reflects it live without a per-user update.
- [ ] Confirm T&C re-consent (`TermsReConsentGuard`) and onboarding terms step (`useOnboardingFlow`) still gate correctly off the new Onyx-backed config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)