### PR TITLE
Align home header profile skeleton with real header layout

### DIFF
--- a/src/screens/HomeScreenSkeleton.tsx
+++ b/src/screens/HomeScreenSkeleton.tsx
@@ -9,16 +9,11 @@ function HomeHeaderSkeleton() {
   const styles = useThemeStyles();
   const avatarSize = variables.avatarSizeMedium;
   return (
-    <View
-      style={[
-        styles.headerBar,
-        styles.borderBottom,
-        styles.flexRow,
-        styles.alignItemsCenter,
-        styles.ph2,
-      ]}>
-      <Skeleton circle height={avatarSize} />
-      <Skeleton width={140} height={16} style={styles.ml3} />
+    <View style={[styles.headerBar, styles.borderBottom, styles.ph2]}>
+      <View style={[styles.flexRow, styles.alignItemsCenter]}>
+        <Skeleton circle height={avatarSize} />
+        <Skeleton width={140} height={16} style={styles.ml3} />
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary

When the app opens, the home-screen header shows a loading skeleton (profile avatar + display name) before user data is ready. The skeleton was rendering **centered in the middle of the screen** instead of matching the real header, where the avatar and display name sit left-aligned and vertically centered.

## Root cause

`HomeHeaderSkeleton` applied `flexRow` directly to the `headerBar` container. Since `headerBar` defines `justifyContent: 'center'`, switching it to a row direction made that `justifyContent` act on the **horizontal** axis, centering the placeholders across the screen.

The real header (`HomeScreen.tsx`) keeps `headerBar` as a column and places a `flexRow` `Button` inside it, so `justifyContent: 'center'` only centers vertically while the content stays left-aligned.

## Fix

Mirror the real header's structure in the skeleton: keep the outer `headerBar` as a column and wrap the avatar/name skeletons in an inner `flexRow` + `alignItemsCenter` row. The skeleton now lines up exactly with the profile picture and display name.

## Testing

- `npx prettier --write` on the changed file
- `npm run lint-changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015uUM3cP27AAwdwuX2g1iKH)_