### PR TITLE
feat(admin): optimistically remove feedback/bug items

### DIFF
--- a/src/libs/actions/Feedback.ts
+++ b/src/libs/actions/Feedback.ts
@@ -1,7 +1,8 @@
 import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
-import type {BugList, FeedbackList} from '@src/types/onyx';
+import type {Bug, BugList, Feedback, FeedbackList} from '@src/types/onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 /**
@@ -12,8 +13,12 @@ import ONYXKEYS from '@src/ONYXKEYS';
  * admin-only and fetched on demand, so the write routes' `onyxData` is empty —
  * there is nothing to optimistically write.
  *
- * The admin removes are also empty-`onyxData` writes; authority is the caller's
- * admin claim, enforced server-side.
+ * The admin removes (`removeFeedback` / `removeBug`) optimistically drop the
+ * item from `FEEDBACK_LIST` / `BUG_LIST` so the row disappears immediately, and
+ * restore it via `failureData` if the server rejects the delete (otherwise only
+ * the next fetch would undo the optimistic removal). The caller passes the item
+ * it is deleting — already in hand from the rendered list — so the restore needs
+ * no separate read. Authority is the caller's admin claim, enforced server-side.
  *
  * The admin reads (`getFeedbackList` / `getBugList`) back the SeeFeedbackScreen /
  * SeeBugsScreen lists. The GET routes return the whole collection as plain JSON
@@ -33,12 +38,44 @@ function reportABug(text: string) {
   API.write(WRITE_COMMANDS.REPORT_BUG, {text});
 }
 
-function removeFeedback(feedbackId: string) {
-  API.write(WRITE_COMMANDS.REMOVE_FEEDBACK, {feedbackId});
+function removeFeedback(feedbackId: string, feedback: Feedback) {
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.FEEDBACK_LIST,
+      value: {[feedbackId]: null},
+    },
+  ];
+  const failureData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.FEEDBACK_LIST,
+      value: {[feedbackId]: feedback},
+    },
+  ];
+  API.write(
+    WRITE_COMMANDS.REMOVE_FEEDBACK,
+    {feedbackId},
+    {optimisticData, failureData},
+  );
 }
 
-function removeBug(bugId: string) {
-  API.write(WRITE_COMMANDS.REMOVE_BUG, {bugId});
+function removeBug(bugId: string, bug: Bug) {
+  const optimisticData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.BUG_LIST,
+      value: {[bugId]: null},
+    },
+  ];
+  const failureData: OnyxUpdate[] = [
+    {
+      onyxMethod: Onyx.METHOD.MERGE,
+      key: ONYXKEYS.BUG_LIST,
+      value: {[bugId]: bug},
+    },
+  ];
+  API.write(WRITE_COMMANDS.REMOVE_BUG, {bugId}, {optimisticData, failureData});
 }
 
 function getFeedbackList(): Promise<void> {

--- a/src/screens/Settings/Admin/SeeBugsScreen.tsx
+++ b/src/screens/Settings/Admin/SeeBugsScreen.tsx
@@ -8,7 +8,7 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import type {NicknameToId} from '@src/types/onyx';
+import type {Bug, NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {getBugList, removeBug} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -67,17 +67,17 @@ function SeeBugsScreen() {
     fetchNicknames();
   }, [bugList, db]);
 
-  const deleteBug = (bugKey: string) => {
-    removeBug(bugKey);
+  const deleteBug = (bugKey: string, bug: Bug) => {
+    removeBug(bugKey, bug);
   };
 
-  const removeBugButton = (id: string) => {
+  const removeBugButton = (id: string, bug: Bug) => {
     return (
       <Button
         icon={KirokuIcons.ThinX}
         iconFill={theme.textError}
         style={styles.bgTransparent}
-        onPress={() => deleteBug(id)}
+        onPress={() => deleteBug(id, bug)}
       />
     );
   };
@@ -117,7 +117,7 @@ function SeeBugsScreen() {
                 description={bug.text}
                 numberOfLinesDescription={20}
                 style={styles.borderTopRounded}
-                rightComponent={removeBugButton(id)}
+                rightComponent={removeBugButton(id, bug)}
                 shouldShowRightComponent
                 disabled
               />

--- a/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
+++ b/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
@@ -8,7 +8,7 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import type {NicknameToId} from '@src/types/onyx';
+import type {Feedback, NicknameToId} from '@src/types/onyx';
 import {useFirebase} from '@context/global/FirebaseContext';
 import {getFeedbackList, removeFeedback} from '@libs/actions/Feedback';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
@@ -69,17 +69,17 @@ function SeeFeedbackScreen() {
     fetchNicknames();
   }, [feedbackList, db]);
 
-  const deleteFeedback = (feedbackKey: string) => {
-    removeFeedback(feedbackKey);
+  const deleteFeedback = (feedbackKey: string, feedback: Feedback) => {
+    removeFeedback(feedbackKey, feedback);
   };
 
-  const removeFeedbackButton = (id: string) => {
+  const removeFeedbackButton = (id: string, feedback: Feedback) => {
     return (
       <Button
         icon={KirokuIcons.ThinX}
         iconFill={theme.textError}
         style={styles.bgTransparent}
-        onPress={() => deleteFeedback(id)}
+        onPress={() => deleteFeedback(id, feedback)}
       />
     );
   };
@@ -122,7 +122,7 @@ function SeeFeedbackScreen() {
                 description={feedback.text}
                 numberOfLinesDescription={20}
                 style={styles.borderTopRounded}
-                rightComponent={removeFeedbackButton(id)}
+                rightComponent={removeFeedbackButton(id, feedback)}
                 shouldShowRightComponent
                 disabled
               />


### PR DESCRIPTION
## What

Deleting a feedback or bug item from the admin screens fired the API write but left the row on screen until the next fetch / re-visit (the remove writes had empty `onyxData`). Now the removal is **optimistic**: the row disappears immediately and is restored if the server rejects the delete.

## How

`removeFeedback` / `removeBug` now carry Onyx data on the `API.write`:
- **`optimisticData`** merges `{[id]: null}` into `FEEDBACK_LIST` / `BUG_LIST` → the item drops from the list the screens render via `useOnyx` instantly.
- **`failureData`** merges the item back if the write fails → no permanent UI/state divergence; otherwise only the next fetch would correct it.

The screen passes the item it's deleting (already in hand from the rendered list), so the restore needs no extra read. This deliberately avoids an `Onyx.connect` cache in the action — the `rulesdir/no-onyx-connect` lint rule forbids it in favour of `useOnyx` + passing data to a pure action.

## Files
- `src/libs/actions/Feedback.ts` — optimistic/failure data on both removes; `removeFeedback(id, feedback)` / `removeBug(id, bug)`.
- `src/screens/Settings/Admin/SeeFeedbackScreen.tsx`, `SeeBugsScreen.tsx` — pass the item to the remove.

## Checks
`prettier` ✅ · `react-compiler-compliance-check check-changed` ✅ · `lint-changed` ✅ · `typecheck-tsgo` ✅

## Verification
⚠️ Device verification: delete a feedback/bug row — it should vanish immediately; on a forced server failure it should reappear.

Follow-up to the admin feedback/bug fixes in #1028. Refs #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)