### PR TITLE
refactor(realtime): cut ProfileScreen's friend userData read off Firebase

### DIFF
--- a/src/hooks/useFriendProfile/index.ts
+++ b/src/hooks/useFriendProfile/index.ts
@@ -1,0 +1,56 @@
+import * as Profile from '@libs/actions/Profile';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type UserData from '@src/types/onyx/UserData';
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+import {useEffect, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
+
+type UseFriendProfileReturn = {
+  /** The viewed user's public data (profile, public_data, is_supporter, friends),
+   *  or `undefined` until loaded. */
+  userData: UserData | undefined;
+  /** True until both reads (profile + friends) settle. `false` for an empty
+   *  `userID`. */
+  isLoading: boolean;
+};
+
+/**
+ * Read a user's public profile + friends list through the kiroku-api
+ * (`GET /v1/users/:uid/profile` + `GET /v1/users/:uid/friends`), replacing the
+ * direct Firebase RTDB read of `users/$uid` the profile screen did via
+ * `useFetchData(['userData'])`. Both responses merge into `userDataList[userID]`
+ * (profile + public_data + is_supporter, and friends), which this hook reads
+ * back via Onyx. `isLoading` is DERIVED from which userID has settled, so the
+ * only setState happens in the async `.finally` below. An empty `userID` is a
+ * no-op.
+ */
+function useFriendProfile(userID: UserID): UseFriendProfileReturn {
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
+  const userData = userID ? userDataList?.[userID] : undefined;
+
+  const [loadedUserID, setLoadedUserID] = useState<UserID | null>(null);
+
+  useEffect(() => {
+    if (!userID) {
+      return;
+    }
+    let isActive = true;
+    Promise.all([
+      Profile.openPublicProfile(userID),
+      Profile.openFriendList(userID),
+    ]).finally(() => {
+      if (isActive) {
+        setLoadedUserID(userID);
+      }
+    });
+    return () => {
+      isActive = false;
+    };
+  }, [userID]);
+
+  const isLoading = !!userID && loadedUserID !== userID;
+
+  return {userData, isLoading};
+}
+
+export default useFriendProfile;

--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -85,6 +85,14 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
       fields: typeof data.fields === 'string' ? data.fields : 'profile,status',
     }),
   },
