### PR TITLE
refactor(realtime): cut onboarding writes over to kiroku-api

### DIFF
--- a/__tests__/actions/Onboarding.test.ts
+++ b/__tests__/actions/Onboarding.test.ts
@@ -2,33 +2,38 @@
  * @jest-environment node
  */
 
-/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule, __path) are dictated by Node module shape */
-/* eslint-disable rulesdir/prefer-actions-set-data -- this test asserts that the Onboarding action calls Onyx.merge with the expected payload */
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 /* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
 
-import {ref, set, update} from 'firebase/database';
-import type {Database} from 'firebase/database';
-import type {User} from 'firebase/auth';
+import type {OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import * as UserActions from '@userActions/User';
-import Log from '@libs/Log';
 import * as Onboarding from '@libs/actions/Onboarding';
 import CONST from '@src/CONST';
-import DBPATHS from '@src/DBPATHS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import type {Database} from 'firebase/database';
+import type {User} from 'firebase/auth';
 
-jest.mock('firebase/database', () => ({
-  ref: jest.fn((_db: unknown, path?: string) => ({__path: path ?? '<root>'})),
-  set: jest.fn(() => Promise.resolve()),
-  update: jest.fn(() => Promise.resolve()),
-}));
+const TEST_UID = 'user-abc';
 
 jest.mock('react-native-onyx', () => ({
   __esModule: true,
   default: {
     merge: jest.fn(() => Promise.resolve()),
+    METHOD: {SET: 'set', MERGE: 'merge'},
   },
+}));
+
+jest.mock('@libs/API', () => ({
+  write: jest.fn(),
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: jest.fn(() => ({currentUser: {uid: 'user-abc'}})),
 }));
 
 jest.mock('@userActions/User', () => ({
@@ -40,108 +45,126 @@ jest.mock('@libs/Navigation/Navigation', () => ({
   default: {navigate: jest.fn(), dismissModal: jest.fn()},
 }));
 
-jest.mock('@libs/Log', () => ({
-  __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-  },
-}));
-
 jest.mock('@libs/Localize', () => ({
   translateLocal: (key: string) => key,
 }));
 
-const mockedRef = jest.mocked(ref);
-const mockedSet = jest.mocked(set);
-const mockedUpdate = jest.mocked(update);
-const mockedOnyx = jest.mocked(Onyx);
-const mockedMerge = mockedOnyx.merge;
+const mockedWrite = jest.mocked(API.write);
+const mockedMerge = jest.mocked(Onyx.merge);
 const mockedSetUsername = jest.mocked(UserActions.setUsername);
-const mockedLog = jest.mocked(Log);
-const mockedLogWarn = mockedLog.warn;
+const mockedGetFirebaseAuth = jest.mocked(getFirebaseAuth);
 
-const TEST_UID = 'user-abc';
 const TEST_USER = {uid: TEST_UID} as User;
 const TEST_DB = {} as Database;
 
-function onyxKeysCalled(): string[] {
-  return mockedMerge.mock.calls.map(call => call[0]);
+type WriteCall = [
+  string,
+  Record<string, unknown>,
+  {optimisticData?: OnyxUpdate[]},
+];
+
+/** The (command, params, onyxData) tuple from the first API.write call. */
+function firstWriteCall(): WriteCall {
+  return mockedWrite.mock.calls[0] as unknown as WriteCall;
+}
+
+/** Find the optimistic update targeting a given Onyx key. */
+function optimisticFor(
+  optimisticData: OnyxUpdate[] | undefined,
+  key: string,
+): OnyxUpdate | undefined {
+  return optimisticData?.find(update => update.key === key);
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockedGetFirebaseAuth.mockReturnValue({
+    currentUser: {uid: TEST_UID},
+  } as ReturnType<typeof getFirebaseAuth>);
 });
 
 describe('acceptTerms', () => {
-  test('inside onboarding flow: writes three Firebase paths + mirrors Onyx', async () => {
+  test('inside onboarding flow: writes via kiroku-api with mirrored optimistic data', () => {
     const before = Date.now();
-    await Onboarding.acceptTerms(TEST_DB, TEST_USER, ROUTES.ONBOARDING_TERMS);
+    Onboarding.acceptTerms(ROUTES.ONBOARDING_TERMS);
     const after = Date.now();
 
-    expect(mockedUpdate).toHaveBeenCalledTimes(1);
-    const updatePayload = mockedUpdate.mock.calls[0][1] as Record<
-      string,
-      unknown
-    >;
-    expect(Object.keys(updatePayload)).toEqual(
-      expect.arrayContaining([
-        DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_AT.getRoute(TEST_UID),
-        DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_VERSION.getRoute(TEST_UID),
-        DBPATHS.USERS_USER_ID_ONBOARDING_LAST_VISITED_PATH.getRoute(TEST_UID),
-      ]),
+    expect(mockedWrite).toHaveBeenCalledTimes(1);
+    const [command, params, onyxData] = firstWriteCall();
+    expect(command).toBe(WRITE_COMMANDS.ACCEPT_TERMS);
+    // The client never sends a terms version — the server decides it.
+    expect(params).toEqual({onboardingPath: ROUTES.ONBOARDING_TERMS});
+
+    const userUpdate = optimisticFor(
+      onyxData.optimisticData,
+      ONYXKEYS.USER_DATA_LIST,
     );
-    expect(
-      updatePayload[
-        DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_VERSION.getRoute(TEST_UID)
-      ],
-    ).toBe(CONST.CURRENT_TERMS_VERSION);
-    const writtenAt = updatePayload[
-      DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_AT.getRoute(TEST_UID)
-    ] as number;
+    const userEntry = (
+      userUpdate?.value as Record<string, Record<string, unknown>>
+    )[TEST_UID];
+    expect(userEntry.agreed_to_terms_version).toBe(CONST.CURRENT_TERMS_VERSION);
+    const writtenAt = userEntry.agreed_to_terms_at as number;
     expect(writtenAt).toBeGreaterThanOrEqual(before);
     expect(writtenAt).toBeLessThanOrEqual(after);
+    expect(userEntry.onboarding).toEqual({
+      last_visited_path: ROUTES.ONBOARDING_TERMS,
+    });
 
-    expect(onyxKeysCalled()).toEqual(
-      expect.arrayContaining([
-        ONYXKEYS.USER_DATA_LIST,
-        ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION,
-        ONYXKEYS.NVP_ONBOARDING,
-      ]),
+    const versionUpdate = optimisticFor(
+      onyxData.optimisticData,
+      ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION,
     );
+    expect(versionUpdate?.onyxMethod).toBe(Onyx.METHOD.SET);
+    expect(versionUpdate?.value).toBe(CONST.CURRENT_TERMS_VERSION);
+
+    const onboardingUpdate = optimisticFor(
+      onyxData.optimisticData,
+      ONYXKEYS.NVP_ONBOARDING,
+    );
+    expect(onboardingUpdate?.value).toEqual({
+      last_visited_path: ROUTES.ONBOARDING_TERMS,
+    });
   });
 
-  test('standalone re-consent (no path): does not touch onboarding state', async () => {
-    await Onboarding.acceptTerms(TEST_DB, TEST_USER);
+  test('standalone re-consent (no path): does not touch onboarding state', () => {
+    Onboarding.acceptTerms();
 
-    const updatePayload = mockedUpdate.mock.calls[0][1] as Record<
-      string,
-      unknown
-    >;
+    const [command, params, onyxData] = firstWriteCall();
+    expect(command).toBe(WRITE_COMMANDS.ACCEPT_TERMS);
+    expect(params).toEqual({});
+
+    const userUpdate = optimisticFor(
+      onyxData.optimisticData,
+      ONYXKEYS.USER_DATA_LIST,
+    );
+    const userEntry = (
+      userUpdate?.value as Record<string, Record<string, unknown>>
+    )[TEST_UID];
+    expect('onboarding' in userEntry).toBe(false);
     expect(
-      DBPATHS.USERS_USER_ID_ONBOARDING_LAST_VISITED_PATH.getRoute(TEST_UID) in
-        updatePayload,
-    ).toBe(false);
-
-    expect(onyxKeysCalled()).not.toContain(ONYXKEYS.NVP_ONBOARDING);
-    expect(onyxKeysCalled()).toEqual(
-      expect.arrayContaining([
-        ONYXKEYS.USER_DATA_LIST,
+      optimisticFor(onyxData.optimisticData, ONYXKEYS.NVP_ONBOARDING),
+    ).toBeUndefined();
+    expect(
+      optimisticFor(
+        onyxData.optimisticData,
         ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION,
-      ]),
-    );
+      ),
+    ).toBeDefined();
   });
 
-  test('rejects when user is null', async () => {
-    await expect(Onboarding.acceptTerms(TEST_DB, null)).rejects.toThrow(
-      'common.error.userNull',
-    );
-    expect(mockedUpdate).not.toHaveBeenCalled();
+  test('no-op when signed out', () => {
+    mockedGetFirebaseAuth.mockReturnValue({
+      currentUser: null,
+    } as ReturnType<typeof getFirebaseAuth>);
+
+    Onboarding.acceptTerms(ROUTES.ONBOARDING_TERMS);
+
+    expect(mockedWrite).not.toHaveBeenCalled();
   });
 });
 
 describe('setDisplayName', () => {
-  test('delegates to setUsername and writes last_visited_path', async () => {
+  test('delegates to setUsername (still Firebase) and writes last_visited_path via kiroku-api', async () => {
     await Onboarding.setDisplayName(TEST_DB, TEST_USER, 'old', 'new');
 
     expect(mockedSetUsername).toHaveBeenCalledWith(
@@ -151,83 +174,93 @@ describe('setDisplayName', () => {
       'new',
     );
 
-    const updatePayload = mockedUpdate.mock.calls[0][1] as Record<
-      string,
-      unknown
-    >;
-    expect(
-      updatePayload[
-        DBPATHS.USERS_USER_ID_ONBOARDING_LAST_VISITED_PATH.getRoute(TEST_UID)
-      ],
-    ).toBe(ROUTES.ONBOARDING_DISPLAY_NAME);
+    expect(mockedWrite).toHaveBeenCalledTimes(1);
+    const [command, params, onyxData] = firstWriteCall();
+    expect(command).toBe(WRITE_COMMANDS.SET_ONBOARDING_LAST_VISITED_PATH);
+    expect(params).toEqual({path: ROUTES.ONBOARDING_DISPLAY_NAME});
 
-    expect(onyxKeysCalled()).toEqual(
-      expect.arrayContaining([
-        ONYXKEYS.USER_DATA_LIST,
-        ONYXKEYS.NVP_ONBOARDING,
-      ]),
+    expect(
+      optimisticFor(onyxData.optimisticData, ONYXKEYS.NVP_ONBOARDING)?.value,
+    ).toEqual({last_visited_path: ROUTES.ONBOARDING_DISPLAY_NAME});
+    const userUpdate = optimisticFor(
+      onyxData.optimisticData,
+      ONYXKEYS.USER_DATA_LIST,
     );
+    expect(userUpdate?.value).toEqual({
+      [TEST_UID]: {
+        onboarding: {last_visited_path: ROUTES.ONBOARDING_DISPLAY_NAME},
+      },
+    });
   });
 
-  test('rejects when user is null', async () => {
+  test('rejects when user is null and never writes', async () => {
     await expect(
       Onboarding.setDisplayName(TEST_DB, null, 'old', 'new'),
     ).rejects.toThrow('common.error.userNull');
     expect(mockedSetUsername).not.toHaveBeenCalled();
+    expect(mockedWrite).not.toHaveBeenCalled();
   });
 });
 
 describe('completeOnboarding', () => {
-  test('merges Onyx before firing the Firebase set, and does not await the write', async () => {
+  test('applies the optimistic Onyx merge BEFORE firing the server write', async () => {
     const callOrder: string[] = [];
     mockedMerge.mockImplementation(() => {
       callOrder.push('onyx');
       return Promise.resolve();
     });
-    mockedSet.mockImplementation(() => {
-      callOrder.push('firebase');
-      return Promise.resolve();
+    mockedWrite.mockImplementation(() => {
+      callOrder.push('api');
     });
 
-    await Onboarding.completeOnboarding(TEST_DB, TEST_USER);
+    await Onboarding.completeOnboarding();
 
-    expect(callOrder[0]).toBe('onyx');
-    expect(callOrder).toContain('firebase');
+    // Both completion merges must precede the write so `shouldFireOnboarding`
+    // flips before the caller's dismissal pop (OnboardingGuard race).
+    expect(callOrder).toEqual(['onyx', 'onyx', 'api']);
 
-    const completedAtPath =
-      DBPATHS.USERS_USER_ID_ONBOARDING_COMPLETED_AT.getRoute(TEST_UID);
-    expect(mockedRef).toHaveBeenCalledWith(TEST_DB, completedAtPath);
-
-    expect(onyxKeysCalled()).toEqual(
+    const mergedKeys = mockedMerge.mock.calls.map(call => call[0]);
+    expect(mergedKeys).toEqual(
       expect.arrayContaining([
         ONYXKEYS.NVP_ONBOARDING,
         ONYXKEYS.USER_DATA_LIST,
       ]),
     );
+
+    const [command, params] = firstWriteCall();
+    expect(command).toBe(WRITE_COMMANDS.COMPLETE_ONBOARDING);
+    expect(params).toEqual({});
   });
 
-  test('swallows a rejecting Firebase write via Log.warn', async () => {
-    mockedSet.mockReturnValueOnce(Promise.reject(new Error('offline')));
+  test('no-op when signed out', async () => {
+    mockedGetFirebaseAuth.mockReturnValue({
+      currentUser: null,
+    } as ReturnType<typeof getFirebaseAuth>);
 
-    await expect(
-      Onboarding.completeOnboarding(TEST_DB, TEST_USER),
-    ).resolves.toBeUndefined();
+    await Onboarding.completeOnboarding();
 
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mockedLogWarn).toHaveBeenCalledTimes(1);
-    const [msg, payload] = mockedLogWarn.mock.calls[0];
-    expect(msg).toContain('[Onboarding]');
-    expect(payload).toBeDefined();
-    expect((payload as {error: unknown}).error).toBeInstanceOf(Error);
-  });
-
-  test('rejects when user is null', async () => {
-    await expect(Onboarding.completeOnboarding(TEST_DB, null)).rejects.toThrow(
-      'common.error.userNull',
-    );
     expect(mockedMerge).not.toHaveBeenCalled();
-    expect(mockedSet).not.toHaveBeenCalled();
+    expect(mockedWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('setLastVisitedPath', () => {
+  test('writes the path via kiroku-api with mirrored optimistic data', () => {
+    Onboarding.setLastVisitedPath(ROUTES.ONBOARDING_TERMS);
+
+    expect(mockedWrite).toHaveBeenCalledTimes(1);
+    const [command, params] = firstWriteCall();
+    expect(command).toBe(WRITE_COMMANDS.SET_ONBOARDING_LAST_VISITED_PATH);
+    expect(params).toEqual({path: ROUTES.ONBOARDING_TERMS});
+  });
+
+  test('no-op when signed out', () => {
+    mockedGetFirebaseAuth.mockReturnValue({
+      currentUser: null,
+    } as ReturnType<typeof getFirebaseAuth>);
+
+    Onboarding.setLastVisitedPath(ROUTES.ONBOARDING_TERMS);
+
+    expect(mockedWrite).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/actions/Onboarding.test.ts
+++ b/__tests__/actions/Onboarding.test.ts
@@ -4,6 +4,8 @@
 
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 /* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-in-views -- this test mocks and asserts the API.write calls the Onboarding action makes */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this test asserts that completeOnboarding calls Onyx.merge with the expected payload */
 
 import type {OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -124,6 +124,18 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/status/sync',
   },
+  [WRITE_COMMANDS.ACCEPT_TERMS]: {
+    method: 'post',
+    path: '/v1/onboarding/accept-terms',
+  },
+  [WRITE_COMMANDS.COMPLETE_ONBOARDING]: {
+    method: 'post',
+    path: '/v1/onboarding/complete',
+  },
+  [WRITE_COMMANDS.SET_ONBOARDING_LAST_VISITED_PATH]: {
+    method: 'post',
+    path: '/v1/onboarding/last-visited-path',
+  },
 };
 
 /** Returns the kiroku-api route for a command, or undefined for legacy commands. */

--- a/src/libs/API/parameters/AcceptTermsParams.ts
+++ b/src/libs/API/parameters/AcceptTermsParams.ts
@@ -1,0 +1,10 @@
+/**
+ * Body for `POST /v1/onboarding/accept-terms`. The server decides the accepted
+ * terms version, so the client never sends one — only the optional onboarding
+ * resume path (present when acceptance happens inside the onboarding flow).
+ */
+type AcceptTermsParams = {
+  onboardingPath?: string;
+};
+
+export default AcceptTermsParams;

--- a/src/libs/API/parameters/SetOnboardingLastVisitedPathParams.ts
+++ b/src/libs/API/parameters/SetOnboardingLastVisitedPathParams.ts
@@ -1,0 +1,9 @@
+/**
+ * Body for `POST /v1/onboarding/last-visited-path`. Records the onboarding
+ * resume point so a user who drops out mid-flow returns where they left off.
+ */
+type SetOnboardingLastVisitedPathParams = {
+  path: string;
+};
+
+export default SetOnboardingLastVisitedPathParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -31,4 +31,6 @@ export type {default as RemoveFeedbackParams} from './RemoveFeedbackParams';
 export type {default as RemoveBugParams} from './RemoveBugParams';
 export type {default as UpdateProfilePhotoParams} from './UpdateProfilePhotoParams';
 export type {default as SyncUserStatusParams} from './SyncUserStatusParams';
+export type {default as AcceptTermsParams} from './AcceptTermsParams';
+export type {default as SetOnboardingLastVisitedPathParams} from './SetOnboardingLastVisitedPathParams';
 // export type {default as UpdateUserAvatarParams} from './UpdateUserAvatarParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -47,6 +47,9 @@ const WRITE_COMMANDS = {
   REMOVE_BUG: 'RemoveBug',
   UPDATE_PROFILE_PHOTO: 'UpdateProfilePhoto',
   SYNC_USER_STATUS: 'SyncUserStatus',
+  ACCEPT_TERMS: 'AcceptTerms',
+  COMPLETE_ONBOARDING: 'CompleteOnboarding',
+  SET_ONBOARDING_LAST_VISITED_PATH: 'SetOnboardingLastVisitedPath',
   // ...
 } as const;
 
@@ -93,6 +96,9 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.REMOVE_BUG]: Parameters.RemoveBugParams;
   [WRITE_COMMANDS.UPDATE_PROFILE_PHOTO]: Parameters.UpdateProfilePhotoParams;
   [WRITE_COMMANDS.SYNC_USER_STATUS]: Parameters.SyncUserStatusParams;
+  [WRITE_COMMANDS.ACCEPT_TERMS]: Parameters.AcceptTermsParams;
+  [WRITE_COMMANDS.COMPLETE_ONBOARDING]: EmptyObject;
+  [WRITE_COMMANDS.SET_ONBOARDING_LAST_VISITED_PATH]: Parameters.SetOnboardingLastVisitedPathParams;
 };
 
 const READ_COMMANDS = {

--- a/src/libs/Navigation/guards/TermsReConsentGuard.tsx
+++ b/src/libs/Navigation/guards/TermsReConsentGuard.tsx
@@ -22,7 +22,7 @@ import {View} from 'react-native';
  * post-onboarding re-consent stay independent flows.
  */
 function TermsReConsentGuard() {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
   const {config} = useConfig();
   // `useCurrentUserData` returns {} (truthy) while loading; the selectors below
@@ -43,9 +43,9 @@ function TermsReConsentGuard() {
     return !hasAcceptedCurrentTerms(userData, config);
   }, [auth?.currentUser, userData, config]);
 
-  const handleAccept = useCallback(async () => {
-    await Onboarding.acceptTerms(db, auth.currentUser);
-  }, [auth, db]);
+  const handleAccept = useCallback(() => {
+    Onboarding.acceptTerms();
+  }, []);
 
   if (!shouldPrompt) {
     return null;

--- a/src/libs/actions/Onboarding/index.ts
+++ b/src/libs/actions/Onboarding/index.ts
@@ -1,78 +1,120 @@
 import type {Database} from 'firebase/database';
-import {ref, set, update} from 'firebase/database';
 import type {User} from 'firebase/auth';
 import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import * as Localize from '@libs/Localize';
-import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
 import {setUsername} from '@userActions/User';
 import CONST from '@src/CONST';
-import DBPATHS from '@src/DBPATHS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 
 /**
- * Persist a user's acceptance of the current Terms & Conditions.
+ * Onboarding writes, cut over from direct Firebase RTDB writes to kiroku-api
+ * `API.write` calls (#778). Authority is server-side (the caller's Firebase ID
+ * token), so the uid is used only for the optimistic Onyx update, which mirrors
+ * each server route's `onyxData` to keep the inline/pushed response idempotent.
  *
- * Writes `agreed_to_terms_at`, `agreed_to_terms_version`, and (when a
- * resume path is supplied) `onboarding.last_visited_path` to Firebase, then
- * mirrors the same values into Onyx so the UI updates without waiting for
- * the server round-trip.
- *
- * @param onboardingPath When acceptance happens inside the onboarding flow,
- *  pass the route to record as the resume point. Omit for standalone
- *  re-consent so onboarding state is not mutated for users who have
- *  already finished onboarding.
+ * `setDisplayName` still wraps {@link setUsername}, which has no server endpoint
+ * yet and remains a direct Firebase write — a separate chip cuts it over.
  */
-async function acceptTerms(
-  db: Database,
-  user: User | null,
-  onboardingPath?: string,
-): Promise<void> {
-  if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
-  }
 
-  const userID = user.uid;
-  const now = Date.now();
-  const version = CONST.CURRENT_TERMS_VERSION;
-
-  const updates: Record<string, number | string> = {};
-  updates[DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_AT.getRoute(userID)] = now;
-  updates[DBPATHS.USERS_USER_ID_AGREED_TO_TERMS_VERSION.getRoute(userID)] =
-    version;
-  if (onboardingPath !== undefined) {
-    updates[
-      DBPATHS.USERS_USER_ID_ONBOARDING_LAST_VISITED_PATH.getRoute(userID)
-    ] = onboardingPath;
-  }
-
-  await update(ref(db), updates);
-
-  await Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-    [userID]: {
-      agreed_to_terms_at: now,
-      agreed_to_terms_version: version,
-      ...(onboardingPath !== undefined && {
-        onboarding: {last_visited_path: onboardingPath},
-      }),
-    },
-  });
-  await Onyx.merge(ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION, version);
-  if (onboardingPath !== undefined) {
-    await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {
-      last_visited_path: onboardingPath,
-    });
-  }
+function getCurrentUserID(): string | undefined {
+  return getFirebaseAuth().currentUser?.uid ?? undefined;
 }
 
 /**
- * Persist the display name chosen during the onboarding flow.
+ * Persist the onboarding resume point via `POST /v1/onboarding/last-visited-path`.
+ * Optimistic data mirrors the route's `onyxData`. No-op when signed out.
+ */
+function writeLastVisitedPath(path: string, uid: string | undefined): void {
+  if (!uid) {
+    return;
+  }
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.NVP_ONBOARDING,
+      value: {last_visited_path: path},
+    },
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {[uid]: {onboarding: {last_visited_path: path}}},
+    },
+  ];
+  API.write(
+    WRITE_COMMANDS.SET_ONBOARDING_LAST_VISITED_PATH,
+    {path},
+    {optimisticData},
+  );
+}
+
+/**
+ * Record acceptance of the current Terms & Conditions via
+ * `POST /v1/onboarding/accept-terms`.
  *
- * Wraps {@link setUsername} (which atomically writes the new
+ * The server decides the accepted version, so the client never sends one; the
+ * locally known `CURRENT_TERMS_VERSION` is used purely for the optimistic echo
+ * (the server's response is authoritative). Optimistic data mirrors the route's
+ * `onyxData`.
+ *
+ * @param onboardingPath When acceptance happens inside the onboarding flow, the
+ *  route to record as the resume point. Omit for standalone re-consent so
+ *  onboarding state is not mutated for users who have already finished.
+ */
+function acceptTerms(onboardingPath?: string): void {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  const now = Date.now();
+  const version = CONST.CURRENT_TERMS_VERSION;
+  const hasPath = onboardingPath !== undefined;
+
+  const userEntry: Record<string, unknown> = {
+    agreed_to_terms_at: now,
+    agreed_to_terms_version: version,
+  };
+  if (hasPath) {
+    userEntry.onboarding = {last_visited_path: onboardingPath};
+  }
+
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {[uid]: userEntry},
+    },
+    {
+      onyxMethod: Onyx.METHOD.SET,
+      key: ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION,
+      value: version,
+    },
+  ];
+  if (hasPath) {
+    optimisticData.push({
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.NVP_ONBOARDING,
+      value: {last_visited_path: onboardingPath},
+    });
+  }
+
+  API.write(WRITE_COMMANDS.ACCEPT_TERMS, hasPath ? {onboardingPath} : {}, {
+    optimisticData,
+  });
+}
+
+/**
+ * Persist the display name chosen during onboarding.
+ *
+ * Wraps {@link setUsername} (still a direct Firebase write — atomically writes
  * `profile.display_name`, flips `profile.username_chosen`, and updates the
  * nickname index + Firebase auth profile) and additionally records the
- * onboarding resume path so the flow can be picked up where it left off.
+ * onboarding resume path via kiroku-api so the flow resumes where it left off.
  */
 async function setDisplayName(
   db: Database,
@@ -86,53 +128,31 @@ async function setDisplayName(
 
   await setUsername(db, user, currentDisplayName, newDisplayName);
 
-  const userID = user.uid;
-  const path = ROUTES.ONBOARDING_DISPLAY_NAME;
-  const updates: Record<string, string> = {};
-  updates[DBPATHS.USERS_USER_ID_ONBOARDING_LAST_VISITED_PATH.getRoute(userID)] =
-    path;
-
-  await update(ref(db), updates);
-
-  await Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-    [userID]: {
-      onboarding: {last_visited_path: path},
-    },
-  });
-  await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {last_visited_path: path});
+  writeLastVisitedPath(ROUTES.ONBOARDING_DISPLAY_NAME, user.uid);
 }
 
 /**
- * Mark the onboarding flow complete for the given user.
+ * Mark the onboarding flow complete via `POST /v1/onboarding/complete`.
  *
- * Performs the Onyx merge first so `shouldFireOnboarding` flips to false
- * before any subsequent navigation — this lets `OnboardingGuard`
- * deactivate before the dismissal pop, preventing it from re-routing the
- * user back into onboarding. The Firebase write is fired without `await`
- * — Firebase RTDB queues offline writes and replays them on reconnect, so
- * blocking the caller would defeat the optimistic guarantee.
+ * The optimistic completion merge is applied and awaited BEFORE the server
+ * write so `shouldFireOnboarding` flips to false before the caller's dismissal
+ * pop — otherwise `OnboardingGuard` races the dismissal and re-routes the user
+ * back into onboarding. Awaiting guarantees the flip has propagated, so this
+ * cannot use `API.write`'s fire-and-forget optimistic update.
  */
-async function completeOnboarding(
-  db: Database,
-  user: User | null,
-): Promise<void> {
-  if (!user) {
-    throw new Error(Localize.translateLocal('common.error.userNull'));
+async function completeOnboarding(): Promise<void> {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
   }
-
-  const userID = user.uid;
   const now = Date.now();
 
   await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {completed_at: now});
   await Onyx.merge(ONYXKEYS.USER_DATA_LIST, {
-    [userID]: {onboarding: {completed_at: now}},
+    [uid]: {onboarding: {completed_at: now}},
   });
 
-  const completedAtPath =
-    DBPATHS.USERS_USER_ID_ONBOARDING_COMPLETED_AT.getRoute(userID);
-  set(ref(db, completedAtPath), now).catch(error => {
-    Log.warn('[Onboarding] Failed to persist onboarding completion', {error});
-  });
+  API.write(WRITE_COMMANDS.COMPLETE_ONBOARDING, {});
 }
 
 /**
@@ -156,9 +176,7 @@ function navigateAfterOnboarding(): void {
 }
 
 function setLastVisitedPath(path: string): void {
-  Log.info(
-    `[Onboarding] setLastVisitedPath stub — not yet implemented (path="${path}")`,
-  );
+  writeLastVisitedPath(path, getCurrentUserID());
 }
 
 export {

--- a/src/screens/Onboarding/DisplayNameScreen.tsx
+++ b/src/screens/Onboarding/DisplayNameScreen.tsx
@@ -53,7 +53,7 @@ function DisplayNameScreen({}: DisplayNameScreenProps) {
           currentDisplayName,
           values.username,
         );
-        await Onboarding.completeOnboarding(db, auth.currentUser);
+        await Onboarding.completeOnboarding();
         Onboarding.navigateAfterOnboarding();
       } catch (error) {
         const appError = ErrorUtils.getAppError(undefined, error);

--- a/src/screens/Onboarding/TermsScreen.tsx
+++ b/src/screens/Onboarding/TermsScreen.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback} from 'react';
 import OnboardingScreenLayout from '@components/OnboardingScreenLayout';
 import TermsScreenContent from '@components/TermsScreenContent';
-import {useFirebase} from '@context/global/FirebaseContext';
 import useLocalize from '@hooks/useLocalize';
 import type {OnboardingModalNavigatorParamList} from '@libs/Navigation/types';
 import * as Onboarding from '@userActions/Onboarding';
@@ -15,7 +14,6 @@ type TermsScreenProps = StackScreenProps<
 >;
 
 function TermsScreen({navigation}: TermsScreenProps) {
-  const {auth, db} = useFirebase();
   const {translate} = useLocalize();
 
   // Navigate within the OnboardingModalNavigator's inner stack instead of
@@ -23,10 +21,10 @@ function TermsScreen({navigation}: TermsScreenProps) {
   // `linkTo`, which dispatches PUSH on the root stack and would append a
   // duplicate `ONBOARDING_MODAL_NAVIGATOR` entry — `dismissModal()` only pops
   // one, exposing the duplicate Terms screen below.
-  const handleAccept = useCallback(async () => {
-    await Onboarding.acceptTerms(db, auth.currentUser, ROUTES.ONBOARDING_TERMS);
+  const handleAccept = useCallback(() => {
+    Onboarding.acceptTerms(ROUTES.ONBOARDING_TERMS);
     navigation.navigate(SCREENS.ONBOARDING.DISPLAY_NAME);
-  }, [auth, db, navigation]);
+  }, [navigation]);
 
   return (
     <OnboardingScreenLayout


### PR DESCRIPTION
## Summary

Cuts the **onboarding writes** off direct Firebase RTDB onto the offline-first `API.write` pattern against kiroku-api (write epic #778). Server endpoints already exist under `/v1/onboarding/*`.

Migrated writes in `src/libs/actions/Onboarding/index.ts`:

- **`acceptTerms`** → `POST /v1/onboarding/accept-terms`. The server decides the terms version, so the client no longer sends `CONST.CURRENT_TERMS_VERSION` (it's still used locally for the optimistic echo). Optimistic data mirrors the route's `onyxData` (`USER_DATA_LIST[uid].agreed_to_terms_*` + optional `onboarding.last_visited_path`, `NVP_TERMS_ACCEPTED_VERSION`, `NVP_ONBOARDING`).
- **`completeOnboarding`** → `POST /v1/onboarding/complete`. Keeps its **awaited** optimistic `Onyx.merge` of `NVP_ONBOARDING.completed_at` + `USER_DATA_LIST` _before_ the server write, preserving the documented `OnboardingGuard` race fix (`shouldFireOnboarding` must flip before the dismissal pop). This is why it can't use `API.write`'s fire-and-forget optimistic update.
- **last-visited-path write** (inside `setDisplayName`, plus the `setLastVisitedPath` stub) → `POST /v1/onboarding/last-visited-path`.

`setUsername` is **intentionally left as a direct Firebase write** — it has no server endpoint yet; a separate chip cuts it over. `setDisplayName` therefore keeps its `db`/`user` args.

Shared infra touched (append-only): `WRITE_COMMANDS` + `WriteCommandParameters` in `API/types.ts`, two new param files + `parameters/index.ts`, and three `post` routes in `kirokuRoutes.ts`.

Call sites updated to the new signatures + fire-and-forget (`TermsScreen`, `DisplayNameScreen`, `TermsReConsentGuard`); no new `try/finally` in React-Compiler-compiled components.

## Test plan

- [x] `__tests__/actions/Onboarding.test.ts` rewritten for `API.write` — 9/9 pass
- [x] `npm run react-compiler-compliance-check check-changed`
- [x] `npm run typecheck-tsgo`
- [x] `npm run lint-changed`
- [x] `npx prettier --write` (clean)
- [x] Device verification of the onboarding flow (terms → display name → complete) before merge

Refs #778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)