### PR TITLE
refactor(realtime): cut friend preference/status/profile reads off Firebase

### DIFF
--- a/src/hooks/useFriendPreferences/index.ts
+++ b/src/hooks/useFriendPreferences/index.ts
@@ -1,0 +1,55 @@
+import * as Preferences from '@libs/actions/Preferences';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Preferences as PreferencesType} from '@src/types/onyx';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+import {useEffect, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
+
+type UseFriendPreferencesReturn = {
+  /** The friend's rendering preferences, or `undefined` until loaded / when the
+   *  server denies access (a denied/hidden read evicts the key — Kiroku #786). */
+  preferences: PreferencesType | undefined;
+  /** True until this user's read settles. `false` for an empty `userID` (the
+   *  self branch of screens that show both). */
+  isLoading: boolean;
+};
+
+/**
+ * Read a FRIEND's rendering preferences (units/colors) through the
+ * privacy-enforced `GET /v1/users/:uid/preferences` API — previously a direct
+ * Firebase RTDB read via `useFetchData(['preferences'])`. The server gates the
+ * read (friends + visibility) and delivers the prefs into
+ * `userDataList[userID].preferences`, which this hook reads back via Onyx; a
+ * denied/hidden read evicts that key so `preferences` becomes `undefined` the
+ * moment access is lost. An empty `userID` is a no-op.
+ */
+function useFriendPreferences(userID: UserID): UseFriendPreferencesReturn {
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
+  const preferences = userID ? userDataList?.[userID]?.preferences : undefined;
+
+  // Track the last userID whose read has settled; `isLoading` is DERIVED from it
+  // rather than set synchronously in the effect (which cascades renders). The
+  // only setState happens in the async `.finally` callback below.
+  const [loadedUserID, setLoadedUserID] = useState<UserID | null>(null);
+
+  useEffect(() => {
+    if (!userID) {
+      return;
+    }
+    let isActive = true;
+    Preferences.openFriendPreferences(userID).finally(() => {
+      if (isActive) {
+        setLoadedUserID(userID);
+      }
+    });
+    return () => {
+      isActive = false;
+    };
+  }, [userID]);
+
+  const isLoading = !!userID && loadedUserID !== userID;
+
+  return {preferences, isLoading};
+}
+
+export default useFriendPreferences;

--- a/src/hooks/useProfileList.tsx
+++ b/src/hooks/useProfileList.tsx
@@ -41,13 +41,10 @@ const useProfileList = (userArray: UserArray) => {
           db,
           newUsers,
         );
+        // fetchUserProfiles now reads via the public-profile API, whose
+        // response also merges `is_supporter` into USER_DATA_LIST — so the
+        // SupporterBadge data path is hydrated without a second fetch.
         setProfileList({...profileList, ...newProfileList});
-        // Hydrate the SupporterBadge data path for these users — the badge
-        // reads `is_supporter` off USER_DATA_LIST, which is otherwise only
-        // populated for the current user.
-        Profile.fetchAndStoreSupporterFlags(db, newUsers).catch(() => {
-          // Non-fatal: badge will simply remain hidden for these users.
-        });
       }
     } catch (error) {
       ErrorUtils.raiseAppError(ERRORS.USER.DATA_FETCH_FAILED, error);

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -46,6 +46,30 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
       `/v1/users/${encodeURIComponent(String(data.userID))}/sessions`,
     toQuery: data => ({from: Number(data.from ?? 0)}),
   },