+  // A user's friends list (public, like the profile read). Backs ProfileScreen's
+  // friend / common-friend counts; merged into userDataList[uid].friends.
+  [READ_COMMANDS.OPEN_FRIEND_LIST]: {
+    method: 'get',
+    path: '/v1/users/:uid/friends',
+    toPath: data =>
+      `/v1/users/${encodeURIComponent(String(data.userID))}/friends`,
+  },
   [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: {
     method: 'get',
     path: '/v1/updates',

--- a/src/libs/API/parameters/OpenFriendListParams.ts
+++ b/src/libs/API/parameters/OpenFriendListParams.ts
@@ -1,0 +1,9 @@
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+/** Params for the public friend-list read (`GET /v1/users/:uid/friends`). */
+type OpenFriendListParams = {
+  /** The user whose friends list is being read. Authority is the Bearer token. */
+  userID: UserID;
+};
+
+export default OpenFriendListParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -17,6 +17,7 @@ export type {default as OpenFriendDrinkingSessionsParams} from './OpenFriendDrin
 export type {default as OpenFriendPreferencesParams} from './OpenFriendPreferencesParams';
 export type {default as OpenFriendStatusParams} from './OpenFriendStatusParams';
 export type {default as GetUsersBatchParams} from './GetUsersBatchParams';
+export type {default as OpenFriendListParams} from './OpenFriendListParams';
 export type {default as OptInOutToPushNotificationsParams} from './OptInOutToPushNotificationsParams';
 export type {default as ReconnectAppParams} from './ReconnectAppParams';
 export type {default as UpdateAutomaticTimezoneParams} from './UpdateAutomaticTimezoneParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -115,6 +115,7 @@ const READ_COMMANDS = {
   OPEN_FRIEND_PREFERENCES: 'OpenFriendPreferences',
   OPEN_FRIEND_STATUS: 'OpenFriendStatus',
   GET_USERS_BATCH: 'GetUsersBatch',
+  OPEN_FRIEND_LIST: 'OpenFriendList',
   //   OPEN_PLAID_BANK_LOGIN: 'OpenPlaidBankLogin',
   //   OPEN_PLAID_BANK_ACCOUNT_SELECTOR: 'OpenPlaidBankAccountSelector',
   //   GET_ROUTE: 'GetRoute',
@@ -138,6 +139,7 @@ type ReadCommandParameters = {
   [READ_COMMANDS.OPEN_FRIEND_PREFERENCES]: Parameters.OpenFriendPreferencesParams;
   [READ_COMMANDS.OPEN_FRIEND_STATUS]: Parameters.OpenFriendStatusParams;
   [READ_COMMANDS.GET_USERS_BATCH]: Parameters.GetUsersBatchParams;
+  [READ_COMMANDS.OPEN_FRIEND_LIST]: Parameters.OpenFriendListParams;
   //    ...
 };
 

--- a/src/libs/actions/Profile.ts
+++ b/src/libs/actions/Profile.ts
@@ -7,7 +7,11 @@ import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
-import type {GetUsersBatchParams} from '@libs/API/parameters';
+import type {
+  GetUsersBatchParams,
+  OpenFriendListParams,
+  OpenPublicProfilePageParams,
+} from '@libs/API/parameters';
 import CONST from '@src/CONST';
 import type {
   Profile,
@@ -220,9 +224,45 @@ async function updateProfileInfo(
   await updateProfile(auth.currentUser, {photoURL: downloadURL});
 }
 
+/**
+ * Read a single user's public profile (profile + public_data + public
+ * is_supporter) via `GET /v1/users/:uid/profile`. The response merges those into
+ * `userDataList[userID]`; this returns the promise so a caller can await the
+ * round-trip. Single-user twin of `fetchUserProfiles` for the profile screen.
+ */
+function openPublicProfile(userID: UserID): Promise<void | Response> {
+  const parameters: OpenPublicProfilePageParams = {userID};
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE,
+    parameters,
+    {},
+    CONST.API_REQUEST_TYPE.READ,
+  );
+}
+
+/**
+ * Read a user's friends list via the public `GET /v1/users/:uid/friends`,
+ * replacing the direct Firebase RTDB read. The response merges
+ * `userDataList[userID].friends`; the profile screen reads it back from Onyx to
+ * compute friend / common-friend counts.
+ */
+function openFriendList(userID: UserID): Promise<void | Response> {
+  const parameters: OpenFriendListParams = {userID};
+  // eslint-disable-next-line rulesdir/no-api-side-effects-method
+  return API.makeRequestWithSideEffects(
+    READ_COMMANDS.OPEN_FRIEND_LIST,
+    parameters,
+    {},
+    CONST.API_REQUEST_TYPE.READ,
+  );
+}
+
 export {
   fetchUserProfiles,
   fetchUserStatuses,
+  openPublicProfile,
+  openFriendList,
   setProfilePictureURL,
   setSupporterFlagInList,
   updateProfileInfo,

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -1,7 +1,6 @@
 import {View} from 'react-native';
 import type {DateData} from 'react-native-calendars';
 import {useFirebase} from '@context/global/FirebaseContext';
-import * as Profile from '@userActions/Profile';
 import type {StatData} from '@components/Items/StatOverview';
 import StatOverview from '@components/Items/StatOverview';
 import ProfileOverview from '@components/Social/ProfileOverview';
@@ -30,10 +29,10 @@ import type SCREENS from '@src/SCREENS';
 import Navigation from '@libs/Navigation/Navigation';
 import DBPATHS from '@src/DBPATHS';
 import ROUTES from '@src/ROUTES';
-import useFetchData from '@hooks/useFetchData';
+import useFriendProfile from '@hooks/useFriendProfile';
+import useFriendPreferences from '@hooks/useFriendPreferences';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import ScreenWrapper from '@components/ScreenWrapper';
-import type {FetchDataKeys} from '@hooks/useFetchData/types';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
@@ -55,23 +54,22 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const {auth, db} = useFirebase();
   const {userID} = route.params;
   const user = auth.currentUser;
-  // `drinkingSessionData` is fetched separately via `useDrinkingSessionsFetch`
-  // — that hook windows the Firebase query by `start_time` and re-fetches when
-  // the calendar widens. `useFetchData` stays for the non-windowed keys.
-  const relevantDataKeys: FetchDataKeys = ['userData', 'preferences'];
+  // Friend data now comes from the kiroku-api (privacy-enforced) instead of
+  // direct Firebase reads: profile + friends via `useFriendProfile`, rendering
+  // preferences via `useFriendPreferences`, and the windowed sessions via
+  // `useDrinkingSessionsFetch`.
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
-  const {data: fetchedData, isLoading: isFetchLoading} = useFetchData(
-    userID,
-    relevantDataKeys,
-  );
+  const {userData, isLoading: isProfileFetchLoading} = useFriendProfile(userID);
+  const {preferences, isLoading: isPrefsLoading} = useFriendPreferences(userID);
   const {
     data: drinkingSessionData,
     isLoading: isSessionsLoading,
     isFetchingOlderMonths,
   } = useDrinkingSessionsFetch(userID);
-  const isLoading = isFetchLoading || isSessionsLoading;
+  const isLoading =
+    isProfileFetchLoading || isPrefsLoading || isSessionsLoading;
   // Defer the (heavy) calendar mount until after the navigation slide. The
   // compact `<SessionsCalendar>` runs `useLazyMarkedDates`' synchronous
   // indexing on first render, which otherwise blocks the push slide-in.
@@ -107,8 +105,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const [unitsConsumed, setUnitsConsumed] = useState(0);
   const [manageFriendModalVisible, setManageFriendModalVisible] =
     useState(false);
-  const userData = fetchedData?.userData;
-  const preferences = fetchedData?.preferences;
   const profileData = userData?.profile;
   const friends = userData?.friends;
 
@@ -177,16 +173,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
     setFriendCount(newFriendCount);
     setCommonFriendCount(newCommonFriendCount);
   }, [friends, selfFriends]);
-
-  // Mirror the viewed user's public `is_supporter` flag into USER_DATA_LIST so
-  // SupporterBadgeForUser (which reads from that collection) can render
-  // immediately on profiles reached via deep link rather than through a list.
-  useEffect(() => {
-    if (!userID || userData === undefined) {
-      return;
-    }
-    Profile.setSupporterFlagInList(userID, userData.is_supporter ?? false);
-  }, [userID, userData]);
 
   // Monitor stats
   useEffect(() => {


### PR DESCRIPTION
## What

The **last** cross-user read still on direct Firebase RTDB: `ProfileScreen` read a friend's `users/$uid` (userData) + preferences via `useFetchData(['userData','preferences'])`. This repoints it to the privacy-enforced kiroku-api, completing the cross-user read migration.

> ⚠️ **RUNTIME-BLOCKED on [kiroku-api#73](https://github.com/PetrCala/kiroku-api/pull/73)** — the `GET /v1/users/:uid/friends` endpoint must be merged + deployed to **dev** first.

## Changes

- **New `useFriendProfile` hook** → `GET /v1/users/:uid/profile` (profile + public_data + is_supporter) **+** `GET /v1/users/:uid/friends` (friends list, new in #73). Both merge into `userDataList[uid]`; the hook reads it back from Onyx. Backed by `Profile.openPublicProfile` / `Profile.openFriendList` actions + a new `OpenFriendList` READ command/route/params.
- **Preferences** via the existing `useFriendPreferences` hook (from #999).
- **`ProfileScreen`** drops `useFetchData(['userData','preferences'])`; `userData` + `preferences` now come from the hooks. Removed the now-redundant `setSupporterFlagInList` effect — `is_supporter` rides the profile read straight into `userDataList`, where the badge already reads it (so the deep-link badge path the effect existed for is covered).

## Why `friends` is its own read

`friends` is fetched separately from `profile` so the per-user profile reads that back friend **list** views (`Profile.fetchUserProfiles`) don't each pull a full friends map. Only ProfileScreen (which needs counts) pays for it. (See #73.)

## Deferred

ProfileScreen still reads the **viewer's own** friends via Firebase `readDataOnce` (for the common-friends count). That's the viewer's *own* data — already in Onyx via `app/open` — so it's a small own-data cleanup, not a cross-user read; out of scope here.

## Gates

- `typecheck-tsgo` ✅
- `react-compiler-compliance-check` (`check-changed`) ✅ (ProfileScreen now compiles clean)
- `lint-changed` ✅ (0 errors)
- `prettier` ✅

Refs #809. Builds on #990 + #999 (merged) and kiroku-api #73 (pending deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)