### PR TITLE
fix(modal): silence Reanimated layout-animation overwrite warning in ReanimatedModal

### DIFF
--- a/__tests__/unit/components/ReanimatedModalLayoutAnimation.test.tsx
+++ b/__tests__/unit/components/ReanimatedModalLayoutAnimation.test.tsx
@@ -1,0 +1,271 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest module-factory keys (__esModule) are Node-module shape, not our convention */
+import {render} from '@testing-library/react-native';
+import React from 'react';
+import type {ValueOf} from 'type-fest';
+import Backdrop from '@components/Modal/ReanimatedModal/Backdrop';
+import Container from '@components/Modal/ReanimatedModal/Container';
+import type {
+  AnimationIn,
+  AnimationOut,
+} from '@components/Modal/ReanimatedModal/types';
+import CONST from '@src/CONST';
+
+// Reanimated emits a dev warning when a view that carries a layout-animation
+// prop (entering/exiting/layout) ALSO sets a property the animation animates
+// (here: opacity / transform) in its own style — the layout animation can
+// overwrite that style. This warning is native-runtime-only (the check is
+// skipped under IS_WEB and is not exercised by the reanimated jest mock), so we
+// can't assert on the warning itself. Instead we assert the structural
+// invariant that prevents it: capture the props handed to every Animated.View
+// and verify no layout-animated view also sets opacity/transform.
+//
+// This fails on the pre-split implementation (single Animated.View carrying
+// both `exiting` and the animated opacity/transform) and passes once the
+// layout animation lives on an outer wrapper and the animated style on the
+// inner view.
+const mockCapturedAnimatedViewProps: Array<Record<string, unknown>> = [];
+
+// A self-contained Reanimated mock: just enough surface for Container/Backdrop
+// (+ utils' Easing). We deliberately do NOT requireActual the real mock — it
+// transitively loads react-native-worklets' native module, which can't init
+// under jest. `Animated.View` is a recording component so we can inspect the
+// exact props (style + layout-animation) each view receives.
+jest.mock('react-native-reanimated', () => {
+  // NOTE: keep `as` casts on function types out of this factory — jest's
+  // hoisting validator scans cast type expressions and rejects their parameter
+  // names. Plain parameter type annotations (below) are fine.
+  const ReactLocal = require('react') as typeof React;
+  const {View} = require('react-native') as {
+    View: React.ComponentType<Record<string, unknown>>;
+  };
+  const RecordingView = ReactLocal.forwardRef<unknown, Record<string, unknown>>(
+    (props, ref) => {
+      mockCapturedAnimatedViewProps.push(props);
+      // Drop the layout-animation props before handing off to a plain View so RN
+      // doesn't choke on unknown props; we've already recorded them above.
+      const {entering, exiting, layout, ...rest} = props;
+      return ReactLocal.createElement(View, {...rest, ref});
+    },
+  );
+
+  const makeSharedValue = (initial: unknown) => {
+    // Container/Backdrop only ever .set() a resolved value (withTiming returns
+    // its target under the mock), so a plain assignment is sufficient.
+    let current = initial;
+    return {
+      get: () => current,
+      set: (next: unknown) => {
+        current = next;
+      },
+    };
+  };
+
+  // Chainable Keyframe stub; truthy so it reads as a layout animation.
+  class Keyframe {
+    duration() {
+      return this;
+    }
+
+    delay() {
+      return this;
+    }
+
+    withCallback() {
+      return this;
+    }
+
+    reduceMotion() {
+      return this;
+    }
+
+    build() {
+      return () => ({initialValues: {}, animations: {}});
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      View: RecordingView,
+      createAnimatedComponent: (c: unknown) => c,
+    },
+    View: RecordingView,
+    Keyframe,
+    ReduceMotion: {System: 'system', Never: 'never', Always: 'always'},
+    // useAnimatedStyle invokes its worklet immediately and returns the style.
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useSharedValue: makeSharedValue,
+    // withTiming runs its completion callback synchronously and resolves to the
+    // target value, mirroring the official reanimated mock.
+    withTiming: (
+      toValue: unknown,
+      _config: unknown,
+      callback?: (finished: boolean) => void,
+    ) => {
+      callback?.(true);
+      return toValue;
+    },
+    Easing: {bezier: () => ({factory: () => () => 0})},
+  };
+});
+
+// Container's open-animation completion callback calls scheduleOnRN; stub it to
+// invoke synchronously so nothing reaches the (uninitialised) native runtime.
+jest.mock('react-native-worklets', () => ({
+  __esModule: true,
+  scheduleOnRN: (fn?: (...args: unknown[]) => unknown, ...args: unknown[]) =>
+    fn?.(...args),
+}));
+
+jest.mock('@hooks/useThemeStyles', () => ({
+  __esModule: true,
+  // Only the keys these two components read, with their real static values.
+  default: () => ({
+    flex1: {flex: 1},
+    modalAnimatedContainer: {width: '100%'},
+    modalBackdrop: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: 'black',
+    },
+  }),
+}));
+
+jest.mock('@hooks/useLocalize', () => ({
+  __esModule: true,
+  default: () => ({translate: () => 'backdrop'}),
+}));
+
+// GestureHandler pulls in gesture-handler + worklets; for layout assertions we
+// only need it to render its children.
+jest.mock('@components/Modal/ReanimatedModal/Container/GestureHandler', () => ({
+  __esModule: true,
+  default: ({children}: {children: React.ReactNode}) => children,
+}));
+
+jest.mock('@components/Pressable', () => {
+  const ReactLocal = require('react') as typeof React;
+  return {
+    __esModule: true,
+    PressableWithoutFeedback: ({children}: {children: React.ReactNode}) =>
+      ReactLocal.createElement(ReactLocal.Fragment, null, children),
+  };
+});
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const visit = (value: unknown) => {
+    if (!value) {
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (typeof value === 'object') {
+      Object.assign(out, value);
+    }
+  };
+  visit(style);
+  return out;
+}
+
+function isLayoutAnimated(props: Record<string, unknown>): boolean {
+  return Boolean(props.entering ?? props.exiting ?? props.layout);
+}
+
+// Properties Reanimated's modal layout animations animate (fade -> opacity,
+// slide -> transform); a layout-animated view must not also set these.
+const CONFLICTING_PROPERTIES = ['opacity', 'transform'] as const;
+
+function expectNoLayoutAnimatedViewSetsConflictingStyle() {
+  const layoutAnimatedViews =
+    mockCapturedAnimatedViewProps.filter(isLayoutAnimated);
+  // Guard against a vacuous pass (e.g. the component stopped using a layout
+  // animation entirely): there must be at least one to check.
+  expect(layoutAnimatedViews.length).toBeGreaterThan(0);
+  layoutAnimatedViews.forEach(props => {
+    const flat = flattenStyle(props.style);
+    CONFLICTING_PROPERTIES.forEach(property => {
+      expect(flat).not.toHaveProperty(property);
+    });
+  });
+}
+
+type ContainerScenario = {
+  name: string;
+  type: ValueOf<typeof CONST.MODAL.MODAL_TYPE>;
+  animationIn: AnimationIn;
+  animationOut: AnimationOut;
+};
+
+const CONTAINER_SCENARIOS: ContainerScenario[] = [
+  {
+    name: 'RIGHT_DOCKED (slide -> transform)',
+    type: CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED,
+    animationIn: 'slideInRight',
+    animationOut: 'slideOutRight',
+  },
+  {
+    name: 'BOTTOM_DOCKED (slide -> transform)',
+    type: CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED,
+    animationIn: 'slideInUp',
+    animationOut: 'slideOutDown',
+  },
+  {
+    name: 'CONFIRM (fade -> opacity)',
+    type: CONST.MODAL.MODAL_TYPE.CONFIRM,
+    animationIn: 'fadeIn',
+    animationOut: 'fadeOut',
+  },
+  {
+    name: 'CENTERED_SMALL (fade -> opacity)',
+    type: CONST.MODAL.MODAL_TYPE.CENTERED_SMALL,
+    animationIn: 'fadeIn',
+    animationOut: 'fadeOut',
+  },
+];
+
+describe('ReanimatedModal layout-animation / style separation', () => {
+  beforeEach(() => {
+    mockCapturedAnimatedViewProps.length = 0;
+  });
+
+  describe('Container', () => {
+    test.each(CONTAINER_SCENARIOS)(
+      '$name: the exiting layout animation is not on a view that also sets opacity/transform',
+      ({type, animationIn, animationOut}) => {
+        render(
+          <Container
+            onOpenCallBack={jest.fn()}
+            onCloseCallBack={jest.fn()}
+            animationIn={animationIn}
+            animationOut={animationOut}
+            type={type}
+          />,
+        );
+
+        expectNoLayoutAnimatedViewSetsConflictingStyle();
+      },
+    );
+  });
+
+  describe('Backdrop', () => {
+    test('the exiting fade animation is not on a view that also sets opacity', () => {
+      render(
+        <Backdrop
+          style={{width: 100, height: 100, backgroundColor: 'black'}}
+          isBackdropVisible
+          animationInTiming={300}
+          animationOutTiming={300}
+          backdropOpacity={0.7}
+        />,
+      );
+
+      expectNoLayoutAnimatedViewSetsConflictingStyle();
+    });
+  });
+});