+  // Public profile read (profile + public_data + public is_supporter flag). Any
+  // authenticated user may read it (mirrors the rules' `users/$uid/profile`).
+  [READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE]: {
+    method: 'get',
+    path: '/v1/users/:uid/profile',
+    toPath: data =>
+      `/v1/users/${encodeURIComponent(String(data.userID))}/profile`,
+  },
+  // Friend rendering preferences (units/colors), privacy-enforced server-side
+  // (friends + visibility). Denied reads evict userDataList[uid].preferences.
+  [READ_COMMANDS.OPEN_FRIEND_PREFERENCES]: {
+    method: 'get',
+    path: '/v1/users/:uid/preferences',
+    toPath: data =>
+      `/v1/users/${encodeURIComponent(String(data.userID))}/preferences`,
+  },
+  // Friend presence + latest session, privacy-enforced (friends + visibility).
+  // Denied reads evict userDataList[uid].user_status.
+  [READ_COMMANDS.OPEN_FRIEND_STATUS]: {
+    method: 'get',
+    path: '/v1/users/:uid/status',
+    toPath: data =>
+      `/v1/users/${encodeURIComponent(String(data.userID))}/status`,
+  },
   [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: {
     method: 'get',
     path: '/v1/updates',

--- a/src/libs/API/parameters/OpenFriendPreferencesParams.ts
+++ b/src/libs/API/parameters/OpenFriendPreferencesParams.ts
@@ -1,0 +1,9 @@
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+/** Params for the privacy-enforced friend-preferences read (`GET /v1/users/:uid/preferences`). */
+type OpenFriendPreferencesParams = {
+  /** The owner whose rendering preferences are being read. Authority is the Bearer token. */
+  userID: UserID;
+};
+
+export default OpenFriendPreferencesParams;

--- a/src/libs/API/parameters/OpenFriendStatusParams.ts
+++ b/src/libs/API/parameters/OpenFriendStatusParams.ts
@@ -1,0 +1,9 @@
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+/** Params for the privacy-enforced friend-status read (`GET /v1/users/:uid/status`). */
+type OpenFriendStatusParams = {
+  /** The owner whose presence / latest session is being read. Authority is the Bearer token. */
+  userID: UserID;
+};
+
+export default OpenFriendStatusParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -14,6 +14,8 @@ export type {default as OpenAppParams} from './OpenAppParams';
 export type {default as OpenPublicProfilePageParams} from './OpenPublicProfilePageParams';
 export type {default as SearchUsersParams} from './SearchUsersParams';
 export type {default as OpenFriendDrinkingSessionsParams} from './OpenFriendDrinkingSessionsParams';
+export type {default as OpenFriendPreferencesParams} from './OpenFriendPreferencesParams';
+export type {default as OpenFriendStatusParams} from './OpenFriendStatusParams';
 export type {default as OptInOutToPushNotificationsParams} from './OptInOutToPushNotificationsParams';
 export type {default as ReconnectAppParams} from './ReconnectAppParams';
 export type {default as UpdateAutomaticTimezoneParams} from './UpdateAutomaticTimezoneParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -112,6 +112,8 @@ const READ_COMMANDS = {
   OPEN_PUBLIC_PROFILE_PAGE: 'OpenPublicProfilePage',
   SEARCH_USERS: 'SearchUsers',
   OPEN_FRIEND_DRINKING_SESSIONS: 'OpenFriendDrinkingSessions',
+  OPEN_FRIEND_PREFERENCES: 'OpenFriendPreferences',
+  OPEN_FRIEND_STATUS: 'OpenFriendStatus',
   //   OPEN_PLAID_BANK_LOGIN: 'OpenPlaidBankLogin',
   //   OPEN_PLAID_BANK_ACCOUNT_SELECTOR: 'OpenPlaidBankAccountSelector',
   //   GET_ROUTE: 'GetRoute',
@@ -132,6 +134,8 @@ type ReadCommandParameters = {
   [READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE]: Parameters.OpenPublicProfilePageParams;
   [READ_COMMANDS.SEARCH_USERS]: Parameters.SearchUsersParams;
   [READ_COMMANDS.OPEN_FRIEND_DRINKING_SESSIONS]: Parameters.OpenFriendDrinkingSessionsParams;
+  [READ_COMMANDS.OPEN_FRIEND_PREFERENCES]: Parameters.OpenFriendPreferencesParams;
+  [READ_COMMANDS.OPEN_FRIEND_STATUS]: Parameters.OpenFriendStatusParams;
   //    ...
 };
 

--- a/src/libs/actions/Preferences.ts
+++ b/src/libs/actions/Preferences.ts
@@ -1,10 +1,14 @@
 import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
-import {WRITE_COMMANDS} from '@libs/API/types';
+import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import type {OpenFriendPreferencesParams} from '@libs/API/parameters';
 import Navigation from '@libs/Navigation/Navigation';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Preferences, Theme} from '@src/types/onyx';
+import type Response from '@src/types/onyx/Response';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
 
 /**
  * Preference writes, cut over from direct Firebase RTDB writes to the kiroku-api
@@ -60,4 +64,25 @@ function updateTheme(theme: Theme): Promise<void> {
   return result;
 }
 
-export {updatePreferences, updateTheme};
+/**
+ * Read a FRIEND's rendering preferences (units→colors, drinks→units, palette)
+ * via the privacy-enforced `GET /v1/users/:uid/preferences` API — replacing the
+ * direct Firebase RTDB read the friend calendar used to do through
+ * `useFetchData(['preferences'])`. The server gates the read (friends +
+ * visibility) and delivers the prefs as onyxData under
+ * `userDataList[userID].preferences`; a denied/hidden read evicts that key
+ * (Kiroku #786). Returns the promise so the friend-preferences hook can settle
+ * its loading state once the round-trip lands.
+ */
+function openFriendPreferences(userID: UserID): Promise<void | Response> {
+  const parameters: OpenFriendPreferencesParams = {userID};
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    READ_COMMANDS.OPEN_FRIEND_PREFERENCES,
+    parameters,
+    {},
+    CONST.API_REQUEST_TYPE.READ,
+  );
+}
+
+export {updatePreferences, updateTheme, openFriendPreferences};

