### PR TITLE
refactor(api): batch friend-list profile/status reads via GET /v1/users/batch

### DIFF
--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -70,6 +70,21 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     toPath: data =>
       `/v1/users/${encodeURIComponent(String(data.userID))}/status`,
   },
+  // Batched cross-user read: one request for up to 100 uids (callers chunk
+  // above that), replacing the per-uid profile/status fan-out that tripped the
+  // per-uid rate limiter. `fields` selects the projections (`profile` is public;
+  // `status` is privacy-gated and simply absent for a denied/hidden user). The
+  // server merges `userDataList[uid].{profile,user_status,...}` per uid, same as
+  // the single-user reads. `uids` is comma-joined here and percent-encoded by
+  // the HTTP layer (matches the SEARCH_USERS style — no pre-encoding).
+  [READ_COMMANDS.GET_USERS_BATCH]: {
+    method: 'get',
+    path: '/v1/users/batch',
+    toQuery: data => ({
+      uids: Array.isArray(data.userIDs) ? data.userIDs.join(',') : '',
+      fields: typeof data.fields === 'string' ? data.fields : 'profile,status',
+    }),
+  },
   [SIDE_EFFECT_REQUEST_COMMANDS.GET_MISSING_ONYX_MESSAGES]: {
     method: 'get',
     path: '/v1/updates',

--- a/src/libs/API/parameters/GetUsersBatchParams.ts
+++ b/src/libs/API/parameters/GetUsersBatchParams.ts
@@ -1,0 +1,22 @@
+import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+/**
+ * Params for the batched cross-user read (`GET /v1/users/batch`). Collapses what
+ * used to be one request per uid (profile / status) into one request per chunk.
+ */
+type GetUsersBatchParams = {
+  /**
+   * The users to read. The server caps each request at 100 uids; callers above
+   * that chunk before calling. Authority is the caller's Bearer token.
+   */
+  userIDs: UserID[];
+
+  /**
+   * Optional comma-separated projection selector (e.g. `profile`, `status`,
+   * `profile,status`). `profile` is public; `status` is privacy-gated and simply
+   * absent for a denied/hidden user.
+   */
+  fields?: string;
+};
+
+export default GetUsersBatchParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -16,6 +16,7 @@ export type {default as SearchUsersParams} from './SearchUsersParams';
 export type {default as OpenFriendDrinkingSessionsParams} from './OpenFriendDrinkingSessionsParams';
 export type {default as OpenFriendPreferencesParams} from './OpenFriendPreferencesParams';
 export type {default as OpenFriendStatusParams} from './OpenFriendStatusParams';
+export type {default as GetUsersBatchParams} from './GetUsersBatchParams';
 export type {default as OptInOutToPushNotificationsParams} from './OptInOutToPushNotificationsParams';
 export type {default as ReconnectAppParams} from './ReconnectAppParams';
 export type {default as UpdateAutomaticTimezoneParams} from './UpdateAutomaticTimezoneParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -114,6 +114,7 @@ const READ_COMMANDS = {
   OPEN_FRIEND_DRINKING_SESSIONS: 'OpenFriendDrinkingSessions',
   OPEN_FRIEND_PREFERENCES: 'OpenFriendPreferences',
   OPEN_FRIEND_STATUS: 'OpenFriendStatus',
+  GET_USERS_BATCH: 'GetUsersBatch',
   //   OPEN_PLAID_BANK_LOGIN: 'OpenPlaidBankLogin',
   //   OPEN_PLAID_BANK_ACCOUNT_SELECTOR: 'OpenPlaidBankAccountSelector',
   //   GET_ROUTE: 'GetRoute',
@@ -136,6 +137,7 @@ type ReadCommandParameters = {
   [READ_COMMANDS.OPEN_FRIEND_DRINKING_SESSIONS]: Parameters.OpenFriendDrinkingSessionsParams;
   [READ_COMMANDS.OPEN_FRIEND_PREFERENCES]: Parameters.OpenFriendPreferencesParams;
   [READ_COMMANDS.OPEN_FRIEND_STATUS]: Parameters.OpenFriendStatusParams;
+  [READ_COMMANDS.GET_USERS_BATCH]: Parameters.GetUsersBatchParams;
   //    ...
 };
 

--- a/src/libs/actions/Profile.ts
+++ b/src/libs/actions/Profile.ts
@@ -7,12 +7,14 @@ import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
-import type {
-  OpenFriendStatusParams,
-  OpenPublicProfilePageParams,
-} from '@libs/API/parameters';
+import type {GetUsersBatchParams} from '@libs/API/parameters';
 import CONST from '@src/CONST';
-import type {ProfileList, UserStatusList} from '@src/types/onyx';
+import type {
+  Profile,
+  ProfileList,
+  UserStatus,
+  UserStatusList,
+} from '@src/types/onyx';
 import type Response from '@src/types/onyx/Response';
 import type UserData from '@src/types/onyx/UserData';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
@@ -49,15 +51,76 @@ function userDataPatchFromResponse(
   return undefined;
 }
 
+/** The kiroku-api caps each `GET /v1/users/batch` request at 100 uids. */
+const USERS_BATCH_CHUNK_SIZE = 100;
+
+/** Split `userIDs` into chunks of at most `USERS_BATCH_CHUNK_SIZE`. */
+function chunkUserIDs(userIDs: UserID[]): UserID[][] {
+  const chunks: UserID[][] = [];
+  for (let i = 0; i < userIDs.length; i += USERS_BATCH_CHUNK_SIZE) {
+    chunks.push(userIDs.slice(i, i + USERS_BATCH_CHUNK_SIZE));
+  }
+  return chunks;
+}
+
 /**
- * Fetches the given users' public profiles via the kiroku-api public-profile
- * read (`GET /v1/users/:uid/profile`), replacing the direct Firebase RTDB read.
- * Each response ALSO merges that user's `profile` + public `is_supporter` flag
- * into `USER_DATA_LIST`, so the SupporterBadge data path is hydrated without a
- * separate fetch (this is why the old `fetchAndStoreSupporterFlags` pass is
- * gone). Returns the same `ProfileList` shape the callers render from. A user
- * whose profile is missing (404) is omitted rather than throwing, so one
- * deleted account can't blank the whole list.
+ * Reads `userIDs` through the batched kiroku-api endpoint
+ * (`GET /v1/users/batch`), chunking at the server's 100-uid cap and running the
+ * chunks in parallel. This collapses the old per-uid fan-out (~one request per
+ * friend, which tripped the per-uid rate limiter) into ~one request per chunk.
+ * `fields` selects the projections the server returns; `select` pulls the wanted
+ * slice out of each uid's merged `userDataList` patch (via
+ * `userDataPatchFromResponse`). A uid the server omits (404 / denied / hidden)
+ * yields no entry, preserving the single-user readers' behaviour.
+ *
+ * @param userIDs The users to read.
+ * @param fields Comma-separated projection selector (e.g. `profile`, `status`).
+ * @param select Maps a uid's patch to the value stored under that uid, or
+ *   `undefined` to omit it.
+ * @returns A promise resolving to the keyed list of selected values.
+ */
+async function fetchUsersBatch<T>(
+  userIDs: UserID[],
+  fields: string,
+  select: (patch: Partial<UserData> | undefined) => T | undefined,
+): Promise<Record<UserID, T>> {
+  const chunkLists = await Promise.all(
+    chunkUserIDs(userIDs).map(async chunk => {
+      const parameters: GetUsersBatchParams = {userIDs: chunk, fields};
+      // eslint-disable-next-line rulesdir/no-api-side-effects-method
+      const response = await API.makeRequestWithSideEffects(
+        READ_COMMANDS.GET_USERS_BATCH,
+        parameters,
+        {},
+        CONST.API_REQUEST_TYPE.READ,
+      );
+      const chunkList: Record<UserID, T> = {};
+      for (const userID of chunk) {
+        const value = select(userDataPatchFromResponse(response, userID));
+        if (value !== undefined) {
+          chunkList[userID] = value;
+        }
+      }
+      return chunkList;
+    }),
+  );
+  const list: Record<UserID, T> = {};
+  for (const chunkList of chunkLists) {
+    Object.assign(list, chunkList);
+  }
+  return list;
+}
+
+/**
+ * Fetches the given users' public profiles via the batched kiroku-api read
+ * (`GET /v1/users/batch?fields=profile`), replacing the per-uid public-profile
+ * fan-out. Each response ALSO merges every returned user's `profile` + public
+ * `is_supporter` flag into `USER_DATA_LIST`, so the SupporterBadge data path is
+ * hydrated without a separate fetch (this is why the old
+ * `fetchAndStoreSupporterFlags` pass is gone). Returns the same `ProfileList`
+ * shape the callers render from. A user whose profile is missing (404) is
+ * omitted rather than throwing, so one deleted account can't blank the whole
+ * list.
  *
  * @param db Unused (retained for call-site compatibility); authority is the
  *   caller's Firebase ID token, attached by the API layer.
@@ -68,27 +131,10 @@ async function fetchUserProfiles(
   db: Database,
   userIDs: UserID[],
 ): Promise<ProfileList> {
-  const list: ProfileList = {};
   if (!db || !userIDs?.length) {
-    return list;
+    return {};
   }
-  await Promise.all(
-    userIDs.map(async userID => {
-      const parameters: OpenPublicProfilePageParams = {userID};
-      // eslint-disable-next-line rulesdir/no-api-side-effects-method
-      const response = await API.makeRequestWithSideEffects(
-        READ_COMMANDS.OPEN_PUBLIC_PROFILE_PAGE,
-        parameters,
-        {},
-        CONST.API_REQUEST_TYPE.READ,
-      );
-      const profile = userDataPatchFromResponse(response, userID)?.profile;
-      if (profile) {
-        list[userID] = profile;
-      }
-    }),
-  );
-  return list;
+  return fetchUsersBatch<Profile>(userIDs, 'profile', patch => patch?.profile);
 }
 
 /**
@@ -107,12 +153,11 @@ async function setSupporterFlagInList(
 }
 
 /**
- * Fetches the given users' presence + latest session via the privacy-enforced
- * kiroku-api friend-status read (`GET /v1/users/:uid/status`), replacing the
- * direct Firebase RTDB read. The server gates the read (friends + visibility);
- * a denied/hidden user simply yields no entry (the response evicts
- * `userDataList[uid].user_status`). Returns the same `UserStatusList` shape the
- * caller renders from.
+ * Fetches the given users' presence + latest session via the batched
+ * privacy-enforced kiroku-api read (`GET /v1/users/batch?fields=status`),
+ * replacing the per-uid friend-status fan-out. The server gates each uid
+ * (friends + visibility); a denied/hidden user simply yields no entry. Returns
+ * the same `UserStatusList` shape the caller renders from.
  *
  * @param db Unused (retained for call-site compatibility); authority is the
  *   caller's Firebase ID token, attached by the API layer.
@@ -123,27 +168,14 @@ async function fetchUserStatuses(
   db: Database,
   userIDs: UserID[],
 ): Promise<UserStatusList> {
-  const list: UserStatusList = {};
   if (!db || !userIDs?.length) {
-    return list;
+    return {};
   }
-  await Promise.all(
-    userIDs.map(async userID => {
-      const parameters: OpenFriendStatusParams = {userID};
-      // eslint-disable-next-line rulesdir/no-api-side-effects-method
-      const response = await API.makeRequestWithSideEffects(
-        READ_COMMANDS.OPEN_FRIEND_STATUS,
-        parameters,
-        {},
-        CONST.API_REQUEST_TYPE.READ,
-      );
-      const status = userDataPatchFromResponse(response, userID)?.user_status;
-      if (status) {
-        list[userID] = status;
-      }
-    }),
+  return fetchUsersBatch<UserStatus>(
+    userIDs,
+    'status',
+    patch => patch?.user_status,
   );
-  return list;
 }
 
 /**


### PR DESCRIPTION
## Summary

Repoints the friend-list reads onto the new batched kiroku-api endpoint
`GET /v1/users/batch`, collapsing the per-uid request fan-out.

`src/libs/actions/Profile.ts`'s `fetchUserProfiles` and `fetchUserStatuses`
each used `Promise.all(userIDs.map(...))` — **one request per friend**. With
~29 friends that's ~58 simultaneous reads, which tripped the per-uid rate
limiter and produced a 429 storm. Both functions now issue **one request per
≤100-uid chunk** (the server cap), run in parallel.

## What changed

- **`src/libs/API/types.ts`** — registers the `GET_USERS_BATCH: 'GetUsersBatch'`
  READ command + its `ReadParameters` entry.
- **`src/libs/API/parameters/GetUsersBatchParams.ts`** (new) — `{ userIDs: string[]; fields?: string }`,
  exported from `parameters/index.ts`.
- **`src/libs/API/kirokuRoutes.ts`** — `GET /v1/users/batch` with
  `toQuery → { uids: <comma-joined>, fields }`. `uids` is joined here and
  percent-encoded by the HTTP layer (SEARCH_USERS style — no pre-encoding;
  only `toPath` needs explicit encoding).
- **`src/libs/actions/Profile.ts`** — both readers now call the batch endpoint
  via a shared `fetchUsersBatch<T>` helper that chunks at 100, `Promise.all`s
  over chunks, and reuses the existing `userDataPatchFromResponse(response, uid)`
  to project each uid's `.profile` / `.user_status`. The `ProfileList` /
  `UserStatusList` return shapes are unchanged, so call sites
  (`useProfileList`, `UserListComponent`, friend screens) are untouched.

`fetchUserProfiles` requests `fields=profile` and `fetchUserStatuses` requests
`fields=status` — two batch calls (~2 requests) instead of ~58. They're kept
separate because the two readers run at different layers with different input
sets (profiles for the paginated display slice via the hook; statuses for the
full array to compute priority ordering), so there is no single call site that
fetches both together to combine.

The `rulesdir/no-api-side-effects-method` eslint-disable +
`CONST.API_REQUEST_TYPE.READ` pattern is preserved, and all API calls stay in
the actions layer (no-API-in-views). The single-user
`OpenPublicProfilePage` / `OpenFriendStatus` commands remain registered for
single-fetch callers.

## ⚠️ Prerequisite

Requires the kiroku-api **`GET /v1/users/batch`** endpoint to already be
deployed (merged + on **dev**). The endpoint returns
`merge userDataList { [uid]: { profile, public_data?, is_supporter?, user_status } }`
— `profile` public, `user_status` privacy-gated (absent when denied).

## Testing

- `npm run typecheck` (tsc) — ✅
- `npm run test` (full jest suite: 1382 passed, 2 suites skipped) — ✅
- `lint-changed` — ✅
- `react-compiler-compliance-check check-changed` — ✅
- prettier — ✅ clean

https://claude.ai/code/session_01QcwWSEqZanwsaayTKo4UJx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcwWSEqZanwsaayTKo4UJx)_