### PR TITLE
fix(admin): unfreeze and correctly render the feedback/bug screens

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -778,6 +778,12 @@ const CONST = {
     MAX_PENDING_TIME_MS: 10 * 1000,
     RECHECK_INTERVAL_MS: 60 * 1000,
     MAX_REQUEST_RETRIES: 10,
+    // Upper bound on how long a kiroku-api request will wait for the Firebase ID
+    // token before failing fast. `getIdToken()` is instant while the cached
+    // token is valid, but a near-expiry refresh has no built-in timeout and can
+    // stall across a connectivity transition, freezing every request until it
+    // settles. See `HttpUtils.getFirebaseIdToken`.
+    ID_TOKEN_TIMEOUT_MS: 15 * 1000,
     NETWORK_STATUS: {
       ONLINE: 'online',
       OFFLINE: 'offline',

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -182,6 +182,12 @@ const ONYXKEYS = {
   /** Indicates whether we should store logs or not */
   SHOULD_STORE_LOGS: 'shouldStoreLogs',
 
+  /** Admin-only: the full feedback collection, fetched on demand by SeeFeedbackScreen */
+  FEEDBACK_LIST: 'feedbackList',
+
+  /** Admin-only: the full bug-report collection, fetched on demand by SeeBugsScreen */
+  BUG_LIST: 'bugList',
+
   //   /** Collection Keys */
   COLLECTION: {
     DOWNLOAD: 'download_',
@@ -318,6 +324,8 @@ type OnyxValuesMapping = {
   [ONYXKEYS.LOGS]: OnyxTypes.CapturedLogs;
   [ONYXKEYS.STATISTICS_FILTERS]: OnyxTypes.StatisticsFilters;
   [ONYXKEYS.SHOULD_STORE_LOGS]: boolean;
+  [ONYXKEYS.FEEDBACK_LIST]: OnyxTypes.FeedbackList;
+  [ONYXKEYS.BUG_LIST]: OnyxTypes.BugList;
 };
 
 type OnyxValues = OnyxValuesMapping &

--- a/src/libs/HttpUtils.ts
+++ b/src/libs/HttpUtils.ts
@@ -221,6 +221,45 @@ function buildKirokuBody(
 }
 
 /**
+ * Resolve the caller's Firebase ID token for the `Bearer` header, bounded by a
+ * timeout. `getIdToken()` returns the cached token instantly while it is valid,
+ * but at/near expiry it triggers a network refresh that has no built-in timeout
+ * — so it can stall indefinitely across a connectivity transition. Awaiting it
+ * unbounded freezes EVERY kiroku-api request for as long as the refresh is stuck
+ * (observed ~3 minutes, until the network recovered), surfacing as "hung" reads.
+ * We race the token fetch against `ID_TOKEN_TIMEOUT_MS` and, on timeout, throw
+ * the standard retryable `FAILED_TO_FETCH` network error so the request fails
+ * fast (and is retried once connectivity/refresh settles) instead of blocking.
+ *
+ * Returns `undefined` only when there is no signed-in user, matching the old
+ * `currentUser?.getIdToken()` behaviour the caller already guards against.
+ */
+function getFirebaseIdToken(): Promise<string | undefined> {
+  const currentUser = getFirebaseAuth().currentUser;
+  if (!currentUser) {
+    return Promise.resolve(undefined);
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new HttpsError({
+          message: CONST.ERROR.FAILED_TO_FETCH,
+          title: 'Firebase ID token refresh timed out',
+        }),
+      );
+    }, CONST.NETWORK.ID_TOKEN_TIMEOUT_MS);
+  });
+
+  return Promise.race([currentUser.getIdToken(), timeout]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+/**
  * Send a request to the kiroku-api REST surface: resolve `{method, path}` from
  * the route map, attach the caller's Firebase ID token as a Bearer header, and
  * send a JSON body (non-GET) or a query string (GET). Returns the same
@@ -230,7 +269,7 @@ async function kirokuXhr(
   data: Record<string, unknown>,
   route: KirokuRoute,
 ): Promise<Response> {
-  const token = await getFirebaseAuth().currentUser?.getIdToken();
+  const token = await getFirebaseIdToken();
   if (!token) {
     throw new HttpsError({
       message: CONST.ERROR.FAILED_TO_FETCH,

--- a/src/libs/actions/Feedback.ts
+++ b/src/libs/actions/Feedback.ts
@@ -1,6 +1,8 @@
+import Onyx from 'react-native-onyx';
 import * as API from '@libs/API';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import type {BugList, FeedbackList} from '@src/types/onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 /**
  * Feedback + bug-report writes and admin reads, cut over from direct Firebase
@@ -15,9 +17,12 @@ import type {BugList, FeedbackList} from '@src/types/onyx';
  *
  * The admin reads (`getFeedbackList` / `getBugList`) back the SeeFeedbackScreen /
  * SeeBugsScreen lists. The GET routes return the whole collection as plain JSON
- * (not an `onyxData` envelope), so `makeRequestWithSideEffects` resolves with the
- * list itself and the screens load it into local component state rather than
- * Onyx. Part of the #809 realtime cutover.
+ * (not an `onyxData` envelope), so these actions take the resolved list and
+ * `Onyx.set` it under `FEEDBACK_LIST` / `BUG_LIST`; the screens render from Onyx
+ * via `useOnyx`. Storing it in Onyx (rather than transient component state) means
+ * a slow response still lands safely after the screen has unmounted, and a
+ * re-visit renders the cached list instantly while a fresh fetch refreshes it.
+ * Part of the #809 realtime cutover.
  */
 
 function submitFeedback(text: string) {
@@ -36,20 +41,26 @@ function removeBug(bugId: string) {
   API.write(WRITE_COMMANDS.REMOVE_BUG, {bugId});
 }
 
-function getFeedbackList(): Promise<FeedbackList> {
+function getFeedbackList(): Promise<void> {
   // eslint-disable-next-line rulesdir/no-api-side-effects-method
   return API.makeRequestWithSideEffects(
     SIDE_EFFECT_REQUEST_COMMANDS.GET_FEEDBACK_LIST,
     {},
-  ).then(response => (response as unknown as FeedbackList | undefined) ?? {});
+  ).then(response => {
+    const list = (response as unknown as FeedbackList | undefined) ?? {};
+    return Onyx.set(ONYXKEYS.FEEDBACK_LIST, list);
+  });
 }
 
-function getBugList(): Promise<BugList> {
+function getBugList(): Promise<void> {
   // eslint-disable-next-line rulesdir/no-api-side-effects-method
   return API.makeRequestWithSideEffects(
     SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST,
     {},
-  ).then(response => (response as unknown as BugList | undefined) ?? {});
+  ).then(response => {
+    const list = (response as unknown as BugList | undefined) ?? {};
+    return Onyx.set(ONYXKEYS.BUG_LIST, list);
+  });
 }
 
 export {

--- a/src/screens/Settings/Admin/SeeBugsScreen.tsx
+++ b/src/screens/Settings/Admin/SeeBugsScreen.tsx
@@ -1,12 +1,14 @@
 import {useEffect, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
+import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import type {BugList, NicknameToId} from '@src/types/onyx';
+import type {NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {getBugList, removeBug} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -17,26 +19,26 @@ import useTheme from '@hooks/useTheme';
 import {fetchUserNicknames} from '@libs/actions/User';
 import type {Timestamp} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 function SeeBugsScreen() {
   const {translate} = useLocalize();
   const {db} = useFirebase();
   const styles = useThemeStyles();
   const theme = useTheme();
+  // Render from Onyx so a slow response still lands after the screen unmounts
+  // and a re-visit shows the cached list instantly. The fetch below refreshes it.
+  const [bugList] = useOnyx(ONYXKEYS.BUG_LIST);
   const [nicknames, setNicknames] = useState<NicknameToId>({});
-  const [bugList, setBugList] = useState<BugList>({});
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
-    getBugList()
-      .then(data => {
-        if (isMounted) {
-          setBugList(data);
-        }
-      })
-      .catch(error => {
-        console.error('Error fetching bugs:', error);
-      });
+    getBugList().finally(() => {
+      if (isMounted) {
+        setIsLoading(false);
+      }
+    });
 
     return () => {
       isMounted = false;
@@ -63,7 +65,7 @@ function SeeBugsScreen() {
     };
 
     fetchNicknames();
-  }, [bugList, db, nicknames]);
+  }, [bugList, db]);
 
   const deleteBug = (bugKey: string) => {
     removeBug(bugKey);
@@ -92,32 +94,37 @@ function SeeBugsScreen() {
     return `${localizedTime} - ${nicknames[userId]}`;
   };
 
+  const bugEntries = Object.entries(bugList ?? {});
+
   return (
     <ScreenWrapper testID={SeeBugsScreen.displayName}>
       <HeaderWithBackButton
         title={translate('adminScreen.bugReports')}
         onBackButtonPress={() => Navigation.goBack()}
       />
-      <ScrollView contentContainerStyle={[styles.w100]}>
-        <Section
-          title=""
-          containerStyles={styles.ph0}
-          childrenStyles={styles.pt3}>
-          {Object.entries(bugList).map(([id, bug]) => (
-            <MenuItem
-              // eslint-disable-next-line react/no-array-index-key
-              key={`${id}`}
-              title={getVerboseBugsHeading(bug.user_id, bug.submit_time)}
-              description={bug.text}
-              numberOfLinesDescription={20}
-              style={styles.borderTopRounded}
-              rightComponent={removeBugButton(id)}
-              shouldShowRightComponent
-              disabled
-            />
-          ))}
-        </Section>
-      </ScrollView>
+      {isLoading && bugEntries.length === 0 ? (
+        <FullScreenLoadingIndicator />
+      ) : (
+        <ScrollView contentContainerStyle={[styles.w100]}>
+          <Section
+            title=""
+            containerStyles={styles.ph0}
+            childrenStyles={styles.pt3}>
+            {bugEntries.map(([id, bug]) => (
+              <MenuItem
+                key={`${id}`}
+                title={getVerboseBugsHeading(bug.user_id, bug.submit_time)}
+                description={bug.text}
+                numberOfLinesDescription={20}
+                style={styles.borderTopRounded}
+                rightComponent={removeBugButton(id)}
+                shouldShowRightComponent
+                disabled
+              />
+            ))}
+          </Section>
+        </ScrollView>
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
+++ b/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
@@ -1,12 +1,14 @@
 import {useEffect, useState} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
+import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import type {FeedbackList, NicknameToId} from '@src/types/onyx';
+import type {NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {getFeedbackList, removeFeedback} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -17,26 +19,26 @@ import useTheme from '@hooks/useTheme';
 import {fetchUserNicknames} from '@libs/actions/User';
 import type {Timestamp} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 function SeeFeedbackScreen() {
   const {translate} = useLocalize();
   const {db} = useFirebase();
   const styles = useThemeStyles();
   const theme = useTheme();
+  // Render from Onyx so a slow response still lands after the screen unmounts
+  // and a re-visit shows the cached list instantly. The fetch below refreshes it.
+  const [feedbackList] = useOnyx(ONYXKEYS.FEEDBACK_LIST);
   const [nicknames, setNicknames] = useState<NicknameToId>({});
-  const [feedbackList, setFeedbackList] = useState<FeedbackList>({});
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
-    getFeedbackList()
-      .then(data => {
-        if (isMounted) {
-          setFeedbackList(data);
-        }
-      })
-      .catch(error => {
-        console.error('Error fetching feedback:', error);
-      });
+    getFeedbackList().finally(() => {
+      if (isMounted) {
+        setIsLoading(false);
+      }
+    });
 
     return () => {
       isMounted = false;
@@ -65,7 +67,7 @@ function SeeFeedbackScreen() {
     };
 
     fetchNicknames();
-  }, [feedbackList, db, nicknames]);
+  }, [feedbackList, db]);
 
   const deleteFeedback = (feedbackKey: string) => {
     removeFeedback(feedbackKey);
@@ -94,35 +96,40 @@ function SeeFeedbackScreen() {
     return `${localizedTime} - ${nicknames[userId]}`;
   };
 
+  const feedbackEntries = Object.entries(feedbackList ?? {});
+
   return (
     <ScreenWrapper testID={SeeFeedbackScreen.displayName}>
       <HeaderWithBackButton
         title={translate('adminScreen.feedback')}
         onBackButtonPress={() => Navigation.goBack()}
       />
-      <ScrollView contentContainerStyle={[styles.w100]}>
-        <Section
-          title=""
-          containerStyles={styles.ph0}
-          childrenStyles={styles.pt3}>
-          {Object.entries(feedbackList).map(([id, feedback]) => (
-            <MenuItem
-              // eslint-disable-next-line react/no-array-index-key
-              key={`${id}`}
-              title={getVerboseFeedbackHeading(
-                feedback.user_id,
-                feedback.submit_time,
-              )}
-              description={feedback.text}
-              numberOfLinesDescription={20}
-              style={styles.borderTopRounded}
-              rightComponent={removeFeedbackButton(id)}
-              shouldShowRightComponent
-              disabled
-            />
-          ))}
-        </Section>
-      </ScrollView>
+      {isLoading && feedbackEntries.length === 0 ? (
+        <FullScreenLoadingIndicator />
+      ) : (
+        <ScrollView contentContainerStyle={[styles.w100]}>
+          <Section
+            title=""
+            containerStyles={styles.ph0}
+            childrenStyles={styles.pt3}>
+            {feedbackEntries.map(([id, feedback]) => (
+              <MenuItem
+                key={`${id}`}
+                title={getVerboseFeedbackHeading(
+                  feedback.user_id,
+                  feedback.submit_time,
+                )}
+                description={feedback.text}
+                numberOfLinesDescription={20}
+                style={styles.borderTopRounded}
+                rightComponent={removeFeedbackButton(id)}
+                shouldShowRightComponent
+                disabled
+              />
+            ))}
+          </Section>
+        </ScrollView>
+      )}
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
Fixes the empty admin **feedback / bug** screens. Two related root causes, two commits.

## 1. `fix(network)` — bound the Firebase ID-token fetch (`3c7a724`)

Every kiroku-api request awaits `getFirebaseAuth().currentUser?.getIdToken()` in `HttpUtils.kirokuXhr` to attach the `Bearer` header. That returns the cached token instantly while valid, but at/near expiry it triggers a network refresh **with no built-in timeout**, which can stall across a connectivity transition. The `await` was unbounded, so a stuck refresh froze *every* kiroku-api request.

**Evidence:** first `GetFeedbackList` after the token went stale finished in `179817ms` (~3 min); a forced `getIdTokenResult(true)` — which never touches kiroku-api — stalled the same ~3 min; `[NetworkConnection] recheck NetInfo` fired right before it unblocked; warm requests return in ~510ms and the `admin` claim was present throughout.

**Fix:** `getFirebaseIdToken` races `getIdToken()` against `CONST.NETWORK.ID_TOKEN_TIMEOUT_MS` (15s) and throws the retryable `FAILED_TO_FETCH` on timeout, so the request fails fast and retries instead of hanging. Scoped to the kiroku-api path; the legacy transport authenticates via a FormData `authToken`.

## 2. `fix(admin)` — render from Onyx with a loading state (`d1c6aa9`)

Even once a response arrives, the screens dropped it: they fetched into **local component state** in a mount `useEffect`, guarded by `isMounted`, with **no loading indicator** and **no caching**. A slow response arrived after the user navigated away → `isMounted` discarded it → next visit re-fetched from zero → the data never rendered.

**Fix:**
- `getFeedbackList` / `getBugList` now `Onyx.set` the fetched list under new `FEEDBACK_LIST` / `BUG_LIST` keys (single keys matching the GET's `Record<id, item>` shape; `set` replaces wholesale so admin deletions sync on the next fetch).
- Screens read via `useOnyx` and show `FullScreenLoadingIndicator` on initial load (only when there's no cached list, so re-visits don't flash).
- Dropped `nicknames` from the nickname effect's deps (it set the state it depended on — a needless re-run loop).

Result: a slow response still lands in Onyx after unmount, re-visits render the cached list instantly while a fresh fetch refreshes it, and the screen shows a spinner instead of looking empty.

## Files
- `src/libs/HttpUtils.ts`, `src/CONST.ts` — bounded token fetch + timeout const.
- `src/libs/actions/Feedback.ts`, `src/ONYXKEYS.ts` — Onyx-backed lists + keys.
- `src/screens/Settings/Admin/SeeFeedbackScreen.tsx`, `SeeBugsScreen.tsx` — `useOnyx` + loading.

## Checks
`prettier` ✅ · `react-compiler-compliance-check check-changed` ✅ · `lint-changed` ✅ · `typecheck-tsgo` ✅

## Verification
⚠️ **Needs device verification before merge.** Open the admin feedback/bug screens: the list should render once fetched (and instantly on re-visit from cache), with a spinner during initial load and no multi-minute freeze. Note: a genuine 42s+ HTTP stall on the dev/simulator network is likely environmental — confirm timing on a stable connection.

Refs #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)