### PR TITLE
refactor(realtime): cut friends-list reads off Firebase onto kiroku-api

### DIFF
--- a/src/screens/Profile/FriendsFriendsScreen.tsx
+++ b/src/screens/Profile/FriendsFriendsScreen.tsx
@@ -4,8 +4,8 @@ import type {
   ProfileList,
   FriendRequestList,
 } from '@src/types/onyx';
-import type {UserList} from '@src/types/onyx/OnyxCommon';
 import {useCallback, useEffect, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {isEmptyArray} from '@src/types/utils/EmptyObject';
 import {searchArrayByText, getNicknameMapping} from '@libs/Search';
@@ -27,8 +27,7 @@ import type SCREENS from '@src/SCREENS';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
-import DBPATHS from '@src/DBPATHS';
-import {readDataOnce} from '@database/baseFunctions';
+import ONYXKEYS from '@src/ONYXKEYS';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
@@ -51,10 +50,11 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
   const userData = useCurrentUserData();
   const user = auth.currentUser;
   const {translate} = useLocalize();
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
+  // The target user's friends, read via the kiroku-api into
+  // `userDataList[userID].friends` (replacing the direct Firebase read).
+  const friends = userDataList?.[userID]?.friends;
   const [searching, setSearching] = useState<boolean>(false);
-  const [friends, setFriends] = useState<UserList | null | undefined>(
-    undefined,
-  );
   const [displayedFriends, setDisplayedFriends] = useState<UserSearchResults>(
     [],
   );
@@ -153,15 +153,13 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
   const fetchData = useCallback(async () => {
     try {
       setIsLoading(true);
-      const userFriends = await readDataOnce<UserList>(
-        db,
-        DBPATHS.USERS_USER_ID_FRIENDS.getRoute(userID),
-      );
-      setFriends(userFriends);
+      // Read the target user's friends via the kiroku-api (merged into
+      // `userDataList[userID].friends`), replacing the direct Firebase read.
+      await Profile.openFriendList(userID);
     } finally {
       setIsLoading(false);
     }
-  }, [db, userID]);
+  }, [userID]);
 
   useEffect(() => {
     fetchData();

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -8,7 +8,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as App from '@userActions/App';
-import {readDataOnce} from '@database/baseFunctions';
+import * as Profile from '@userActions/Profile';
 import {
   calculateThisMonthUnits,
   dateToDateData,
@@ -22,12 +22,10 @@ import {getCommonFriendsCount} from '@libs/FriendUtils';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {DrinkingSessionArray} from '@src/types/onyx';
-import type {UserList} from '@src/types/onyx/OnyxCommon';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import Navigation from '@libs/Navigation/Navigation';
-import DBPATHS from '@src/DBPATHS';
 import ROUTES from '@src/ROUTES';
 import useFriendProfile from '@hooks/useFriendProfile';
 import useFriendPreferences from '@hooks/useFriendPreferences';
@@ -51,7 +49,7 @@ type ProfileScreenProps = StackScreenProps<
 >;
 
 function ProfileScreen({route}: ProfileScreenProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {userID} = route.params;
   const user = auth.currentUser;
   // Friend data now comes from the kiroku-api (privacy-enforced) instead of
@@ -75,7 +73,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // indexing on first render, which otherwise blocks the push slide-in.
   const {isReady: didScreenTransitionEnd, onEntryTransitionEnd} =
     useReadyAfterScreenTransition();
-  const [selfFriends, setSelfFriends] = useState<UserList | null | undefined>();
+  const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
   const [friendCount, setFriendCount] = useState(0);
   const [commonFriendCount, setCommonFriendCount] = useState(0);
   const [localVisibleDateData, setLocalVisibleDateData] = useState(
@@ -107,6 +105,11 @@ function ProfileScreen({route}: ProfileScreenProps) {
     useState(false);
   const profileData = userData?.profile;
   const friends = userData?.friends;
+  // The common-friends count compares the viewed user's friends against the
+  // viewer's OWN. On your own profile they're the same list; otherwise read the
+  // viewer's own friends back from Onyx (hydrated below via `openFriendList`).
+  const selfFriends =
+    user && user.uid !== userID ? userDataList?.[user.uid]?.friends : friends;
 
   const statsData: StatData = [
     {
@@ -145,23 +148,14 @@ function ProfileScreen({route}: ProfileScreenProps) {
     Navigation.navigate(screenRoute);
   };
 
-  // Track own friends
+  // Hydrate the viewer's own friends (for the common-friends count) when viewing
+  // someone else's profile, via the kiroku-api instead of a direct Firebase read.
   useEffect(() => {
-    const getOwnFriends = async () => {
-      if (!user) {
-        return;
-      }
-      let ownFriends: UserList | null | undefined = friends;
-      if (user?.uid !== userID) {
-        ownFriends = await readDataOnce<UserList>(
-          db,
-          DBPATHS.USERS_USER_ID_FRIENDS.getRoute(user.uid),
-        );
-      }
-      setSelfFriends(ownFriends);
-    };
-    getOwnFriends();
-  }, [db, friends, user, userID]);
+    if (!user || user.uid === userID) {
+      return;
+    }
+    Profile.openFriendList(user.uid);
+  }, [user, userID]);
 
   // Monitor friends count
   useEffect(() => {


### PR DESCRIPTION
## What

Cuts the **last two cross-user friends-list reads** off Firebase RTDB and onto the first-party kiroku-api. These were the remaining direct `readDataOnce<UserList>(db, USERS_USER_ID_FRIENDS.getRoute(uid))` call sites flagged as gap **C1** in `contributingGuides/REALTIME_MIGRATION_AUDIT.md`.

Both screens now go through the already-existing `Profile.openFriendList` (`GET /v1/users/:uid/friends`, public — mirrors the RTDB rule `users/$uid/friends` `.read: auth != null`), which merges `userDataList[uid].friends` into Onyx. The screens read the list back from Onyx — exactly how `useFriendProfile` already consumes the same endpoint. No server work was required (endpoint + client plumbing were pre-staged in #809's earlier PRs).

## Changes

- **`ProfileScreen.tsx`** — the viewer's own friends (used only for the common-friends count when viewing *another* user) now derive from `userDataList[user.uid].friends`, hydrated by `openFriendList(user.uid)` in an effect. Replaces the `getOwnFriends` RTDB read.
- **`FriendsFriendsScreen.tsx`** — the target user's friends now derive from `userDataList[userID].friends`, hydrated by `openFriendList(userID)` in `fetchData` (loading spinner preserved).
- Drops the now-orphaned `readDataOnce` / `DBPATHS` / `UserList` imports from both screens, plus the unused `db` handle in `ProfileScreen`.

No behavioral change to the common-friends math; only the data source moves from RTDB to kiroku-api + Onyx.

## Testing

- `npm run react-compiler-compliance-check check-changed` ✅
- `npx prettier --write` (both files already formatted) ✅
- `npm run lint-changed` ✅ (no new errors; eslint-seatbelt baseline unchanged)
- `npm run typecheck-tsgo` ✅

## Notes

- Part of the RTDB read-cutover epic #809 (audit gap **C1**).
- ⚠️ **Do not self-merge** — this rides a realtime transport path that is device-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)