### PR TITLE
test(statistics): harden timezone edge-case coverage

### DIFF
--- a/__tests__/unit/libs/DrinkingSessionUtils.test.ts
+++ b/__tests__/unit/libs/DrinkingSessionUtils.test.ts
@@ -5,10 +5,12 @@
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import type {
   DrinkingSession,
+  DrinkingSessionArray,
   DrinkingSessionList,
   DrinksList,
   DrinksToUnits,
 } from '@src/types/onyx';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {getZeroDrinksList} from '@libs/DataHandling';
@@ -239,82 +241,154 @@ describe('setLocalSessionCache / compose-on-latest', () => {
   });
 });
 
-// TODO
-// describe('getSingleDayDrinkingSessions', () => {
-//   it('should return sessions that only fall within the given date', () => {
-//     const baseDate = new Date('2023-08-20');
-//     const testSessions: DrinkingSessionList = {
-//       [new Date().getTime()]: createMockSession(baseDate, 0), // Session from 'today'
-//       [new Date().getTime() + 1]: createMockSession(baseDate, -1), // Session from 'yesterday'
-//       [new Date().getTime() + 2]: createMockSession(baseDate, 1), // Session from 'tomorrow'
-//     };
+const UTC = 'UTC' as SelectedTimezone;
+const TOKYO = 'Asia/Tokyo' as SelectedTimezone; // UTC+9
+const LA = 'America/Los_Angeles' as SelectedTimezone; // UTC-8 (Jan)
+const NY = 'America/New_York' as SelectedTimezone;
 
-//     const result = DSUtils.getSingleDayDrinkingSessions(baseDate, testSessions);
-//     expect(result).toHaveLength(1);
-//   });
+/**
+ * Local-noon `Date` whose `yyyy-MM-dd` label is stable under any process tz —
+ * the bucketers read the viewed day via `format(date)`, so a noon anchor keeps
+ * that label from drifting while the window is computed in the session tz.
+ */
+function viewDay(year: number, monthZeroBased: number, day: number): Date {
+  return new Date(year, monthZeroBased, day, 12);
+}
 
