### PR TITLE
feat(day-overview): long-press a session to open it for editing

### DIFF
--- a/src/components/DrinkingSessionOverview/index.tsx
+++ b/src/components/DrinkingSessionOverview/index.tsx
@@ -28,6 +28,7 @@ function DrinkingSessionOverview({
   session,
   isEditModeOn,
   readOnly = false,
+  enableLongPressToEdit = false,
   preferences: preferencesProp,
 }: DrinkingSessionOverviewProps) {
   const ownPreferences = useCurrentUserPreferences();
@@ -144,13 +145,22 @@ function DrinkingSessionOverview({
     return <View style={rowStyle}>{sessionDetails}</View>;
   }
 
+  // Long-press jumps straight to edit, skipping the Edit/Done toggle. Withheld
+  // for ongoing sessions, which surface the live-session button instead of an
+  // edit affordance. The heavy-impact haptic fires from GenericPressable.
+  const onLongPress =
+    enableLongPressToEdit && !session?.ongoing
+      ? onNavigateToEditSession
+      : undefined;
+
   return (
     <PressableWithFeedback
       accessibilityLabel={translate('dayOverviewScreen.sessionWindow', {
         sessionId,
       })}
       style={rowStyle}
-      onPress={() => onSessionButtonPress()}>
+      onPress={() => onSessionButtonPress()}
+      onLongPress={onLongPress}>
       {sessionDetails}
       {session?.ongoing ? (
         <Button

--- a/src/components/DrinkingSessionOverview/types.ts
+++ b/src/components/DrinkingSessionOverview/types.ts
@@ -13,6 +13,11 @@ type DrinkingSessionOverviewProps = {
    *  no edit/ongoing buttons. Used for viewing a friend's sessions. */
   readOnly?: boolean;
 
+  /** Open the session for editing on a long-press — a shortcut that mirrors the
+   *  Edit/Done toggle's edit button without entering edit mode. No-op for
+   *  read-only (friend) tiles and ongoing sessions, which can't be edited. */
+  enableLongPressToEdit?: boolean;
+
   /** Preferences to use for color/unit computation. Falls back to the current
    *  user's preferences when omitted — pass the viewed user's preferences when
    *  rendering someone else's session. */

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -331,6 +331,7 @@ function DayOverviewListView({
           session={item.entry.session}
           isEditModeOn={isEditModeOn ?? false}
           readOnly={isReadOnly}
+          enableLongPressToEdit
           preferences={preferences}
         />
       );


### PR DESCRIPTION
## Summary
- Long-pressing a session tile in the day-overview scroll now jumps straight to that session's edit screen — the same destination as toggling **Edit** and tapping a tile's edit button, but without entering edit mode. Mirrors the existing calendar day-tile long-press shortcut.
- Gated to editable tiles only: read-only (friend) tiles short-circuit to a non-interactive view, and ongoing sessions are excluded (they surface the live-session button, not an edit affordance).
- Heavy-impact haptic fires automatically via `GenericPressable`, consistent with the day-tile long-press.

## Implementation
- `DrinkingSessionOverview`: new opt-in `enableLongPressToEdit` prop wires `onLongPress` → `onNavigateToEditSession` on the tile's main pressable, withheld for ongoing sessions.
- `DayOverviewListView`: enables the prop on its session tiles. The two drill-down sheets (stats, calendar day) intentionally keep the previous behavior and are unchanged.

## Test plan
- [ ] On your own day-overview scroll, long-press a completed session → opens its edit screen with a haptic tap.
- [ ] Long-press an ongoing session → no edit navigation (live-session button still works on tap).
- [ ] Viewing a friend's day overview → long-press does nothing (read-only).
- [ ] Normal tap still opens the session summary; Edit/Done toggle + edit button still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)