### PR TITLE
fix(statistics): make drill-down session tiles read-only

### DIFF
--- a/src/screens/Statistics/StatsDrillDownSheet.tsx
+++ b/src/screens/Statistics/StatsDrillDownSheet.tsx
@@ -168,10 +168,18 @@ function StatsDrillDownSheet() {
             data={sessions}
             keyExtractor={item => String(item.sessionId)}
             renderItem={({item}) => (
+              // Read-only: the drill-down is an analytics surface, so tiles
+              // surface session detail but aren't tappable. Editing/deleting a
+              // session lives on the calendar/day-overview, whose back-navigation
+              // (popModalFlow) is built to reveal the Day Overview beneath the
+              // modal — not another RHP screen like Statistics. Letting users
+              // edit from here routed delete through that unsupported path and
+              // froze the Statistics screen on return.
               <DrinkingSessionOverview
                 sessionId={item.sessionId}
                 session={item.session}
                 isEditModeOn={false}
+                readOnly
               />
             )}
           />


### PR DESCRIPTION
### Details

The statistics drill-down sheet ([`StatsDrillDownSheet.tsx`](https://github.com/PetrCala/Kiroku/blob/master/src/screens/Statistics/StatsDrillDownSheet.tsx)) — opened by tapping a point on the Trends weekly-units graph or a slice on the Breakdown donut chart — reused the **interactive** `DrinkingSessionOverview` tile. Tapping a session navigated into its summary, and from there into edit → delete.

That path is unsupported by the navigation model. The session edit/delete back-navigation (`popModalFlow` / [`EditSessionScreen.tsx`](https://github.com/PetrCala/Kiroku/blob/master/src/screens/DrinkingSession/EditSessionScreen.tsx)) is built around the **Day Overview as its origin** — its comments and [`getPopModalFlowTarget`](https://github.com/PetrCala/Kiroku/blob/master/src/libs/Navigation/getPopModalFlowTarget.ts) explicitly expect a *sibling root screen beneath the modal*, not another RHP screen like Statistics. Deleting a session reached from Statistics routed through that unanticipated path and left the **Statistics screen frozen** (stuck modal backdrop) on return.

**Fix:** make the drill-down tiles **read-only** (`readOnly` on `DrinkingSessionOverview`). Statistics is an analytics surface — the tiles still surface units + per-drink breakdown, but they no longer navigate anywhere. Editing/deleting a session stays on its canonical surface, the calendar / day-overview (incl. the long-press picker from #1004).

> Supersedes this PR's original `useIsFocused` hide/reappear approach. That was only needed because the tiles navigated away; with read-only tiles there is no navigation round-trip to handle, so it was dropped. Net change is now a single prop + comment.

### Tests

1. Open **Statistics → Trends**, tap a point on the weekly-units graph → the drill-down sheet opens listing that week's sessions.
2. Verify each session tile shows its units and per-drink breakdown but is **not tappable** (no navigation, no highlight/press-through to a summary).
3. Repeat on the **Breakdown** tab via a donut slice.
4. Verify the close icon, the Close button, and the backdrop still dismiss the sheet.
5. Regression: confirm editing/deleting a session from the **calendar day overview** still works and lands back on the day overview (unchanged path).

- [ ] Verify that no errors appear in the JS console

### Offline tests

Read-only / navigation-only change, independent of network state; same steps apply offline.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Statistics → Trends → tap a weekly-units point → confirm listed session tiles are non-interactive.
2. Statistics → Breakdown → tap a donut slice → same check.
3. Confirm you can no longer reach a session's edit/delete from Statistics, and that the Statistics screen is never left frozen.
4. Confirm calendar/day-overview edit + delete is unaffected.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors related to this change
- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified all code is DRY (reuses the existing `readOnly` mode of `DrinkingSessionOverview`)
- [x] No copy / text was added or modified (no localization needed)

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)