--- a/src/libs/actions/Profile.ts
+++ b/src/libs/actions/Profile.ts
@@ -6,20 +6,61 @@ import {updateProfile} from 'firebase/auth';
 import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
-import {WRITE_COMMANDS} from '@libs/API/types';
+import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import type {
+  OpenFriendStatusParams,
+  OpenPublicProfilePageParams,
+} from '@libs/API/parameters';
+import CONST from '@src/CONST';
 import type {ProfileList, UserStatusList} from '@src/types/onyx';
+import type Response from '@src/types/onyx/Response';
+import type UserData from '@src/types/onyx/UserData';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
-import DBPATHS from '@src/DBPATHS';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {
-  fetchDisplayDataForUsers,
-  readDataOnce,
-} from '@src/database/baseFunctions';
 
 /**
- * Fetches user profiles from the database.
+ * Pull a single user's merged `userDataList` patch out of a read response's
+ * `onyxData`. The cross-user read endpoints all return
+ * `merge userDataList { [uid]: { ... } }`; this extracts that `{ ... }` so a
+ * caller can return the legacy list shape synchronously. Returns `undefined`
+ * when the response carried no such patch (a denied/evicted read or a 404).
+ */
+function userDataPatchFromResponse(
+  response: void | Response,
+  userID: UserID,
+): Partial<UserData> | undefined {
+  if (!response || !Array.isArray(response.onyxData)) {
+    return undefined;
+  }
+  for (const update of response.onyxData) {
+    if (
+      update.onyxMethod === Onyx.METHOD.MERGE &&
+      update.key === ONYXKEYS.USER_DATA_LIST
+    ) {
+      const value = update.value as
+        | Record<UserID, Partial<UserData>>
+        | undefined;
+      const patch = value?.[userID];
+      if (patch) {
+        return patch;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Fetches the given users' public profiles via the kiroku-api public-profile
+ * read (`GET /v1/users/:uid/profile`), replacing the direct Firebase RTDB read.
+ * Each response ALSO merges that user's `profile` + public `is_supporter` flag
+ * into `USER_DATA_LIST`, so the SupporterBadge data path is hydrated without a
+ * separate fetch (this is why the old `fetchAndStoreSupporterFlags` pass is
+ * gone). Returns the same `ProfileList` shape the callers render from. A user
+ * whose profile is missing (404) is omitted rather than throwing, so one
+ * deleted account can't blank the whole list.
  *
- * @param db The database instance.
+ * @param db Unused (retained for call-site compatibility); authority is the
+ *   caller's Firebase ID token, attached by the API layer.
  * @param userIDs An array of user IDs.
  * @returns A promise that resolves to a list of user profiles.
  */
@@ -27,41 +68,27 @@ async function fetchUserProfiles(
   db: Database,
   userIDs: UserID[],
 ): Promise<ProfileList> {
-  const profileRef = 'users/{userID}/profile'; // TODO clear this up
-  return (await fetchDisplayDataForUsers(
-    db,
-    userIDs,
-    profileRef,
-  )) as ProfileList;
-}
-
-/**
- * Fetches each given user's public `is_supporter` flag and merges the result
- * into `USER_DATA_LIST` so the SupporterBadge can render for friends. The
- * public flag is the only supporter field readable across users — renewal
- * dates stay private. A missing node is treated as `false` to keep the badge
- * a positive-only signal.
- */
-async function fetchAndStoreSupporterFlags(
-  db: Database | undefined,
-  userIDs: UserID[],
-): Promise<void> {
-  if (!db || !userIDs || userIDs.length === 0) {
-    return;
+  const list: ProfileList = {};
+  if (!db || !userIDs?.length) {
+    return list;
   }
-  const flags = await Promise.all(
-    userIDs.map(id =>
-      readDataOnce<boolean>(
-        db,
-        DBPATHS.USERS_USER_ID_IS_SUPPORTER.getRoute(id),
-      ),
-    ),
+  await Promise.all(
+    userIDs.map(async userID => {
+      const parameters: OpenPublicProfilePageParams = {userID};
+      // eslint-disable-next-line rulesdir/no-api-side-effects-method
+      const response = await API.makeRequestWithSideEffects(
+        READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE,
+        parameters,
+        {},
+        CONST.API_REQUEST_TYPE.READ,
+      );
+      const profile = userDataPatchFromResponse(response, userID)?.profile;
+      if (profile) {
+        list[userID] = profile;
+      }
+    }),
   );
-  const merge: Record<UserID, {is_supporter: boolean}> = {};
-  userIDs.forEach((id, index) => {
-    merge[id] = {is_supporter: flags[index] ?? false};
-  });
-  await Onyx.merge(ONYXKEYS.USER_DATA_LIST, merge);
+  return list;
 }
 
 /**
@@ -80,9 +107,15 @@ async function setSupporterFlagInList(
 }
 
 /**
- * Fetches the statuses of multiple users from the database.
+ * Fetches the given users' presence + latest session via the privacy-enforced
+ * kiroku-api friend-status read (`GET /v1/users/:uid/status`), replacing the
+ * direct Firebase RTDB read. The server gates the read (friends + visibility);
+ * a denied/hidden user simply yields no entry (the response evicts
+ * `userDataList[uid].user_status`). Returns the same `UserStatusList` shape the
+ * caller renders from.
  *
- * @param db The database instance.
+ * @param db Unused (retained for call-site compatibility); authority is the
+ *   caller's Firebase ID token, attached by the API layer.
  * @param userIDs An array of user IDs.
  * @returns A promise that resolves to a UserStatusList object.
  */
@@ -90,12 +123,27 @@ async function fetchUserStatuses(
   db: Database,
   userIDs: UserID[],
 ): Promise<UserStatusList> {
-  const profileRef = 'user_status/{userID}';
-  return (await fetchDisplayDataForUsers(
-    db,
-    userIDs,
-    profileRef,
-  )) as UserStatusList;
+  const list: UserStatusList = {};
+  if (!db || !userIDs?.length) {
+    return list;
+  }
+  await Promise.all(
+    userIDs.map(async userID => {
+      const parameters: OpenFriendStatusParams = {userID};
+      // eslint-disable-next-line rulesdir/no-api-side-effects-method
+      const response = await API.makeRequestWithSideEffects(
+        READ_COMMANDS.OPEN_FRIEND_STATUS,
+        parameters,
+        {},
+        CONST.API_REQUEST_TYPE.READ,
+      );
+      const status = userDataPatchFromResponse(response, userID)?.user_status;
+      if (status) {
+        list[userID] = status;
+      }
+    }),
+  );
+  return list;
 }
 
 /**
@@ -141,7 +189,6 @@ async function updateProfileInfo(
 }
 
 export {
-  fetchAndStoreSupporterFlags,
   fetchUserProfiles,
   fetchUserStatuses,
   setProfilePictureURL,

--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -14,9 +14,8 @@ import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import {useFirebase} from '@context/global/FirebaseContext';
-import useFetchData from '@hooks/useFetchData';
+import useFriendPreferences from '@hooks/useFriendPreferences';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
-import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import {dateStringToDate, dateToDateData} from '@libs/DataHandling';
 import CONST from '@src/CONST';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -63,10 +62,6 @@ const internalStyles = StyleSheet.create({
 
 function noop() {}
 
-// Non-windowed keys to fetch for a friend (their session data is fetched
-// separately via `useDrinkingSessionsFetch`). Mirrors `SessionsCalendarScreen`.
-const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
-
 function DayOverviewScreen({route}: DayOverviewScreenProps) {
   const {userID, date} = route.params;
   const {isOnline} = useUserConnection();
@@ -99,8 +94,8 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   // `userID`, which both hooks treat as a no-op.
   const ownPreferences = useCurrentUserPreferences();
   const currentUserSessions = useCurrentUserDrinkingSessions();
-  const {data: friendFetchedData, isLoading: isFriendFetchLoading} =
-    useFetchData(isSelf ? '' : userID, FRIEND_FETCH_KEYS);
+  const {preferences: friendPreferences, isLoading: isFriendFetchLoading} =
+    useFriendPreferences(isSelf ? '' : userID);
   const {
     data: friendSessionData,
     isLoading: isFriendSessionsLoading,
@@ -108,7 +103,7 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   } = useDrinkingSessionsFetch(isSelf ? '' : userID);
 
   const drinkingSessionData = isSelf ? currentUserSessions : friendSessionData;
-  const preferences = isSelf ? ownPreferences : friendFetchedData?.preferences;
+  const preferences = isSelf ? ownPreferences : friendPreferences;
   const isFetchingOlderMonths = isSelf ? false : friendFetchingOlder;
   // Hold the list invisible (skeleton on top) until it has scrolled to the
   // focused day. With no `date` (shouldn't happen via the calendar) we never

--- a/src/screens/Profile/FriendsFriendsScreen.tsx
+++ b/src/screens/Profile/FriendsFriendsScreen.tsx
@@ -122,9 +122,6 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
         searchResultData,
       );
       setDisplayData(newDisplayData);
-      Profile.fetchAndStoreSupporterFlags(db, searchResultData).catch(() => {
-        // Non-fatal: badge will simply remain hidden for these users.
-      });
     },
     [db],
   );

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -8,7 +8,7 @@ import DayDrillDownSheet from '@components/SessionsCalendar/DayDrillDownSheet';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useFirebase} from '@context/global/FirebaseContext';
-import useFetchData from '@hooks/useFetchData';
+import useFriendPreferences from '@hooks/useFriendPreferences';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
@@ -21,14 +21,11 @@ import type {SessionsCalendarNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
-import type {FetchDataKeys} from '@hooks/useFetchData/types';
 
 type SessionsCalendarScreenProps = StackScreenProps<
   SessionsCalendarNavigatorParamList,
   typeof SCREENS.SESSIONS_CALENDAR.FULLSCREEN
 >;
-
-const FRIEND_FETCH_KEYS: FetchDataKeys = ['preferences'];
 
 const internalStyles = StyleSheet.create({
   // Render the calendar mounted but invisible so FlashList can lay out and
@@ -58,8 +55,8 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
 
   const ownPreferences = useCurrentUserPreferences();
   const currentUserSessions = useCurrentUserDrinkingSessions();
-  const {data: friendFetchedData, isLoading: isFriendFetchLoading} =
-    useFetchData(isSelf ? '' : userID, FRIEND_FETCH_KEYS);
+  const {preferences: friendPreferences, isLoading: isFriendFetchLoading} =
+    useFriendPreferences(isSelf ? '' : userID);
   const {
     data: friendSessionData,
     isLoading: isFriendSessionsLoading,
@@ -71,7 +68,7 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
     : friendSessionData;
   const preferences: Preferences | undefined = isSelf
     ? ownPreferences
-    : friendFetchedData?.preferences;
+    : friendPreferences;
   const isFetchingOlderMonths = isSelf ? false : friendFetchingOlder;
   const isLoading = isSelf
     ? !preferences || drinkingSessionData === undefined

--- a/src/screens/Social/FriendRequestScreen.tsx
+++ b/src/screens/Social/FriendRequestScreen.tsx
@@ -226,9 +226,6 @@ function FriendRequestScreen() {
       userIDs,
     );
     setDisplayData(newDisplayData);
-    Profile.fetchAndStoreSupporterFlags(database, userIDs).catch(() => {
-      // Non-fatal: badge will simply remain hidden for these users.
-    });
   };
 
   useEffect(() => {

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -98,9 +98,6 @@ function FriendSearchScreen() {
         setDisplayData(newDisplayData);
         setNoUsersFound(isEmptyArray(newData));
         setSearchResultData(newData);
-        Profile.fetchAndStoreSupporterFlags(db, newData).catch(() => {
-          // Non-fatal: badge will simply remain hidden for these users.
-        });
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.DATABASE.SEARCH_FAILED, error);
       } finally {

--- a/src/types/onyx/UserData.ts
+++ b/src/types/onyx/UserData.ts
@@ -2,6 +2,8 @@ import type {TupleToUnion} from 'type-fest';
 import type TIMEZONES from '@src/TIMEZONES';
 import type {Timestamp, UserID, UserList} from './OnyxCommon';
 import type FriendRequestList from './FriendRequestList';
+import type Preferences from './Preferences';
+import type UserStatus from './UserStatus';
 
 /** Selectable timezones */
 type SelectedTimezone = TupleToUnion<typeof TIMEZONES>;
@@ -130,6 +132,24 @@ type UserData = {
    * server-side by the RevenueCat webhook; undefined is treated as false.
    */
   is_supporter?: boolean;
+
+  /**
+   * A FRIEND's rendering preferences (units→colors, drinks→units, palette),
+   * denormalized here by the privacy-enforced `GET /v1/users/:uid/preferences`
+   * read so their sessions render with their own colors. Only present for
+   * friends whose data the viewer is allowed to see; a denied/hidden read
+   * evicts it (Kiroku #786). The signed-in user's own preferences live in the
+   * top-level `preferences` Onyx key, not here.
+   */
+  preferences?: Preferences;
+
+  /**
+   * A FRIEND's presence + latest session (`user_status`), denormalized here by
+   * the privacy-enforced `GET /v1/users/:uid/status` read. Only present for
+   * friends whose data the viewer is allowed to see; a denied/hidden read
+   * evicts it (#786). The own user's status has no top-level Onyx key.
+   */
+  user_status?: UserStatus;
 };
 
 /** A collection of user data of multiple users */


### PR DESCRIPTION
## What

Follow-up to [#990](https://github.com/PetrCala/Kiroku/pull/990) — moves the **remaining** cross-user friend reads (preferences, status, profiles + supporter) off direct Firebase RTDB onto the privacy-enforced kiroku-api endpoints. Those endpoints shipped in [kiroku-api#60](https://github.com/PetrCala/kiroku-api/pull/60) and are **live on dev**, so this is not runtime-blocked.

Privacy was previously enforced only by RTDB security rules (which the API's admin SDK bypasses); the gate now lives server-side (friends + visibility, per `canViewerReadOwnerData`).

## Approach — swap internals, keep call sites

Where a function already returned a list shape its callers render from, I swapped the **internals** to the API and kept the return type — so the 7 call sites barely change:

- **`Profile.fetchUserProfiles`** → `GET /v1/users/:uid/profile` (per user, parallel). Same `ProfileList` return. The response also merges `profile` + public `is_supporter` into `userDataList`, so **`fetchAndStoreSupporterFlags` is removed** along with its 4 redundant call sites — the supporter flag now rides along with the profile read (one round-trip instead of two). A missing profile (404) is skipped rather than thrown, so one deleted account can't blank a list.
- **`Profile.fetchUserStatuses`** → `GET /v1/users/:uid/status` (friends + visibility gated). Same `UserStatusList` return; `UserListComponent` unchanged. A hidden friend's status (which embeds `latest_session`) is now correctly withheld.
- **Friend preferences** → new **`useFriendPreferences`** hook (`GET /v1/users/:uid/preferences`), sourcing `userDataList[uid].preferences` from Onyx. `DayOverviewScreen` + `SessionsCalendarScreen` swap off `useFetchData(['preferences'])`.

New wiring: `OpenPublicProfilePage` route + `OpenFriendPreferences` / `OpenFriendStatus` READ commands (+ params + `kirokuRoutes`), and `Preferences.openFriendPreferences`. `UserData` gains denormalized friend-meta keys `preferences?` / `user_status?` (mirroring `is_supporter` / `earliest_session_at`).

## #786 — denied reads evict

All three reads are served by the server's evict-on-deny contract: a denied/hidden read returns 200 with the relevant `userDataList[uid]` key merged to `null`, so a viewer who has lost access stops showing cached friend prefs/status (and profiles are public). Flows through `SaveResponseInOnyx` like the sessions repoint.

## Deferred

`ProfileScreen` still reads a friend's `userData` + `preferences` via `useFetchData` — that screen needs the broader **`users/$uid` (userData) read** migrated, which is its own slice. `useFetchData` + `fetchDataKeyToDbPath` stay for it (`readDataOnce`/`generateDatabaseKey` untouched).

## Gates

- `typecheck-tsgo` ✅
- `react-compiler-compliance-check` (`check-changed`) ✅
- `lint-changed` ✅ (0 errors; only pre-existing seatbelt warnings)
- `prettier` ✅

Refs #809, #786. Builds on the now-merged #990 and the deployed kiroku-api #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)