### PR TITLE
feat: hint tappable month/range labels with a subtle caret

### DIFF
--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -239,6 +239,13 @@ function SessionsCalendarView({
               accessibilityLabel={formatted}
               style={styles.sessionsCalendarHeaderLabel}>
               {monthText}
+              <Icon
+                src={KirokuIcons.DownArrow}
+                fill={theme.textSupporting}
+                width={12}
+                height={12}
+                additionalStyles={styles.sessionsCalendarHeaderCaret}
+              />
             </PressableWithFeedback>
           ) : (
             <View style={styles.sessionsCalendarHeaderLabel}>{monthText}</View>
@@ -260,11 +267,13 @@ function SessionsCalendarView({
       translate,
       styles.sessionsCalendarHeader,
       styles.sessionsCalendarHeaderLabel,
+      styles.sessionsCalendarHeaderCaret,
       styles.sessionsCalendarHeaderMonthText,
       styles.sessionsCalendarHeaderSideSlot,
       styles.sessionsCalendarHeaderRevert,
       theme.spinner,
       theme.textReversed,
+      theme.textSupporting,
     ],
   );
 

--- a/src/components/Statistics/StatsFilterToolbar/StatsRangeNavigator.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/StatsRangeNavigator.tsx
@@ -31,7 +31,7 @@ function StatsRangeNavigator({
 }: Props) {
   const {translate, preferredLocale} = useLocalize();
   const styles = useThemeStyles();
-  const {text, textReversed} = useTheme();
+  const {text, textReversed, textSupporting} = useTheme();
 
   const label = getStatsRangeLabel({range, translate, preferredLocale});
   const {isPageable, canGoPrev, canGoNext, isLatest} = range;
@@ -93,6 +93,13 @@ function StatsRangeNavigator({
               numberOfLines={1}>
               {label}
             </Text>
+            <Icon
+              src={KirokuIcons.DownArrow}
+              fill={textSupporting}
+              width={12}
+              height={12}
+              additionalStyles={styles.ml1}
+            />
           </PressableWithFeedback>
           {/* Right slot: a fixed-width reserve keeps the label centered. Holds
               the jump-to-latest button (fades in) or the custom-range revert

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1629,9 +1629,16 @@ const styles = (theme: ThemeColors) =>
     // Padding around the month label, matching the Statistics range navigator's
     // label so the gap to the revert control reads the same on both screens.
     sessionsCalendarHeaderLabel: {
+      flexDirection: 'row',
       paddingHorizontal: 8,
       paddingVertical: 4,
       alignItems: 'center',
+    },
+
+    // Subtle caret trailing the month label, hinting that tapping it expands to
+    // the full-screen calendar. Shown only when the header is tappable.
+    sessionsCalendarHeaderCaret: {
+      marginLeft: 4,
     },
 
     // Equal-width slots flanking the month label: a phantom spacer on the left,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -778,6 +778,7 @@ const styles = (theme: ThemeColors) =>
     },
 
     statsRangeNavigatorLabelPressable: {
+      flexDirection: 'row',
       paddingHorizontal: 8,
       paddingVertical: 4,
       alignItems: 'center',


### PR DESCRIPTION
### Details

Follow-up to #954. Introduces one consistent "this label is tappable to open / change something" cue — a subtle trailing down-caret — across the two calendar/stats labels that open a picker but had no visual affordance.

**1. Compact calendar header.** When the up/down expand arrows were removed in #954 to declutter the header, the "tap the month label to open the full-screen calendar" affordance (active under the `FULLSCREEN_CALENDAR` flag) lost its cue. A down-caret now trails the month label, shown only when the header is tappable.

**2. Statistics range label.** The stats range label opens the custom-range picker on tap (its a11y label already says "double-tap to change") but had no visual cue either. The same caret now trails it.

Both reuse `KirokuIcons.DownArrow` — the same glyph the date-picker modal uses for its month↔year dropdown — at 12×12 in the muted `textSupporting` color, so it reads as "tap to open / more" without the weight of the old `⇅` double-arrow. The caret is static (it doesn't toggle on runtime state), so it doesn't affect the label-centering or the jump/revert-button stability from #954.

### Tests

Static gates run locally: `typecheck-tsgo` ✅, React Compiler compliance ✅, Prettier ✅.

Manual steps for a reviewer:
1. **Calendar** (with `FULLSCREEN_CALENDAR` enabled): open Home/Profile → a small caret trails the month label; tapping it opens the full-screen calendar. With the flag off, no caret and the label is plain text.
2. **Statistics**: open any stats tab → a caret trails the range label; tapping it opens the range picker. Confirm it reads cleanly alongside the jump-to-latest / revert pill when that's showing.

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed — presentation-only affordance.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. With the full-screen calendar feature enabled, open Home and confirm a caret sits just right of the month/year label; tap it and confirm the full-screen calendar opens.
2. Open Statistics and confirm a caret sits right of the range label; tap it and confirm the range picker opens.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [ ] design review (UI change — tag @Kiroku/design)

> Author note: static gates pass; on-device/visual verification on Android & iOS is still outstanding — in particular, eyeball the stats caret next to the jump/revert pill for density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
