### PR TITLE
feat(statistics): switch drink-type palette to "true to glass"

### DIFF
--- a/src/libs/Statistics/drinkKeyMeta.ts
+++ b/src/libs/Statistics/drinkKeyMeta.ts
@@ -36,10 +36,10 @@ const DRINK_PALETTES: Record<
   },
 };
 
-// Single switch point for the drink-type palette. Flip to `'trueToGlass'` to
-// swap the whole app over. A future centralized design-toggle system (akin to
-// feature flags) could drive this selection.
-const ACTIVE_DRINK_PALETTE: keyof typeof DRINK_PALETTES = 'vivid';
+// Single switch point for the drink-type palette. Flip to `'vivid'` to swap the
+// whole app over. A future centralized design-toggle system (akin to feature
+// flags) could drive this selection.
+const ACTIVE_DRINK_PALETTE: keyof typeof DRINK_PALETTES = 'trueToGlass';
 
 /**
  * One color per `DrinkKey` — the single source of truth for drink-type color


### PR DESCRIPTION
Flips the drink-type palette switch added in #1030 from the **vivid & distinct** palette to the **true to glass** (naturalistic) alternative.

## Change
A single line in `src/libs/Statistics/drinkKeyMeta.ts`:

```ts
const ACTIVE_DRINK_PALETTE: keyof typeof DRINK_PALETTES = 'trueToGlass'; // was 'vivid'
```

This swaps the Breakdown donut + per-type multiples, the Trends "drink mix over time" stack, and their legends over to the naturalistic hues (straw / ochre / maroon / sage / cocoa / coral / mauve — already defined as color tokens in `src/styles/theme/colors.ts`). No other code changes; both palettes were wired up in #1030.

## How to revert
Flip the same line back to `'vivid'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)