### PR TITLE
fix(day-overview): align ongoing button left padding with edit icon

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -155,6 +155,7 @@ function DrinkingSessionOverview({
       {session?.ongoing ? (
         <Button
           danger
+          style={styles.ml2}
           onPress={() => onSessionButtonPress()}
           text={translate('dayOverviewScreen.ongoing')}
         />


### PR DESCRIPTION
### Details

In a drinking-session tile ([`DrinkingSessionOverview`](src/components/DrinkingSessionOverview/index.tsx)), the right-hand control is either an "ongoing" button (live session) or an edit icon (edit mode on). The edit icon's pressable wrapper has `styles.p2` (8px padding all around), giving it an 8px gap from the session details. The "ongoing" button had only its own internal `ph3` padding, so it sat flush against the details and looked cramped compared to the edit-mode layout.

This adds `style={styles.ml2}` (marginLeft: 8) to the button so its left spacing matches the edit icon's 8px left padding, keeping the two tile states visually aligned.

One-line change; the `Button` component already forwards `style` to its outer wrapper.

### Tests

1. Open a day with an **ongoing** session in the calendar / day overview.
2. Verify the "ongoing" button has an 8px gap to its left, matching the gap the edit icon shows when edit mode is on for non-ongoing sessions.
3. Toggle edit mode on a day with both ongoing and completed sessions and verify the ongoing button and the edit icons line up consistently.
- [ ] Verify that no errors appear in the JS console

### Offline tests

Pure styling change with no network interaction; behavior is identical offline.

### QA Steps

1. Navigate to a day that contains an ongoing drinking session.
2. Confirm the "ongoing" button is not flush against the session details and aligns with the edit-icon spacing seen in edit mode.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] If the PR modifies the UI (changing the padding/spacing/sizing):
  - [x] I verified the change reuses an existing spacing util (`styles.ml2`) rather than introducing a new CSS style.
- [x] I verified all code is DRY and follows existing patterns (`Button` `style` prop + spacing utilities).

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>