### PR TITLE
refactor(realtime): cut cross-user friend reads off Firebase

### DIFF
--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -1,57 +1,69 @@
-import {useFirebase} from '@context/global/FirebaseContext';
-import {fetchDataKeyToDbPath} from '@hooks/useFetchData/utils';
+import * as DrinkingSession from '@libs/actions/DrinkingSession';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {DrinkingSessionList} from '@src/types/onyx';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import {startOfMonth, subMonths} from 'date-fns';
-import {get, orderByChild, query, ref, startAt} from 'firebase/database';
 import {useEffect, useRef, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
 
 type UseDrinkingSessionsFetchReturn = {
   /** Last-good snapshot of the windowed session list. Stays populated across
-   *  widen re-fetches so the calendar doesn't blank out during the round trip. */
+   *  widen re-fetches so the calendar doesn't blank out during the round trip.
+   *  `undefined` once the server denies/evicts access (see below). */
   data: DrinkingSessionList | undefined;
   /** True only on the initial fetch — later widens swap `data` on resolve
    *  without flipping this back to true. Consumers should NOT show a full
    *  loading state on widens. */
   isLoading: boolean;
   /** True while a wider-window re-fetch is in flight (user scrolled the
-   *  calendar past the loaded edge). Cleared when the new `get()` resolves. */
+   *  calendar past the loaded edge). Cleared when the read resolves. */
   isFetchingOlderMonths: boolean;
 };
 
 /**
- * One-shot Firebase `get()` for a target user's drinking sessions, windowed
- * server-side by `start_time` to the most recent
- * `CONST.SESSIONS_INITIAL_FETCH_MONTHS` months (or wider if the user has
- * scrolled the calendar back, persisted per-UID in
- * `${COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`).
+ * Windowed read of a target user's drinking sessions through the
+ * privacy-enforced `GET /v1/users/:uid/sessions` API — previously a direct
+ * Firebase RTDB `get()` of `user_drinking_sessions/$uid`.
  *
- * Used by the friend-profile screen so opening a profile with thousands of
- * sessions doesn't download the entire collection. When the calendar widens
- * (via [[useLazyMarkedDates.loadMoreMonths]]) the Onyx entry bumps and this
- * hook fires a new `get()` with an earlier `startAt`. Stale in-flight
- * responses are dropped via a request token.
+ * The server windows by `start_time` to the most recent
+ * `CONST.SESSIONS_INITIAL_FETCH_MONTHS` months (or wider if the calendar has
+ * scrolled back, persisted per-UID in
+ * `${COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`) AND enforces the
+ * friends + visibility check that used to live only in the RTDB security rules
+ * (which the admin SDK bypasses). The windowed map is delivered as onyxData into
+ * `cachedDrinkingSessions[userID]`, which this hook reads back via Onyx.
+ *
+ * When the server denies/hides the data it evicts that key (Kiroku #786), so
+ * `data` becomes `undefined` the instant a viewer loses access — the UI can no
+ * longer show sessions it cached while previously allowed.
+ *
+ * When the calendar widens (via [[useLazyMarkedDates.loadMoreMonths]]) the Onyx
+ * depth bumps and this hook re-issues the read with an earlier `from`. A request
+ * token guards the loading flags so a stale in-flight widen does not clear them
+ * early. An empty `userID` (the self branch of screens that show both) is a
+ * no-op.
  */
 function useDrinkingSessionsFetch(
   userID: UserID,
 ): UseDrinkingSessionsFetchReturn {
-  const {db} = useFirebase();
   const [monthsLoaded, monthsLoadedMeta] = useOnyx(
     `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
   );
+  // The API delivers the windowed sessions into cachedDrinkingSessions[userID];
+  // reading them back here means eviction-on-deny (#786) flows straight to the
+  // UI without any local bookkeeping.
+  const [cachedDrinkingSessions] = useOnyx(ONYXKEYS.CACHED_DRINKING_SESSIONS);
+  const data = userID ? cachedDrinkingSessions?.[userID] : undefined;
 
-  const [data, setData] = useState<DrinkingSessionList | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isFetchingOlderMonths, setIsFetchingOlderMonths] =
     useState<boolean>(false);
   const prevSessionsMonthsBackRef = useRef<number | null>(null);
 
   // Latest-wins request token. Bumped before each fetch; on resolve we ignore
-  // the response unless its token still matches `currentTokenRef.current`.
-  // Prevents stale wider/narrower responses from clobbering a newer fetch.
+  // the result unless its token still matches `currentTokenRef.current`, so a
+  // stale wider/narrower round-trip can't clear the loading flags out of turn.
   const currentTokenRef = useRef(0);
   const hasResolvedInitialRef = useRef(false);
 
@@ -62,20 +74,10 @@ function useDrinkingSessionsFetch(
 
   useEffect(() => {
     // Skip until prerequisites are in place. `isLoading` stays `true` —
-    // ProfileScreen mounts after auth so `db` and `userID` are always set in
-    // practice, and Onyx hydration is fast.
-    if (
-      !db ||
-      !userID ||
-      // Wait for Onyx to hydrate so we don't fetch the default 3 months and
-      // then immediately re-fetch when the saved wider depth arrives.
-      monthsLoadedMeta.status !== 'loaded'
-    ) {
-      return;
-    }
-
-    const path = fetchDataKeyToDbPath('drinkingSessionData', userID);
-    if (!path) {
+    // ProfileScreen mounts after auth so `userID` is always set in practice,
+    // and Onyx hydration is fast. Wait for the saved depth to hydrate so we
+    // don't fetch the default 3 months and then immediately re-fetch wider.
+    if (!userID || monthsLoadedMeta.status !== 'loaded') {
       return;
     }
 
@@ -89,25 +91,14 @@ function useDrinkingSessionsFetch(
     // Snap to the start of the earliest visible month so every month inside the
     // fetched window is loaded in full — without this, a sliding window that
     // stops mid-month would leave the early days unfetched and misrender them as
-    // "before tracking started".
-    const startAtMillis = startOfMonth(
+    // "before tracking started". Matches the server's `start_time >= from`.
+    const from = startOfMonth(
       subMonths(new Date(), sessionsMonthsBack),
     ).getTime();
-    const sessionsQuery = query(
-      ref(db, path),
-      orderByChild('start_time'),
-      startAt(startAtMillis),
-    );
 
-    const finalize = (next: DrinkingSessionList | undefined) => {
+    const finalize = () => {
       if (token !== currentTokenRef.current) {
         return;
-      }
-      if (next !== undefined) {
-        setData(next);
-      } else if (!hasResolvedInitialRef.current) {
-        // First resolve with no sessions — clear any stale state.
-        setData(undefined);
       }
       if (!hasResolvedInitialRef.current) {
         hasResolvedInitialRef.current = true;
@@ -116,16 +107,8 @@ function useDrinkingSessionsFetch(
       setIsFetchingOlderMonths(false);
     };
 
-    get(sessionsQuery)
-      .then(snapshot => {
-        finalize(
-          snapshot.exists()
-            ? (snapshot.val() as DrinkingSessionList)
-            : undefined,
-        );
-      })
-      .catch(() => finalize(undefined));
-  }, [db, userID, sessionsMonthsBack, monthsLoadedMeta.status]);
+    DrinkingSession.openFriendDrinkingSessions(userID, from).finally(finalize);
+  }, [userID, sessionsMonthsBack, monthsLoadedMeta.status]);
 
   return {data, isLoading, isFetchingOlderMonths};
 }

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -36,6 +36,16 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'get',
     path: '/v1/app/open',
   },
+  // Friend drinking sessions, windowed by start_time and privacy-enforced
+  // server-side (friends + visibility). Denied reads return 200 with an
+  // eviction patch (cachedDrinkingSessions[uid] -> null), see Kiroku #786.
+  [READ_COMMANDS.OPEN_FRIEND_DRINKING_SESSIONS]: {
+    method: 'get',
+    path: '/v1/users/:uid/sessions',
+    toPath: data =>
+      `/v1/users/${encodeURIComponent(String(data.userID))}/sessions`,
+    toQuery: data => ({from: Number(data.from ?? 0)}),
+  },
   [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: {
     method: 'get',
     path: '/v1/updates',

--- a/src/libs/API/parameters/OpenFriendDrinkingSessionsParams.ts
+++ b/src/libs/API/parameters/OpenFriendDrinkingSessionsParams.ts
@@ -1,0 +1,11 @@
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+/** Params for the privacy-enforced friend-sessions read (`GET /v1/users/:uid/sessions`). */
+type OpenFriendDrinkingSessionsParams = {
+  /** The owner whose sessions are being read (never the caller's own uid is assumed; authority is the Bearer token). */
+  userID: UserID;
+  /** Window floor — only sessions with `start_time >= from` are returned. `0` for the whole collection. */
+  from: number;
+};
+
+export default OpenFriendDrinkingSessionsParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -13,6 +13,7 @@ export type {default as HandleRestrictedEventParams} from './HandleRestrictedEve
 export type {default as OpenAppParams} from './OpenAppParams';
 export type {default as OpenPublicProfilePageParams} from './OpenPublicProfilePageParams';
 export type {default as SearchUsersParams} from './SearchUsersParams';
+export type {default as OpenFriendDrinkingSessionsParams} from './OpenFriendDrinkingSessionsParams';
 export type {default as OptInOutToPushNotificationsParams} from './OptInOutToPushNotificationsParams';
 export type {default as ReconnectAppParams} from './ReconnectAppParams';
 export type {default as UpdateAutomaticTimezoneParams} from './UpdateAutomaticTimezoneParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -111,6 +111,7 @@ const READ_COMMANDS = {
   //   OPEN_USER_DATA: 'OpenUserDataPage',
   OPEN_PUBLIC_PROFILE_PAGE: 'OpenPublicProfilePage',
   SEARCH_USERS: 'SearchUsers',
+  OPEN_FRIEND_DRINKING_SESSIONS: 'OpenFriendDrinkingSessions',
   //   OPEN_PLAID_BANK_LOGIN: 'OpenPlaidBankLogin',
   //   OPEN_PLAID_BANK_ACCOUNT_SELECTOR: 'OpenPlaidBankAccountSelector',
   //   GET_ROUTE: 'GetRoute',
@@ -130,6 +131,7 @@ type ReadCommandParameters = {
   //   [READ_COMMANDS.OPEN_USER_DATA]: EmptyObject;
   [READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE]: Parameters.OpenPublicProfilePageParams;
   [READ_COMMANDS.SEARCH_USERS]: Parameters.SearchUsersParams;
+  [READ_COMMANDS.OPEN_FRIEND_DRINKING_SESSIONS]: Parameters.OpenFriendDrinkingSessionsParams;
   //    ...
 };
 

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -18,7 +18,9 @@ import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {buildSessionTimeParts} from '@libs/Statistics/sessionTimeParts';
-import {WRITE_COMMANDS} from '@libs/API/types';
+import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import type Response from '@src/types/onyx/Response';
+import type {OpenFriendDrinkingSessionsParams} from '@libs/API/parameters';
 import type {OnyxKey} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import Navigation from '@libs/Navigation/Navigation';
@@ -750,8 +752,37 @@ async function navigateToEditSessionScreen(
   );
 }
 
+/**
+ * Read a FRIEND's drinking sessions, windowed by `start_time` (`>= from`), via
+ * the privacy-enforced `GET /v1/users/:uid/sessions` endpoint. This replaces the
+ * client's direct, unguarded Firebase RTDB `get()` of `user_drinking_sessions/$uid`:
+ * the API now enforces the friends + visibility check that used to live only in
+ * the RTDB security rules (which the admin SDK bypasses).
+ *
+ * The server returns the windowed map as onyxData merged under
+ * `cachedDrinkingSessions[userID]`. A denied / hidden read returns an EVICTION
+ * (that key set to `null`) so a viewer who has lost access stops showing the
+ * sessions they cached while previously allowed (Kiroku #786). Both flow through
+ * the standard `SaveResponseInOnyx` pipeline; this returns the promise so the
+ * fetch hook can clear its own loading state once the round-trip settles.
+ */
+function openFriendDrinkingSessions(
+  userID: UserID,
+  from: number,
+): Promise<void | Response> {
+  const parameters: OpenFriendDrinkingSessionsParams = {userID, from};
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    READ_COMMANDS.OPEN_FRIEND_DRINKING_SESSIONS,
+    parameters,
+    {},
+    CONST.API_REQUEST_TYPE.READ,
+  );
+}
+
 export {
   generateDrinkingSessionId,
+  openFriendDrinkingSessions,
   navigateToEditSessionScreen,
   navigateToOngoingSessionScreen,
   removeDrinkingSessionData,


### PR DESCRIPTION
## What

Begins the **cross-user (friends') read** cutover: moving reads of *other* users' data off direct Firebase RTDB `get()`s and onto the privacy-enforced kiroku-api. This is the security-sensitive half of the migration — privacy was previously enforced **only** by Firebase RTDB security rules, which the API's admin SDK bypasses, so the gate now lives server-side.

This PR lands the **friend SESSIONS** repoint (the one path with a dedicated hook). Friend **preferences / status / profile** reads are the immediate follow-up — see *Deferred* below.

> ⚠️ **RUNTIME-BLOCKED on [kiroku-api#60](https://github.com/PetrCala/kiroku-api/pull/60)** — the `GET /v1/users/:uid/sessions` endpoint must be merged + deployed to **dev** before this works at runtime. Do not merge until #60 is live on dev.

## Changes

- **`useDrinkingSessionsFetch`** no longer does a direct windowed Firebase `get()` of a friend's `user_drinking_sessions/$uid`. It now calls `GET /v1/users/:uid/sessions?from=` via the API and reads the windowed result back from `cachedDrinkingSessions[userID]`. All Firebase imports (`db`/`get`/`query`/`ref`/`startAt`) are gone from the hook — windowing **and** privacy are now the server's responsibility.
- **New READ command** `OpenFriendDrinkingSessions` + params type + `kirokuRoutes` entry (`GET /v1/users/:uid/sessions`, `toPath` for `:uid`, `toQuery` for `from`).
- **`DrinkingSession.openFriendDrinkingSessions(userID, from)`** wraps the read (`makeRequestWithSideEffects`, READ type) and returns the promise so the hook can settle its loading flags.

## #786 — denied reads evict stale data

The server returns a denied/hidden read as **HTTP 200 with an eviction patch** (`merge cachedDrinkingSessions { [uid]: null }`), which flows through `SaveResponseInOnyx` → `Onyx.update`. Because the hook now sources `data` from `cachedDrinkingSessions[userID]`, the instant access is lost `data` becomes `undefined` and the UI stops showing sessions the viewer cached while previously allowed — no extra client bookkeeping needed.

## Deferred (immediate follow-up — server endpoints already exist in #60)

To keep this PR focused and reviewable (and because it can't be runtime-verified until #60 deploys), these still read Firebase directly and are the next PR:

- `useFetchData(['preferences'])` (friend rendering prefs) → `GET /v1/users/:uid/preferences`
- `Profile.fetchUserStatuses` (friend presence/latest_session) → `GET /v1/users/:uid/status`
- `Profile.fetchUserProfiles` / `fetchAndStoreSupporterFlags` → `GET /v1/users/:uid/profile`

Path pruning in `useFetchData/utils.ts` is also deferred with that work (its `drinkingSessionData`/`preferences` cases are still referenced by the not-yet-migrated `useFetchData` surface; `readDataOnce`/`generateDatabaseKey` stay).

## Gates

- `typecheck-tsgo` ✅
- `react-compiler-compliance-check` (per-file + `check-changed`) ✅
- `lint-changed` ✅ (only the 2 pre-existing `Onyx.connect()` seatbelt warnings in `DrinkingSession.ts`, untouched by this PR)
- `prettier` ✅

Refs #809, #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)