### PR TITLE
fix(home): keep the compact calendar mounted during save/delete

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -206,12 +206,6 @@ function HomeScreen({route}: HomeScreenProps) {
     return <UserOffline />;
   }
 
-  // Active operations (e.g. saving a session) still take a full-screen overlay
-  // so they don't compete with the home UI for attention.
-  if (loadingText) {
-    return <FullScreenLoadingIndicator loadingText={loadingText} />;
-  }
-
   // Render the shell + skeletons immediately. Real components swap in for
   // their skeletons as each piece of data resolves from Firebase. The
   // calendar renders even when the user has no sessions yet — empty days
@@ -245,49 +239,60 @@ function HomeScreen({route}: HomeScreenProps) {
   };
 
   return (
-    <ScreenWrapper
-      testID={HomeScreen.displayName}
-      includePaddingTop={false}
-      includeSafeAreaPaddingBottom={getPlatform() !== CONST.PLATFORM.IOS}>
-      {/* // TODO rewrite this into the HeaderWithBackButton component */}
-      {isUserDataReady ? (
-        <View style={[styles.headerBar, styles.borderBottom, styles.ph2]}>
-          <Button
-            style={[styles.flexRow, styles.bgTransparent]}
-            onPress={() =>
-              Navigation.navigate(ROUTES.PROFILE.getRoute(user.uid))
-            }>
-            <ProfileImage
-              storage={storage}
-              userID={user.uid}
-              downloadPath={userData.profile.photo_url}
-              style={styles.avatarMedium}
-              // refreshTrigger={refreshCounter}
-              refreshTrigger={0}
-            />
-            <Text style={[styles.headerText, styles.textLarge, styles.ml3]}>
-              {userData?.profile?.display_name ?? ''}
-            </Text>
-            <View style={styles.ml1}>
-              <SupporterBadgeForUser userID={user.uid} size="medium" />
-            </View>
-          </Button>
-        </View>
-      ) : (
-        <HomeHeaderSkeleton />
-      )}
-      <ScrollView contentContainerStyle={styles.ph2}>
-        {!!ongoingSessionData?.ongoing && (
-          <MessageBanner
-            danger
-            text={translate('homeScreen.currentlyInSession')}
-            onPress={() => DS.navigateToOngoingSessionScreen()}
-          />
+    <>
+      <ScreenWrapper
+        testID={HomeScreen.displayName}
+        includePaddingTop={false}
+        includeSafeAreaPaddingBottom={getPlatform() !== CONST.PLATFORM.IOS}>
+        {/* // TODO rewrite this into the HeaderWithBackButton component */}
+        {isUserDataReady ? (
+          <View style={[styles.headerBar, styles.borderBottom, styles.ph2]}>
+            <Button
+              style={[styles.flexRow, styles.bgTransparent]}
+              onPress={() =>
+                Navigation.navigate(ROUTES.PROFILE.getRoute(user.uid))
+              }>
+              <ProfileImage
+                storage={storage}
+                userID={user.uid}
+                downloadPath={userData.profile.photo_url}
+                style={styles.avatarMedium}
+                // refreshTrigger={refreshCounter}
+                refreshTrigger={0}
+              />
+              <Text style={[styles.headerText, styles.textLarge, styles.ml3]}>
+                {userData?.profile?.display_name ?? ''}
+              </Text>
+              <View style={styles.ml1}>
+                <SupporterBadgeForUser userID={user.uid} size="medium" />
+              </View>
+            </Button>
+          </View>
+        ) : (
+          <HomeHeaderSkeleton />
         )}
-        {renderMainContent()}
-      </ScrollView>
-      <BottomTabBar />
-    </ScreenWrapper>
+        <ScrollView contentContainerStyle={styles.ph2}>
+          {!!ongoingSessionData?.ongoing && (
+            <MessageBanner
+              danger
+              text={translate('homeScreen.currentlyInSession')}
+              onPress={() => DS.navigateToOngoingSessionScreen()}
+            />
+          )}
+          {renderMainContent()}
+        </ScrollView>
+        <BottomTabBar />
+      </ScreenWrapper>
+      {/* Active operations (e.g. saving a session) take a full-screen overlay so
+          they don't compete with the home UI for attention. Rendered as an
+          overlay layer (not an early-return) so the heavy compact calendar stays
+          mounted underneath: a transient loadingText must not tear it down and
+          force a from-scratch re-render (the synchronous useLazyMarkedDates
+          re-index) when it clears. */}
+      {!!loadingText && (
+        <FullScreenLoadingIndicator loadingText={loadingText} />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Third in the series (#1024, #1029). Removes the brief compact-calendar re-render flash on **HomeScreen** after finishing/saving/deleting a session.

## Root cause

Same pattern as the Day Overview fix. Saving/deleting sets a global `APP_LOADING_TEXT` ("Saving…"/"Deleting…") and clears it ([`DrinkingSessionWindow`](src/components/DrinkingSessionWindow/index.tsx#L75)). HomeScreen is a persistent bottom-tab screen, but its early-return tore its own tree down whenever that text was truthy:

```ts
if (loadingText) {
  return <FullScreenLoadingIndicator loadingText={loadingText} />;
}
```

So the text flipping on/off **remounted** the compact `<SessionsCalendar>`, re-running `useLazyMarkedDates`' synchronous `O(N)` index pass un-deferred (the work it normally pays only once on first mount) and blocking first paint. HomeScreen — unlike DayOverviewScreen / ProfileScreen — has no `useReadyAfterScreenTransition` deferral, so the cost lands directly on the user as they arrive on Home (the default post-session destination).

## Fix

Render the loader as a **non-destructive overlay layer** instead of an early-return. `FullScreenLoadingIndicator` is already `position: absolute`, opaque (`theme.componentBG`) and full-screen, so as the last sibling of `<ScreenWrapper>` it covers the home UI exactly as the early-return did:

```tsx
return (
  <>
    <ScreenWrapper …>{/* header / scroll / calendar / tab bar */}</ScreenWrapper>
    {!!loadingText && <FullScreenLoadingIndicator loadingText={loadingText} />}
  </>
);
```

The calendar subtree underneath is never unmounted, so the saved/deleted session flows through as a cheap memoized data-diff — **no remount, no re-index, no flash**.

## Why keep the overlay

The root-level `loadingText` loader in `Kiroku.tsx` is covered by `NavigationRoot` in z-order, so it's not visible over screens — Home's own overlay is the **only** visible "Saving…" feedback during a save. Deleting the guard (or gating it like DayOverview's `!isScrollReady`) would silently drop that feedback, so this keeps it as a layer instead.

## Notes

- The diff looks large but is almost entirely re-indentation from wrapping the body in a fragment; the functional change is the removed early-return + the overlay sibling.
- Audit context: Home was the last heavy instance of this pattern. Form/onboarding screens share the guard but have no heavy subtree (cheap remount); `ProfileScreen` and the fullscreen `SessionsCalendarScreen` don't read `APP_LOADING_TEXT` at all.

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — pass (Home is compiled)
- `npx prettier --check` — clean

Manual device verification recommended: finish/save a session, then discard/delete one, and edit-from-calendar → Home calendar should not flash on return, and the "Saving…"/"Deleting…" overlay still appears during the op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)