-//   it('should return an empty array if no sessions fall within the given date', () => {
-//     const baseDate = new Date('2023-08-22');
-//     const testSessions: DrinkingSessionList = {
-//       [new Date().getTime()]: createMockSession(baseDate, -2),
-//       [new Date().getTime() + 1]: createMockSession(baseDate, -3),
-//     };
+describe('getSingleDayDrinkingSessions — buckets by each session timezone', () => {
+  // 06:00 UTC on 2024-01-15 is 15:00 (Jan 15) in Tokyo but 22:00 (Jan 14) in LA.
+  const crossInstant = Date.UTC(2024, 0, 15, 6, 0);
+  const sessions: DrinkingSessionList = {
+    tk: {start_time: crossInstant, timezone: TOKYO},
+    la: {start_time: crossInstant, timezone: LA},
+  };
 
-//     const result = DSUtils.getSingleDayDrinkingSessions(baseDate, testSessions);
-//     expect(result).toHaveLength(0);
-//     expect(result).toEqual([]);
-//   });
-// });
+  it('includes only the session whose own tz places the instant on that day', () => {
+    const onJan15 = DSUtils.getSingleDayDrinkingSessions(
+      viewDay(2024, 0, 15),
+      sessions,
+    ) as DrinkingSessionArray;
+    expect(onJan15).toHaveLength(1);
+    expect(onJan15[0].timezone).toBe(TOKYO);
+  });
 
-// describe('getSingleMonthDrinkingSessions', () => {
-//   it('should return sessions that only fall within the given month', () => {
-//     const baseDate = new Date('2023-08-20');
-//     const testSessions: DrinkingSessionArray = [
-//       createMockSession(baseDate, 0), // Session from this month
-//       createMockSession(baseDate, -30), // Session from last month
-//       createMockSession(baseDate, 30), // Session from next month
-//     ];
+  it('buckets the same instant onto the previous day for a behind-UTC tz', () => {
+    const onJan14 = DSUtils.getSingleDayDrinkingSessions(
+      viewDay(2024, 0, 14),
+      sessions,
+    ) as DrinkingSessionArray;
+    expect(onJan14).toHaveLength(1);
+    expect(onJan14[0].timezone).toBe(LA);
+  });
 
-//     const result = DSUtils.getSingleMonthDrinkingSessions(
-//       baseDate,
-//       testSessions,
-//     );
-//     expect(result).toHaveLength(1);
-//   });
+  it('returns the keyed subset (not an array) when returnArray is false', () => {
+    const subset = DSUtils.getSingleDayDrinkingSessions(
+      viewDay(2024, 0, 15),
+      sessions,
+      false,
+    ) as DrinkingSessionList;
+    expect(Object.keys(subset)).toEqual(['tk']);
+  });
 
-//   it('should return sessions until today when untilToday flag is true', () => {
-//     const baseDate = new Date('2023-08-20');
-//     const futureSessionDate = new Date();
-//     futureSessionDate.setDate(futureSessionDate.getDate() + 5); // A session 5 days into the future
+  it('falls back to the base timezone when a session has no timezone', () => {
+    // Under the TZ=utc test process the base resolves to UTC, so 06:00 UTC on
+    // 2024-01-15 belongs to Jan 15 and not Jan 14.
+    const noTz: DrinkingSessionList = {x: {start_time: crossInstant}};
+    expect(
+      DSUtils.getSingleDayDrinkingSessions(viewDay(2024, 0, 15), noTz),
+    ).toHaveLength(1);
+    expect(
+      DSUtils.getSingleDayDrinkingSessions(viewDay(2024, 0, 14), noTz),
+    ).toHaveLength(0);
+  });
 
-//     const testSessions: DrinkingSessionArray = [
-//       createMockSession(baseDate, 0), // Session from this month
-//       {
-//         ...createMockSession(baseDate, 0),
-//         start_time: futureSessionDate.getTime(),
-//       },
-//     ];
+  it('returns an empty array for undefined sessions', () => {
+    expect(
+      DSUtils.getSingleDayDrinkingSessions(viewDay(2024, 0, 15), undefined),
+    ).toEqual([]);
+  });
+});
 
