### PR TITLE
feat(calendar): reflect the live session's units on the owner's own calendar views

### DIFF
--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -3,7 +3,12 @@
 import {act, renderHook} from '@testing-library/react-native';
 import {addMonths, differenceInMonths, subMonths} from 'date-fns';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
-import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+import type {
+  DrinkingSession,
+  DrinkingSessionList,
+  Preferences,
+} from '@src/types/onyx';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
 
 jest.mock('@hooks/useResolvedPalette', () => ({
   __esModule: true,
@@ -126,5 +131,86 @@ describe('useLazyMarkedDates earliest-month cap', () => {
     const depth = differenceInMonths(new Date(), getLoadedFrom(result));
     expect(depth).toBeGreaterThanOrEqual(9);
     expect(depth).toBeLessThanOrEqual(11);
+  });
+});
+
+describe('useLazyMarkedDates ongoing overlay', () => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const dayKeyFor = (d: Date) =>
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` as DateString;
+
+  test('overlays the live session, replacing the stale cached entry for its day', () => {
+    const today = new Date();
+    const ts = today.getTime();
+    // The cached snapshot holds a finished session (1 unit) plus the stale
+    // ongoing session seeded at start (0 drinks).
+    const sessions = {
+      done: {
+        id: 'done',
+        type: 'edit',
+        start_time: ts,
+        timezone: 'UTC',
+        drinks: {[ts]: {beer: 1}},
+      },
+      'live-1': {
+        id: 'live-1',
+        type: 'live',
+        ongoing: true,
+        start_time: ts,
+        timezone: 'UTC',
+        drinks: {},
+      },
+    } as unknown as DrinkingSessionList;
+    // The live buffer carries the real in-progress drinks (2 units).
+    const overlay = {
+      id: 'live-1',
+      type: 'live',
+      ongoing: true,
+      start_time: ts,
+      timezone: 'UTC',
+      drinks: {[ts]: {beer: 2}},
+    } as unknown as DrinkingSession;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences(), overlay),
+    );
+
+    const dayKey = dayKeyFor(today);
+    const monthKey = dayKey.slice(0, 7);
+
+    // 1 (finished) + 2 (live) = 3 units on the day and in the month total.
+    expect(result.current.unitsMap.get(dayKey)).toBe(3);
+    expect(result.current.monthlyTotalsMap.get(monthKey)).toBe(3);
+    expect(result.current.markedDates[dayKey]).toBeDefined();
+
+    const entries = result.current.sessionEntriesByDay.get(dayKey) ?? [];
+    expect(entries).toHaveLength(2);
+    const liveEntry = entries.find(entry => entry.sessionId === 'live-1');
+    expect(liveEntry?.session.drinks).toEqual({[ts]: {beer: 2}});
+  });
+
+  test('does not inject a live session when no overlay is provided', () => {
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, {}, makePreferences(), undefined),
+    );
+    expect(result.current.unitsMap.size).toBe(0);
+    expect(result.current.sessionEntriesByDay.size).toBe(0);
+  });
+
+  test('ignores an overlay that is not ongoing', () => {
+    const today = new Date();
+    const overlay = {
+      id: 'live-1',
+      ongoing: false,
+      start_time: today.getTime(),
+      timezone: 'UTC',
+      drinks: {[today.getTime()]: {beer: 2}},
+    } as unknown as DrinkingSession;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, {}, makePreferences(), overlay),
+    );
+    expect(result.current.unitsMap.size).toBe(0);
+    expect(result.current.sessionEntriesByDay.size).toBe(0);
   });
 });

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -18,6 +18,7 @@ import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {useFirebase} from '@context/global/FirebaseContext';
 import SessionsCalendarView from './SessionsCalendarView';
 import SessionsCalendarWeekListView from './SessionsCalendarWeekListView';
 import DayOverviewListView from './DayOverviewListView';
@@ -50,6 +51,16 @@ function SessionsCalendar({
   onVisibleDayChange,
   onInitialScrollReady,
 }: SessionsCalendarProps) {
+  const {auth} = useFirebase();
+  const [ongoingSession] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
+  // Overlay the live session's drinks onto the calendar, but only on the
+  // signed-in user's OWN calendar — this same component renders friends' data,
+  // which must never receive our local live buffer.
+  const isSelf = auth?.currentUser?.uid === userID;
+  const ongoingOverlay =
+    isSelf && ongoingSession?.ongoing && ongoingSession.id
+      ? ongoingSession
+      : undefined;
   const {
     markedDates,
     unitsMap,
@@ -60,7 +71,12 @@ function SessionsCalendar({
     loadMoreMonths,
     loadUpTo,
     isLoading,
-  } = useLazyMarkedDates(userID, drinkingSessionData ?? {}, preferences);
+  } = useLazyMarkedDates(
+    userID,
+    drinkingSessionData ?? {},
+    preferences,
+    ongoingOverlay,
+  );
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
   // Persisted floor for the viewed user — the canonical "started tracking on"
   // boundary. Falls back to the in-memory derivation when undefined, which

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -1,4 +1,5 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
+import {useIsFocused} from '@react-navigation/native';
 import type {DateData} from 'react-native-calendars';
 import {
   differenceInMonths,
@@ -53,12 +54,21 @@ function SessionsCalendar({
 }: SessionsCalendarProps) {
   const {auth} = useFirebase();
   const [ongoingSession] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
-  // Overlay the live session's drinks onto the calendar, but only on the
-  // signed-in user's OWN calendar — this same component renders friends' data,
-  // which must never receive our local live buffer.
+  // `useIsFocused` is false whenever this calendar's screen sits behind the live
+  // session screen (it is presented over the central pane via the RHP, which
+  // blurs the screen underneath — the same signal `FreezeWrapper` relies on).
+  const isFocused = useIsFocused();
+  // Overlay the live session's drinks onto the calendar, but only:
+  //  - on the signed-in user's OWN calendar (this same component renders
+  //    friends' data, which must never receive our local live buffer), and
+  //  - while this calendar is actually on screen. The live buffer mutates on
+  //    every drink tap; recomputing the (heavy, react-native-calendars) grid for
+  //    an occluded calendar on each tap stalled the live screen's own paint. Drop
+  //    the overlay while blurred so taps stay snappy; it recomputes once when the
+  //    user returns and the screen refocuses.
   const isSelf = auth?.currentUser?.uid === userID;
   const ongoingOverlay =
-    isSelf && ongoingSession?.ongoing && ongoingSession.id
+    isSelf && isFocused && ongoingSession?.ongoing && ongoingSession.id
       ? ongoingSession
       : undefined;
   const {

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -1,6 +1,7 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {toZonedTime} from 'date-fns-tz';
 import type {
+  DrinkingSession,
   DrinkingSessionArray,
   DrinkingSessionList,
   Preferences,
@@ -61,11 +62,18 @@ function toDateKey(date: Date): DateString {
  * @param userID  ID of the user whose sessions/preferences these are
  * @param sessions Session list to render
  * @param preferences Preferences driving thresholds and palette
+ * @param ongoingOverlay The current user's live (in-progress) session, when its
+ *   live drinks should be reflected on top of `sessions`. The caller is
+ *   responsible for gating this to the signed-in user (a friend's calendar must
+ *   never receive it). Live drinks live only in `ONGOING_SESSION_DATA`, not the
+ *   cached snapshot — see `DrinkingSession.flushLiveSessionPersist`. Overlaid as
+ *   a cheap single-day patch so the heavy index passes stay off the per-tap path.
  */
 function useLazyMarkedDates(
   userID: UserID,
   sessions: DrinkingSessionList,
   preferences: Preferences,
+  ongoingOverlay?: DrinkingSession,
 ) {
   const [monthsLoaded, monthsLoadedMeta] = useOnyx(
     `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
@@ -222,6 +230,85 @@ function useLazyMarkedDates(
     [markedDatesMap],
   );
 
+  // Overlay the live (in-progress) session on top of the base outputs. The live
+  // buffer's drinks are deliberately kept out of `cachedDrinkingSessions` (the
+  // server skips the cache echo while `sessionIsLive && ongoing`), so without
+  // this the day tile / day-overview / month totals show the session flagged
+  // ongoing but with 0 units until it is finalized. Patches only the overlay
+  // session's single day — the O(N)/Intl index pass and the O(D) marking pass
+  // above stay keyed on `sessions`, so a drink tap costs one day's recompute
+  // plus shallow map clones, not a full re-index. When there is no live session
+  // the base outputs are returned untouched (refs stable, zero overhead).
+  const {
+    markedDates: overlaidMarkedDates,
+    unitsMap: overlaidUnitsMap,
+    monthlyTotalsMap: overlaidMonthlyTotalsMap,
+    sessionEntriesByDay: overlaidSessionEntriesByDay,
+  } = useMemo(() => {
+    if (!ongoingOverlay?.ongoing || !ongoingOverlay.id) {
+      return {markedDates, unitsMap, monthlyTotalsMap, sessionEntriesByDay};
+    }
+
+    const overlayId = ongoingOverlay.id;
+    const overlayDate = toZonedTime(
+      ongoingOverlay.start_time,
+      ongoingOverlay.timezone ?? defaultTimezone,
+    );
+    const dayKey = toDateKey(overlayDate);
+    const monthKey = dayKey.slice(0, 7);
+
+    // Replace the stale cached entry for this session (same id) with the live
+    // one, keeping any other sessions on that day; append if the cache has not
+    // seeded it yet.
+    const baseEntries = sessionEntriesByDay.get(dayKey) ?? [];
+    const liveEntry = {sessionId: overlayId, session: ongoingOverlay};
+    const patchedEntries = baseEntries.some(
+      entry => entry.sessionId === overlayId,
+    )
+      ? baseEntries.map(entry =>
+          entry.sessionId === overlayId ? liveEntry : entry,
+        )
+      : [...baseEntries, liveEntry];
+
+    const newMarking = sessionsToDayMarking(
+      patchedEntries.map(entry => entry.session),
+      effectivePreferences,
+    );
+    const newUnits = newMarking?.units ?? 0;
+    const oldUnits = unitsMap.get(dayKey) ?? 0;
+
+    const nextUnitsMap = new Map(unitsMap);
+    nextUnitsMap.set(dayKey, newUnits);
+
+    const nextMonthlyTotalsMap = new Map(monthlyTotalsMap);
+    nextMonthlyTotalsMap.set(
+      monthKey,
+      (monthlyTotalsMap.get(monthKey) ?? 0) - oldUnits + newUnits,
+    );
+
+    const nextSessionEntriesByDay = new Map(sessionEntriesByDay);
+    nextSessionEntriesByDay.set(dayKey, patchedEntries);
+
+    return {
+      markedDates: {
+        ...markedDates,
+        [dayKey]: newMarking ? newMarking.marking : {color: paletteGreen},
+      },
+      unitsMap: nextUnitsMap,
+      monthlyTotalsMap: nextMonthlyTotalsMap,
+      sessionEntriesByDay: nextSessionEntriesByDay,
+    };
+  }, [
+    ongoingOverlay,
+    markedDates,
+    unitsMap,
+    monthlyTotalsMap,
+    sessionEntriesByDay,
+    effectivePreferences,
+    paletteGreen,
+    defaultTimezone,
+  ]);
+
   // Mirror `loadedFromDate` into a ref for the orchestrator's arrow handler,
   // which needs a stable reference (preserves the existing public interface).
   // Only read in event handlers, so an effect-driven update is safe.
@@ -274,10 +361,10 @@ function useLazyMarkedDates(
   };
 
   return {
-    markedDates,
-    unitsMap,
-    monthlyTotalsMap,
-    sessionEntriesByDay,
+    markedDates: overlaidMarkedDates,
+    unitsMap: overlaidUnitsMap,
+    monthlyTotalsMap: overlaidMonthlyTotalsMap,
+    sessionEntriesByDay: overlaidSessionEntriesByDay,
     loadedFrom,
     loadedFromDate,
     loadMoreMonths,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -103,27 +103,45 @@ function HomeScreen({route}: HomeScreenProps) {
   // Narrowed to `drinksToUnits` so unrelated preference updates (e.g. picking
   // a color palette) don't recompute the stats.
   const drinksToUnits = preferences?.drinks_to_units;
-  const {drinkingSessionsCount, unitsConsumed} = useMemo(() => {
-    if (!drinksToUnits || !drinkingSessionData) {
-      return {drinkingSessionsCount: 0, unitsConsumed: 0};
+  const {drinkingSessionsCount, unitsConsumed: baseUnitsConsumed} =
+    useMemo(() => {
+      if (!drinksToUnits || !drinkingSessionData) {
+        return {drinkingSessionsCount: 0, unitsConsumed: 0};
+      }
+      const drinkingSessionArray: DrinkingSessionArray =
+        Object.values(drinkingSessionData);
+      const monthUnits = calculateThisMonthUnits(
+        visibleDate,
+        drinkingSessionArray,
+        drinksToUnits,
+      );
+      const monthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
+        timestampToDate(visibleDate.timestamp),
+        drinkingSessionArray,
+        false,
+      ).length;
+      return {
+        drinkingSessionsCount: monthSessionCount,
+        unitsConsumed: monthUnits,
+      };
+    }, [drinkingSessionData, visibleDate, drinksToUnits]);
+
+  // The live session's drinks live only in ONGOING_SESSION_DATA, not the cached
+  // snapshot the base stats read from, so add them on top. Reusing the month
+  // filter keeps it scoped to the visible month (0 for past months / no live
+  // session). The session COUNT is left untouched — the cache already seeds the
+  // ongoing session (with 0 units) at start, so it is already counted once.
+  const liveExtraUnits = useMemo(() => {
+    if (!drinksToUnits || !ongoingSessionData?.ongoing) {
+      return 0;
     }
-    const drinkingSessionArray: DrinkingSessionArray =
-      Object.values(drinkingSessionData);
-    const monthUnits = calculateThisMonthUnits(
+    return calculateThisMonthUnits(
       visibleDate,
-      drinkingSessionArray,
+      [ongoingSessionData],
       drinksToUnits,
     );
-    const monthSessionCount = DSUtils.getSingleMonthDrinkingSessions(
-      timestampToDate(visibleDate.timestamp),
-      drinkingSessionArray,
-      false,
-    ).length;
-    return {
-      drinkingSessionsCount: monthSessionCount,
-      unitsConsumed: monthUnits,
-    };
-  }, [drinkingSessionData, visibleDate, drinksToUnits]);
+  }, [ongoingSessionData, visibleDate, drinksToUnits]);
+  const unitsConsumed = baseUnitsConsumed + liveExtraUnits;
 
   const statsData: StatData = [
     {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -19,7 +19,7 @@ import type {DrinkingSessionArray} from '@src/types/onyx';
 import ROUTES from '@src/ROUTES';
 import Navigation from '@navigation/Navigation';
 import type {StackScreenProps} from '@react-navigation/stack';
-import {useFocusEffect} from '@react-navigation/native';
+import {useFocusEffect, useIsFocused} from '@react-navigation/native';
 import type {BottomTabNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
@@ -131,8 +131,14 @@ function HomeScreen({route}: HomeScreenProps) {
   // filter keeps it scoped to the visible month (0 for past months / no live
   // session). The session COUNT is left untouched — the cache already seeds the
   // ongoing session (with 0 units) at start, so it is already counted once.
+  //
+  // Gated on `isFocused` for the same reason as the calendar overlay: the live
+  // buffer mutates on every drink tap, and Home stays mounted behind the live
+  // session screen. Skipping this while blurred keeps taps snappy; it recomputes
+  // when the user returns to Home.
+  const isFocused = useIsFocused();
   const liveExtraUnits = useMemo(() => {
-    if (!drinksToUnits || !ongoingSessionData?.ongoing) {
+    if (!isFocused || !drinksToUnits || !ongoingSessionData?.ongoing) {
       return 0;
     }
     return calculateThisMonthUnits(
@@ -140,7 +146,7 @@ function HomeScreen({route}: HomeScreenProps) {
       [ongoingSessionData],
       drinksToUnits,
     );
-  }, [ongoingSessionData, visibleDate, drinksToUnits]);
+  }, [isFocused, ongoingSessionData, visibleDate, drinksToUnits]);
   const unitsConsumed = baseUnitsConsumed + liveExtraUnits;
 
   const statsData: StatData = [


### PR DESCRIPTION
## Summary

Follow-up to #940. While a session is **live/ongoing**, its drinks live only in Onyx `ONGOING_SESSION_DATA` and are deliberately kept out of `cachedDrinkingSessions` (the server skips the cache echo while `sessionIsLive && ongoing`). Because the Home calendar, the Day Overview scroll, and Home's "this month" stats read only the cached snapshot, an in-progress session showed up flagged **"ongoing" but with 0 units** until it was finalized.

This overlays `ONGOING_SESSION_DATA` on top of the cached session set so the **signed-in user's own** views reflect their live units in real time — without re-introducing the per-tap heavy recompute the migration avoided. **Cross-device / cross-user** live propagation is intentionally **out of scope** here.

## Changes
- **`useLazyMarkedDates`** — new optional `ongoingOverlay` param. The existing O(N)/Intl index pass and O(D) marking pass stay keyed on `sessions`; a new memo patches **only the overlay session's single day** (replacing the stale cached entry by id, or appending it), so a drink tap costs one day's recompute + shallow map clones, not a full re-index. With no live session the base outputs are returned untouched (zero overhead).
- **`SessionsCalendar`** — reads `ONGOING_SESSION_DATA`, computes `isSelf = auth.currentUser.uid === userID`, and passes the live session only for the user's own calendar. This drives all self calendar surfaces (Home compact, self Profile, fullscreen, Day Overview) and never a friend's. It also removes an adjacent clobber risk: the Day Overview "ongoing" tile now holds the live session, so tapping it re-seeds the buffer from live (not stale) data.
- **`HomeScreen`** — adds the live session's units to the month total via a cheap delta memo; the base stats memo is unchanged (no per-tap O(N)). The session **count is untouched** — the cache already seeds the ongoing session (0 units) at start, so it's already counted once.

## Why gating matters
3 of the 4 `SessionsCalendar` call sites can render a **friend's** data, so the overlay is gated to the current user — your live session never bleeds into someone else's calendar.

## Test plan
- [x] Unit — `__tests__/unit/useLazyMarkedDates.test.ts`: overlay reflects live units in `unitsMap`/`markedDates`/`sessionEntriesByDay`, `monthlyTotalsMap` moves by the delta (replacing the stale entry), no-overlay and non-ongoing cases inject nothing.
- [x] `npm run react-compiler-compliance-check check-changed`, `typecheck-tsgo`, `lint-changed`, prettier — all green.
- [ ] **Manual (simulator, pending):** start a live session from Home → log drinks → the day tile colors/units and the "this month" units update (count not doubled); open today's Day Overview → ongoing tile shows live units AND keeps the "ongoing" badge; a **friend's** calendar does NOT show your live session; ending the session stays consistent through the live→finalized handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)