### PR TITLE
refactor(realtime): cut provisioning + account-close writes to kiroku-api

### DIFF
--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -46,7 +46,7 @@ function useOnboardingFlow(): OnboardingFlowState {
     // Treat both `undefined` (listener not yet emitted) and `null` (RTDB node
     // missing — either pre-write during signup or post-delete during account
     // closure) as "not enough info, defer." Without this, account deletion
-    // briefly flashes the T&C screen: `deleteUserData` wipes the RTDB node
+    // briefly flashes the T&C screen: account closure wipes the RTDB node
     // before `signOut` runs, the listener emits `null`, and the onboarding
     // selectors interpret that as "needs onboarding" while the user is still
     // authenticated.

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -40,6 +40,14 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
       to: Number(data.updateIDTo ?? 0),
     }),
   },
+  [WRITE_COMMANDS.PROVISION_USER]: {
+    method: 'post',
+    path: '/v1/provisioning',
+  },
+  [WRITE_COMMANDS.CLOSE_ACCOUNT]: {
+    method: 'post',
+    path: '/v1/account/close',
+  },
   [WRITE_COMMANDS.SEND_FRIEND_REQUEST]: {
     method: 'post',
     path: '/v1/friends/request',

--- a/src/libs/API/parameters/CloseAccountParams.ts
+++ b/src/libs/API/parameters/CloseAccountParams.ts
@@ -1,3 +1,3 @@
-type CloseAccountParams = {message: string};
+type CloseAccountParams = {reasonForLeaving?: string};
 
 export default CloseAccountParams;

--- a/src/libs/API/parameters/ProvisionUserParams.ts
+++ b/src/libs/API/parameters/ProvisionUserParams.ts
@@ -1,0 +1,10 @@
+import type {Preferences, Profile} from '@src/types/onyx';
+import type {Timezone} from '@src/types/onyx/UserData';
+
+type ProvisionUserParams = {
+  profile: Profile;
+  timezone?: Timezone;
+  preferences?: Preferences;
+};
+
+export default ProvisionUserParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -1,3 +1,4 @@
+export type {default as ProvisionUserParams} from './ProvisionUserParams';
 export type {default as CloseAccountParams} from './CloseAccountParams';
 export type {default as SendFriendRequestParams} from './SendFriendRequestParams';
 export type {default as AcceptFriendRequestParams} from './AcceptFriendRequestParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -20,6 +20,7 @@ const WRITE_COMMANDS = {
   UPDATE_SELECTED_TIMEZONE: 'UpdateSelectedTimezone',
   // UPDATE_USER_AVATAR: 'UpdateUserAvatar',
   DELETE_USER_AVATAR: 'DeleteUserAvatar',
+  PROVISION_USER: 'ProvisionUser',
   CLOSE_ACCOUNT: 'CloseAccount',
   //   OPEN_PROFILE: 'OpenProfile',
   //   SIGN_IN_WITH_APPLE: 'SignInWithApple',
@@ -66,6 +67,7 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.UPDATE_SELECTED_TIMEZONE]: Parameters.UpdateSelectedTimezoneParams;
   // [WRITE_COMMANDS.UPDATE_USER_AVATAR]: Parameters.UpdateUserAvatarParams;
   [WRITE_COMMANDS.DELETE_USER_AVATAR]: EmptyObject;
+  [WRITE_COMMANDS.PROVISION_USER]: Parameters.ProvisionUserParams;
   [WRITE_COMMANDS.CLOSE_ACCOUNT]: Parameters.CloseAccountParams;
   //   [WRITE_COMMANDS.OPEN_PROFILE]: Parameters.OpenProfileParams;
   //   [WRITE_COMMANDS.SIGN_IN_WITH_APPLE]: Parameters.BeginAppleSignInParams;

--- a/src/libs/actions/CloseAccount.ts
+++ b/src/libs/actions/CloseAccount.ts
@@ -1,16 +1,12 @@
 import Onyx from 'react-native-onyx';
 import type {Auth} from 'firebase/auth';
 import {deleteUser, signOut} from 'firebase/auth';
-import type {Database} from 'firebase/database';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {UserData} from '@src/types/onyx';
 import * as Localize from '@libs/Localize';
