### PR TITLE
fix(#810): pusher window guard + API.write optimistic/return-promise (align upstream)

### DIFF
--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -2,9 +2,11 @@ import type {OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import Log from '@libs/Log';
 import * as Middleware from '@libs/Middleware';
+import * as NetworkStore from '@libs/Network/NetworkStore';
 import * as SequentialQueue from '@libs/Network/SequentialQueue';
 import * as Pusher from '@libs/Pusher/pusher';
 import * as Request from '@libs/Request';
+import * as PersistedRequests from '@userActions/PersistedRequests';
 import CONST from '@src/CONST';
 import type OnyxRequest from '@src/types/onyx/Request';
 import type {RequestConflictResolver} from '@src/types/onyx/Request';
@@ -37,6 +39,11 @@ Request.use(Middleware.Reauthentication);
 // middlewares after this, because the SequentialQueue depends on the result of this middleware to pause the queue (if needed) to bring the app to an up-to-date state.
 Request.use(Middleware.SaveResponseInOnyx);
 
+// Use timestamp-based IDs to avoid collisions between browser tabs.
+// Each tab has its own JS context with its own counter, so a simple
+// incrementing number would collide across tabs.
+let requestIndex = Date.now();
+
 type OnyxData = {
   optimisticData?: OnyxUpdate[];
   successData?: OnyxUpdate[];
@@ -64,12 +71,24 @@ function write<TCommand extends WriteCommand>(
   apiCommandParameters: ApiRequestCommandParameters[TCommand],
   onyxData: OnyxData = {},
   conflictResolver: RequestConflictResolver = {},
-) {
+): Promise<void> {
   Log.info('Called API write', false, {command, ...apiCommandParameters});
+
+  // When a conflict resolver decides this request is a no-op against the queue (e.g. it cancels
+  // out a previously queued request), we must NOT apply its optimistic data: there is no request
+  // that will later reconcile it, so the optimistic update would never be cleared.
+  let shouldApplyOptimisticData = true;
+  if (conflictResolver.checkAndFixConflictingRequest) {
+    const {conflictAction} = conflictResolver.checkAndFixConflictingRequest(
+      PersistedRequests.getAll(),
+    );
+    shouldApplyOptimisticData = conflictAction.type !== 'noAction';
+  }
+
   const {optimisticData, ...onyxDataWithoutOptimisticData} = onyxData;
 
   // Optimistically update Onyx
-  if (optimisticData) {
+  if (optimisticData && shouldApplyOptimisticData) {
     Onyx.update(optimisticData);
   }
 
@@ -94,12 +113,14 @@ function write<TCommand extends WriteCommand>(
       shouldRetry: true,
       canCancel: true,
     },
+    initiatedOffline: NetworkStore.isOffline(),
+    requestID: requestIndex++,
     ...onyxDataWithoutOptimisticData,
     ...conflictResolver,
   };
 
   // Write commands can be saved and retried, so push it to the SequentialQueue
-  SequentialQueue.push(request);
+  return SequentialQueue.push(request);
 }
 
 /**
@@ -154,6 +175,8 @@ function makeRequestWithSideEffects<
   const request: OnyxRequest = {
     command,
     data,
+    initiatedOffline: NetworkStore.isOffline(),
+    requestID: requestIndex++,
     ...onyxDataWithoutOptimisticData,
   };
 

--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -262,7 +262,7 @@ function handleConflictActions(
   }
 }
 
-function push(newRequest: OnyxRequest) {
+function push(newRequest: OnyxRequest): Promise<void> {
   const {checkAndFixConflictingRequest} = newRequest;
 
   if (checkAndFixConflictingRequest) {
@@ -281,18 +281,20 @@ function push(newRequest: OnyxRequest) {
     PersistedRequests.save(newRequest);
   }
 
+  // The request is persisted synchronously above, so the returned promise can resolve immediately.
   // If we are offline we don't need to trigger the queue to empty as it will happen when we come back online
   if (NetworkStore.isOffline()) {
-    return;
+    return Promise.resolve();
   }
 
   // If the queue is running this request will run once it has finished processing the current batch
   if (isSequentialQueueRunning) {
     isReadyPromise.then(flush);
-    return;
+    return Promise.resolve();
   }
 
   flush();
+  return Promise.resolve();
 }
 
 function getCurrentRequest(): Promise<void> {

--- a/src/libs/Pusher/pusher.ts
+++ b/src/libs/Pusher/pusher.ts
@@ -408,7 +408,7 @@ function getPusherSocketID(): string {
     return pusherSocketID;
 }
 
-if (window) {
+if (typeof window !== 'undefined') {
     /**
      * Pusher socket for debugging purposes
      */

--- a/src/types/onyx/Request.ts
+++ b/src/types/onyx/Request.ts
@@ -53,6 +53,16 @@ type RequestData = {
 
   /** Whether the app should skip the web proxy to connect to API endpoints */
   shouldSkipWebProxy?: boolean;
+
+  /**
+   * Whether the request is initiated offline.
+   *
+   * This field is used to indicate if the app initiates the request while offline.
+   */
+  initiatedOffline?: boolean;
+
+  /** The unique ID of the request */
+  requestID?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

Two confirmed infra-hardening fixes from epic #810 (surfaced by an Expensify-parity audit). For shared plumbing this matches Expensify upstream (`/Users/petr/code/Expensify`) rather than inventing local behavior.

### Fix 1 — Pusher `window` guard (`src/libs/Pusher/pusher.ts`)
`if (window) { ... }` referenced a bare `window` identifier in shared native+web code, which throws a `ReferenceError` in any context where `window` is undeclared. Guarded with `if (typeof window !== 'undefined')`.

> **Upstream note / decision flag:** Upstream split this into `src/libs/Pusher/index.ts` + `index.native.ts`, and both still use the bare `if (window)` form (RN polyfills `window`, so it doesn't throw at runtime there). Kiroku keeps a single shared `pusher.ts`. I applied the strictly-safer `typeof` guard as explicitly requested — a deliberate hardening over the literal upstream text, not a behavioral divergence (identical truthiness on web/native, additionally safe when `window` is undeclared, e.g. node/test). If you'd prefer literal upstream parity (`if (window)`), say so and I'll switch it.

### Fix 2 — `API.write` optimistic data + return promise + request stamps (`src/libs/API/index.ts`)
Ported from upstream `prepareRequest` in `/Users/petr/code/Expensify/src/libs/API/index.ts`:
- **Skip optimistic data on a `noAction` conflict.** When a `conflictResolver.checkAndFixConflictingRequest` resolves to `noAction`, the request is dropped from the queue, so its optimistic update would never be reconciled. We now gate `Onyx.update(optimisticData)` on `shouldApplyOptimisticData`. (Kiroku's only current resolver, `resolveDuplicationConflictAction`, returns `push`/`replace` — never `noAction` — so this is forward-looking and behavior-preserving for existing callers.)
- **`write()` returns a `Promise<void>`** so callers may await it. Its only consumer, `SequentialQueue.push`, now returns `Promise<void>` (resolves once the request is synchronously persisted, matching upstream's persistence-promise semantics).
- **Stamp `requestID` / `initiatedOffline`** on the request (timestamp-seeded counter + `NetworkStore.isOffline()`), mirroring upstream. Applied to `makeRequestWithSideEffects` too, to keep the two request builders consistent.
- Added `requestID` / `initiatedOffline` to the `Request` type (`src/types/onyx/Request.ts`).

The conflict resolver is intentionally invoked in both `write()` (to decide the optimistic gate) and again in `SequentialQueue.push` (to act on it) — this double-call exactly mirrors upstream and is safe (`resolveDuplicationConflictAction` is pure). Kiroku's kiroku-api routing (`getKirokuRoute` in `HttpUtils`/`kirokuRoutes.ts`) is untouched.

### Out of scope (left for separate #810 investigations)
- `DeferredOnyxUpdates.process()` missing-`()` bug.
- Dead `MainQueue` / `NetworkStore.isSupportRequest` stubs (`MainQueue.process` is still referenced in `src/libs/Network/index.ts`, so not trivially dead).

## Upstream files matched
- `/Users/petr/code/Expensify/src/libs/API/index.ts` (`prepareRequest` / `processRequest`)
- `/Users/petr/code/Expensify/src/libs/Network/SequentialQueue.ts` (`push(): Promise<void>`)
- `/Users/petr/code/Expensify/src/types/onyx/Request.ts` (`requestID` / `initiatedOffline`)
- `/Users/petr/code/Expensify/src/libs/Pusher/index.ts` + `index.native.ts` (window guard — see note above)

## Test plan
- [x] `npm run typecheck-tsgo` — passes
- [x] `npm run lint-changed` — exit 0
- [x] `npm run react-compiler-compliance-check check-changed` — passes (4 files)
- [x] `npx prettier --write` on changed files — clean (`pusher.ts` keeps its grandfathered 4-space style; only the single guard line changed)
- [x] `__tests__/actions/DrinkingSession.test.ts` + `Onboarding.test.ts` — 19/19 pass (exercise `API.write` optimistic + conflict-resolver path)
- [ ] Not done: full simulator/device boot against live kiroku-api (out of reach in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)