--- a/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.tsx
@@ -58,22 +58,29 @@ function Backdrop({
     .duration(animationOutTiming)
     .reduceMotion(ReduceMotion.Never);
 
-  // The reveal opacity (0->1) lives on the Animated.View; the dim color and its
-  // target opacity live on a plain fill child, so the two compose to a
+  // The reveal opacity (0->1) lives on the inner Animated.View; the dim color and
+  // its target opacity live on a plain fill child, so the two compose to a
   // 0 -> backdropOpacity fade and the surface paints reliably.
   const {backgroundColor, ...frame} =
     StyleSheet.flatten([styles.modalBackdrop, style]) ?? {};
 
+  // The exiting (fadeOut) layout animation lives on the OUTER wrapper, which
+  // carries no opacity of its own; the reveal opacity (`animatedStyles`) lives on
+  // the inner view. Keeping the layout animation and the animated opacity on
+  // separate elements avoids Reanimated's "Property "opacity" may be overwritten
+  // by a layout animation" dev warning.
   const BackdropOverlay = (
-    <Animated.View style={[frame, animatedStyles]} exiting={Exiting}>
-      {customBackdrop ?? (
-        <View
-          style={[
-            StyleSheet.absoluteFill,
-            {backgroundColor, opacity: backdropOpacity},
-          ]}
-        />
-      )}
+    <Animated.View style={frame} exiting={Exiting}>
+      <Animated.View style={[StyleSheet.absoluteFill, animatedStyles]}>
+        {customBackdrop ?? (
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              {backgroundColor, opacity: backdropOpacity},
+            ]}
+          />
+        )}
+      </Animated.View>
     </Animated.View>
   );
 

