### PR TITLE
copy(stats): drop "quiet" wording + cut em-dashes from UI prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,8 @@ The skill provides guidance on:
 
 `src/languages/en.ts` is the source of truth; every other locale mirrors its key structure. Do **not** hand-write non-English translations in a feature PR — add English keys only, then fill other locales with the `translate` skill, which translates against each language's glossary in `src/languages/context/`. Every locale needs a context file (enforced by a unit test). An optional AI quality review can be run manually via the `translation-review` workflow.
 
+**Copy voice — avoid em-dashes (`—`) in UI strings.** They read as artificial in running prose. Prefer two short sentences, a comma, or parentheses. This applies to the English source in `en.ts` and to every translation; the per-language guides in `src/languages/context/` restate the rule for translators.
+
 ### Code Quality
 
 - **TypeScript**: Strict mode enabled

--- a/src/languages/context/_TEMPLATE.md
+++ b/src/languages/context/_TEMPLATE.md
@@ -90,6 +90,9 @@ Brand names, platform names, and any string that must stay in English (e.g.
 - Time format (12h vs 24h).
 - Date format.
 - Punctuation specifics (quotes, ellipsis, …).
+- **Em-dashes (`—`)**: avoid them in running copy; they read as artificial in
+  prose. Prefer two sentences, a comma, or parentheses. The English source is
+  kept dash-free, so keep translations dash-free too.
 
 ## Known inconsistencies to fix (audit backlog)
 

--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -117,6 +117,9 @@ helper only takes two arguments (singular + one plural).
   shared across locales — leave as-is unless the product asks for Czech
   `D. M. YYYY`.
 - **Ellipsis**: use the single `…` character, not three dots.
+- **Em-dashes (`—`)**: avoid them in running copy; they read as artificial in
+  prose. Split into two sentences, or use a comma or parentheses instead. The
+  English source is kept dash-free, so translations should be too.
 
 ## Known inconsistencies to fix (audit backlog)
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -25,7 +25,6 @@ import type {
   SessionWindowIdParams,
   StatsAfDaysParams,
   StatsDrillDownTitleParams,
-  StatsQuietDaysParams,
   SupporterCancelledStatusParams,
   SupporterPriceParams,
   SupporterPurchaseCtaParams,
@@ -756,16 +755,16 @@ export default {
       pricePerYear: ({price}: SupporterPriceParams) => `${price} / rok`,
       pricePerMonth: ({price}: SupporterPriceParams) => `${price} / měsíc`,
       startSupportingCta: ({price}: SupporterPriceParams) =>
-        `Podpořit — ${price}`,
+        `Podpořit za ${price}`,
       loading: 'Načítám detaily předplatného…',
       thanksTitle: 'Jste Kiroku Supporter',
       thanksSubtitle:
-        'Děkujeme za podporu — odznak podporovatele je nyní viditelný na vašem profilu.',
+        'Děkujeme za podporu. Odznak podporovatele je nyní viditelný na vašem profilu.',
       unavailableTitle: 'Předplatné není dostupné',
       unavailableSubtitle:
         'Nepodařilo se nám načíst předplatné podporovatele. Zkontrolujte připojení a zkuste to znovu.',
       purchaseCta: ({price}: SupporterPurchaseCtaParams) =>
-        `Stát se podporovatelem — ${price} / měsíc`,
+        `Stát se podporovatelem za ${price} / měsíc`,
       purchaseError: ({message}: SupporterPurchaseErrorParams) =>
         `Nákup se nezdařil: ${message}. Zkuste to prosím znovu.`,
       restoreError: ({message}: SupporterPurchaseErrorParams) =>
@@ -784,7 +783,7 @@ export default {
       status: {
         active: 'Aktivní',
         cancelled: ({date}: SupporterCancelledStatusParams) =>
-          `Zrušeno — aktivní do ${date}`,
+          `Zrušeno, aktivní do ${date}`,
         gracePeriod: 'Problém s platbou',
         expired: 'Vypršelo',
       },
@@ -793,7 +792,7 @@ export default {
       manageInAppStore: 'Spravovat v App Store',
       manageInGooglePlay: 'Spravovat v Google Play',
       restorePurchases: 'Obnovit nákupy',
-      restoreSuccess: 'Nákupy obnoveny — váš status podporovatele je aktivní.',
+      restoreSuccess: 'Nákupy obnoveny. Váš status podporovatele je aktivní.',
       restoreError: ({message}: SupporterPurchaseErrorParams) =>
         `Obnovení se nezdařilo: ${message}. Zkuste to prosím znovu.`,
       restoreEmpty:
@@ -896,7 +895,8 @@ export default {
     skipVerificationDevOnly: 'Přeskočit ověření (pouze pro vývoj)',
     changeEmail: {
       title: 'Použít jiný e-mail',
-      prompt: 'Zadejte novou adresu a heslo — ověřovací odkaz vám pošleme tam.',
+      prompt:
+        'Zadejte novou adresu a heslo. Ověřovací odkaz vám pošleme na ni.',
       newEmailLabel: 'Nová e-mailová adresa',
       passwordLabel: 'Vaše heslo',
       submit: 'Odeslat ověřovací odkaz',
@@ -999,8 +999,8 @@ export default {
           bandCaption:
             'Stínovaný pás je tam, kde se odehrála většina vašich posledních 8 týdnů.',
           chip: {
-            down: 'Trend dolů — vaše týdenní jednotky postupně klesají.',
-            up: 'Trend nahoru — vaše týdenní jednotky postupně rostou.',
+            down: 'Vaše týdenní jednotky postupně klesají.',
+            up: 'Vaše týdenní jednotky postupně rostou.',
             none: 'Vaše týdny se proměňují jako obvykle.',
           },
           a11yLabel: 'Posledních 8 týdnů týdenních jednotek, vyhlazeno',
@@ -1010,11 +1010,11 @@ export default {
             title: 'Zatím není co zobrazit',
             body: 'Až zaznamenáte relaci, objeví se zde týdenní trendy a měsíční přehled.',
           },
-          noDataInWindow: ({quietDays}: StatsQuietDaysParams) =>
-            `${quietDays} klidných dnů a počítáme dál — vaše trendy se vyjasní, jak budete přidávat data.`,
+          noDataInRange:
+            'Žádné relace v tomto období. Každý uplynulý den byl bez alkoholu.',
         },
         sparseFooter:
-          'Zatím jen pár týdnů historie — vaše trendy se vyjasní, jak budete přidávat data.',
+          'Zatím jen pár týdnů historie. Vaše trendy se vyjasní, jak budete přidávat data.',
       },
       trends: {
         label: 'Trendy',
@@ -1028,7 +1028,7 @@ export default {
             trendingUp: 'Vaše týdenní jednotky mají vzestupný trend.',
             neutral: 'Vaše týdny se mění obvyklým způsobem.',
             notEnoughData:
-              'Pokračujte v zaznamenávání — trend se ukáže, až bude víc dat.',
+              'Pokračujte v zaznamenávání. Trend se ukáže, až bude víc dat.',
           },
         },
         cumulativeAf: {
@@ -1045,7 +1045,7 @@ export default {
       },
       patterns: {
         label: 'Vzorce',
-        placeholder: 'Kdy a jak — hodina dne a den v týdnu — bude tady.',
+        placeholder: 'Kdy a jak (hodina dne a den v týdnu) uvidíte tady.',
       },
       breakdown: {
         label: 'Rozpis',
@@ -1062,7 +1062,7 @@ export default {
         multiples: {
           title: 'Týdenní trend podle druhu',
           subtitle: 'Malý graf pro každý druh s daty v tomto období.',
-          empty: 'Zatím žádné trendy podle druhu — zkus širší období.',
+          empty: 'Zatím žádné trendy podle druhu. Zkus širší období.',
           tileSubtitle: ({units}: BreakdownTileSubtitleParams) =>
             `${units} jednotek za období`,
           a11yTile: ({label}: BreakdownDrinkLabelParams) =>
@@ -1122,9 +1122,9 @@ export default {
         month: ({label}: StatsDrillDownTitleParams) =>
           `Relace v měsíci ${label}`,
         hour: ({label}: StatsDrillDownTitleParams) => `Relace kolem ${label}`,
-        dow: ({label}: StatsDrillDownTitleParams) => `Relace — ${label}`,
+        dow: ({label}: StatsDrillDownTitleParams) => `Relace: ${label}`,
         dowHour: ({label}: StatsDrillDownTitleParams) => label,
-        drinkType: ({label}: StatsDrillDownTitleParams) => `Relace — ${label}`,
+        drinkType: ({label}: StatsDrillDownTitleParams) => `Relace: ${label}`,
         isoWeekDrinkType: ({label}: StatsDrillDownTitleParams) => label,
         sessionDrinkCountBin: ({label}: StatsDrillDownTitleParams) =>
           `Relace s ${label}`,
@@ -1307,7 +1307,7 @@ export default {
     title: 'Testovací nástroje',
     intro: 'Vývojářský panel pro úpravy za běhu a ladění.',
     placeholderNotice:
-      'Toto je zástupný panel. Skutečné přepínače — feature flagy, přepsání prostředí, vynucené stavy sítě — sem postupně přibudou.',
+      'Toto je zástupný panel. Skutečné přepínače (feature flagy, přepsání prostředí, vynucené stavy sítě) sem postupně přibudou.',
     environmentLabel: 'Prostředí',
     howToOpen:
       'Otevřete přes ⌘D → Open Test Preferences nebo čtyřprstovým ťuknutím kdekoli v aplikaci.',
@@ -1390,7 +1390,7 @@ export default {
   },
   pickUsernameScreen: {
     heading: 'Zvolte si uživatelské jméno',
-    explainer: 'Vyberte si uživatelské jméno — pod tímto vás uvidí ostatní.',
+    explainer: 'Vyberte si uživatelské jméno. Pod ním vás uvidí ostatní.',
     saving: 'Ukládám…',
     error: {
       generic:
@@ -1431,7 +1431,7 @@ export default {
   connectedAccounts: {
     title: 'Propojené účty',
     subtitle:
-      'Vyberte si, jak se chcete přihlašovat. Můžete propojit více způsobů — všechny vás přihlásí ke stejnému účtu.',
+      'Vyberte si, jak se chcete přihlašovat. Můžete propojit více způsobů. Všechny vás přihlásí ke stejnému účtu.',
     providers: {
       password: 'E-mail a heslo',
       apple: 'Apple',
@@ -1485,7 +1485,7 @@ export default {
     appleSubmit: 'Propojit účet Apple',
     googleSubmit: 'Propojit účet Google',
     resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
-      `Odkaz pro reset hesla byl odeslán na adresu ${email}. Zkontrolujte si schránku — a složku spamu, pokud ho nevidíte.`,
+      `Odkaz pro reset hesla byl odeslán na adresu ${email}. Zkontrolujte si schránku i složku spamu, pokud ho nevidíte.`,
   },
   passwordScreen: {
     title: 'Změnit heslo',
@@ -1622,7 +1622,7 @@ export default {
       lastProvider: {
         title: 'Nelze odpojit',
         message:
-          'Nelze odpojit poslední způsob přihlášení — ztratili byste přístup k účtu. Nejprve přidejte jiný způsob.',
+          'Nelze odpojit poslední způsob přihlášení, jinak byste ztratili přístup k účtu. Nejprve přidejte jiný způsob.',
       },
     },
     database: {

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1033,7 +1033,7 @@ export default {
         },
         cumulativeAf: {
           title: 'Dny bez alkoholu letos',
-          emptyLabel: 'Každý letošní klidný den se počítá.',
+          emptyLabel: 'Každý letošní den bez alkoholu se počítá.',
         },
         drinkTypeStack: {
           title: 'Mix drinků v čase',
@@ -1054,7 +1054,7 @@ export default {
           subtitle: 'Složení za aktuální období.',
           centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
           centerCaption: 'jednotek',
-          empty: 'Klidné období — zatím není co rozdělit.',
+          empty: 'Zatím není co rozdělit.',
           sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
             `${label}: ${units} jednotek (${share} %)`,
           a11y: 'Koláč složení podle druhu drinku',
@@ -1094,21 +1094,21 @@ export default {
       },
       hourOfDay: {
         title: 'Hodina dne',
-        empty: 'Klidné období — zatím není co zobrazit.',
+        empty: 'Zatím není co zobrazit.',
       },
       dowHour: {
         title: 'Den v týdnu × hodina',
-        empty: 'Klidné období — zatím není co zobrazit.',
+        empty: 'Zatím není co zobrazit.',
       },
       drinksPerSession: {
         title: 'Drinků na relaci',
-        empty: 'Klidné období — žádné relace k započtení.',
+        empty: 'Žádné relace k započtení.',
         p75Copy: ({value}: {value: number}) =>
           `75 % vašich relací má ${value} drinků nebo méně.`,
       },
       sessionDuration: {
         title: 'Délka relace',
-        empty: 'Klidné období — žádné relace k změření.',
+        empty: 'Žádné relace k změření.',
         p75Copy: ({value}: {value: string}) =>
           `75 % vašich relací je kratších než ${value}.`,
       },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -751,16 +751,16 @@ export default {
       pricePerYear: ({price}: SupporterPriceParams) => `${price} / year`,
       pricePerMonth: ({price}: SupporterPriceParams) => `${price} / month`,
       startSupportingCta: ({price}: SupporterPriceParams) =>
-        `Start Supporting — ${price}`,
+        `Start supporting for ${price}`,
       loading: 'Loading subscription details...',
       thanksTitle: "You're a Kiroku Supporter",
       thanksSubtitle:
-        'Thanks for backing the app — your supporter badge is live on your profile.',
+        'Thanks for backing the app. Your supporter badge is live on your profile.',
       unavailableTitle: 'Subscription unavailable',
       unavailableSubtitle:
         "We couldn't load the supporter subscription right now. Check your connection and try again.",
       purchaseCta: ({price}: SupporterPurchaseCtaParams) =>
-        `Become a supporter — ${price} / month`,
+        `Become a supporter for ${price} / month`,
       purchaseError: ({message}: SupporterPurchaseErrorParams) =>
         `Purchase failed: ${message}. Please try again.`,
       restoreError: ({message}: SupporterPurchaseErrorParams) =>
@@ -779,7 +779,7 @@ export default {
       status: {
         active: 'Active',
         cancelled: ({date}: SupporterCancelledStatusParams) =>
-          `Cancelled — active until ${date}`,
+          `Cancelled, active until ${date}`,
         gracePeriod: 'Payment issue',
         expired: 'Expired',
       },
@@ -788,7 +788,7 @@ export default {
       manageInAppStore: 'Manage in App Store',
       manageInGooglePlay: 'Manage in Google Play',
       restorePurchases: 'Restore purchases',
-      restoreSuccess: 'Purchases restored — your supporter status is active.',
+      restoreSuccess: 'Purchases restored. Your supporter status is active.',
       restoreError: ({message}: SupporterPurchaseErrorParams) =>
         `Restore failed: ${message}. Please try again.`,
       restoreEmpty:
@@ -892,7 +892,7 @@ export default {
     changeEmail: {
       title: 'Use a different email',
       prompt:
-        "Enter a new address and your password — we'll send the verification link there instead.",
+        "Enter a new address and your password. We'll send the verification link there instead.",
       newEmailLabel: 'New email address',
       passwordLabel: 'Your password',
       submit: 'Send verification link',
@@ -1020,10 +1020,10 @@ export default {
             body: 'When you log a session, your period scorecard will show up here.',
           },
           noDataInRange:
-            'No sessions in this period — every elapsed day was alcohol-free.',
+            'No sessions in this period. Every elapsed day was alcohol-free.',
         },
         sparseFooter:
-          'Only a little history so far — these numbers will sharpen as you log more.',
+          'Only a little history so far. These numbers will sharpen as you log more.',
       },
       trends: {
         label: 'Trends',
@@ -1037,7 +1037,7 @@ export default {
             trendingUp: 'Your weekly units are trending up.',
             neutral: 'Your weeks vary as usual.',
             notEnoughData:
-              'Keep logging — your trend will surface as data builds.',
+              'Keep logging. Your trend will surface as data builds.',
           },
         },
         cumulativeAf: {
@@ -1055,7 +1055,7 @@ export default {
       patterns: {
         label: 'Patterns',
         placeholder:
-          'Your when-and-how — hour of day and day of week — will live here.',
+          'Your when-and-how (hour of day and day of week) will live here.',
       },
       breakdown: {
         label: 'Breakdown',
@@ -1074,7 +1074,7 @@ export default {
         multiples: {
           title: 'Weekly trend by type',
           subtitle: 'One mini chart per drink type with data in this range.',
-          empty: 'No per-type trends yet — try a wider range.',
+          empty: 'No per-type trends yet. Try a wider range.',
           tileSubtitle: ({units}: BreakdownTileSubtitleParams) =>
             `${units} units this range`,
           a11yTile: ({label}: BreakdownDrinkLabelParams) =>
@@ -1320,7 +1320,7 @@ export default {
     title: 'Test Tools',
     intro: 'Developer-only panel for runtime tweaks and debugging.',
     placeholderNotice:
-      'This is a placeholder. Real toggles — feature flags, environment overrides, forced network states — will land here over time.',
+      'This is a placeholder. Real toggles (feature flags, environment overrides, forced network states) will land here over time.',
     environmentLabel: 'Environment',
     howToOpen:
       'Open via ⌘D → Open Test Preferences, or a four-finger tap anywhere in the app.',
@@ -1399,7 +1399,7 @@ export default {
   },
   pickUsernameScreen: {
     heading: 'Choose a username',
-    explainer: 'Pick a username — this is how others will see you.',
+    explainer: 'Pick a username. This is how others will see you.',
     saving: 'Saving...',
     error: {
       generic: 'Could not save your username. Please try again.',
@@ -1439,7 +1439,7 @@ export default {
   connectedAccounts: {
     title: 'Connected accounts',
     subtitle:
-      'Choose how you want to sign in. You can connect more than one — any of them will sign you into the same account.',
+      'Choose how you want to sign in. You can connect more than one. Any of them will sign you into the same account.',
     providers: {
       password: 'Email & password',
       apple: 'Apple',
@@ -1492,7 +1492,7 @@ export default {
     appleSubmit: 'Connect Apple account',
     googleSubmit: 'Connect Google account',
     resetEmailSent: ({email}: ForgotPasswordSuccessParams) =>
-      `We sent a reset link to ${email}. Check your inbox — and your spam folder if you don't see it.`,
+      `We sent a reset link to ${email}. Check your inbox, and your spam folder if you don't see it.`,
   },
   passwordScreen: {
     title: 'Change your password',
@@ -1636,7 +1636,7 @@ export default {
       lastProvider: {
         title: "Can't Remove",
         message:
-          "You can't disconnect your last sign-in method — you'd be locked out. Connect another method first.",
+          "You can't disconnect your last sign-in method, or you'd be locked out. Connect another method first.",
       },
     },
     database: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1042,7 +1042,7 @@ export default {
         },
         cumulativeAf: {
           title: 'Alcohol-free days this year',
-          emptyLabel: 'Every quiet day this year adds up.',
+          emptyLabel: 'Every alcohol-free day this year adds up.',
         },
         drinkTypeStack: {
           title: 'Drink mix over time',
@@ -1064,7 +1064,7 @@ export default {
           subtitle: 'Composition over the current range.',
           centerUnits: ({count}: BreakdownCenterUnitsParams) => `${count}`,
           centerCaption: 'units',
-          empty: 'A quiet range — nothing to break down yet.',
+          empty: 'Nothing to break down yet.',
           sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
             `${label}: ${units} units (${share}%)`,
           a11y: 'Drink-type composition donut',
@@ -1106,21 +1106,21 @@ export default {
       },
       hourOfDay: {
         title: 'Hour of day',
-        empty: 'A quiet range — nothing to plot here.',
+        empty: 'Nothing to plot here.',
       },
       dowHour: {
         title: 'Day of week × hour',
-        empty: 'A quiet range — nothing to plot here.',
+        empty: 'Nothing to plot here.',
       },
       drinksPerSession: {
         title: 'Drinks per session',
-        empty: 'A quiet range — no sessions to count.',
+        empty: 'No sessions to count.',
         p75Copy: ({value}: {value: number}) =>
           `75% of your sessions are ${value} drinks or fewer.`,
       },
       sessionDuration: {
         title: 'Session length',
-        empty: 'A quiet range — no sessions to measure.',
+        empty: 'No sessions to measure.',
         p75Copy: ({value}: {value: string}) =>
           `75% of your sessions are ${value} or shorter.`,
       },

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -55,10 +55,6 @@ type StatsAfDaysParams = {
   total: number;
 };
 
-type StatsQuietDaysParams = {
-  quietDays: number;
-};
-
 type StatsThresholdParams = {
   threshold: number;
 };
@@ -141,7 +137,6 @@ export type {
   SessionWindowIdParams,
   StatsAfDaysParams,
   StatsDrillDownTitleParams,
-  StatsQuietDaysParams,
   StatsThresholdParams,
   SupporterCancelledStatusParams,
   SupporterPriceParams,


### PR DESCRIPTION
## Summary

Copy cleanup across the **English** and **Czech** locales, in three parts:

### 1. Drop the "quiet" metaphor (statistics empty states)
- `A quiet range — …` → just the actionable remainder (`Nothing to plot here.`, etc.).
- `Every quiet day this year adds up.` → `Every alcohol-free day this year adds up.` (glossary-consistent; CS `Každý letošní den bez alkoholu se počítá.`).

### 2. Reduce em-dashes in prose (they read as artificial)
Audited every `—` in the locale files (16 EN / 20 CS lines — the only two files that used it).
- **Prose joiners** → two sentences or a comma (supporter flow, change-email, sign-in, account, statistics empties).
- **Parenthetical pairs** → parentheses (patterns placeholder, dev placeholder).
- **Supporter price buttons** → `for ${price}` instead of `— ${price}`.
- **Czech-only em-dashes** (trend captions, drilldown titles) aligned to the dash-free English style.

Result: em-dashes in locale prose drop from 16→0 (EN) and 20→0 (CS).

### 3. Fix a real EN/CS key desync (found while auditing)
[`OverviewTab.tsx`](src/screens/Statistics/tabs/OverviewTab.tsx) reads `statistics.tabs.overview.empty.noDataInRange`, which existed **only in English** — Czech had an orphan `noDataInWindow` key, so Czech users were shown the **English fallback** for that scorecard empty state. Fixed by:
- Renaming the CS key to `noDataInRange` (plain string, matching EN's shape).
- Removing the now-unused `StatsQuietDaysParams` type + imports.

## Validation
- `npm run typecheck-tsgo` passes (validates EN↔CS structural parity).
- No locales added/removed, so the translation context-file gate is unaffected.
- Full jest/lint suite runs in CI (can't run locally from a `.claude/` worktree — jest ignores that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)