### PR TITLE
feat(calendar): long-press a day to create a session for that date

### DIFF
--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -11,6 +11,7 @@ function DayComponent({
   marking,
   theme, // eslint-disable-line @typescript-eslint/no-unused-vars
   onPress,
+  onLongPress,
 }: DayComponentProps) {
   const StyleUtils = useStyleUtils();
   const isDisabled = state === 'disabled';
@@ -24,7 +25,8 @@ function DayComponent({
       <PressableWithFeedback
         accessibilityLabel=""
         disabled={isDisabled}
-        onPress={() => onPress && date && onPress(date)}>
+        onPress={() => onPress && date && onPress(date)}
+        onLongPress={onLongPress ? () => date && onLongPress(date) : undefined}>
         <View
           style={StyleUtils.getSessionsCalendarDayCellStyle(
             marking,

--- a/src/components/SessionsCalendar/DayComponent/types.ts
+++ b/src/components/SessionsCalendar/DayComponent/types.ts
@@ -12,6 +12,7 @@ type DayComponentProps = {
   marking?: MarkingProps;
   theme?: Theme;
   onPress?: (day: DateData) => void;
+  onLongPress?: (day: DateData) => void;
 };
 
 export type {DayComponentProps, CalendarColors};

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -51,6 +51,9 @@ type SessionsCalendarViewProps = {
   /** Tapped-day handler; omit to make the calendar non-interactive */
   onDayPress?: (day: DateData) => void;
 
+  /** Long-pressed-day handler; omit to disable the long-press shortcut */
+  onDayLongPress?: (day: DateData) => void;
+
   /** Month-arrow handlers; omit (with hideArrows) to make the calendar static */
   onLeftArrowPress?: (subtractMonth: () => void) => void;
   onRightArrowPress?: (addMonth: () => void) => void;
@@ -88,6 +91,7 @@ function SessionsCalendarView({
   minDate,
   maxDate,
   onDayPress,
+  onDayLongPress,
   onLeftArrowPress,
   onRightArrowPress,
   hideArrows,
@@ -115,9 +119,10 @@ function SessionsCalendarView({
         marking={marking}
         theme={dayTheme}
         onPress={onDayPress}
+        onLongPress={onDayLongPress}
       />
     ),
-    [unitsMap, onDayPress],
+    [unitsMap, onDayPress, onDayLongPress],
   );
 
   // Custom header: matches the default month-text styling but reserves space

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -57,6 +57,8 @@ type SessionsCalendarWeekListViewProps = {
   isFetchingOlderMonths?: boolean;
   /** Day cell tap handler. */
   onDayPress?: (day: DateData) => void;
+  /** Day cell long-press handler (create-session shortcut). */
+  onDayLongPress?: (day: DateData) => void;
   /** Called when the user scrolls within `LOAD_AHEAD_BUFFER_WEEKS` of the
    *  loaded floor; receives the date of the earliest in-range day currently
    *  visible. The parent decides (via `computeLoadTarget`) whether to
@@ -109,6 +111,7 @@ function SessionsCalendarWeekListView({
   endDate,
   isFetchingOlderMonths,
   onDayPress,
+  onDayLongPress,
   onRequestOlder,
   initialMonthYear,
   onInitialScrollReady,
@@ -359,6 +362,7 @@ function SessionsCalendarWeekListView({
           markedDates={markedDates}
           unitsMap={unitsMap}
           onDayPress={onDayPress}
+          onDayLongPress={onDayLongPress}
         />
       );
     },
@@ -367,6 +371,7 @@ function SessionsCalendarWeekListView({
       unitsMap,
       monthlyTotalsMap,
       onDayPress,
+      onDayLongPress,
       translate,
       styles.sessionsCalendarMonthLabel,
       styles.sessionsCalendarMonthLabelText,

--- a/src/components/SessionsCalendar/WeekRow.tsx
+++ b/src/components/SessionsCalendar/WeekRow.tsx
@@ -14,6 +14,7 @@ type WeekRowProps = {
   markedDates: MarkedDates;
   unitsMap: Map<DateString, number>;
   onDayPress?: (day: DateData) => void;
+  onDayLongPress?: (day: DateData) => void;
 };
 
 function dayKeyToDateData(key: DateString): DateData {
@@ -38,7 +39,13 @@ function dayKeyToDateData(key: DateString): DateData {
  * draws for "today" is redundant chrome. The compact calendar still uses the
  * rim because today can sit anywhere in its fixed month grid.
  */
-function WeekRow({row, markedDates, unitsMap, onDayPress}: WeekRowProps) {
+function WeekRow({
+  row,
+  markedDates,
+  unitsMap,
+  onDayPress,
+  onDayLongPress,
+}: WeekRowProps) {
   const styles = useThemeStyles();
   return (
     <View style={styles.sessionsCalendarWeekRow}>
@@ -61,6 +68,7 @@ function WeekRow({row, markedDates, unitsMap, onDayPress}: WeekRowProps) {
               units={unitsMap.get(dayKey)}
               marking={marking}
               onPress={onDayPress}
+              onLongPress={onDayLongPress}
             />
           </View>
         );

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -8,18 +8,23 @@ import {
   startOfMonth,
   subMonths,
 } from 'date-fns';
-import {getPreviousMonth, getNextMonth} from '@libs/DataHandling';
+import {
+  dateStringToDate,
+  getPreviousMonth,
+  getNextMonth,
+} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import {computeLoadTarget} from '@libs/SessionsCalendarUtils';
 import CONST from '@src/CONST';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import type {DateString, Timestamp} from '@src/types/onyx/OnyxCommon';
+import {useFirebase} from '@context/global/FirebaseContext';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
+import useStartEditSessionForDate from '@hooks/useStartEditSessionForDate';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {useFirebase} from '@context/global/FirebaseContext';
 import SessionsCalendarView from './SessionsCalendarView';
 import SessionsCalendarWeekListView from './SessionsCalendarWeekListView';
 import DayOverviewListView from './DayOverviewListView';
@@ -87,6 +92,7 @@ function SessionsCalendar({
     preferences,
     ongoingOverlay,
   );
+  const startEditSessionForDate = useStartEditSessionForDate();
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
   // Persisted floor for the viewed user — the canonical "started tracking on"
   // boundary. Falls back to the in-memory derivation when undefined, which
@@ -218,6 +224,20 @@ function SessionsCalendar({
     [mode, userID, onDayDrillDown],
   );
 
+  // Long-press a day → create a new edit session dated to that day and jump
+  // straight to the edit screen. Gated to self at the call site below, so the
+  // heavy-impact haptic (fired by GenericPressable when an onLongPress is
+  // present) never triggers on a friend's calendar.
+  const onDayLongPress = useCallback(
+    (dateData: DateData) => {
+      startEditSessionForDate(
+        dateStringToDate(dateData.dateString as DateString),
+      );
+    },
+    [startEditSessionForDate],
+  );
+  const dayLongPressHandler = isSelf ? onDayLongPress : undefined;
+
   if (isLoading) {
     return <FlexibleLoadingIndicator />;
   }
@@ -250,6 +270,7 @@ function SessionsCalendar({
         loadedFromDate={loadedFromDate}
         isFetchingOlderMonths={isFetchingOlderMonths}
         onDayPress={onDayPress}
+        onDayLongPress={dayLongPressHandler}
         onRequestOlder={handleRequestOlder}
         initialMonthYear={initialMonthYear}
         onInitialScrollReady={onInitialScrollReady}
@@ -266,6 +287,7 @@ function SessionsCalendar({
       visibleDate={visibleDate}
       minDate={minDate}
       onDayPress={onDayPress}
+      onDayLongPress={dayLongPressHandler}
       onLeftArrowPress={handleLeftArrowPress}
       onRightArrowPress={handleRightArrowPress}
       isFetchingOlderMonths={isFetchingOlderMonths}

--- a/src/hooks/useStartEditSessionForDate.ts
+++ b/src/hooks/useStartEditSessionForDate.ts
@@ -1,0 +1,62 @@
+import {useCallback} from 'react';
+import type {Database} from 'firebase/database';
+import type {User} from 'firebase/auth';
+import {useFirebase} from '@context/global/FirebaseContext';
+import * as App from '@userActions/App';
+import * as DS from '@userActions/DrinkingSession';
+import * as ErrorUtils from '@libs/ErrorUtils';
+import ERRORS from '@src/ERRORS';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+import useCurrentUserData from './useCurrentUserData';
+import useLocalize from './useLocalize';
+
+// Module-level so React Compiler skips it — the `try/finally` it needs bails
+// the compiler, and that would regress the compilation of any component that
+// inlines it.
+async function startEditSessionForDate(
+  db: Database,
+  user: User | null,
+  date: Date,
+  timezone: SelectedTimezone | undefined,
+  loadingText: string,
+) {
+  try {
+    await App.setLoadingText(loadingText);
+    const newSession = await DS.getNewSessionToEdit(db, user, date, timezone);
+    await DS.navigateToEditSessionScreen(newSession?.id);
+  } catch (error) {
+    ErrorUtils.raiseAppError(ERRORS.DATABASE.USER_CREATION_FAILED, error);
+  } finally {
+    await App.setLoadingText(null);
+  }
+}
+
+/**
+ * Returns a callback that creates a new editable (draft) drinking session for
+ * the given date and navigates to the edit-session screen. Always operates on
+ * the current user. Used by the day-overview add-session picker and the
+ * calendar day long-press shortcut.
+ */
+function useStartEditSessionForDate(): (date: Date) => void {
+  const {auth, db} = useFirebase();
+  const userData = useCurrentUserData();
+  const {translate} = useLocalize();
+  const selectedTimezone = userData?.timezone?.selected;
+
+  return useCallback(
+    (date: Date) => {
+      // startEditSessionForDate handles its own errors; the .catch is a no-op
+      // to satisfy no-floating-promises.
+      startEditSessionForDate(
+        db,
+        auth.currentUser,
+        date,
+        selectedTimezone,
+        translate('liveSessionScreen.loading'),
+      ).catch(() => {});
+    },
+    [db, auth, selectedTimezone, translate],
+  );
+}
+
+export default useStartEditSessionForDate;

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -4,15 +4,12 @@ import {endOfToday} from 'date-fns';
 import UserOffline from '@components/UserOfflineModal';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import type {StackScreenProps} from '@react-navigation/stack';
-import type {Database} from 'firebase/database';
-import type {User} from 'firebase/auth';
 import type {DayOverviewNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
-import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import Navigation from '@libs/Navigation/Navigation';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
-import useCurrentUserData from '@hooks/useCurrentUserData';
+import useStartEditSessionForDate from '@hooks/useStartEditSessionForDate';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -20,10 +17,6 @@ import useFetchData from '@hooks/useFetchData';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import {dateStringToDate, dateToDateData} from '@libs/DataHandling';
-import * as App from '@userActions/App';
-import * as DS from '@userActions/DrinkingSession';
-import * as ErrorUtils from '@libs/ErrorUtils';
-import ERRORS from '@src/ERRORS';
 import CONST from '@src/CONST';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -73,35 +66,16 @@ function noop() {}
 // separately via `useDrinkingSessionsFetch`). Mirrors `SessionsCalendarScreen`.
 const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
 
-// Module-level so React Compiler skips it — the `try/finally` it needs bails
-// the compiler, and that would regress the screen's compilation.
-async function createSessionForDay(
-  db: Database,
-  user: User | null,
-  date: Date,
-  timezone: SelectedTimezone | undefined,
-  loadingText: string,
-) {
-  try {
-    await App.setLoadingText(loadingText);
-    const newSession = await DS.getNewSessionToEdit(db, user, date, timezone);
-    await DS.navigateToEditSessionScreen(newSession?.id);
-  } catch (error) {
-    ErrorUtils.raiseAppError(ERRORS.DATABASE.USER_CREATION_FAILED, error);
-  } finally {
-    await App.setLoadingText(null);
-  }
-}
-
 function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const {userID, date} = route.params;
   const {isOnline} = useUserConnection();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const theme = useTheme();
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const user = auth.currentUser;
   const isSelf = user?.uid === userID;
+  const startEditSessionForDate = useStartEditSessionForDate();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
 
   // Self reads the current user's sessions from the dedicated hook; a friend's
@@ -124,10 +98,6 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const isFetchingOlderMonths = isSelf
     ? ownData.isFetchingOlderMonths
     : friendFetchingOlder;
-  // Timezone is only read by the self-only add-session flow, so the current
-  // user's own data is always the right source here.
-  const userData = useCurrentUserData();
-
   // Hold the list invisible (skeleton on top) until it has scrolled to the
   // focused day. With no `date` (shouldn't happen via the calendar) we never
   // wait.
@@ -157,21 +127,12 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   // `SessionsCalendar` props require them.
   const placeholderVisibleDate = useMemo(() => dateToDateData(new Date()), []);
 
-  const selectedTimezone = userData?.timezone?.selected;
   const onPickDate = useCallback(
     (selectedDate: Date) => {
       setIsDatePickerVisible(false);
-      // createSessionForDay handles its own errors; the .catch is a no-op to
-      // satisfy no-floating-promises.
-      createSessionForDay(
-        db,
-        auth.currentUser,
-        selectedDate,
-        selectedTimezone,
-        translate('liveSessionScreen.loading'),
-      ).catch(() => {});
+      startEditSessionForDate(selectedDate);
     },
-    [db, auth, selectedTimezone, translate],
+    [startEditSessionForDate],
   );
 
   if (!isOnline) {


### PR DESCRIPTION
### Details

Adds a long-press shortcut on calendar day tiles: long-pressing a day on the user's **own** calendar fires a heavy haptic and immediately opens a new edit session dated to that day — skipping the `+` → date-picker → confirm flow.

- **Centralized** in the `SessionsCalendar` orchestrator and **self-gated** (`auth.currentUser?.uid === userID`), so it works on the compact home/profile calendars and the full-screen calendar, but never on a friend's history (no gesture, no stray haptic there).
- **Haptic is free**: day tiles are already `PressableWithFeedback` → `GenericPressable`, which fires `HapticFeedback.longPress()` (heavy impact) whenever an `onLongPress` is supplied.
- **Reuses the existing create-and-edit flow** (`getNewSessionToEdit` → `navigateToEditSessionScreen`) by extracting it into a new `useStartEditSessionForDate` hook. The day-overview add-session picker now uses the same hook, removing a duplicated local helper. The hook keeps its `try/finally` body at module scope so React Compiler doesn't bail (the same reason the old helper was module-level).
- Disabled/future days are already inert (compact `maxDate = today` + `disableAllTouchEventsForDisabledDays`; fullscreen never renders past today), so no extra future-date guard is needed. Tap behavior is unchanged — RN `Pressable` suppresses `onPress` after a long-press.

Automated gates run locally and passing: `prettier`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed` (7 files), and `lint` on the changed files.

> Note: haptics are a native-only effect, so the heavy-impact feedback and the navigation round-trip still need verification on a real iOS/Android device — that has **not** been done yet.

### Tests

1. On the Home compact calendar, **long-press a past day** → feel a heavy haptic and land on the edit-session screen dated to that day. Add a drink, save, and verify the session appears on that day.
2. Open the **full-screen calendar** (tap the month header) and repeat step 1 — same result.
3. **Tap** (not long-press) a day → still navigates to the Day Overview (compact) / opens the drill-down sheet (fullscreen): no regression.
4. Open a **friend's** profile / full-screen calendar → long-press does nothing (no haptic, no navigation).
5. **Long-press a future day** → nothing happens.
6. Day Overview `+` FAB → date picker → confirm still creates and opens an edit session as before (now routed through the shared hook).
- [ ] Verify that no errors appear in the JS console

### Offline tests

Session creation is a local Onyx write (the draft only persists to Firebase on save), so the shortcut works offline.
1. Go offline, long-press a past day → edit session opens dated to that day.
2. Save → the session is queued and syncs on reconnect (same path as the existing add-session flow).
- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Long-press a past day on the home calendar → heavy haptic + edit screen for that date; save and confirm it shows up.
2. Repeat on the full-screen calendar.
3. Tap a day → day overview / drill-down opens (unchanged).
4. On a friend's calendar, long-press does nothing.
5. Long-press a future/pre-tracking (disabled) day → nothing happens.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified all code is DRY (extracted the create-and-edit flow into a single reusable hook).
- [x] I verified that any callback methods that were added or modified are named for what the method does (`onDayLongPress`, `startEditSessionForDate`).
- [x] I verified that comments were added to code that is not self explanatory.
- [ ] I ran the tests on **all platforms** & verified they passed on Android / iOS (device verification of haptic + navigation still pending).

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- pending device capture -->

</details>

<details>
<summary>iOS</summary>

<!-- pending device capture -->

</details>