--- a/src/components/Modal/ReanimatedModal/Container/index.tsx
+++ b/src/components/Modal/ReanimatedModal/Container/index.tsx
@@ -92,6 +92,13 @@ function Container({
       .reduceMotion(ReduceMotion.Never);
   }, [animationOutTiming, onCloseCallBack, animationOut]);
 
+  // BOTTOM_DOCKED, CENTERED_SMALL and CONFIRM stay content-sized so the outer
+  // `style` (flex-end / center) can position the sheet; the others fill.
+  const fillContainer =
+    type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED &&
+    type !== CONST.MODAL.MODAL_TYPE.CENTERED_SMALL &&
+    type !== CONST.MODAL.MODAL_TYPE.CONFIRM;
+
   return (
     <View
       // `flex1` fills the RN Modal's content area so each modal type's own
@@ -106,20 +113,22 @@ function Container({
         swipeThreshold={swipeThreshold}
         swipeDirection={swipeDirection}
         onSwipeComplete={onSwipeComplete}>
+        {/*
+          The outer wrapper carries ONLY the `exiting` layout animation; the open
+          transform/opacity (`animatedStyles`) lives on the inner view. Keeping the
+          layout animation and the animated style on separate elements avoids
+          Reanimated's "Property ... may be overwritten by a layout animation"
+          dev warning (the exiting Keyframe animates the same transform/opacity).
+          The wrapper keeps the sizing so the exiting transform's percentage and
+          the inner view's flex fill both resolve against the full container.
+        */}
         <Animated.View
-          style={[
-            styles.modalAnimatedContainer,
-            // BOTTOM_DOCKED, CENTERED_SMALL and CONFIRM stay content-sized so the
-            // outer `style` (flex-end / center) can position the sheet; the
-            // others fill.
-            type !== CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED &&
-              type !== CONST.MODAL.MODAL_TYPE.CENTERED_SMALL &&
-              type !== CONST.MODAL.MODAL_TYPE.CONFIRM &&
-              styles.flex1,
-            animatedStyles,
-          ]}
+          style={[styles.modalAnimatedContainer, fillContainer && styles.flex1]}
           exiting={Exiting}>
-          {props.children}
+          <Animated.View
+            style={[fillContainer && styles.flex1, animatedStyles]}>
+            {props.children}
+          </Animated.View>
         </Animated.View>
       </GestureHandler>
     </View>


### PR DESCRIPTION
## Problem

A dev-only Reanimated warning fired repeatedly while navigating the drinking-session RHP flow (Day Overview → session tile → Summary → Edit → Delete → Day Overview):

```
[Reanimated] Property "opacity" of AnimatedComponent(View) may be overwritten by a layout animation. Please wrap your component with an animated view and apply the layout animation on the wrapper.
[Reanimated] Property "transform" of AnimatedComponent(View) may be overwritten by a layout animation. ...
```

It originates from `react-native-reanimated`'s `maybeReportOverwrittenProperties` → `checkStyleOverwriting` → `_configureLayoutAnimation`, fired at an `AnimatedComponent`'s `componentDidMount` (the `EXITING` branch). The check is **native-only** (`_configureLayoutAnimation` returns early under `IS_WEB`) and only runs for `entering`/`exiting` configs, not `layout`.

## Root cause

Both `ReanimatedModal` native sub-components rendered a single `Animated.View` that carried **both**:
- an `exiting` layout animation — a fade-out/slide-out `Keyframe` (which animates `opacity` or `transform`), **and**
- an `opacity`/`transform` style driven by `useAnimatedStyle` (the open animation).

Reanimated warns because the layout animation can overwrite those static/animated style properties.

- [`Backdrop/index.tsx`](src/components/Modal/ReanimatedModal/Backdrop/index.tsx) — `exiting` fadeOut + reveal `opacity` → **"opacity"** warning.
- [`Container/index.tsx`](src/components/Modal/ReanimatedModal/Container/index.tsx) — `exiting` slideOut + open `transform` (right-docked / bottom-docked) → **"transform"** warning; fade types → "opacity".

The right-docked RHP container plus the always-present backdrop are exactly what mounts during the session flow, which is why both the "transform" and "opacity" warnings appeared together.

> Note: this is Expensify-forked plumbing, but Kiroku intentionally diverged here — the native components drive the *open* animation via `useAnimatedStyle` + a shared value (instead of an `entering` Keyframe) to avoid a New-Architecture first-paint flash. So aligning with upstream isn't applicable; upstream's structure would warn too. This fix preserves Kiroku's approach.

## Fix

Split responsibilities exactly as the warning's own guidance recommends — the layout animation and the animated style never share an element:

- **Outer** `Animated.View`: carries **only** the `exiting` Keyframe (plus the sizing styles, so the exit transform's percentage and the inner view's flex fill still resolve against the full container).
- **Inner** `Animated.View`: carries the open `opacity`/`transform` (`animatedStyles`).

The animations themselves are unchanged — purely a restructure.

## Tests

Adds [`ReanimatedModalLayoutAnimation.test.tsx`](__tests__/unit/components/ReanimatedModalLayoutAnimation.test.tsx). The warning is native-runtime-only (not exercised by the reanimated jest mock), so the test instead asserts the **structural invariant** that prevents it: it captures the props handed to every `Animated.View` and verifies no view carrying a layout-animation prop (`entering`/`exiting`/`layout`) also sets `opacity`/`transform`.

Verified it **fails on the pre-split code** (transform for the slide/docked modals, opacity for the fade modals + backdrop — matching the two reported warnings) and **passes after the fix**.

## Gates

- `npx prettier --write` on changed files ✓
- `npm run typecheck-tsgo` ✓
- `npm run react-compiler-compliance-check check-changed` ✓ (both changed components)
- `npm run lint-changed` ✓ (exit 0)
- `npx jest …ReanimatedModalLayoutAnimation` ✓ (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)