### PR TITLE
feat(auth): cut OAuth provisioning over to server 409, drop last RTDB read

### DIFF
--- a/__tests__/actions/UserOAuth.test.ts
+++ b/__tests__/actions/UserOAuth.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-in-views -- this test asserts on the mocked API.makeRequestWithSideEffects pipeline; it is not a view */
+
+import {signInWithCredential, updateProfile} from 'firebase/auth';
+import type {Auth, AuthCredential} from 'firebase/auth';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import HttpsError from '@libs/Errors/HttpsError';
+import * as Session from '@userActions/Session';
+import * as UserActions from '@userActions/User';
+
+// Stub Onyx so importing User.ts doesn't start real Onyx.connect timers, which
+// otherwise fire after the jest environment is torn down and crash the run.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({currentUser: {uid: 'user-1'}}),
+}));
+
+// User.ts pulls native-only modules (apple-auth via OAuthCredential) that jest
+// can't transform; stub them so importing the action under test doesn't load them.
+jest.mock('@libs/OAuthCredential', () => ({getOAuthCredential: jest.fn()}));
+jest.mock('@database/baseFunctions', () => ({readDataOnce: jest.fn()}));
+jest.mock('@userActions/Session', () => ({clearSignInData: jest.fn()}));
+
+// Log schedules a periodic flush timer at import that fires after teardown.
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    alert: jest.fn(),
+    hmmm: jest.fn(),
+  },
+}));
+
+jest.mock('@libs/Pusher/pusher', () => ({
+  TYPE: {
+    ONYX_API_UPDATE: 'onyxApiUpdate',
+    MULTIPLE_EVENT_TYPE: {ONYX_API_UPDATE: 'onyxApiUpdate'},
+  },
+}));
+
+jest.mock('@libs/PusherUtils', () => ({
+  __esModule: true,
+  default: {
+    subscribeToMultiEvent: jest.fn(),
+    subscribeToPrivateUserChannelEvent: jest.fn(),
+    subscribeToPublicChannelEvent: jest.fn(),
+  },
+}));
+
+jest.mock('@userActions/OnyxUpdates', () => ({
+  apply: jest.fn(),
+  saveUpdateInformation: jest.fn(),
+  doesClientNeedToBeUpdated: jest.fn(),
+}));
+
+// Replace the whole Firebase Auth surface User.ts imports — only the two calls
+// exercised by signInWithOAuth need real behavior; the rest must merely exist.
+jest.mock('firebase/auth', () => ({
+  signInWithCredential: jest.fn(),
+  updateProfile: jest.fn(() => Promise.resolve()),
+  EmailAuthProvider: {credential: jest.fn()},
+  GoogleAuthProvider: {credential: jest.fn()},
+  OAuthProvider: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  linkWithCredential: jest.fn(),
+  reauthenticateWithCredential: jest.fn(),
+  sendEmailVerification: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  unlink: jest.fn(),
+  updatePassword: jest.fn(),
+  verifyBeforeUpdateEmail: jest.fn(),
+}));
+
+// provisionUser routes through API.makeRequestWithSideEffects; control it to
+// simulate the brand-new (resolve) vs returning (409 reject) server outcomes.
+jest.mock('@libs/API', () => ({
+  makeRequestWithSideEffects: jest.fn(),
+  write: jest.fn(),
+  read: jest.fn(),
+}));
+
+const mockedSignIn = jest.mocked(signInWithCredential);
+const mockedUpdateProfile = jest.mocked(updateProfile);
+const mockedProvision = jest.mocked(API.makeRequestWithSideEffects);
+const mockedClearSignInData = jest.mocked(Session.clearSignInData);
+
+const fakeAuth = {} as Auth;
+const fakeCredential = {} as AuthCredential;
+const fakeUser = {
+  uid: 'oauth-uid',
+  displayName: null,
+  email: 'jane@example.com',
+  photoURL: null,
+};
+
+describe('signInWithOAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSignIn.mockResolvedValue({
+      user: fakeUser,
+    } as unknown as Awaited<ReturnType<typeof signInWithCredential>>);
+  });
+
+  it('provisions and sets the display name for a brand-new account (no optimistic data)', async () => {
+    mockedProvision.mockResolvedValue(undefined);
+
+    await UserActions.signInWithOAuth(fakeAuth, fakeCredential, 'Jane Doe');
+
+    expect(mockedSignIn).toHaveBeenCalledWith(fakeAuth, fakeCredential);
+    // The speculative OAuth provision must NOT apply optimistic Onyx data: the
+    // third arg is an empty options object, not `{optimisticData}`.
+    expect(mockedProvision).toHaveBeenCalledWith(
+      WRITE_COMMANDS.PROVISION_USER,
+      expect.objectContaining({
+        profile: {
+          display_name: 'Jane Doe',
+          photo_url: '',
+          username_chosen: false,
+        },
+      }),
+      {},
+    );
+    expect(mockedUpdateProfile).toHaveBeenCalledWith(fakeUser, {
+      displayName: 'Jane Doe',
+    });
+    expect(mockedClearSignInData).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a 409 (returning account) and does not re-set the display name', async () => {
+    mockedProvision.mockRejectedValue(
+      new HttpsError({message: 'Conflict', status: '409'}),
+    );
+
+    await expect(
+      UserActions.signInWithOAuth(fakeAuth, fakeCredential, 'Jane Doe'),
+    ).resolves.toBeUndefined();
+
+    expect(mockedProvision).toHaveBeenCalledTimes(1);
+    // A returning user already has their Firebase Auth profile — must not be touched.
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+    // Sign-in still proceeds.
+    expect(mockedClearSignInData).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a non-409 HttpsError and does not complete sign-in', async () => {
+    mockedProvision.mockRejectedValue(
+      new HttpsError({message: 'Server error', status: '500'}),
+    );
+
+    await expect(
+      UserActions.signInWithOAuth(fakeAuth, fakeCredential, 'Jane Doe'),
+    ).rejects.toThrow('Server error');
+
+    expect(mockedClearSignInData).not.toHaveBeenCalled();
+  });
+
+  it('propagates a generic (non-HttpsError) failure', async () => {
+    mockedProvision.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      UserActions.signInWithOAuth(fakeAuth, fakeCredential, 'Jane Doe'),
+    ).rejects.toThrow('network down');
+
+    expect(mockedClearSignInData).not.toHaveBeenCalled();
+  });
+});

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -345,6 +345,9 @@ const CONST = {
     UNDEFINED: 'undefined',
   },
   HTTP_STATUS: {
+    // The resource already exists — e.g. provisioning an already-provisioned
+    // user. Expected/benign for idempotent retries, not a service failure.
+    CONFLICT: 409,
     // When Cloudflare throttles
     TOO_MANY_REQUESTS: 429,
     INTERNAL_SERVER_ERROR: 500,

--- a/src/components/SignInButtons/AppleSignIn/index.android.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.android.tsx
@@ -67,7 +67,7 @@ function AppleSignIn({
   onPress = () => {},
   onError = () => {},
 }: AppleSignInProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
 
   const handleSignIn = async () => {
@@ -92,7 +92,7 @@ function AppleSignIn({
       await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
-        await User.signInWithOAuth(auth, db, credential, displayName);
+        await User.signInWithOAuth(auth, credential, displayName);
       } catch (firebaseError: unknown) {
         const fe = firebaseError as {code?: string};
         if (

--- a/src/components/SignInButtons/AppleSignIn/index.ios.tsx
+++ b/src/components/SignInButtons/AppleSignIn/index.ios.tsx
@@ -72,7 +72,7 @@ function AppleSignIn({
   onPress = () => {},
   onError = () => {},
 }: AppleSignInProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
 
   const handleSignIn = async () => {
@@ -102,7 +102,7 @@ function AppleSignIn({
       await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
-        await User.signInWithOAuth(auth, db, credential, displayName);
+        await User.signInWithOAuth(auth, credential, displayName);
       } catch (firebaseError: unknown) {
         const fe = firebaseError as {code?: string};
         if (

--- a/src/components/SignInButtons/GoogleSignIn/index.native.tsx
+++ b/src/components/SignInButtons/GoogleSignIn/index.native.tsx
@@ -77,7 +77,7 @@ function GoogleSignIn({
   onPress = () => {},
   onError = () => {},
 }: GoogleSignInProps) {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
 
   const handleSignIn = async () => {
@@ -97,7 +97,7 @@ function GoogleSignIn({
       await App.setLoadingText(translate('signUpScreen.signingYouIn'));
       loadingShown = true;
       try {
-        await User.signInWithOAuth(auth, db, credential);
+        await User.signInWithOAuth(auth, credential);
       } catch (firebaseError: unknown) {
         const fe = firebaseError as {code?: string};
         if (

--- a/src/libs/Middleware/Logging.ts
+++ b/src/libs/Middleware/Logging.ts
@@ -183,6 +183,16 @@ const Logging: Middleware = (response, request) => {
           false,
           logParams,
         );
+      } else if (error.status === CONST.HTTP_STATUS.CONFLICT.toString()) {
+        // A 409 means the resource already exists — e.g. re-provisioning an
+        // already-provisioned account on every returning OAuth sign-in. Expected
+        // and benign for idempotent retries, so log at info level rather than
+        // raising an unknown-error alert.
+        Log.info(
+          '[Network] API request error: resource already exists (409)',
+          false,
+          logParams,
+        );
       } else {
         // If we get any error that is not known log an alert so we can learn more about it and document it here.
         Log.alert(

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -1,5 +1,4 @@
 import type {Database} from 'firebase/database';
-import {ref, get} from 'firebase/database';
 import type {
   AppSettings,
   Config,
@@ -38,6 +37,7 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
 import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import HttpsError from '@libs/Errors/HttpsError';
 import * as API from '@libs/API';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import type Response from '@src/types/onyx/Response';
@@ -94,23 +94,6 @@ const getDefaultUserData = (profileData: Profile): UserData => {
 };
 
 /**
- * Check if a user exists in the realtime database.
- *
- * @param db - The database object against which to validate this conditio
- * @param userID - User ID of the user to check.
- * @returns - Returns true if the user exists, false otherwise.
- */
-async function userExistsInDatabase(
-  db: Database,
-  userID: string,
-): Promise<boolean> {
-  const profilePath = DBPATHS.USERS_USER_ID_PROFILE.getRoute(userID);
-  const dbRef = ref(db, profilePath);
-  const snapshot = await get(dbRef);
-  return snapshot.exists();
-}
-
-/**
  * Provision a brand-new user's backing data via kiroku-api. Replaces the former
  * direct RTDB write (`pushNewUserInfo`): the server owns the atomic creation of
  * `users/$uid`, `user_status/$uid`, `user_preferences/$uid`, and the
@@ -126,10 +109,24 @@ async function userExistsInDatabase(
  *
  * @param userID The new user's Firebase uid — used only for the optimistic update
  * @param profileData Profile data of the user to create
+ * @param options.applyOptimisticData Whether to optimistically write the default
+ *   user data/preferences/theme into Onyx before the request. `true` (default)
+ *   for the email/password signup flow, where the caller KNOWS the account is
+ *   brand-new. The OAuth sign-in path passes `false`: there, provisioning is
+ *   SPECULATIVE — it is attempted on every sign-in and a returning account is
+ *   expected to come back `409`. Applying the optimistic defaults in that case
+ *   would transiently overwrite a returning user's real `username_chosen` /
+ *   preferences / theme (and, with their real account data not yet loaded, could
+ *   mis-route them into onboarding) with no way to undo it: the `409` surfaces as
+ *   a thrown HTTP rejection that never reaches `SaveResponseInOnyx`, so neither
+ *   `onyxData` nor `failureData` is applied. A brand-new OAuth user is
+ *   unaffected — the server's `200` response carries the same `onyxData`, applied
+ *   when this promise resolves (before the sign-in overlay drops).
  */
 function provisionUser(
   userID: string,
   profileData: Profile,
+  {applyOptimisticData = true}: {applyOptimisticData?: boolean} = {},
 ): Promise<void | Response> {
   const userData = getDefaultUserData(profileData);
   const preferences = getDefaultPreferences();
@@ -155,7 +152,7 @@ function provisionUser(
   return API.makeRequestWithSideEffects(
     WRITE_COMMANDS.PROVISION_USER,
     {profile: profileData, timezone: userData.timezone, preferences},
-    {optimisticData},
+    applyOptimisticData ? {optimisticData} : {},
   );
 }
 
@@ -463,32 +460,50 @@ function setUsername(user: User | null, newUsername: string): void {
 
 /**
  * Sign in (or sign up) using a Firebase OAuth credential from Apple or Google.
- * If the user does not yet exist in the Realtime Database, creates their profile.
+ *
+ * There is no longer a client-side existence pre-check (the last direct RTDB
+ * read in this module): provisioning is attempted unconditionally and the server
+ * is the authority. `provisionUser` creates a brand-new account; a returning
+ * account is refused with `409` (the route is 409-guarded so a replay can never
+ * clobber an established record), which we treat as "already provisioned" and
+ * swallow. Any other failure propagates so the caller can surface it.
  *
  * @param auth The Firebase authentication object
- * @param db The Firebase Realtime Database object
  * @param credential The OAuth credential (OAuthProvider or GoogleAuthProvider)
  * @param displayName Optional display name captured from the OAuth provider response
  */
 async function signInWithOAuth(
   auth: Auth,
-  db: Database,
   credential: AuthCredential,
   displayName?: string | null,
 ): Promise<void> {
   const userCredential = await signInWithCredential(auth, credential);
   const {user} = userCredential;
-  const exists = await userExistsInDatabase(db, user.uid);
-  if (!exists) {
-    const name =
-      displayName ?? user.displayName ?? user.email?.split('@').at(0) ?? 'User';
-    const profileData: Profile = {
-      display_name: name,
-      photo_url: user.photoURL ?? '',
-      username_chosen: false,
-    };
-    await provisionUser(user.uid, profileData);
+  const name =
+    displayName ?? user.displayName ?? user.email?.split('@').at(0) ?? 'User';
+  const profileData: Profile = {
+    display_name: name,
+    photo_url: user.photoURL ?? '',
+    username_chosen: false,
+  };
+  try {
+    // Speculative: optimistic Onyx defaults are intentionally NOT applied (see
+    // `provisionUser`) because a returning user reaches this on every sign-in
+    // and the defaults would briefly overwrite their real data with no rollback.
+    await provisionUser(user.uid, profileData, {applyOptimisticData: false});
+    // Brand-new account only — a `409` jumps to the catch and skips this, since a
+    // returning user already has their Firebase Auth display name.
     await updateProfile(user, {displayName: name});
+  } catch (error) {
+    // `409 Conflict` = the account already exists (returning user). That is the
+    // expected replay outcome — proceed to sign-in. Everything else is a real
+    // provisioning failure and must propagate.
+    if (
+      !(error instanceof HttpsError) ||
+      error.status !== String(CONST.HTTP_STATUS.CONFLICT)
+    ) {
+      throw error;
+    }
   }
   Session.clearSignInData();
   // Post-auth routing is owned by OnboardingGuard. Navigating here would
@@ -845,7 +860,6 @@ export {
   setUsername,
   syncUserStatus,
   updatePassword,
-  userExistsInDatabase,
   logIn,
   signInWithOAuth,
   stashPendingOAuthCredential,


### PR DESCRIPTION
## What

Read-cutover for the Firebase RTDB → kiroku-api migration (epic #809, gap **C3**). Removes the **last direct `firebase/database` value import** from the client's `User.ts`.

`signInWithOAuth` previously did a direct RTDB existence check (`userExistsInDatabase` → `ref`/`get`) to decide whether to provision a new user. That check is gone. Provisioning is now attempted unconditionally; the server is the authority.

## How it works

- **Brand-new account** → `POST /v1/provisioning` returns `200`; its `onyxData` is applied on resolve, then the Firebase Auth display name is set.
- **Returning account** → the route is 409-guarded and returns `409 "User already exists"`. kiroku-api sets a real HTTP 409 (`res.status(409)`), so the client's `processHTTPRequest` throws an `HttpsError` with `status: '409'` and the `provisionUser` promise rejects. `signInWithOAuth` catches it, confirms `error instanceof HttpsError && error.status === '409'`, swallows it, and proceeds to sign-in. **Any other error propagates.**

`userExistsInDatabase` is deleted, along with the now-unused `{ref, get}` value import and the `db` parameter of `signInWithOAuth` (updated at all 3 native sign-in callers). `import type {Database}` stays — `signUp`/`fetchUserNicknames` still use it. After this, **`FirebaseContext` + `baseFunctions` are the only `firebase/database` value importers in `src/`.**

## Correctness care (the account-creation branch)

Because provisioning is now **speculative on every OAuth sign-in**, the optimistic Onyx defaults are **skipped for that path** (`provisionUser(..., {applyOptimisticData: false})`):

- A `409` surfaces as a **thrown HTTP rejection** that never reaches `SaveResponseInOnyx`, so neither `onyxData` nor `failureData` is applied — the optimistic defaults (`username_chosen: false`, default prefs/theme) would otherwise **linger un-rolled-back** for a returning user, transiently clobbering their real data and risking an **onboarding mis-route** (traced through `useOnboardingFlow` → `OnboardingGuard`, which navigates *into* onboarding but never auto-exits).
- A **brand-new** OAuth user is unaffected: the `200` response carries the same `onyxData`, applied via `OnyxUpdates.apply` before the promise resolves (and before the sign-in overlay drops). `signUp` (email/password) keeps the optimistic update — unchanged.

The now-**expected** 409 (fires on every returning OAuth sign-in) is logged at **info** level instead of the misleading `ENSURE_BUGBOT` "unknown API request error" alert.

> Email/password `signUp` is a separate path and is **not** touched here.

## Tests

New `__tests__/actions/UserOAuth.test.ts` covers:
- brand-new account → provisions (no optimistic data) + sets display name + clears sign-in data
- returning account (`409`) → swallowed, **no** double `updateProfile`, sign-in still completes
- non-409 `HttpsError` → propagates, sign-in **not** completed
- generic error → propagates

## Checklist
- ✅ `react-compiler-compliance-check check-changed`
- ✅ `prettier`
- ✅ `lint-changed`
- ✅ `typecheck-tsgo`
- ✅ `jest` (new + existing `UserRealtime` suites green)

Part of #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)