### PR TITLE
fix(session): compute edit/calendar day boundaries in the session timezone

### DIFF
--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -332,3 +332,89 @@ describe('finalize is the deterministic last writer', () => {
     ).toHaveLength(1);
   });
 });
+
+describe('updateSessionDate shifts in the session timezone', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  // Pin the "device" timezone to one that differs from every session timezone
+  // used below, so these assertions exercise the device-tz ≠ session-tz path
+  // (the bug). The computed delta must depend only on the session timezone, so
+  // it stays correct regardless of this value.
+  const originalTZ = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = 'Pacific/Honolulu';
+  });
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+  });
+  beforeEach(() => {
+    // Pass the session through unchanged so the (real) updateLocalData runs and
+    // we can assert on the millisecond shift this helper receives.
+    mockedDSUtils.shiftSessionTimestamps.mockImplementation(
+      (s: DrinkingSession) => s,
+    );
+  });
+
+  function makeEditSession(
+    startTime: number,
+    timezone: DrinkingSession['timezone'],
+  ): DrinkingSession {
+    return {
+      id: 's1',
+      start_time: startTime,
+      end_time: startTime,
+      blackout: false,
+      note: '',
+      timezone,
+      type: CONST.SESSION.TYPES.EDIT,
+      drinks: {},
+    };
+  }
+
+  it('does not shift when the picked day already matches the session-tz day', async () => {
+    // 2026-06-05 06:30 UTC is still 2026-06-04 23:30 in Los Angeles, so picking
+    // June 4 is a no-op. Device-local (UTC/Honolulu) math would see June 5 and
+    // wrongly shift by a day.
+    const session = makeEditSession(
+      Date.UTC(2026, 5, 5, 6, 30),
+      'America/Los_Angeles',
+    );
+
+    await DS.updateSessionDate('s1', session, new Date(2026, 5, 4));
+
+    expect(mockedDSUtils.shiftSessionTimestamps).toHaveBeenCalledWith(
+      session,
+      0,
+    );
+  });
+
+  it('shifts by the calendar-day delta measured in the session tz', async () => {
+    // Same instant (June 4 in LA); moving it to June 6 is a +2 calendar-day
+    // move. The buggy device-local path would compute only +1.
+    const session = makeEditSession(
+      Date.UTC(2026, 5, 5, 6, 30),
+      'America/Los_Angeles',
+    );
+
+    await DS.updateSessionDate('s1', session, new Date(2026, 5, 6));
+
+    expect(mockedDSUtils.shiftSessionTimestamps).toHaveBeenCalledWith(
+      session,
+      -2 * DAY_MS,
+    );
+  });
+
+  it('computes the delta for a standard (non-diverging) session tz', async () => {
+    // June 5 10:00 UTC is June 5 12:00 in Prague; moving to June 8 is -3 days.
+    const session = makeEditSession(
+      Date.UTC(2026, 5, 5, 10, 0),
+      'Europe/Prague',
+    );
+
+    await DS.updateSessionDate('s1', session, new Date(2026, 5, 8));
+
+    expect(mockedDSUtils.shiftSessionTimestamps).toHaveBeenCalledWith(
+      session,
+      -3 * DAY_MS,
+    );
+  });
+});

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -33,7 +33,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import Navigation from '@libs/Navigation/Navigation';
 import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
-import {differenceInDays, startOfDay} from 'date-fns';
+import {differenceInCalendarDays} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import type {ValueOf} from 'type-fest';
 import DBPATHS from '@src/DBPATHS';
