### PR TITLE
fix(day-overview): keep the session list mounted during save/delete

### DIFF
--- a/src/screens/DayOverview/DayOverviewScreen.tsx
+++ b/src/screens/DayOverview/DayOverviewScreen.tsx
@@ -148,7 +148,16 @@ function DayOverviewScreen({route}: DayOverviewScreenProps) {
   if (!isOnline) {
     return <UserOffline />;
   }
-  if (!date || !!loadingText) {
+  // Show the global loading overlay only before the list has first rendered.
+  // Once the list is up (`isScrollReady`), a transient loadingText from a child
+  // edit/delete flow (the "Saving…"/"Deleting…" set in `DrinkingSessionWindow`)
+  // must NOT swap the tree for the full-screen loader: that unmounts and then
+  // remounts the heavy session list, which loses its scroll position and forces
+  // a visible from-scratch re-render — the synchronous `useLazyMarkedDates`
+  // re-index plus a FlashList remount — on return. Keeping the list mounted lets
+  // the edited/deleted session update in place via FlashList's normal data diff,
+  // with the scroll position preserved exactly. See #1015 / #1024.
+  if (!date || (!!loadingText && !isScrollReady)) {
     return <FullScreenLoadingIndicator loadingText={loadingText} />;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1024. Removes the brief from-scratch re-render ("sessions re-render right after I'm back on the day overview") seen after **deleting** (and editing) a session, by stopping the Day Overview list from remounting during the save/delete round-trip.

## Root cause

Same mechanism as #1015, surfacing as a second symptom. Saving or deleting calls `App.setLoadingText('Saving…'/'Deleting…')` then clears it ([`DrinkingSessionWindow`](src/components/DrinkingSessionWindow/index.tsx#L116-L132)). `DayOverviewScreen` sits mounted under the edit modal, and its guard rendered the global full-screen loader whenever `APP_LOADING_TEXT` was truthy:

```ts
if (!date || !!loadingText) {
  return <FullScreenLoadingIndicator loadingText={loadingText} />;
}
```

So the screen's whole tree was swapped to the loader and back, **remounting** `SessionsCalendar → DayOverviewListView`. The delete itself is optimistic ([`removeDrinkingSessionData`](src/libs/actions/DrinkingSession.ts#L450-L457) — `API.write` is fire-and-forget, only two local `Onyx.set`s awaited), so the delay isn't I/O. It's the **remount**: on a fresh mount the list redoes the synchronous `useLazyMarkedDates` re-index (the `O(N)` filter+index over every loaded session) plus a full FlashList mount — the exact work the screen normally **defers behind the entry transition + skeleton** on first open — now run un-deferred, blocking first paint.

#1024 only corrected *where* the remounted list landed; it didn't remove the remount.

## Fix

Scope the loading-overlay guard so it only short-circuits **before the list has first rendered**:

```diff
- if (!date || !!loadingText) {
+ if (!date || (!!loadingText && !isScrollReady)) {
```

`isScrollReady` flips true once the list applies its initial scroll and stays true. After that, a transient `Saving…`/`Deleting…` from a child flow no longer tears the list down — the edited/deleted session updates **in place** via FlashList's normal data diff, with scroll position preserved exactly. On a genuine cold open the overlay still works (`loadingText` truthy while `isScrollReady` is still false).

The #1024 `visibleDay` restore is now belt-and-suspenders (only matters if the subtree remounts for some other reason); kept intentionally.

## Tradeoff

The day overview no longer flashes its own `Saving…`/`Deleting…` overlay during the modal pop. The op is optimistic and the edit modal covers the screen until the pop, so that overlay provided no real feedback. Other screens that own a blocking op still render their own overlay (unchanged).

## Related

Likely also resolves #1012 (drill-down sheet doesn't reopen after deleting one of several sessions) — its "keep the sheet mounted across the round-trip" trick was defeated by this same host-screen remount. Worth re-checking on device after this lands.

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — pass
- `npx prettier` — no changes

Manual device verification of edit-save and delete from the Day Overview scroll (scroll preserved, no re-render flash) still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)