-import {
-  deleteUserData,
-  reauthentificateUser,
-  reauthenticateWithOAuth,
-} from './User';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import {reauthentificateUser, reauthenticateWithOAuth} from './User';
 
 /**
  * Clear CloseAccount error message to hide modal
@@ -35,16 +31,14 @@ function setSuccessMessage(message: string) {
 }
 
 async function closeAccount(
-  db: Database | null,
   auth: Auth | null,
-  userData: UserData | undefined,
   reasonForLeaving: string,
   password: string,
   providerId: string,
 ) {
   const user = auth?.currentUser;
 
-  if (!db || !userData || !user) {
+  if (!auth || !user) {
     throw new Error('Missing data. Try reloading the page');
   }
 
@@ -62,15 +56,19 @@ async function closeAccount(
     }
   }
 
-  const userNickname = userData.profile.display_name;
-  await deleteUserData(
-    db,
-    user.uid,
-    userNickname,
-    userData.friends,
-    userData.friend_requests,
-    reasonForLeaving,
+  // kiroku-api owns the RTDB graph cleanup — the user's own subtrees, their
+  // removal from every friend's/requester's map, and the exit-survey reason —
+  // keyed off the caller's Firebase ID token. Awaited via
+  // makeRequestWithSideEffects so the Firebase Auth deletion below only runs
+  // after the server cleanup succeeds AND while the token is still valid (a
+  // deleted Auth user can no longer mint one). The server emits the
+  // state-clearing onyxData; an empty reason is omitted so none is recorded.
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  await API.makeRequestWithSideEffects(
+    WRITE_COMMANDS.CLOSE_ACCOUNT,
+    reasonForLeaving ? {reasonForLeaving} : {},
   );
+
   await deleteUser(user);
 
   // Updating the loading state here might cause some issues

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -3,17 +3,14 @@ import {update, ref, get} from 'firebase/database';
 import type {
   AppSettings,
   Config,
-  FriendRequestList,
   NicknameToId,
   OnyxUpdatesFromServer,
   PendingOAuthCredential,
   Preferences,
   Profile,
-  ReasonForLeaving,
-  ReasonForLeavingId,
   UserData,
 } from '@src/types/onyx';
-import type {Timestamp, UserID, UserList} from '@src/types/onyx/OnyxCommon';
+import type {Timestamp, UserID} from '@src/types/onyx/OnyxCommon';
 import type {Auth, AuthCredential, User, UserCredential} from 'firebase/auth';
 import {
   EmailAuthProvider,
@@ -34,7 +31,6 @@ import {getNicknameKeys} from '@libs/StringUtilsKiroku';
 import {getOAuthCredential} from '@libs/OAuthCredential';
 import DBPATHS from '@src/DBPATHS';
 import {readDataOnce} from '@database/baseFunctions';
-import type {FirebaseUpdates} from '@database/updates';
 import * as Localize from '@libs/Localize';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/UserData';
 import {validateAppVersion} from '@libs/Validation';
@@ -45,10 +41,10 @@ import CONST from '@src/CONST';
 import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import * as API from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import type Response from '@src/types/onyx/Response';
 import PusherUtils from '@libs/PusherUtils';
 import * as Pusher from '@libs/Pusher/pusher';
 import * as OnyxUpdates from '@userActions/OnyxUpdates';
-import {getReasonForLeavingID} from '@libs/ReasonForLeaving';
 import {PALETTES} from '@libs/SessionColorPalettes';
 import Log from '@libs/Log';
 import ERRORS from '@src/ERRORS';
@@ -97,10 +93,6 @@ const getDefaultUserData = (profileData: Profile): UserData => {
   };
 };
 
-const getDefaultUserStatus = (): {last_online: number} => ({
-  last_online: new Date().getTime(),
-});
-
 /**
  * Check if a user exists in the realtime database.
  *
@@ -118,100 +110,53 @@ async function userExistsInDatabase(
   return snapshot.exists();
 }
 
-/** In the database, create base info for a user. This will
- * be stored under the "users" object in the database.
+/**
+ * Provision a brand-new user's backing data via kiroku-api. Replaces the former
+ * direct RTDB write (`pushNewUserInfo`): the server owns the atomic creation of
+ * `users/$uid`, `user_status/$uid`, `user_preferences/$uid`, and the
+ * nickname-index tokens, keyed off the caller's Firebase ID token (so a new
+ * user can only provision their OWN record) and 409-guarded so a replay can
+ * never clobber an established account.
  *
- * @param db The firebase realtime database object
- * @param userID The user ID
+ * Routed through `makeRequestWithSideEffects` rather than the fire-and-forget
+ * `API.write` because the signup flow must observe success/failure to roll the
+ * Firebase Auth user back on failure. The optimistic Onyx update mirrors the
+ * server's `onyxData` so the post-auth routing gate can read the new user
+ * immediately.
+ *
+ * @param userID The new user's Firebase uid — used only for the optimistic update
  * @param profileData Profile data of the user to create
- * @returns
  */
