### PR TITLE
refactor(realtime): cut admin feedback/bug reads off Firebase

### DIFF
--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -117,6 +117,14 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/privacy/friend',
   },
+  [SIDE_EFFECT_REQUEST_COMMANDS.GET_FEEDBACK_LIST]: {
+    method: 'get',
+    path: '/v1/feedback',
+  },
+  [SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST]: {
+    method: 'get',
+    path: '/v1/feedback/bug',
+  },
   [WRITE_COMMANDS.SUBMIT_FEEDBACK]: {
     method: 'post',
     path: '/v1/feedback',

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -141,6 +141,8 @@ const SIDE_EFFECT_REQUEST_COMMANDS = {
   GET_MISSING_ONYX_MESSAGES: 'GetMissingOnyxMessages',
   //   JOIN_POLICY_VIA_INVITE_LINK: 'JoinWorkspaceViaInviteLink',
   RECONNECT_APP: 'ReconnectApp',
+  GET_FEEDBACK_LIST: 'GetFeedbackList',
+  GET_BUG_LIST: 'GetBugList',
 } as const;
 
 type SideEffectRequestCommand = ValueOf<typeof SIDE_EFFECT_REQUEST_COMMANDS>;
@@ -151,6 +153,8 @@ type SideEffectRequestCommandParameters = {
   // [SIDE_EFFECT_REQUEST_COMMANDS.OPEN_OLD_DOT_LINK]: Parameters.OpenOldDotLinkParams;
   [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: Parameters.GetMissingOnyxMessagesParams;
   [SIDE_EFFECT_REQUEST_COMMANDS.RECONNECT_APP]: Parameters.ReconnectAppParams;
+  [SIDE_EFFECT_REQUEST_COMMANDS.GET_FEEDBACK_LIST]: EmptyObject;
+  [SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST]: EmptyObject;
 };
 
 type ApiRequestCommandParameters = WriteCommandParameters &

--- a/src/libs/actions/Feedback.ts
+++ b/src/libs/actions/Feedback.ts
@@ -1,19 +1,23 @@
 import * as API from '@libs/API';
-import {WRITE_COMMANDS} from '@libs/API/types';
+import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import type {BugList, FeedbackList} from '@src/types/onyx';
 
 /**
- * Feedback + bug-report writes, cut over from direct Firebase RTDB writes to
- * kiroku-api `API.write` calls. The server owns
- * the generated id, `submit_time`, and `user_id` (derived from the caller's
- * Firebase ID token), so callers pass only the free-text body. The feedback/bug
- * collections are admin-only and fetched on demand, so the server route's
- * `onyxData` is empty — there is nothing to optimistically write.
+ * Feedback + bug-report writes and admin reads, cut over from direct Firebase
+ * RTDB access to kiroku-api calls. The server owns the generated id,
+ * `submit_time`, and `user_id` (derived from the caller's Firebase ID token), so
+ * callers pass only the free-text body. The feedback/bug collections are
+ * admin-only and fetched on demand, so the write routes' `onyxData` is empty —
+ * there is nothing to optimistically write.
  *
- * The admin removes are also empty-`onyxData` writes: the SeeFeedbackScreen /
- * SeeBugsScreen lists are still hydrated by a Firebase read listener (read
- * cutover is #809), so the server-side delete drives the list refresh and no
- * optimistic Onyx data is needed. Authority is the caller's admin claim,
- * enforced server-side.
+ * The admin removes are also empty-`onyxData` writes; authority is the caller's
+ * admin claim, enforced server-side.
+ *
+ * The admin reads (`getFeedbackList` / `getBugList`) back the SeeFeedbackScreen /
+ * SeeBugsScreen lists. The GET routes return the whole collection as plain JSON
+ * (not an `onyxData` envelope), so `makeRequestWithSideEffects` resolves with the
+ * list itself and the screens load it into local component state rather than
+ * Onyx. Part of the #809 realtime cutover.
  */
 
 function submitFeedback(text: string) {
@@ -32,4 +36,27 @@ function removeBug(bugId: string) {
   API.write(WRITE_COMMANDS.REMOVE_BUG, {bugId});
 }
 
-export {submitFeedback, reportABug, removeFeedback, removeBug};
+function getFeedbackList(): Promise<FeedbackList> {
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    SIDE_EFFECT_REQUEST_COMMANDS.GET_FEEDBACK_LIST,
+    {},
+  ).then(response => (response as unknown as FeedbackList | undefined) ?? {});
+}
+
+function getBugList(): Promise<BugList> {
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST,
+    {},
+  ).then(response => (response as unknown as BugList | undefined) ?? {});
+}
+
+export {
+  submitFeedback,
+  reportABug,
+  removeFeedback,
+  removeBug,
+  getFeedbackList,
+  getBugList,
+};

--- a/src/screens/Settings/Admin/SeeBugsScreen.tsx
+++ b/src/screens/Settings/Admin/SeeBugsScreen.tsx
@@ -8,14 +8,12 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import type {BugList, NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
-import {removeBug} from '@libs/actions/Feedback';
+import {getBugList, removeBug} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import DateUtils from '@libs/DateUtils';
 import MenuItem from '@components/MenuItem';
 import Button from '@components/Button';
 import useTheme from '@hooks/useTheme';
-import {listenForDataChanges} from '@database/baseFunctions';
-import DBPATHS from '@src/DBPATHS';
 import {fetchUserNicknames} from '@libs/actions/User';
 import type {Timestamp} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
@@ -29,21 +27,21 @@ function SeeBugsScreen() {
   const [bugList, setBugList] = useState<BugList>({});
 
   useEffect(() => {
-    const dbRef = DBPATHS.BUGS;
-    const stopListening = listenForDataChanges(
-      db,
-      dbRef,
-      (data: BugList | null) => {
-        const newData = data ?? {};
-        setBugList(newData);
-      },
-    );
+    let isMounted = true;
+    getBugList()
+      .then(data => {
+        if (isMounted) {
+          setBugList(data);
+        }
+      })
+      .catch(error => {
+        console.error('Error fetching bugs:', error);
+      });
 
-    // Stop listening for changes when the component unmounts
     return () => {
-      stopListening();
+      isMounted = false;
     };
-  }, [db]);
+  }, []);
 
   useEffect(() => {
     const fetchNicknames = async () => {

--- a/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
+++ b/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
@@ -8,14 +8,12 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import type {FeedbackList, NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
-import {removeFeedback} from '@libs/actions/Feedback';
+import {getFeedbackList, removeFeedback} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import DateUtils from '@libs/DateUtils';
 import MenuItem from '@components/MenuItem';
 import Button from '@components/Button';
 import useTheme from '@hooks/useTheme';
-import {listenForDataChanges} from '@database/baseFunctions';
-import DBPATHS from '@src/DBPATHS';
 import {fetchUserNicknames} from '@libs/actions/User';
 import type {Timestamp} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
@@ -29,21 +27,21 @@ function SeeFeedbackScreen() {
   const [feedbackList, setFeedbackList] = useState<FeedbackList>({});
 
   useEffect(() => {
-    const dbRef = DBPATHS.FEEDBACK;
-    const stopListening = listenForDataChanges(
-      db,
-      dbRef,
-      (data: FeedbackList | null) => {
-        const newData = data ?? {};
-        setFeedbackList(newData);
-      },
-    );
+    let isMounted = true;
+    getFeedbackList()
+      .then(data => {
+        if (isMounted) {
+          setFeedbackList(data);
+        }
+      })
+      .catch(error => {
+        console.error('Error fetching feedback:', error);
+      });
 
-    // Stop listening for changes when the component unmounts
     return () => {
-      stopListening();
+      isMounted = false;
     };
-  }, [db]);
+  }, []);
 
   useEffect(() => {
     const fetchNicknames = async () => {


### PR DESCRIPTION
## Summary
- Replace the Firebase `listenForDataChanges` subscriptions in `SeeFeedbackScreen` and `SeeBugsScreen` with a one-shot fetch on mount from the new kiroku-api admin GET endpoints (`GET /v1/feedback`, `GET /v1/feedback/bug`).
- Add `GetFeedbackList` / `GetBugList` side-effect commands + their GET route mappings in `kirokuRoutes.ts`, and `getFeedbackList` / `getBugList` actions in `@libs/actions/Feedback` that call `API.makeRequestWithSideEffects`. The endpoints return the raw collection (plain JSON, not an `onyxData` envelope), so the promise resolves with the list, which is loaded into the same local component state.
- Remove the now-unused `listenForDataChanges` and `DBPATHS` imports from both screens. `fetchUserNicknames` (display-name resolution) and the delete buttons are unchanged.

## Why
These two admin screens were the **last consumers of the `baseFunctions` listener helpers outside `useListenToData`**. kiroku-api already had POST submit/report + admin remove endpoints but no GET list endpoint, so the read couldn't move until now. Part of the #809 realtime/multi-device cutover.

## Blocked on
⚠️ **RUNTIME-BLOCKED** on the kiroku-api PR that ships the GET endpoints (PetrCala/kiroku-api#52). That must merge + deploy to dev before this is merged, or the screens will 404 at runtime. This PR is otherwise self-contained and passes all gates.

## Test plan
- [x] `npm run react-compiler-compliance-check check-changed` — passed (5 changed files)
- [x] `npx prettier --write` on changed files — no changes (already formatted)
- [x] `npm run lint-changed` — passed (exit 0)
- [x] `npm run typecheck-tsgo` — passed (exit 0)
- [ ] Manual: as an admin, open Feedback and Bug Reports screens once kiroku-api#52 is on dev; confirm both lists populate and delete still works.

## Follow-up
The `listenForDataChanges` / `listenForQueryChanges` helpers in `src/database/baseFunctions.ts` are intentionally **not** deleted here — `useListenToData` still uses them until the config cutover lands. They become deletable in the #809 capstone once this + the config cutover merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)