### PR TITLE
refactor(user): cut admin nickname resolution over to kiroku-api batch read

### DIFF
--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -45,6 +45,7 @@ import type {UserSearchResults} from '@src/types/various/Search';
 import PusherUtils from '@libs/PusherUtils';
 import * as Pusher from '@libs/Pusher/pusher';
 import * as OnyxUpdates from '@userActions/OnyxUpdates';
+import {fetchUserProfiles} from '@userActions/Profile';
 import {PALETTES} from '@libs/SessionColorPalettes';
 import Log from '@libs/Log';
 import ERRORS from '@src/ERRORS';
@@ -386,13 +387,22 @@ function changeUserName(
 }
 
 /**
- * Fetches the Firebase nickname of an array of users. Returns these nicknames as a mapping object in the form of {[userId]: userNickname}.
+ * Resolves the display names of an array of users, returning them as a mapping
+ * object in the form `{[userId]: displayName}`.
  *
- * @param db The Realtime Database instance.
- * @param uid The user's UID.
- * @returns{Promise<string|null>} The nickname or null if not found.
+ * Reads through the batched kiroku-api endpoint
+ * (`GET /v1/users/batch?fields=profile`, via `Profile.fetchUserProfiles`)
+ * instead of the per-uid Firebase RTDB `users/$uid/profile` reads it used to
+ * fire. A user whose profile the server omits (404 / denied) maps to an empty
+ * string, preserving the previous reader's contract that every requested uid
+ * gets an entry.
  *
- * @example const userNickname = await fetchNicknameByUID(db, "userUIDHere");
+ * @param db Unused (retained for call-site compatibility); authority is the
+ *   caller's Firebase ID token, attached by the API layer.
+ * @param userIds The users whose display names to resolve.
+ * @returns A promise resolving to the nickname-by-id mapping.
+ *
+ * @example const nicknames = await fetchUserNicknames(db, ["userUIDHere"]);
  */
 async function fetchUserNicknames(
   db: Database,
@@ -401,22 +411,11 @@ async function fetchUserNicknames(
   if (isEmptyObject(userIds)) {
     return {};
   }
-  const urls = userIds.map(userId =>
-    DBPATHS.USERS_USER_ID_PROFILE.getRoute(userId),
-  );
 
-  const fetchPromises = urls.map(url =>
-    readDataOnce<Profile>(db, url).then(response => response),
-  );
+  const profiles = await fetchUserProfiles(db, userIds);
 
-  const results = await Promise.all(fetchPromises);
-
-  if (!results) {
-    return {};
-  }
-
-  return userIds.reduce((acc, key, index) => {
-    acc[key] = results[index]?.display_name ?? '';
+  return userIds.reduce((acc, userId) => {
+    acc[userId] = profiles[userId]?.display_name ?? '';
     return acc;
   }, {} as NicknameToId);
 }


### PR DESCRIPTION
## What

Closes gap **C2** of the Firebase RTDB → kiroku-api read migration (epic #809): the admin **feedback** and **bug** screens resolved each reporter's display name through a direct per-uid Firebase RTDB read. This moves that resolution onto the already-migrated batched kiroku-api endpoint.

`fetchUserNicknames` (`src/libs/actions/User.ts`) previously fanned out one `readDataOnce<Profile>` per uid against `users/$uid/profile` and mapped each to `display_name`. It now delegates to `Profile.fetchUserProfiles` (`GET /v1/users/batch?fields=profile`) and maps the returned profiles to `display_name`, returning the same `NicknameToId` shape.

## Why this approach (audit option a)

The audit (gap C2) offered two options:
- **(a) client cutover** — reimplement `fetchUserNicknames` on top of `fetchUserProfiles`. ✅ chosen.
- (b) fold display-name resolution into the admin GET responses server-side — heavier, no kiroku-api change needed here.

(a) reuses the batched endpoint and the chunk-at-100 / parallel logic already wrapping it, so it's a small, self-contained client change with no server work.

## Behaviour preserved

- Every requested uid still gets an entry in the returned map.
- A user whose profile the server omits (404 / denied) maps to `''`, exactly as before (`fetchUserProfiles` omits missing users; the `?? ''` fallback restores the old contract).
- The early `isEmptyObject(userIds)` guard is unchanged.

## Why the call sites are untouched

`Profile.fetchUserProfiles(db, userIDs)` still takes — and truthiness-guards on — `db`, matching every other migrated cross-user reader (`fetchUsersData`, `openFriendList`, …) which retain `db` "for call-site compatibility." So `fetchUserNicknames` keeps its `(db, userIds)` signature and passes `db` through. The two consumers — [SeeBugsScreen.tsx](src/screens/Settings/Admin/SeeBugsScreen.tsx) and [SeeFeedbackScreen.tsx](src/screens/Settings/Admin/SeeFeedbackScreen.tsx) — need no changes. Removing `db` would have required changing `fetchUserProfiles`'s signature (wider blast radius, out of scope).

## Imports

The `readDataOnce` import **stays** — it's still used by the app-settings read in the same file. `Database`, `DBPATHS`, and the `Profile` type also remain in use elsewhere, so nothing is dropped. Added a named import of `fetchUserProfiles` from `@userActions/Profile` (named, not `* as Profile`, to avoid colliding with the `Profile` type already in scope; no import cycle — `Profile.ts` does not import `User.ts`).

## Checks

- `npm run react-compiler-compliance-check check-changed` ✅
- `npx prettier --write` (unchanged) ✅
- `npm run lint-changed` ✅ (clean)
- `npm run typecheck-tsgo` ✅

## Notes

Refs #809. **Do not self-merge** — this is gated on device verification per the migration's read-cutover policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)