### PR TITLE
fix(day-overview): preserve scroll position after editing a session

### DIFF
--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -128,6 +128,9 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
 
   // The day the user is currently looking at — opens the add-session picker on
   // the viewed month. Seeded with the focused day, updated as the user scrolls.
+  // Also drives the list's restore target (see `initialDay` below): because it
+  // lives on this screen (which stays mounted across the edit round-trip), it
+  // outlives the list subtree, so the list lands back where the user was.
   const [visibleDay, setVisibleDay] = useState<DateString | undefined>(date);
 
   // dayList mode ignores `visibleDate`/`onDateChange`, but the shared
@@ -208,7 +211,17 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
               preferences={preferences}
               isFetchingOlderMonths={isFetchingOlderMonths}
               mode="dayList"
-              initialDay={date}
+              // Restore to where the user last was, not the route's `date`.
+              // Saving a session sets a global "Saving…" loading text, which
+              // momentarily swaps this screen's tree for the full-screen loader
+              // (see the `loadingText` guard above) and so remounts the list.
+              // The remounted list re-applies its initial centering — on `date`
+              // (often a recent day, i.e. the bottom of the oldest→newest list)
+              // that reads as "jumped to the bottom". `visibleDay` tracks the
+              // user's scroll position and survives the remount, so centering on
+              // it lands them back where they left off. On first mount it equals
+              // `date`, preserving the open-on-the-tapped-day behavior.
+              initialDay={visibleDay ?? date}
               onInitialScrollReady={onInitialScrollReady}
               onVisibleDayChange={setVisibleDay}
               isReadOnly={!isSelf}


### PR DESCRIPTION
## Summary

Fixes #1015. When a user long-presses a session (or taps its edit button) from the **Day Overview** scroll, edits it, and saves, they were returned to the Day Overview list scrolled to the very bottom instead of where they left off.

## Root cause

Saving a session calls `App.setLoadingText('Saving…')` then `setLoadingText(null)` ([`DrinkingSessionWindow`](src/components/DrinkingSessionWindow/index.tsx#L75)). `DayOverviewScreen` sits mounted underneath the edit modal, and its early-return guard renders the global full-screen loader whenever `APP_LOADING_TEXT` is truthy:

```ts
if (!date || !!loadingText) {
  return <FullScreenLoadingIndicator loadingText={loadingText} />;
}
```

So during the save round-trip the screen's tree is swapped to the loader and back, **remounting the session list** (`SessionsCalendar` → `DayOverviewListView`). On remount the list re-applies its initial centering scroll — and it centered on the route's `date`, which is typically a recent day. Since the list runs oldest→newest, a recent day sits at the bottom, which the user perceives as "jumped to the very bottom". (`useLazyMarkedDates` returns `isLoading: false` and `useReadyAfterScreenTransition` never resets, so the loading-text guard is the only thing that tears the subtree down.)

## Fix

Seed the list's `initialDay` from `visibleDay` instead of the static route `date`:

```diff
- initialDay={date}
+ initialDay={visibleDay ?? date}
```

`visibleDay` already tracks the center-most day as the user scrolls (via `onVisibleDayChange`), and it lives on `DayOverviewScreen` — which **stays mounted** across the edit round-trip — so it survives the subtree remount. The remounted list now re-centers on the user's last position rather than the original route day.

On first mount `visibleDay` is initialized to `date`, so the open-on-the-tapped-day behavior is unchanged. The mounted list never re-centers mid-session (the centering effect is guarded by `hasAppliedInitialScrollRef`), so feeding it a live `visibleDay` only affects a fresh mount.

## Scope / why this approach

This deliberately leaves the global "Saving…" loading overlay untouched — restoring to the right day is all that's needed to fix the symptom, and it's robust to the remount happening for any reason, not just this one. Restoration is day-centered (matching the list's day-centric `scrollToIndex({viewPosition: 0.5})` model) rather than pixel-exact.

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — pass
- `npx prettier --write` — no changes

Manual device verification of the long-press → edit → save → return flow is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)