@@ -670,8 +671,14 @@ async function updateSessionDate(
   newDate: Date,
   shouldUpdateLiveSessionData?: boolean,
 ): Promise<void> {
-  const currentDate = startOfDay(new Date(session.start_time));
-  const daysDelta = differenceInDays(currentDate, startOfDay(newDate));
+  // Resolve the day shift in the session's own timezone, not the device's.
+  // `newDate` carries the picked calendar day in its local fields; `currentDay`
+  // re-expresses the session start in the same frame so the difference is the
+  // number of calendar days the user actually moved, even when the device tz
+  // differs from the session tz.
+  const sessionTimezone = session.timezone ?? CONST.DEFAULT_TIME_ZONE.selected;
+  const currentDay = toZonedTime(session.start_time, sessionTimezone);
+  const daysDelta = differenceInCalendarDays(currentDay, newDate);
   const millisecondsToSub = daysDelta * 24 * 60 * 60 * 1000;
   const modifiedSession = DSUtils.shiftSessionTimestamps(
     session,

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -85,6 +85,14 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   // than the device's local day.
   const timezone =
     userData?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected;
+  // `toZonedTime` goes through Intl (slow on Hermes) and this screen re-renders
+  // on calendar scroll, so snapshot "today" in the user's tz once per tz change
+  // rather than recomputing it every frame.
+  const todayInTz = useMemo(
+    () => toZonedTime(new Date(), timezone),
+    [timezone],
+  );
+  const maxDate = useMemo(() => endOfDay(todayInTz), [todayInTz]);
 
   // Self reads the current user's sessions from the dedicated hook; a friend's
   // data is fetched on demand (same self/other gating as
@@ -244,12 +252,8 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
           mode="single"
           isVisible={isDatePickerVisible}
           title={translate('dayOverviewScreen.selectSessionDate')}
-          initialDate={
-            visibleDay
-              ? dateStringToDate(visibleDay)
-              : toZonedTime(new Date(), timezone)
-          }
-          maxDate={endOfDay(toZonedTime(new Date(), timezone))}
+          initialDate={visibleDay ? dateStringToDate(visibleDay) : todayInTz}
+          maxDate={maxDate}
           applyText={translate('common.confirm')}
           cancelText={translate('common.cancel')}
           onApply={onPickDate}

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {endOfToday} from 'date-fns';
+import {endOfDay} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
 import UserOffline from '@components/UserOfflineModal';
 import {useUserConnection} from '@context/global/UserConnectionContext';
 import type {StackScreenProps} from '@react-navigation/stack';
@@ -10,6 +11,7 @@ import type {DateString} from '@src/types/onyx/OnyxCommon';
 import Navigation from '@libs/Navigation/Navigation';
 import {useDatabaseData} from '@context/global/DatabaseDataContext';
 import useStartEditSessionForDate from '@hooks/useStartEditSessionForDate';
+import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {useFirebase} from '@context/global/FirebaseContext';
@@ -77,6 +79,12 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const isSelf = user?.uid === userID;
   const startEditSessionForDate = useStartEditSessionForDate();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
+  const userData = useCurrentUserData();
+  // The add-session date picker spans the user's calendar days in their selected
+  // timezone, so the "today" cap matches the day they actually live in rather
+  // than the device's local day.
+  const timezone =
+    userData?.timezone?.selected ?? CONST.DEFAULT_TIME_ZONE.selected;
 
   // Self reads the current user's sessions from the dedicated hook; a friend's
   // data is fetched on demand (same self/other gating as
@@ -236,8 +244,12 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
           mode="single"
           isVisible={isDatePickerVisible}
           title={translate('dayOverviewScreen.selectSessionDate')}
-          initialDate={visibleDay ? dateStringToDate(visibleDay) : new Date()}
-          maxDate={endOfToday()}
+          initialDate={
+            visibleDay
+              ? dateStringToDate(visibleDay)
+              : toZonedTime(new Date(), timezone)
+          }
+          maxDate={endOfDay(toZonedTime(new Date(), timezone))}
           applyText={translate('common.confirm')}
           cancelText={translate('common.cancel')}
           onApply={onPickDate}

--- a/src/screens/DrinkingSession/SessionDateScreen.tsx
+++ b/src/screens/DrinkingSession/SessionDateScreen.tsx
@@ -1,6 +1,6 @@
 import {endOfDay} from 'date-fns';
 import {toZonedTime} from 'date-fns-tz';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {Alert, View} from 'react-native';
 import Button from '@components/Button';
 import Calendar from '@components/DateSelectorModal/Calendar';
@@ -47,6 +47,12 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
     CONST.DEFAULT_TIME_ZONE.selected;
   const [selectedDate, setSelectedDate] = useState<Date>(() =>
     toZonedTime(session?.start_time ?? new Date(), sessionTimezone),
+  );
+  // `toZonedTime` is an Intl-backed (Hermes-slow) call; cache the picker cap so
+  // it is computed once per tz change rather than on every render.
+  const maxDate = useMemo(
+    () => endOfDay(toZonedTime(new Date(), sessionTimezone)),
+    [sessionTimezone],
   );
 
   const confirmTextKey: TranslationPaths = isBeingCreated
@@ -104,7 +110,7 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
         <Calendar
           mode="single"
           initialDate={selectedDate}
-          maxDate={endOfDay(toZonedTime(new Date(), sessionTimezone))}
+          maxDate={maxDate}
           onChangeSingle={setSelectedDate}
         />
       </View>

--- a/src/screens/DrinkingSession/SessionDateScreen.tsx
+++ b/src/screens/DrinkingSession/SessionDateScreen.tsx
@@ -1,4 +1,5 @@
-import {endOfToday} from 'date-fns';
+import {endOfDay} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
 import React, {useState} from 'react';
 import {Alert, View} from 'react-native';
 import Button from '@components/Button';
@@ -16,6 +17,8 @@ import type SCREENS from '@src/SCREENS';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as DS from '@userActions/DrinkingSession';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
+import useCurrentUserData from '@hooks/useCurrentUserData';
+import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import {useOnyx} from 'react-native-onyx';
 import type {Route} from '@src/ROUTES';
@@ -34,8 +37,16 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const session = DSUtils.getDrinkingSessionData(sessionId);
-  const [selectedDate, setSelectedDate] = useState<Date>(
-    session?.start_time ? new Date(session.start_time) : new Date(),
+  const userData = useCurrentUserData();
+  // Resolve the day in the session's own timezone (falling back to the user's
+  // selected tz) so the picker shows — and saves — the correct calendar day
+  // even when the device tz differs from the session/selected tz.
+  const sessionTimezone =
+    session?.timezone ??
+    userData?.timezone?.selected ??
+    CONST.DEFAULT_TIME_ZONE.selected;
+  const [selectedDate, setSelectedDate] = useState<Date>(() =>
+    toZonedTime(session?.start_time ?? new Date(), sessionTimezone),
   );
 
   const confirmTextKey: TranslationPaths = isBeingCreated
@@ -93,7 +104,7 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
         <Calendar
           mode="single"
           initialDate={selectedDate}
-          maxDate={endOfToday()}
+          maxDate={endOfDay(toZonedTime(new Date(), sessionTimezone))}
           onChangeSingle={setSelectedDate}
         />
       </View>


### PR DESCRIPTION
## Summary

The session-edit and calendar "today" helpers used bare date-fns functions (`startOfDay`, `endOfToday`, `new Date()`), which operate in the **device OS timezone** rather than the user's selected/session timezone. When those diverge (the user manually picked a zone, or they traveled), the edit/display layer computed the wrong calendar day — even though the statistics/bucketing layer was already timezone-correct.

This fixes the three concrete sites:

- **`updateSessionDate`** ([DrinkingSession.ts](src/libs/actions/DrinkingSession.ts)) — the day delta is now measured in the session's own timezone via `toZonedTime(start_time, session.timezone ?? default)` + `differenceInCalendarDays`, instead of two device-local `startOfDay` calls fed to `differenceInDays`. `differenceInCalendarDays` is also DST-immune. In the common case (device tz == session tz) the result is identical, so no regression.
- **`SessionDateScreen`** ([SessionDateScreen.tsx](src/screens/DrinkingSession/SessionDateScreen.tsx)) — the picker's initial day is seeded with the session's day **in the session/selected timezone**, and the `maxDate` cap is end-of-today in that zone (was `endOfToday()` = device-local). Seed and the `updateSessionDate` math now share the same frame, so a no-op confirm yields a zero shift.
- **DayOverview add-session picker** ([DayOverviewScreen.tsx](src/screens/DayOverview/DayOverviewScreen.tsx)) — same `endOfToday()` cap bug; now capped (and its fallback seed) in the user's selected timezone.

### Deliberately out of scope
- `SessionsCalendarScreen`'s and DayOverview's bare `new Date()` *seeds* are harmless UX defaults (immediately overridden by the initial-month scroll / `onDateChange` / ignored in dayList mode), so they're left unchanged.
- `getNewSessionToEdit` turns a picked local-midnight `Date` into `start_time` tagged with the selected tz, which can also land a *new* session on the wrong day when device ≠ selected. Same bug class, but a separate site on the shared create flow (also used by the calendar long-press shortcut) — flagged as a follow-up rather than widening this PR.

## Test plan

- [x] `npm run typecheck-tsgo` (exit 0)
- [x] `npm run react-compiler-compliance-check check-changed` (4 React files pass)
- [x] `npm run lint-changed` (exit 0)
- [x] `npx prettier --write` (clean)
- [x] New `updateSessionDate` tests in `__tests__/actions/DrinkingSession.test.ts` — device tz pinned to `Pacific/Honolulu`, session tz divergent; cover the near-midnight no-op, the day-flip delta, and a standard non-diverging zone. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)