-//     const result = DSUtils.getSingleMonthDrinkingSessions(
-//       baseDate,
-//       testSessions,
-//       true,
-//     );
-//     expect(result).toHaveLength(1);
-//   });
+describe('getSingleMonthDrinkingSessions — buckets by each session timezone', () => {
+  // 20:00 UTC on 2024-01-31 is 05:00 (Feb 1) in Tokyo but 12:00 (Jan 31) in LA.
+  const monthEdgeInstant = Date.UTC(2024, 0, 31, 20, 0);
+  const arr: DrinkingSessionArray = [
+    {start_time: monthEdgeInstant, timezone: TOKYO},
+    {start_time: monthEdgeInstant, timezone: LA},
+  ];
 
-//   it('should return an empty array if no sessions fall within the given month', () => {
-//     const baseDate = new Date('2023-08-22');
-//     const testSessions: DrinkingSessionArray = [
-//       createMockSession(baseDate, -60),
-//       createMockSession(baseDate, -90),
-//     ];
+  it('keeps the behind-UTC session in January and the ahead-of-UTC session in February', () => {
+    const january = DSUtils.getSingleMonthDrinkingSessions(
+      viewDay(2024, 0, 15),
+      arr,
+    );
+    expect(january).toHaveLength(1);
+    expect(january[0].timezone).toBe(LA);
 
-//     const result = DSUtils.getSingleMonthDrinkingSessions(
-//       baseDate,
-//       testSessions,
-//     );
-//     expect(result).toHaveLength(0);
-//     expect(result).toEqual([]);
-//   });
-// });
+    const february = DSUtils.getSingleMonthDrinkingSessions(
+      viewDay(2024, 1, 15),
+      arr,
+    );
+    expect(february).toHaveLength(1);
+    expect(february[0].timezone).toBe(TOKYO);
+  });
+
+  it('untilToday=true drops sessions later than the current instant', () => {
+    // Pin "now" so the until-today clamp is deterministic.
+    jest.useFakeTimers({now: new Date('2024-01-15T12:00:00Z')});
+    try {
+      const sameMonth: DrinkingSessionArray = [
+        {start_time: Date.UTC(2024, 0, 10, 12), timezone: UTC},
+        {start_time: Date.UTC(2024, 0, 20, 12), timezone: UTC},
+      ];
+      const upToToday = DSUtils.getSingleMonthDrinkingSessions(
+        viewDay(2024, 0, 15),
+        sameMonth,
+        true,
+      );
+      expect(upToToday).toHaveLength(1);
+      expect(upToToday[0].start_time).toBe(Date.UTC(2024, 0, 10, 12));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('isDifferentDay', () => {
+  it('is false when the session tz and target tz agree on the day', () => {
+    // 06:00 UTC = 15:00 Jan 15 in Tokyo.
+    const session: DrinkingSession = {
+      start_time: Date.UTC(2024, 0, 15, 6, 0),
+      timezone: TOKYO,
+    };
+    expect(DSUtils.isDifferentDay(session, TOKYO)).toBe(false);
+  });
+
+  it('is true when converting to the target tz crosses midnight', () => {
+    // Same instant is Jan 15 in Tokyo but Jan 14 in LA.
+    const session: DrinkingSession = {
+      start_time: Date.UTC(2024, 0, 15, 6, 0),
+      timezone: TOKYO,
+    };
+    expect(DSUtils.isDifferentDay(session, LA)).toBe(true);
+  });
+
+  it('does not flip the day across a same-tz DST transition', () => {
+    // NY spring-forward 2025: 07:00 UTC = 03:00 EDT, still 2025-03-09.
+    const session: DrinkingSession = {
+      start_time: Date.UTC(2025, 2, 9, 7, 0),
+      timezone: NY,
+    };
+    expect(DSUtils.isDifferentDay(session, NY)).toBe(false);
+  });
+
+  it('falls back to the device-formatted day when the session has no timezone', () => {
+    // No session.timezone → the current day comes from the process tz (UTC here):
+    // 23:30 UTC on 2024-01-15 is still Jan 15 locally, but Jan 16 in Tokyo.
+    const session: DrinkingSession = {
+      start_time: Date.UTC(2024, 0, 15, 23, 30),
+    };
+    expect(DSUtils.isDifferentDay(session, TOKYO)).toBe(true);
+    expect(DSUtils.isDifferentDay(session, UTC)).toBe(false);
+  });
+});

--- a/__tests__/unit/libs/Statistics/localParts.test.ts
+++ b/__tests__/unit/libs/Statistics/localParts.test.ts
@@ -75,6 +75,18 @@ describe('resolveLocalParts — exact DST transition instants', () => {
       label: 'NY fall-back',
     },
     {
+      // The exact instant date-fns-tz is documented to mishandle: 02:00 EST
+      // jumps to 03:00 EDT at 07:00 UTC. The cached-offset path must match Intl.
+      zone: 'America/New_York',
+      instant: Date.UTC(2025, 2, 9, 7),
+      label: 'NY spring-forward (2025)',
+    },
+    {
+      zone: 'America/New_York',
+      instant: Date.UTC(2025, 10, 2, 6),
+      label: 'NY fall-back (2025)',
+    },
+    {
       zone: 'Europe/London',
       instant: Date.UTC(2024, 2, 31, 1),
       label: 'London spring-forward',
@@ -132,6 +144,57 @@ describe('resolveLocalParts — cache behaviour within a month', () => {
     // Same wall hour (07:00 -> different offsets give different local hours)
     expect(resolveLocalParts(before, 'America/New_York')?.localHour).toBe(7); // 12:00 UTC = 07:00 EST
     expect(resolveLocalParts(after, 'America/New_York')?.localHour).toBe(8); // 12:00 UTC = 08:00 EDT
+  });
+});
+
+describe('resolveLocalParts — exact named DST instants (America/New_York)', () => {
+  const NY = 'America/New_York';
+
+  it('skips the lost hour at the 2025 spring-forward (01:59 EST → 03:00 EDT)', () => {
+    // The clock jumps 02:00 → 03:00 at 07:00 UTC; 02:xx local never exists.
+    const jump = Date.UTC(2025, 2, 9, 7);
+    expect(resolveLocalParts(jump - 60_000, NY)).toMatchObject({
+      localDay: '2025-03-09',
+      localHour: 1, // 06:59 UTC = 01:59 EST
+    });
+    expect(resolveLocalParts(jump, NY)).toMatchObject({
+      localDay: '2025-03-09',
+      localHour: 3, // 07:00 UTC = 03:00 EDT
+    });
+  });
+
+  it('resolves the repeated hour at the 2025 fall-back (01:00 EDT then 01:00 EST)', () => {
+    // The clock falls 02:00 → 01:00 at 06:00 UTC, so 01:00 local occurs twice.
+    const fallBack = Date.UTC(2025, 10, 2, 6);
+    expect(resolveLocalParts(fallBack - 60 * 60_000, NY)).toMatchObject({
+      localDay: '2025-11-02',
+      localHour: 1, // 05:00 UTC = 01:00 EDT (first pass)
+    });
+    expect(resolveLocalParts(fallBack, NY)).toMatchObject({
+      localDay: '2025-11-02',
+      localHour: 1, // 06:00 UTC = 01:00 EST (second pass)
+    });
+  });
+});
+
+describe('resolveLocalParts — the date-fns-tz failure instant', () => {
+  // The header for localParts.ts cites date-fns-tz being off-by-one at the exact
+  // spring-forward instant as the reason it uses Intl instead. London flips
+  // 00:00→01:00 (GMT→BST) at 01:00 UTC, so the first BST instant is 02:00 local.
+  // Pin that the Intl-backed path lands on 02:00 (date-fns-tz's miscount here is
+  // host-tz-dependent, so we assert our own correctness rather than its bug).
+  const londonSpringForward = Date.UTC(2025, 2, 30, 1, 0, 0);
+
+  it('resolves the London spring-forward instant to 02:00 local', () => {
+    expect(
+      resolveLocalParts(londonSpringForward, 'Europe/London'),
+    ).toMatchObject({localDay: '2025-03-30', localHour: 2});
+  });
+
+  it('agrees with the independent Intl reference at that instant', () => {
+    expect(resolveLocalParts(londonSpringForward, 'Europe/London')).toEqual(
+      referenceLocalParts(londonSpringForward, 'Europe/London'),
+    );
   });
 });
 

--- a/__tests__/unit/libs/timezoneDeviceVsSession.test.ts
+++ b/__tests__/unit/libs/timezoneDeviceVsSession.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ *
+ * Device timezone ≠ session/selected timezone.
+ *
+ * The rest of the suite runs under `TZ=utc`, which hides a whole class of bugs:
+ * code that accidentally reads the *device* timezone instead of the session's
+ * own timezone looks correct as long as the device is UTC. These tests assert
+ * that resolution and bucketing depend only on the *session* timezone, and that
+ * the no-timezone fallback in `isDifferentDay` tracks whatever the device tz is.
+ *
+ * The Jest process timezone is fixed at launch and cannot be changed reliably
+ * mid-process (Node honours `TZ` only at startup, so `Intl` with an explicit
+ * zone updates but date-fns `format`/the default zone do not). So instead of
+ * mutating `process.env.TZ`, these expectations are written to hold under ANY
+ * launch timezone: the session-tz assertions use fixed values (a device leak
+ * would change them and fail), and the device-fallback assertion is checked
+ * against the *actual* effective device tz. The file is verified by launching it
+ * under several zones, e.g.:
+ *
+ *   TZ=America/Los_Angeles jest timezoneDeviceVsSession
+ *   TZ=Pacific/Kiritimati   jest timezoneDeviceVsSession   // UTC+14
+ *   TZ=Asia/Kolkata         jest timezoneDeviceVsSession   // UTC+5:30
+ *
+ * CI runs it under the default `TZ=utc`.
+ */
+
+import {formatInTimeZone} from 'date-fns-tz';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
+import {resolveLocalParts} from '@libs/Statistics/localParts';
+import type {
+  DrinkingSession,
+  DrinkingSessionArray,
+  DrinkingSessionList,
+} from '@src/types/onyx';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
+
+const UTC = 'UTC' as SelectedTimezone;
+const TOKYO = 'Asia/Tokyo' as SelectedTimezone; // UTC+9
+const LA = 'America/Los_Angeles' as SelectedTimezone; // UTC-8 (Jan)
+
+/** The timezone the Jest process actually launched with. */
+const DEVICE_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+/** Local-noon anchor: its `yyyy-MM-dd` label is the same under any device tz. */
+function viewDay(year: number, monthZeroBased: number, day: number): Date {
+  return new Date(year, monthZeroBased, day, 12);
+}
+
+// 10:00 UTC on 2024-01-15 (a Monday).
+const INSTANT = Date.UTC(2024, 0, 15, 10, 0);
+
+describe(`device tz = ${DEVICE_TZ} — session tz is the only input that matters`, () => {
+  it('resolveLocalParts reads the session tz, not the device', () => {
+    // Fixed expectations: were the device tz to leak in, a non-UTC launch would
+    // shift these and fail.
+    expect(resolveLocalParts(INSTANT, UTC)).toMatchObject({
+      localDay: '2024-01-15',
+      localHour: 10,
+      calendarDow: 1,
+      localIsoWeek: '2024-W03',
+    });
+    expect(resolveLocalParts(INSTANT, TOKYO)).toMatchObject({
+      localDay: '2024-01-15',
+      localHour: 19, // 10:00 UTC + 9
+    });
+    expect(resolveLocalParts(INSTANT, LA)).toMatchObject({
+      localDay: '2024-01-15',
+      localHour: 2, // 10:00 UTC − 8
+    });
+  });
+
+  it('getSingleDayDrinkingSessions buckets by the session tz, not the device', () => {
+    // A UTC-tagged session at 10:00 UTC belongs to Jan 15 in its own tz. Under a
+    // +14 device a device-based window would push it off Jan 15, so stable
+    // membership here proves the device tz never leaks in.
+    const sessions: DrinkingSessionList = {
+      u: {start_time: INSTANT, timezone: UTC},
+    };
+    expect(
+      DSUtils.getSingleDayDrinkingSessions(viewDay(2024, 0, 15), sessions),
+    ).toHaveLength(1);
+    expect(
+      DSUtils.getSingleDayDrinkingSessions(viewDay(2024, 0, 16), sessions),
+    ).toHaveLength(0);
+  });
+
+  it('getSingleMonthDrinkingSessions buckets by the session tz, not the device', () => {
+    const sessions: DrinkingSessionArray = [
+      {start_time: INSTANT, timezone: UTC},
+    ];
+    expect(
+      DSUtils.getSingleMonthDrinkingSessions(viewDay(2024, 0, 15), sessions),
+    ).toHaveLength(1);
+    expect(
+      DSUtils.getSingleMonthDrinkingSessions(viewDay(2024, 1, 15), sessions),
+    ).toHaveLength(0);
+  });
+
+  it('isDifferentDay falls back to the device tz when the session has none', () => {
+    // 12:00 UTC can land on different calendar days depending on the device tz;
+    // the no-timezone branch must use that device day, so it agrees with an
+    // oracle built from the actual effective device tz.
+    const session: DrinkingSession = {start_time: Date.UTC(2024, 0, 15, 12, 0)};
+    const fmt = 'yyyy-MM-dd';
+    const deviceDay = formatInTimeZone(session.start_time, DEVICE_TZ, fmt);
+    const tokyoDay = formatInTimeZone(session.start_time, TOKYO, fmt);
+    expect(DSUtils.isDifferentDay(session, TOKYO)).toBe(deviceDay !== tokyoDay);
+  });
+});


### PR DESCRIPTION
## Summary

Purely **additive test coverage** for the timezone statistics/bucketing layer — no production code changes. The timezone layer is already correct, but the exact edge cases where timezone bugs hide were under-tested (existing tests mostly hardcode `'UTC'`). This pins those cases.

### What's added

- **`localParts.test.ts`** (DST transitions)
  - Exact NY 2025 **spring-forward** (`02:00→03:00`, the lost hour) and **fall-back** (`02:00→01:00`, the repeated hour) instants, asserting the right local day/hour on each side of the gap.
  - The **London spring-forward** instant (`2025-03-30 01:00Z`), the kind of instant `date-fns-tz` is documented to mishandle, pinning that the Intl-backed `resolveLocalParts` lands on `02:00` and matches an independent Intl reference. (Why `localParts.ts` uses Intl instead of `date-fns-tz`.)

- **`DrinkingSessionUtils.test.ts`** (per-session timezone bucketing — fills the long-standing commented-out TODO stubs)
  - `getSingleDayDrinkingSessions` / `getSingleMonthDrinkingSessions`: identical instants tagged with different `session.timezone` (Asia/Tokyo vs America/Los_Angeles) bucket onto **each session's own** local day/month across the midnight and month boundaries; plus the keyed (`returnArray=false`) shape, the no-timezone base fallback, and `untilToday`.
  - First direct **`isDifferentDay`** tests: same-tz agreement, cross-midnight divergence, same-tz DST instant doesn't spuriously flip the day, and the **no-`timezone` device-format fallback**.

- **`timezoneDeviceVsSession.test.ts`** (new — device tz ≠ session tz)
  - Proves resolution and bucketing depend only on the **session** timezone, never the device, and that `isDifferentDay`'s no-timezone branch tracks the device tz.

## Why

These are the precise instants/relationships where a "reads the device timezone instead of the session's" bug would pass under the repo's default `TZ=utc` and only surface for real users in other zones. The tests lock the current (correct) behavior so the two in-flight behavioral PRs (session-editing/calendar tz, and the automatic-timezone update lifecycle) can't regress it.

## Notes for reviewers

- **No production behavior was found to be wrong.** Every case the new tests cover matched expected correct behavior; nothing in `src/` is touched.
- The Jest process timezone is fixed at launch and can't be changed reliably mid-process (Node honours `TZ` only at startup). So `timezoneDeviceVsSession.test.ts` is written **launch-TZ-agnostic**: session-tz assertions use fixed values (a device leak would fail them) and the device-fallback assertion is checked against the actual effective device tz. CI runs it under the default `TZ=utc`; it was verified locally under `America/Los_Angeles`, `Pacific/Kiritimati` (+14), and `Asia/Kolkata` (+5:30) — all green.

## Test plan

- [x] `TZ=utc jest` over the three files — 50/50 pass
- [x] `timezoneDeviceVsSession.test.ts` launched under UTC / LA / Kiritimati / Kolkata — 4/4 pass each
- [x] `npm run typecheck-tsgo` — clean
- [x] `npm run lint-changed` — clean
- [x] `npx prettier --write` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)