-async function pushNewUserInfo(
-  db: Database,
+function provisionUser(
   userID: string,
   profileData: Profile,
-): Promise<void> {
-  const userNickname = profileData.display_name;
+): Promise<void | Response> {
+  const userData = getDefaultUserData(profileData);
+  const preferences = getDefaultPreferences();
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.USER_DATA_LIST,
+      value: {[userID]: userData},
+    },
+    {
+      onyxMethod: Onyx.METHOD.SET,
+      key: ONYXKEYS.PREFERENCES,
+      value: preferences,
+    },
+    {
+      onyxMethod: Onyx.METHOD.SET,
+      key: ONYXKEYS.PREFERRED_THEME,
+      value: preferences.theme ?? CONST.THEME.SYSTEM,
+    },
+  ];
 
-  const nicknameRef = DBPATHS.NICKNAME_TO_ID_NICKNAME_KEY_USER_ID;
-  const userStatusRef = DBPATHS.USER_STATUS_USER_ID;
-  const userPreferencesRef = DBPATHS.USER_PREFERENCES_USER_ID;
-  const userRef = DBPATHS.USERS_USER_ID;
-
-  const updates: FirebaseUpdates = {};
-  getNicknameKeys(userNickname).forEach(key => {
-    updates[nicknameRef.getRoute(key, userID)] = userNickname;
-  });
-  updates[userStatusRef.getRoute(userID)] = getDefaultUserStatus();
-  updates[userPreferencesRef.getRoute(userID)] = getDefaultPreferences();
-  updates[userRef.getRoute(userID)] = getDefaultUserData(profileData);
-
-  await update(ref(db), updates);
-}
-
-/** Delete all user info from the realtime database, including their
- * user information, drinking sessions, etc.
- *
- *
- * @param db The firebase database object;
- * @param userID The user ID
- * @param userNickname The user nickname
- * @param friends The user's friends
- * @param friendRequests The user's friend requests
- * @param reasonForLeaving The reason for leaving
- * @returns
- */
-async function deleteUserData(
-  db: Database,
-  userID: string,
-  userNickname: string,
-  friends: UserList | undefined,
-  friendRequests: FriendRequestList | undefined,
-  reasonForLeaving?: ReasonForLeaving,
-): Promise<void> {
-  const nicknameRef = DBPATHS.NICKNAME_TO_ID_NICKNAME_KEY_USER_ID;
-  const userStatusRef = DBPATHS.USER_STATUS_USER_ID;
-  const userPreferencesRef = DBPATHS.USER_PREFERENCES_USER_ID;
-  const userRef = DBPATHS.USERS_USER_ID;
-  const drinkingSessionsRef = DBPATHS.USER_DRINKING_SESSIONS_USER_ID;
-  const unconfirmedDaysRef = DBPATHS.USER_UNCONFIRMED_DAYS_USER_ID;
-  const dataVisibilityRef = DBPATHS.USER_DATA_VISIBILITY_USER_ID;
-  const sessionLocationsRef = DBPATHS.USER_SESSION_LOCATIONS_USER_ID;
-  const sessionPlaceholderRef = DBPATHS.USER_SESSION_PLACEHOLDER_USER_ID;
-  const friendsRef = DBPATHS.USERS_USER_ID_FRIENDS_FRIEND_ID;
-  const friendRequestsRef = DBPATHS.USERS_USER_ID_FRIEND_REQUESTS_REQUEST_ID;
-  const reasonForLeavingRef = DBPATHS.REASONS_FOR_LEAVING_REASON_ID;
-
-  const updates: Record<string, null | false | ReasonForLeaving> = {};
-  getNicknameKeys(userNickname).forEach(key => {
-    updates[nicknameRef.getRoute(key, userID)] = null;
-  });
-  updates[userStatusRef.getRoute(userID)] = null;
-  updates[userPreferencesRef.getRoute(userID)] = null;
-  updates[userRef.getRoute(userID)] = null;
-  updates[drinkingSessionsRef.getRoute(userID)] = null;
-  updates[unconfirmedDaysRef.getRoute(userID)] = null;
-  updates[dataVisibilityRef.getRoute(userID)] = null;
-  updates[sessionLocationsRef.getRoute(userID)] = null;
-  updates[sessionPlaceholderRef.getRoute(userID)] = null;
-
-  if (reasonForLeaving) {
-    const reasonID: ReasonForLeavingId = getReasonForLeavingID(userID);
-    updates[reasonForLeavingRef.getRoute(reasonID)] = reasonForLeaving;
-  }
-
-  // Data stored in other users' nodes
-  if (friends) {
-    Object.keys(friends).forEach(friendId => {
-      updates[friendsRef.getRoute(friendId, userID)] = null;
-    });
-  }
-  if (friendRequests) {
-    Object.keys(friendRequests).forEach(friendRequestId => {
-      updates[friendRequestsRef.getRoute(friendRequestId, userID)] = null;
-    });
-  }
-  await update(ref(db), updates);
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    WRITE_COMMANDS.PROVISION_USER,
+    {profile: profileData, timezone: userData.timezone, preferences},
+    {optimisticData},
+  );
 }
 
 /**
@@ -591,7 +536,7 @@ async function signInWithOAuth(
       photo_url: user.photoURL ?? '',
       username_chosen: false,
     };
-    await pushNewUserInfo(db, user.uid, profileData);
+    await provisionUser(user.uid, profileData);
     await updateProfile(user, {displayName: name});
   }
   Session.clearSignInData();
@@ -832,8 +777,9 @@ async function signUp(
   });
 
   try {
-    // Realtime Database updates
-    await pushNewUserInfo(db, newUserID, newProfileData);
+    // Provision the user's backing data server-side (kiroku-api owns the atomic
+    // RTDB creation). Awaited so a failure can roll the Auth user back below.
+    await provisionUser(newUserID, newProfileData);
 
     // Update Firebase authentication
     await updateProfile(newUser, {displayName: derivedName});
@@ -845,17 +791,15 @@ async function signUp(
     // lose (its useEffect runs after this synchronous nav, then its own
     // lastTargetRef debounce blocks any retry).
   } catch (error) {
-    // Attempt to rollback the changes if the 'transaction' fails
-    await deleteUserData(
-      db,
-      newUserID,
-      newProfileData.display_name,
-      undefined,
-      undefined,
-    );
-
-    // Delete the user from Firebase authentication
-    await newUser.delete();
+    // Provisioning is atomic + 409-guarded server-side, so a failure leaves no
+    // partial RTDB graph to clean up — only the just-created Firebase Auth user
+    // needs rolling back, which frees the claimed email for a retry. The delete
+    // is best-effort; surface the canonical creation-failed error regardless.
+    await newUser.delete().catch(deleteError => {
+      Log.alert('[signUp] failed to roll back Firebase Auth user', {
+        error: deleteError,
+      });
+    });
     throw new Error('database/user-creation-failed');
   }
 }
@@ -935,12 +879,9 @@ export {
   subscribeToConfigEvents,
   changeDisplayName,
   changeUserName,
-  deleteUserData,
   fetchUserNicknames,
   getDefaultPreferences,
   getDefaultUserData,
-  getDefaultUserStatus,
-  pushNewUserInfo,
   reauthentificateUser,
   reauthenticateWithOAuth,
   saveSelectedTimezone,

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -777,12 +777,15 @@ async function signUp(
   });
 
   try {
+    // Set the Auth profile display name BEFORE provisioning so the rollback
+    // path below is always orphan-free: the only RTDB write (provisionUser) is
+    // the last statement, so if anything in this block throws there is no
+    // half-created RTDB graph to clean up — deleting the Auth user suffices.
+    await updateProfile(newUser, {displayName: derivedName});
+
     // Provision the user's backing data server-side (kiroku-api owns the atomic
     // RTDB creation). Awaited so a failure can roll the Auth user back below.
     await provisionUser(newUserID, newProfileData);
-
-    // Update Firebase authentication
-    await updateProfile(newUser, {displayName: derivedName});
 
     Session.clearSignInData();
 

--- a/src/screens/Settings/DeleteAccountScreen.tsx
+++ b/src/screens/Settings/DeleteAccountScreen.tsx
@@ -23,8 +23,6 @@ import type SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/CloseAccountForm';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import {useFirebase} from '@context/global/FirebaseContext';
-import useCurrentUserData from '@hooks/useCurrentUserData';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import ERRORS from '@src/ERRORS';
 
 type DeleteAccountScreenProps = StackScreenProps<
@@ -36,11 +34,7 @@ type DeleteAccountScreenProps = StackScreenProps<
 function DeleteAccountScreen({route}: DeleteAccountScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
-  const currentUserData = useCurrentUserData();
-  // `useCurrentUserData` returns {} (truthy) while loading; closeAccount guards
-  // on `!userData` then dereferences `userData.profile`, so map empty → undefined.
-  const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
+  const {auth} = useFirebase();
 
   const currentUser = auth?.currentUser;
   const providerId =
@@ -69,9 +63,7 @@ function DeleteAccountScreen({route}: DeleteAccountScreenProps) {
         setLoadingText(translate('deleteAccountScreen.deletingAccount'));
         setIsLoading(true);
         await CloseAccount.closeAccount(
-          db,
           auth,
-          userData,
           reasonForLeaving,
           password,
           providerId,


### PR DESCRIPTION
## Summary

Migrates the two **user-lifecycle** RTDB writes off direct Firebase RTDB onto kiroku-api `API` calls (write epic #778). These are higher-risk than prior cutovers because they sit in the signup and account-deletion paths.

- **Provisioning** — `User.pushNewUserInfo` (direct `update(ref(db))` creating `users/$uid`, `user_status/$uid`, `user_preferences/$uid`, and the nickname index) → new `User.provisionUser` → `POST /v1/provisioning`. Callers `signUp` and `signInWithOAuth` updated.
- **Account-close** — `User.deleteUserData` (direct multi-subtree null + cross-user friend/requester map cleanup) → `POST /v1/account/close`. The server owns the social-graph cleanup keyed off the caller's Firebase ID token; `CloseAccount.closeAccount` now just calls the route.

### Why `makeRequestWithSideEffects` (not fire-and-forget `API.write`)
Both flows are sequenced against Firebase Auth and must observe success/failure, so they route through `makeRequestWithSideEffects` (with the standard `rulesdir/no-api-side-effects-method` disable, as in `App.ts`):
- **signUp** must know if provisioning failed to roll the just-created Auth user back.
- **closeAccount** must finish the server cleanup *before* `deleteUser()` invalidates the ID token (a deleted Auth user can no longer mint one).

### Firebase Auth stays client-side
`createUserWithEmailAndPassword` / `signInWithCredential` / `updateProfile` (create) and `deleteUser` + `signOut` (close) remain client-side, plus the client-side reauth before close. Only the RTDB writes moved server-side.

### signUp rollback handling
The old rollback called `deleteUserData(...)` (a second RTDB write) then deleted the Auth user. Server provisioning is **atomic + 409-guarded**, so a failure leaves **no partial RTDB graph** — the rollback now only deletes the Auth user (freeing the claimed email for a retry). `updateProfile` is ordered *before* `provisionUser` so the only RTDB write is the last statement in the `try`, making the rollback path always orphan-free. The OAuth path keeps its existing no-rollback behavior (a failed provision self-heals on the next sign-in via the `userExistsInDatabase` guard).

### Onyx
- Provisioning sends `{profile, timezone, preferences}` and mirrors the server `onyxData` (`userDataList` merge, `preferences`/`preferredTheme` set) as optimistic data.
- Account-close relies on the server's state-clearing `onyxData` (applied on success, before the awaited call resolves); an empty exit reason is omitted so none is recorded.

Also drops the now-dead `pushNewUserInfo`, `deleteUserData`, `getDefaultUserStatus` and their unused imports/`db` args, and updates a stale `deleteUserData` reference in a `useOnboardingFlow` comment.

## Test plan
- [x] `npm run typecheck-tsgo`
- [x] `npm run react-compiler-compliance-check check-changed`
- [x] `npx prettier --check` on changed files
- [x] `npm run lint-changed`
- [ ] **Device verification (merge gate, per #778):** email/password signup → record created, routed to username/onboarding; provisioning-failure path deletes the Auth user (email reusable); OAuth (Apple/Google) first sign-in provisions; account deletion removes the user + their entry from friends'/requesters' graphs and signs out.

> Merge-gated on device verification — please do not merge until the flows above are confirmed on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)