### PR TITLE
fix(test): repair master typecheck — API.write mock must return a promise

### DIFF
--- a/__tests__/actions/Onboarding.test.ts
+++ b/__tests__/actions/Onboarding.test.ts
@@ -213,6 +213,7 @@ describe('completeOnboarding', () => {
     });
     mockedWrite.mockImplementation(() => {
       callOrder.push('api');
+      return Promise.resolve();
     });
 
     await Onboarding.completeOnboarding();


### PR DESCRIPTION
## Problem

The **Process new code merged to master** workflow ([run 27012765426](https://github.com/PetrCala/Kiroku/actions/runs/27012765426)) failed on the `typecheck` job, which in turn failed `confirmPassingBuild` and blocked the staging/production deploy.

Root cause: commit bc03822f9 (*"fix(#810): pusher window guard + API.write optimistic/return-promise"*) changed `API.write` to return `Promise<void>` (it now returns the `SequentialQueue.push` promise so callers can await). But the `completeOnboarding` mock in `__tests__/actions/Onboarding.test.ts` still returned `void`:

```
__tests__/actions/Onboarding.test.ts(214,36): error TS2345:
Argument of type '() => void' is not assignable to parameter of type
'(command, params, onyxData?, conflictResolver?) => Promise<...>'.
  Type 'void' is not assignable to type 'Promise<void>'.
```

The commit that changed the signature didn't update this test mock.

## Fix

Return `Promise.resolve()` from the `mockedWrite` mock, mirroring the `mockedMerge` mock directly above it. One line.

This is a **type-level fix only** — the jest `test` jobs already passed in the failing run (they don't care about the mock's return value); only `typecheck` was red.

## Verification

- `npm run typecheck-tsgo` → 0 errors
- `npx jest __tests__/actions/Onboarding.test.ts` → 9/9 pass
- `prettier` → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)