### PR TITLE
refactor(onboarding): drop unused db arg from setDisplayName

### DIFF
--- a/__tests__/actions/Onboarding.test.ts
+++ b/__tests__/actions/Onboarding.test.ts
@@ -17,7 +17,6 @@ import * as Onboarding from '@libs/actions/Onboarding';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {Database} from 'firebase/database';
 import type {User} from 'firebase/auth';
 
 const TEST_UID = 'user-abc';
@@ -57,7 +56,6 @@ const mockedSetUsername = jest.mocked(UserActions.setUsername);
 const mockedGetFirebaseAuth = jest.mocked(getFirebaseAuth);
 
 const TEST_USER = {uid: TEST_UID} as User;
-const TEST_DB = {} as Database;
 
 type WriteCall = [
   string,
@@ -167,7 +165,7 @@ describe('acceptTerms', () => {
 
 describe('setDisplayName', () => {
   test('delegates to setUsername (now via kiroku-api) and writes last_visited_path via kiroku-api', async () => {
-    await Onboarding.setDisplayName(TEST_DB, TEST_USER, 'new');
+    await Onboarding.setDisplayName(TEST_USER, 'new');
 
     expect(mockedSetUsername).toHaveBeenCalledWith(TEST_USER, 'new');
 
@@ -191,9 +189,9 @@ describe('setDisplayName', () => {
   });
 
   test('rejects when user is null and never writes', async () => {
-    await expect(
-      Onboarding.setDisplayName(TEST_DB, null, 'new'),
-    ).rejects.toThrow('common.error.userNull');
+    await expect(Onboarding.setDisplayName(null, 'new')).rejects.toThrow(
+      'common.error.userNull',
+    );
     expect(mockedSetUsername).not.toHaveBeenCalled();
     expect(mockedWrite).not.toHaveBeenCalled();
   });

--- a/src/libs/actions/Onboarding/index.ts
+++ b/src/libs/actions/Onboarding/index.ts
@@ -1,4 +1,3 @@
-import type {Database} from 'firebase/database';
 import type {User} from 'firebase/auth';
 import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
@@ -118,11 +117,9 @@ function acceptTerms(onboardingPath?: string): void {
  * it left off.
  *
  * `setUsername` is fire-and-forget (optimistic API write), so it is not
- * awaited; only the resume-path write is awaited here. `db` is retained for
- * call-site compatibility and is no longer used (a follow-up can drop it).
+ * awaited; only the resume-path write is awaited here.
  */
 async function setDisplayName(
-  db: Database,
   user: User | null,
   newDisplayName: string,
 ): Promise<void> {

--- a/src/screens/Onboarding/DisplayNameScreen.tsx
+++ b/src/screens/Onboarding/DisplayNameScreen.tsx
@@ -31,7 +31,7 @@ type DisplayNameScreenProps = StackScreenProps<
 function DisplayNameScreen({}: DisplayNameScreenProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
-  const {db, auth} = useFirebase();
+  const {auth} = useFirebase();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const userData = useCurrentUserData();
   const currentDisplayName = userData?.profile?.display_name ?? '';
@@ -47,7 +47,7 @@ function DisplayNameScreen({}: DisplayNameScreenProps) {
       }
       setIsSaving(true);
       try {
-        await Onboarding.setDisplayName(db, auth.currentUser, values.username);
+        await Onboarding.setDisplayName(auth.currentUser, values.username);
         await Onboarding.completeOnboarding();
         Onboarding.navigateAfterOnboarding();
       } catch (error) {


### PR DESCRIPTION
## What

`Onboarding.setDisplayName` no longer uses its `db: Database` parameter. `setUsername` was cut over to kiroku-api (it's now `setUsername(user, newUsername)`) and the resume-path write goes through `writeLastVisitedPath(...)`, so the body only ever touches `user`. This removes the dead param.

## Changes

- **`src/libs/actions/Onboarding/index.ts`** — `setDisplayName(db, user, newDisplayName)` → `setDisplayName(user, newDisplayName)`. Removed the now-unused `import type {Database} from 'firebase/database'` and the stale JSDoc sentence noting `db` was retained for call-site compatibility.
- **`src/screens/Onboarding/DisplayNameScreen.tsx`** (sole caller) — updated the call site and dropped `db` from `const {db, auth} = useFirebase()` (now unused since `completeOnboarding()` takes no args). No new try/finally introduced (React Compiler).
- **`__tests__/actions/Onboarding.test.ts`** — updated the two `setDisplayName` calls and removed the now-unused `TEST_DB` declaration and `Database` import.

Pure cleanup follow-up to the `setUsername` kiroku-api cutover (#778). No behavior change.

## Gates

- ✅ `prettier --write`
- ✅ `react-compiler-compliance-check check-changed`
- ✅ `scripts/lint.sh` (scoped eslint)
- ✅ `typecheck-tsgo`
- ✅ `jest __tests__/actions/Onboarding.test.ts` (9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)