### PR TITLE
fix(session): pop the modal off the root so save/delete reach day overview

### DIFF
--- a/__tests__/unit/libs/popModalFlow.test.ts
+++ b/__tests__/unit/libs/popModalFlow.test.ts
@@ -54,7 +54,7 @@ function buildRootState(innerModalIndex: number): State {
       },
     ],
   };
-  return state as State;
+  return state;
 }
 
 describe('getPopModalFlowTarget', () => {
@@ -93,7 +93,7 @@ describe('getPopModalFlowTarget', () => {
       ],
     };
 
-    expect(getPopModalFlowTarget(state as State)).toBeUndefined();
+    expect(getPopModalFlowTarget(state)).toBeUndefined();
   });
 
   it('returns undefined when the modal navigator has no inner state', () => {
@@ -106,6 +106,6 @@ describe('getPopModalFlowTarget', () => {
       ],
     };
 
-    expect(getPopModalFlowTarget(state as State)).toBeUndefined();
+    expect(getPopModalFlowTarget(state)).toBeUndefined();
   });
 });

--- a/__tests__/unit/libs/popModalFlow.test.ts
+++ b/__tests__/unit/libs/popModalFlow.test.ts
@@ -1,0 +1,111 @@
+import getPopModalFlowTarget from '@libs/Navigation/getPopModalFlowTarget';
+import type {State} from '@libs/Navigation/types';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+type FakeRoute = {
+  name: string;
+  key?: string;
+  state?: FakeState;
+};
+
+type FakeState = {
+  key?: string;
+  index?: number;
+  routes: FakeRoute[];
+};
+
+/**
+ * Builds the real runtime tree at delete time: the ROOT stack holds the central
+ * pane, the Day Overview as its OWN sibling root navigator, and the RHP modal
+ * navigator last (top). The RHP's inner stack holds the single DrinkingSession
+ * flow, whose deeper stack is [Summary, Edit]. `innerModalIndex` controls how
+ * many flow groups are stacked inside the RHP — 0 for the single-flow case the
+ * bug reproduces in, >0 when several flows are stacked.
+ */
+function buildRootState(innerModalIndex: number): State {
+  const state: FakeState = {
+    key: 'root-stack-key',
+    index: 2,
+    routes: [
+      {name: NAVIGATORS.BOTTOM_TAB_NAVIGATOR, key: 'bottom-tab-key'},
+      {name: NAVIGATORS.DAY_OVERVIEW_NAVIGATOR, key: 'day-overview-key'},
+      {
+        name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+        key: 'right-modal-key',
+        state: {
+          key: 'right-modal-inner-key',
+          index: innerModalIndex,
+          routes: [
+            {
+              name: SCREENS.RIGHT_MODAL.DRINKING_SESSION,
+              key: 'drinking-session-flow-key',
+              state: {
+                key: 'drinking-session-inner-key',
+                index: 1,
+                routes: [
+                  {name: SCREENS.DRINKING_SESSION.SUMMARY},
+                  {name: SCREENS.DRINKING_SESSION.EDIT},
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+  return state as State;
+}
+
+describe('getPopModalFlowTarget', () => {
+  it('targets the ROOT key when the modal holds a single flow', () => {
+    // The RHP inner stack is at index 0 (only the DrinkingSession flow). A pop
+    // targeted at the inner stack would be a structural no-op (StackRouter
+    // clamps POP at the navigator's first route), so the target must be the
+    // ROOT — that removes the modal navigator and lands on the Day Overview
+    // sibling navigator beneath it.
+    expect(getPopModalFlowTarget(buildRootState(0))).toBe('root-stack-key');
+  });
+
+  it('targets the inner modal stack key when several flows are stacked', () => {
+    // With more than one flow group stacked inside the RHP (inner index > 0),
+    // popping the inner stack reveals the flow beneath while keeping the modal
+    // open — preserving the documented "pop only the top flow" intent.
+    expect(getPopModalFlowTarget(buildRootState(2))).toBe(
+      'right-modal-inner-key',
+    );
+  });
+
+  it('returns undefined when the top root route is not a modal navigator', () => {
+    const state: FakeState = {
+      key: 'root-stack-key',
+      index: 0,
+      routes: [
+        {
+          name: NAVIGATORS.BOTTOM_TAB_NAVIGATOR,
+          key: 'bottom-tab-key',
+          state: {
+            key: 'bottom-tab-inner-key',
+            index: 0,
+            routes: [{name: 'Home'}],
+          },
+        },
+      ],
+    };
+
+    expect(getPopModalFlowTarget(state as State)).toBeUndefined();
+  });
+
+  it('returns undefined when the modal navigator has no inner state', () => {
+    const state: FakeState = {
+      key: 'root-stack-key',
+      index: 1,
+      routes: [
+        {name: NAVIGATORS.BOTTOM_TAB_NAVIGATOR, key: 'bottom-tab-key'},
+        {name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR, key: 'right-modal-key'},
+      ],
+    };
+
+    expect(getPopModalFlowTarget(state as State)).toBeUndefined();
+  });
+});

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -48,10 +48,6 @@ function DrinkingSessionWindow({
   // const [dbSyncSuccessful, setDbSyncSuccessful] = useState(false);
   const [discardModalVisible, setDiscardModalVisible] =
     useState<boolean>(false);
-  // Set when the user confirms the discard. The actual delete + navigation run
-  // from the confirm modal's `onModalHide` (see `handleDiscardModalHide`) so
-  // they only fire once the modal has fully closed.
-  const discardConfirmedRef = useRef(false);
   const [shouldShowLeaveConfirmation, setShouldShowLeaveConfirmation] =
     useState(false);
   const sessionIsLive = session?.ongoing;
@@ -112,25 +108,12 @@ function DrinkingSessionWindow({
   };
 
   const handleConfirmDiscard = () => {
-    // Only close the modal here. The delete + navigation are deferred to
-    // `handleDiscardModalHide` (the modal's `onModalHide`): dispatching the pop
-    // while the confirm modal is still dismissing swallows it, stranding the
-    // user on the just-deleted session screen. The save flow has no confirm
-    // modal, which is why it redirects correctly today.
-    discardConfirmedRef.current = true;
-    setDiscardModalVisible(false);
-  };
-
-  const handleDiscardModalHide = () => {
-    if (!discardConfirmedRef.current) {
-      return;
-    }
-    discardConfirmedRef.current = false;
     (async () => {
       if (!user) {
         return;
       }
       try {
+        setDiscardModalVisible(false);
         await App.setLoadingText(
           translate('liveSessionScreen.discardingSession', {
             discardWord: sessionIsLive ? 'Discarding' : 'Deleting',
@@ -268,7 +251,6 @@ function DrinkingSessionWindow({
         title={translate('common.warning')}
         onConfirm={handleConfirmDiscard}
         onCancel={() => setDiscardModalVisible(false)}
-        onModalHide={handleDiscardModalHide}
         isVisible={discardModalVisible}
         prompt={translate(
           'liveSessionScreen.discardSessionWarning',

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -29,6 +29,7 @@ import type {
 import getTopmostCentralPaneRoute from './getTopmostCentralPaneRoute';
 import getTopmostBottomTabRoute from './getTopmostBottomTabRoute';
 import getPreviousScreenNameFromState from './getPreviousScreenName';
+import getPopModalFlowTarget from './getPopModalFlowTarget';
 import getMatchingBottomTabRouteForState from './linkingConfig/getMatchingBottomTabRouteForState';
 
 let resolveNavigationIsReadyPromise: () => void;
@@ -318,30 +319,19 @@ function pop(count = 1) {
 }
 
 /**
- * Pop the entire topmost modal flow (e.g. the whole DrinkingSession modal —
- * Summary + Edit) off the modal navigator, landing on the modal flow beneath it
- * (e.g. the Day Overview), or the central pane if nothing is beneath.
- *
- * `pop(n)` can't do this: `StackActions.pop` clamps at the focused navigator's
- * own first route, so it never crosses out of the modal flow. `dismissModal`
- * over-shoots the other way: it targets the root and closes the whole modal
- * navigator down to the central pane. This targets the modal navigator itself,
- * removing just its top flow.
+ * Pop the topmost modal flow off, landing on whatever is beneath it (e.g. the
+ * Day Overview), or the central pane if nothing is beneath. The target-selection
+ * logic — and why a single-flow modal must be popped off the ROOT rather than
+ * its own inner stack — lives in {@link getPopModalFlowTarget}.
  */
 function popModalFlow() {
-  const rootState = navigationRef.getRootState();
-  const modalNavigatorRoute = rootState.routes[rootState.routes.length - 1];
-  if (
-    !modalNavigatorRoute?.state?.key ||
-    (modalNavigatorRoute.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR &&
-      modalNavigatorRoute.name !== NAVIGATORS.LEFT_MODAL_NAVIGATOR) ||
-    !canNavigate('popModalFlow')
-  ) {
+  const target = getPopModalFlowTarget(navigationRef.getRootState());
+  if (!target || !canNavigate('popModalFlow')) {
     return;
   }
   navigationRef.current?.dispatch({
     ...StackActions.pop(),
-    target: modalNavigatorRoute.state.key,
+    target,
   });
 }
 

--- a/src/libs/Navigation/getPopModalFlowTarget.ts
+++ b/src/libs/Navigation/getPopModalFlowTarget.ts
@@ -1,0 +1,44 @@
+import NAVIGATORS from '@src/NAVIGATORS';
+import type {State} from './types';
+
+/**
+ * Computes the `StackActions.pop` target that pops the topmost modal flow off,
+ * landing on whatever is beneath it (e.g. the Day Overview), or `undefined` when
+ * the top root route is not a modal navigator (popModalFlow should then no-op).
+ *
+ * The modal navigator (RIGHT/LEFT_MODAL_NAVIGATOR) is the LAST route of the ROOT
+ * stack; the screen the user expects to return to — the Day Overview — is a
+ * SIBLING root navigator sitting beneath it, NOT a flow nested inside the modal.
+ * Two cases follow:
+ *  - The modal holds more than one flow group stacked (its inner `index > 0`):
+ *    target the inner stack so the pop reveals the flow beneath, keeping the
+ *    modal open — the documented "pop only the top flow" behaviour.
+ *  - The modal holds a single flow (inner `index === 0` — e.g. DrinkingSession =
+ *    Summary + Edit): a pop targeted at the inner stack is a structural no-op,
+ *    because `StackActions.pop` clamps at the focused navigator's own first route
+ *    and never crosses out of it (`StackRouter` returns `null` when the inner
+ *    index is 0). That no-op is exactly what stranded save/delete on the Edit
+ *    screen. Target the ROOT instead so the whole modal navigator comes off and
+ *    the sibling root navigator beneath it (the Day Overview) takes focus — the
+ *    same mechanism `dismissModal` uses.
+ *
+ * @returns The dispatch target key, or undefined when there is no modal flow to
+ * pop.
+ */
+function getPopModalFlowTarget(
+  rootState: State | undefined,
+): string | undefined {
+  const routes = rootState?.routes;
+  const modalNavigatorRoute = routes?.[routes.length - 1];
+  if (
+    !modalNavigatorRoute?.state?.key ||
+    (modalNavigatorRoute.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR &&
+      modalNavigatorRoute.name !== NAVIGATORS.LEFT_MODAL_NAVIGATOR)
+  ) {
+    return undefined;
+  }
+  const modalState = modalNavigatorRoute.state;
+  return (modalState.index ?? 0) > 0 ? modalState.key : rootState?.key;
+}
+
+export default getPopModalFlowTarget;


### PR DESCRIPTION
### Details

**Stacked on top of #975 (`claude/jolly-boyd-e09bf4`).**

Fixes the navigation bug where deleting a session from the Edit screen (Day Overview → session tile → Summary → Edit → Delete → confirm "Yes") left the user stranded on the just-deleted session's Edit screen instead of returning to the Day Overview. The session was deleted; only the redirect failed.

#### Root cause — `popModalFlow()` was a structural no-op

The two prior fixes on the base branch both targeted *timing*; the real cause is *structural*, so neither could have worked:

At delete time the real runtime tree is:

- Root stack = `[BottomTabNavigator, DayOverviewNavigator, RightModalNavigator]` (the RHP modal is the top root route, index 2).
- `DayOverviewNavigator` is its **own** top-level root navigator — a **sibling** beneath the RHP, **not** a flow nested under it (see [`AuthScreens.tsx`](src/libs/Navigation/AppNavigator/AuthScreens.tsx)).
- The `RightModalNavigator`'s inner `Stack.Navigator` holds exactly one route for this flow — `DrinkingSession`, at **index 0**.

Old [`popModalFlow`](src/libs/Navigation/Navigation.ts) dispatched `{...StackActions.pop(), target: modalNavigatorRoute.state.key}` — i.e. the RHP's **inner single-route stack**. `StackActions.pop()` carries no `source`, so in `@react-navigation/routers` `StackRouter` POP uses `currentIndex = state.index = 0`; the `if (currentIndex > 0)` guard is false → returns `null`. In `@react-navigation/core` `useOnAction`, a `null` result whose `action.target === state.key` is rewritten to `state` (handled, not bubbled), and since `state === result`, `setState` is never called. **The dispatch is fully consumed with zero navigation change** — regardless of timing. That is why moving *when* it fired (`Navigation.pop(2)` → `popModalFlow()` → deferring into `onModalHide`) never helped.

`getPreviousScreenName()` correctly returns `DrinkingSession_Summary`, so `EditSessionScreen.onNavigateBack` does take the `popModalFlow()` branch — confirming the failure was inside `popModalFlow`, not branch selection.

#### Fix

Extract the target selection into a pure helper [`getPopModalFlowTarget`](src/libs/Navigation/getPopModalFlowTarget.ts) and have `popModalFlow` dispatch against it:

- **Single flow in the modal (inner `index === 0`)** — target the **ROOT** (`rootState.key`), mirroring [`dismissModal`](src/libs/Navigation/dismissModal.ts). A root-targeted POP turns `[BottomTab, DayOverviewNavigator, RightModalNavigator]` (index 2) into `[BottomTab, DayOverviewNavigator]` (index 1) → lands on the Day Overview. Verified by hand-simulating `StackRouter` against the installed source.
- **Several flows stacked (inner `index > 0`)** — keep targeting the inner stack (non-no-op there), preserving the documented "pop only the top flow" intent.

This fixes **both** save and delete, which share the identical `onNavigateBack → popModalFlow()` path.

#### Save/delete asymmetry, reconciled

The report that "save reaches Day Overview but delete doesn't" is **imprecise/stale**, not a second code path. Grep confirms `saveSession`'s only navigation is `onNavigateBack(SAVE)`, and the `DrinkingSession` action helpers (`saveDrinkingSessionData`/`removeDrinkingSessionData`) never navigate — so save and delete go through the *same* `popModalFlow()`. Git history shows the shared path was `Navigation.pop(2)` in `7f5c418a3` (which, per `4208f9205`'s own message, landed on the **stale Summary** — i.e. it left the editor, which can read as "worked"), then `popModalFlow()` in `4208f9205` (the structural no-op). Per current code both are no-ops; this fix repairs both identically, and because they share one path there is no double-pop.

#### What this supersedes

- **Reverts Fix 2** (`DrinkingSessionWindow`): the `handleDiscardModalHide` / `discardConfirmedRef` / `onModalHide` deferral was built on the "the pop is swallowed while the confirm modal closes" theory, which is disproven (the dispatch never navigates at all). Delete + `onNavigateBack(DISCARD)` go back into `handleConfirmDiscard` directly.
- **Keeps Fix 1** (`EditSessionScreen.displaySession`): a harmless/beneficial flash guard against the "Loading your session" loader when `EDIT_SESSION_DATA` is cleared mid-teardown.

### Tests

New unit suite [`__tests__/unit/libs/popModalFlow.test.ts`](__tests__/unit/libs/popModalFlow.test.ts) covers the extracted helper against the production-shaped tree (the same fixture pattern `Navigation.test.ts` uses for `getPreviousScreenName`):

1. Single-flow modal (inner index 0) → target is the **ROOT** key.
2. Stacked flows (inner index > 0) → target is the **inner modal stack** key.
3. Top root route is not a modal navigator → returns `undefined` (no-op).
4. Modal navigator with no inner state → returns `undefined`.

Gates run locally (all green):

- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `npx jest __tests__/unit/libs/popModalFlow.test.ts __tests__/unit/libs/Navigation.test.ts __tests__/actions/DrinkingSession.test.ts __tests__/unit/libs/DrinkingSessionUtils.test.ts` → **29 passed** ✅
- `npx prettier --write` on changed files ✅

> **On-device QA pending.** No iOS simulator/Android emulator was bootable in this environment, so the static diagnosis (triple-verified against the installed `@react-navigation` source) was not confirmed on device. The QA steps below should be run before merge.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Open **Day Overview** for a date that has at least one session → tap a session tile → **Summary** → tap **Edit**.
2. Tap **Delete** → confirm **Yes** in the modal.
3. **Verify** you land back on the **Day Overview** for that date (not the deleted session's Edit screen, not a stale Summary), and the deleted session is gone from the list.
4. Open another session via Summary → **Edit**, change something, tap **Save**.
5. **Verify** you land back on the **Day Overview** (same destination as delete), with the edit reflected, and that the screen does **not** double-pop (no flash of an extra screen).
6. **Regression — create flow:** from the Day Overview FAB, create a session (the edit screen is the modal root). Save/discard and verify it still returns to the Day Overview via the single `goBack` path (unchanged by this PR).
7. **Regression — Back button:** open Summary → Edit → tap the header back button and verify it returns to the **Summary** (the `BACK` action is unaffected).

- [ ] Verify that no errors appear in the JS console
