### PR TITLE
refactor(realtime): sever the last RTDB handle from session-key minting

### DIFF
--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -71,8 +71,9 @@ jest.mock('firebase/database', () => ({
   ref: jest.fn(),
   update: jest.fn(),
 }));
-jest.mock('@database/baseFunctions', () => ({
-  generateDatabaseKey: jest.fn(() => 'generated-id'),
+jest.mock('@libs/generatePushID', () => ({
+  __esModule: true,
+  default: jest.fn(() => 'generated-id'),
 }));
 jest.mock('@libs/Navigation/Navigation', () => ({
   __esModule: true,

--- a/__tests__/unit/generatePushID.test.ts
+++ b/__tests__/unit/generatePushID.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+import {getRandomBytes} from 'expo-crypto';
+import generatePushID from '@libs/generatePushID';
+
+// The 64-char, sort-order-preserving Firebase push-ID alphabet, kept in lockstep
+// with the generator under test. The ordering is load-bearing: lexicographic
+// string order must equal chronological order.
+const PUSH_CHARS =
+  '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+const ALPHABET = new Set(PUSH_CHARS.split(''));
+
+// A fixed UTC instant the fake clock starts from in each test.
+const START_MS = new Date('2026-01-01T00:00:00.000Z').getTime();
+
+// Mock the secure RNG with a deterministic, per-call-varying byte source so the
+// random suffix exercises a spread of alphabet chars without making the test
+// flaky. The generator only calls this when minting in a fresh millisecond.
+jest.mock('expo-crypto', () => ({
+  __esModule: true,
+  getRandomBytes: jest.fn(),
+}));
+
+const mockedGetRandomBytes = jest.mocked(getRandomBytes);
+
+beforeEach(() => {
+  jest.setSystemTime(START_MS);
+  let counter = 0;
+  mockedGetRandomBytes.mockImplementation((byteCount: number) => {
+    const out = new Uint8Array(byteCount);
+    for (let i = 0; i < byteCount; i += 1) {
+      // Deterministic but varied across calls and byte positions.
+      out[i] = (counter * 37 + i * 53) % 256;
+    }
+    counter += 1;
+    return out;
+  });
+});
+
+describe('generatePushID', () => {
+  it('produces a 20-character key drawn only from the push-ID alphabet', () => {
+    const id = generatePushID();
+    expect(id).toHaveLength(20);
+    expect(Array.from(id).every(ch => ALPHABET.has(ch))).toBe(true);
+  });
+
+  it('only ever emits in-alphabet characters across many calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i += 1) {
+      jest.advanceTimersByTime(7);
+      const id = generatePushID();
+      expect(id).toHaveLength(20);
+      Array.from(id).forEach(ch => seen.add(ch));
+    }
+    expect(Array.from(seen).every(ch => ALPHABET.has(ch))).toBe(true);
+  });
+
+  it('is strictly lexicographically increasing as time advances (time-sortable)', () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      jest.advanceTimersByTime(1 + (i % 5));
+      ids.push(generatePushID());
+    }
+    // Default string sort is by UTF-16 code unit, which for this ASCII alphabet
+    // equals the intended lexicographic (== chronological) order.
+    expect(ids).toEqual([...ids].sort());
+    // Strictly increasing: no two keys are equal.
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps strict ordering for keys minted in the same millisecond', () => {
+    // No timer advance → identical Date.now() → exercises the monotonic-increment
+    // path (random suffix incremented, not re-rolled).
+    const a = generatePushID();
+    const b = generatePushID();
+    const c = generatePushID();
+    expect(a < b).toBe(true);
+    expect(b < c).toBe(true);
+    // Same-millisecond keys share the 8-char timestamp prefix.
+    expect(b.slice(0, 8)).toBe(a.slice(0, 8));
+    expect(c.slice(0, 8)).toBe(a.slice(0, 8));
+  });
+});

--- a/contributingGuides/REALTIME_MIGRATION_AUDIT.md
+++ b/contributingGuides/REALTIME_MIGRATION_AUDIT.md
@@ -22,17 +22,19 @@ friend preferences, and user search are migrated to kiroku-api. What remains tou
 `firebase/database` at **runtime** is:
 
 - **1 legitimate, permanent keep** — the `db` handle provider (`FirebaseContext`).
-- **1 legitimate-for-now keep** — `generateDatabaseKey` (local push-id generation, no
-  network), the last RTDB-handle dependency on the write path. Severable via UUID.
+- **1 keep, now SEVERED** — `generateDatabaseKey` was the last RTDB-handle dependency on
+  the write path. A follow-up on this branch replaced it with `src/libs/generatePushID.ts`,
+  a local Firebase-push-ID-shaped generator (identical 20-char format, no `db` handle), so
+  session-key minting no longer touches `firebase/database`.
 - **4 real read gaps** (category C) — all cross-user/pre-auth `get()`-style reads:
   cross-user friends list, admin nickname resolution, OAuth user-exists pre-check, and
   the pre-auth signup version gate. **3 of the 4 already have a server endpoint** and
   are quick client cutovers; only the pre-auth version gate needs a new unauthenticated
   endpoint.
 
-After this PR's dead-code removal, the only remaining `firebase/database` **value
-imports** in `src/` are in exactly three files: `FirebaseContext.tsx` (handle),
-`baseFunctions.ts` (`readDataOnce` + `generateDatabaseKey`), and `User.ts`
+After this PR's dead-code removal (and the `generatePushID` follow-up on this branch), the
+only remaining `firebase/database` **value imports** in `src/` are in exactly three files:
+`FirebaseContext.tsx` (handle), `baseFunctions.ts` (`readDataOnce`), and `User.ts`
 (`ref`/`get` for the OAuth user-exists check).
 
 ---
@@ -41,21 +43,21 @@ imports** in `src/` are in exactly three files: `FirebaseContext.tsx` (handle),
 
 `firebase/database` imports across `src/` and their classification:
 
-| File                                           | Symbol(s)                                                    | What it does                                                                                                            | Class                         |
-| ---------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `src/context/global/FirebaseContext.tsx`       | `getDatabase`, `connectDatabaseEmulator` (+ `type Database`) | Constructs the singleton `db` handle exposed via `useFirebase()`; wires the emulator in test mode                       | **A — keep**                  |
-| `src/database/baseFunctions.ts`                | `push`, `child`, `ref` (+ `type Database`)                   | `generateDatabaseKey` — local push-id key generation, **no network call**                                               | **A — keep (severable)**      |
-| `src/database/baseFunctions.ts`                | `get`, `ref`                                                 | `readDataOnce<T>` — one-shot read; still called by the 4 category-C gaps below                                          | **A — keep until C done**     |
-| `src/libs/actions/User.ts`                     | `ref`, `get` (+ `type Database`)                             | `userExistsInDatabase` — reads `users/$uid/profile` to test existence (OAuth path)                                      | **C — needs-migration**       |
-| `src/libs/actions/User.ts`                     | `readDataOnce<Profile>`                                      | `fetchUserNicknames` — cross-user display-name resolution for admin screens                                             | **C — needs-migration**       |
-| `src/libs/actions/User.ts`                     | `readDataOnce<AppSettings>`                                  | `signUp` pre-auth app-version gate (reads `config/app_settings`)                                                        | **C — needs-migration**       |
-| `src/screens/Profile/ProfileScreen.tsx`        | `readDataOnce<UserList>`                                     | Reads the **viewer's own** friends list when viewing another user (common-friends count)                                | **C — needs-migration**       |
-| `src/screens/Profile/FriendsFriendsScreen.tsx` | `readDataOnce<UserList>`                                     | Reads **another user's** friends list                                                                                   | **C — needs-migration**       |
-| `src/components/Social/SearchWindow.tsx`       | `type Database` only                                         | Types an optional `database?` arg plumbed to the `onSearch` callback (search already migrated)                          | **D — type-only**             |
-| `src/hooks/useStartEditSessionForDate.ts`      | `type Database` only                                         | Types `db` passed to `DS.getNewSessionToEdit` → flows to `generateDatabaseKey`                                          | **D — type-only**             |
-| `src/libs/actions/DrinkingSession.ts`          | `type Database` only                                         | Types `db` consumed by `generateDatabaseKey` (category A)                                                               | **D — type-only**             |
-| `src/libs/actions/Profile.ts`                  | `type Database` only                                         | Types `db` in `fetchUserProfiles`/`fetchUserStatuses`; param documented "Unused (retained for call-site compatibility)" | **D — type-only (vestigial)** |
-| `src/screens/Social/FriendRequestScreen.tsx`   | `type Database` only                                         | Types `database` plumbed into `Profile.fetchUserProfiles` (which ignores it)                                            | **D — type-only (vestigial)** |
+| File                                           | Symbol(s)                                                    | What it does                                                                                                             | Class                         |
+| ---------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| `src/context/global/FirebaseContext.tsx`       | `getDatabase`, `connectDatabaseEmulator` (+ `type Database`) | Constructs the singleton `db` handle exposed via `useFirebase()`; wires the emulator in test mode                        | **A — keep**                  |
+| `src/database/baseFunctions.ts`                | ~~`push`, `child`, `ref`~~ (removed)                         | `generateDatabaseKey` **removed**; key minting moved to local `src/libs/generatePushID.ts` (no `db` handle, same format) | **A — severed**               |
+| `src/database/baseFunctions.ts`                | `get`, `ref`                                                 | `readDataOnce<T>` — one-shot read; still called by the 4 category-C gaps below                                           | **A — keep until C done**     |
+| `src/libs/actions/User.ts`                     | `ref`, `get` (+ `type Database`)                             | `userExistsInDatabase` — reads `users/$uid/profile` to test existence (OAuth path)                                       | **C — needs-migration**       |
+| `src/libs/actions/User.ts`                     | `readDataOnce<Profile>`                                      | `fetchUserNicknames` — cross-user display-name resolution for admin screens                                              | **C — needs-migration**       |
+| `src/libs/actions/User.ts`                     | `readDataOnce<AppSettings>`                                  | `signUp` pre-auth app-version gate (reads `config/app_settings`)                                                         | **C — needs-migration**       |
+| `src/screens/Profile/ProfileScreen.tsx`        | `readDataOnce<UserList>`                                     | Reads the **viewer's own** friends list when viewing another user (common-friends count)                                 | **C — needs-migration**       |
+| `src/screens/Profile/FriendsFriendsScreen.tsx` | `readDataOnce<UserList>`                                     | Reads **another user's** friends list                                                                                    | **C — needs-migration**       |
+| `src/components/Social/SearchWindow.tsx`       | `type Database` only                                         | Types an optional `database?` arg plumbed to the `onSearch` callback (search already migrated)                           | **D — type-only**             |
+| `src/hooks/useStartEditSessionForDate.ts`      | ~~`type Database`~~ (removed)                                | `db` param + type removed by the A.2 severing                                                                            | **D — resolved**              |
+| `src/libs/actions/DrinkingSession.ts`          | ~~`type Database`~~ (removed)                                | `db` params + `generateDatabaseKey` call removed by the A.2 severing                                                     | **D — resolved**              |
+| `src/libs/actions/Profile.ts`                  | `type Database` only                                         | Types `db` in `fetchUserProfiles`/`fetchUserStatuses`; param documented "Unused (retained for call-site compatibility)"  | **D — type-only (vestigial)** |
+| `src/screens/Social/FriendRequestScreen.tsx`   | `type Database` only                                         | Types `database` plumbed into `Profile.fetchUserProfiles` (which ignores it)                                             | **D — type-only (vestigial)** |
 
 **RTDB write/query/listener APIs (`set`, `update`, `remove`, `onValue`, `onChild*`,
 `off`, `runTransaction`, `orderByChild`, `query`, `startAt`, `limitToFirst`, …):**
@@ -69,17 +71,20 @@ two dead listener helpers removed below; the rest were already migrated.)
 ### A — Legitimate keep
 
 1. **`FirebaseContext.tsx` (`getDatabase`)** — the `db` handle provider. Permanent as
-   long as anything (even `generateDatabaseKey`) needs a handle, and Firebase Auth +
-   Storage are still provided from the same context.
-2. **`generateDatabaseKey` (`baseFunctions.ts`)** — used by `DrinkingSession.ts`
-   (`generateDrinkingSessionId`, `getNewSessionToEdit`). `push(child(ref(db)))` derives a
-   chronologically-sortable unique key **locally** from the SDK pushId algorithm — no
-   network I/O. **Recommendation (do not implement here):** replace with a UUID
-   (`expo-crypto` `randomUUID()`, already a dependency, or a Firebase-pushId-shaped
-   local generator) to fully sever the `db` handle from the write path. This is the
-   single remaining write-path dependency on the RTDB handle; severing it would let
-   `DrinkingSession.ts` and `useStartEditSessionForDate.ts` drop their `Database` type
-   imports too. Low risk, but a behavior-adjacent change (key format) — worth its own PR.
+   long as anything (e.g. `readDataOnce` for the category-C reads) needs a handle, and
+   Firebase Auth + Storage are still provided from the same context.
+2. **`generateDatabaseKey` (`baseFunctions.ts`) — SEVERED (follow-up on this branch).**
+   It was the single remaining write-path dependency on the RTDB handle:
+   `push(child(ref(db)))` derived a chronologically-sortable unique key **locally** from
+   the SDK pushId algorithm (no network I/O), but still needed the `db` handle. It is now
+   replaced by `src/libs/generatePushID.ts`, a faithful local port of Firebase's
+   `generatePushID` (secure RNG via `expo-crypto` `getRandomBytes`). The keys are
+   **format-identical** to Firebase push IDs — 20 chars, same 64-char sort-preserving
+   alphabet, timestamp-prefixed — so they stay co-sortable with every existing session
+   key. A UUID was explicitly **not** used (wrong length/charset, not time-sortable).
+   `generateDatabaseKey` is deleted, and `DrinkingSession.ts` /
+   `useStartEditSessionForDate.ts` have dropped their `Database` type imports and `db`
+   params. The session write path no longer touches `firebase/database`.
 
 ### B — Dead code (removed in this PR)
 
@@ -99,8 +104,8 @@ the repo (src + tests + config). See the PR body for the exact grep evidence.
 | `src/libs/FriendUtils.ts: fetchUserFriends`                                                                     | **Orphan** — exported but imported nowhere. The live cross-user friend reads are in `ProfileScreen`/`FriendsFriendsScreen`, which call `readDataOnce` directly. (This corrects the original audit premise that `FriendUtils` held a _live_ gap.) |
 | `eslint.seatbelt.tsv` entry for `src/hooks/useFetchData/index.ts`                                               | Stale grandfathered-violation row for a now-deleted file                                                                                                                                                                                         |
 
-`readDataOnce` and `generateDatabaseKey` are **retained** in `baseFunctions.ts` — both
-still have live consumers.
+`readDataOnce` is **retained** in `baseFunctions.ts` (it still has live consumers — the
+category-C reads below). `generateDatabaseKey` has been **removed** (severed — see A.2).
 
 ### C — Needs-migration (real gaps — REPORT only, not migrated here)
 
@@ -116,16 +121,16 @@ Cross-referenced against `kiroku-api/src/routes/`:
 ### D — Type-only imports (cosmetic, intentionally left)
 
 `import type {Database}` annotations that only type a `db`/`database` parameter. None
-perform RTDB I/O. Most flow into either `generateDatabaseKey` (category A) or a function
-whose `db` arg is already vestigial (`Profile.fetchUserProfiles`/`fetchUserStatuses`
+perform RTDB I/O. The two that flowed into `generateDatabaseKey` (`DrinkingSession.ts`,
+`useStartEditSessionForDate.ts`) are **gone** with the A.2 severing; the rest type a
+function whose `db` arg is already vestigial (`Profile.fetchUserProfiles`/`fetchUserStatuses`
 document it as "Unused (retained for call-site compatibility)").
 
-These are left untouched to avoid churn. They become trivially removable once:
-
-- C1–C4 land (removes the `Database`-typed plumbing through `User.ts`, the profile
-  screens, and `FriendRequestScreen`/`SearchWindow`), and
-- `generateDatabaseKey` is converted to a UUID (removes it from `DrinkingSession.ts` and
-  `useStartEditSessionForDate.ts`).
+The remaining ones are left untouched to avoid churn. They become trivially removable once
+C1–C4 land (removing the `Database`-typed plumbing through `User.ts`, the profile screens,
+and `FriendRequestScreen`/`SearchWindow`). The `generateDatabaseKey` → local
+`generatePushID` severing has already removed the `Database` imports from
+`DrinkingSession.ts` and `useStartEditSessionForDate.ts`.
 
 At that point `FirebaseContext.tsx` would be the **only** `firebase/database` importer in
 `src/`, and the RTDB migration would be 100% complete on the client read/write paths.
@@ -147,5 +152,6 @@ Ordered by effort/value:
    kiroku-api endpoint; coordinate with the kiroku-api repo. Lowest urgency — the gate is
    a soft "is your app new enough to create an account" check.
 
-Severing `generateDatabaseKey` (UUID) is an independent, optional cleanup that closes out
-the write-path handle dependency.
+Severing `generateDatabaseKey` (done on this branch via a local `generatePushID` port —
+**not** a UUID, so the Firebase push-ID key format is preserved) closed out the write-path
+handle dependency.

--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -62,7 +62,7 @@ function StartSessionButtonAndPopover(
   ref: ForwardedRef<StartSessionButtonAndPopoverRef>,
 ) {
   const styles = useThemeStyles();
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const {translate} = useLocalize();
   const user = auth.currentUser;
   const userData = useCurrentUserData();
@@ -79,11 +79,7 @@ function StartSessionButtonAndPopover(
     try {
       await App.setLoadingText(translate('liveSessionScreen.loading'));
       if (!ongoingSessionData?.ongoing) {
-        await DS.startLiveDrinkingSession(
-          db,
-          user,
-          userData?.timezone?.selected,
-        );
+        await DS.startLiveDrinkingSession(user, userData?.timezone?.selected);
       }
       DS.navigateToOngoingSessionScreen();
     } catch (error) {
@@ -96,7 +92,6 @@ function StartSessionButtonAndPopover(
       await App.setLoadingText(translate('common.loading'));
       await DS.setIsCreatingNewSession(true);
       const newSession = await DS.getNewSessionToEdit(
-        db,
         auth.currentUser,
         new Date(),
         userData?.timezone?.selected,

--- a/src/database/baseFunctions.ts
+++ b/src/database/baseFunctions.ts
@@ -1,5 +1,5 @@
 import type {Database} from 'firebase/database';
-import {get, ref, child, push} from 'firebase/database';
+import {get, ref} from 'firebase/database';
 
 /** Read data once from the realtime database using get(). Return the data if it exists.
  *
@@ -22,21 +22,9 @@ async function readDataOnce<T>(
   return null;
 }
 
-/**
- * Generates a database key based on the provided reference string.
- *
- * NOTE: This is the last RTDB-handle dependency on the write path. It performs
- * NO network call — `push()` derives a chronologically-sortable unique key
- * locally from the SDK's pushId algorithm. It could be replaced by a UUID
- * (e.g. `expo-crypto` randomUUID) to fully sever the `db` handle from session
- * creation; see contributingGuides/REALTIME_MIGRATION_AUDIT.md.
- *
- * @param db The database object.
- * @param refString The reference string used to generate the key.
- * @returns The generated database key, or null if the key cannot be generated.
- */
-function generateDatabaseKey(db: Database, refString: string): string | null {
-  return push(child(ref(db), refString)).key;
-}
-
-export {generateDatabaseKey, readDataOnce};
+// `readDataOnce` is the sole remaining export now that `generateDatabaseKey` has been
+// severed (key minting moved to `@libs/generatePushID`). Keep it a named export — its
+// call sites and the rest of this shrinking RTDB shim use named imports — rather than
+// flipping to a default purely to satisfy this single-export preference.
+// eslint-disable-next-line import/prefer-default-export
+export {readDataOnce};

--- a/src/hooks/useStartEditSessionForDate.ts
+++ b/src/hooks/useStartEditSessionForDate.ts
@@ -1,5 +1,4 @@
 import {useCallback} from 'react';
-import type {Database} from 'firebase/database';
 import type {User} from 'firebase/auth';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as App from '@userActions/App';
@@ -14,7 +13,6 @@ import useLocalize from './useLocalize';
 // the compiler, and that would regress the compilation of any component that
 // inlines it.
 async function startEditSessionForDate(
-  db: Database,
   user: User | null,
   date: Date,
   timezone: SelectedTimezone | undefined,
@@ -22,7 +20,7 @@ async function startEditSessionForDate(
 ) {
   try {
     await App.setLoadingText(loadingText);
-    const newSession = await DS.getNewSessionToEdit(db, user, date, timezone);
+    const newSession = await DS.getNewSessionToEdit(user, date, timezone);
     await DS.navigateToEditSessionScreen(newSession?.id);
   } catch (error) {
     ErrorUtils.raiseAppError(ERRORS.DATABASE.USER_CREATION_FAILED, error);
@@ -38,7 +36,7 @@ async function startEditSessionForDate(
  * calendar day long-press shortcut.
  */
 function useStartEditSessionForDate(): (date: Date) => void {
-  const {auth, db} = useFirebase();
+  const {auth} = useFirebase();
   const userData = useCurrentUserData();
   const {translate} = useLocalize();
   const selectedTimezone = userData?.timezone?.selected;
@@ -48,14 +46,13 @@ function useStartEditSessionForDate(): (date: Date) => void {
       // startEditSessionForDate handles its own errors; the .catch is a no-op
       // to satisfy no-floating-promises.
       startEditSessionForDate(
-        db,
         auth.currentUser,
         date,
         selectedTimezone,
         translate('liveSessionScreen.loading'),
       ).catch(() => {});
     },
-    [db, auth, selectedTimezone, translate],
+    [auth, selectedTimezone, translate],
   );
 }
 

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -1,4 +1,3 @@
-import type {Database} from 'firebase/database';
 import type {
   DrinkingSession,
   DrinkingSessionId,
@@ -13,7 +12,7 @@ import * as DSUtils from '@libs/DrinkingSessionUtils';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import type {User} from 'firebase/auth';
 import CONST from '@src/CONST';
-import {generateDatabaseKey} from '@database/baseFunctions';
+import generatePushID from '@libs/generatePushID';
 import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
@@ -30,7 +29,6 @@ import {differenceInCalendarDays} from 'date-fns';
 import {toZonedTime} from 'date-fns-tz';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
 import type {ValueOf} from 'type-fest';
-import DBPATHS from '@src/DBPATHS';
 import {Alert, InteractionManager} from 'react-native';
 
 let ongoingSessionData: DrinkingSession | undefined;
@@ -305,12 +303,10 @@ async function syncLocalLiveSessionData(
  *
  * Assume that if a session is ongoing, it is a live session and its data is stored in the local database.
  *
- * @param db Firebase Database object
  * @param user User object
  * @returnsPromise newSessionId Id of the newly started session.
  *  */
 async function startLiveDrinkingSession(
-  db: Database,
   user: User | null,
   timezone: SelectedTimezone | undefined,
 ): Promise<void> {
@@ -318,15 +314,7 @@ async function startLiveDrinkingSession(
     throw new Error('Failed to start a live session: User is null');
   }
 
-  const newSessionId = generateDatabaseKey(
-    db,
-    DBPATHS.USER_DRINKING_SESSIONS_USER_ID.getRoute(user.uid),
-  );
-  if (!newSessionId) {
-    throw new Error(
-      "Failed to start a live session: Couldn't generate a new session ID",
-    );
-  }
+  const newSessionId = generatePushID();
 
   // The user is not in an active session
   const newSessionData: DrinkingSession = DSUtils.getEmptySession({
@@ -647,25 +635,14 @@ async function updateSessionDate(
 }
 
 /** Generate a new key for a drinking session */
-function generateDrinkingSessionId(
-  db: Database,
-  user: User | null,
-): DrinkingSessionId {
+function generateDrinkingSessionId(user: User | null): DrinkingSessionId {
   if (!user) {
     throw new Error(Localize.translateLocal('common.error.userNull'));
   }
-  const newKey = generateDatabaseKey(
-    db,
-    DBPATHS.USER_DRINKING_SESSIONS_USER_ID.getRoute(user.uid),
-  );
-  if (!newKey) {
-    throw new Error(Localize.translateLocal('common.error.sessionIdCreation'));
-  }
-  return newKey;
+  return generatePushID();
 }
 
 async function getNewSessionToEdit(
-  db: Database,
   user: User | null,
   currentDate: Date,
   timezone: SelectedTimezone | undefined,
@@ -674,7 +651,7 @@ async function getNewSessionToEdit(
   if (!user) {
     throw new Error('User is null when trying to create a new session');
   }
-  const newSessionId = generateDrinkingSessionId(db, user);
+  const newSessionId = generateDrinkingSessionId(user);
   const timestamp = currentDate.getTime();
   const newSession: DrinkingSession = DSUtils.getEmptySession({
     id: newSessionId,

--- a/src/libs/generatePushID.ts
+++ b/src/libs/generatePushID.ts
@@ -1,0 +1,103 @@
+/* eslint-disable no-bitwise */
+import {getRandomBytes} from 'expo-crypto';
+
+/**
+ * Local re-implementation of Firebase's `generatePushID` (Michael Lehenbauer's
+ * canonical algorithm). Produces 20-character, lexicographically-sortable keys
+ * that are format-compatible with the Firebase RTDB push IDs every existing
+ * drinking-session key already uses, WITHOUT touching the Firebase `db` handle.
+ * This severs the last RTDB-handle dependency on the session write path; see
+ * contributingGuides/REALTIME_MIGRATION_AUDIT.md (category A).
+ *
+ * Key layout (20 chars over the 64-char, sort-order-preserving alphabet below):
+ *   - chars 0–7:  `Date.now()` (ms) encoded big-endian → keys sort by creation time.
+ *   - chars 8–19: 72 bits of randomness (secure RNG) → collision resistance.
+ *
+ * Two IDs minted in the same millisecond stay strictly ordered: the 72-bit random
+ * suffix from the previous call is incremented by one (with carry) rather than
+ * re-rolled, so a burst within a single ms remains monotonically increasing.
+ */
+
+// Modeled after the Firebase JS SDK. The ordering of this alphabet is load-bearing:
+// ASCII '-' < digits < uppercase < '_' < lowercase, so lexicographic string order
+// equals chronological order.
+const PUSH_CHARS =
+  '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+
+// Timestamp of the last push, used to detect collisions within the same millisecond.
+let lastPushTime = 0;
+
+// The 12 random "digits" (each 0–63) from the previous call. On a same-ms collision
+// they are incremented (not re-randomized) to preserve strict ordering.
+const lastRandChars: number[] = new Array<number>(12).fill(0);
+
+/**
+ * Refill `lastRandChars` with 12 fresh 6-bit values (0–63) derived from 72 bits of
+ * secure randomness (`expo-crypto`). The 9 random bytes are read as a single
+ * big-endian 72-bit stream and sliced into 12 six-bit chunks (9 × 8 === 12 × 6).
+ */
+function rerollRandChars(): void {
+  const bytes = getRandomBytes(9);
+  for (let i = 0; i < 12; i++) {
+    const bitPos = i * 6;
+    const bytePos = bitPos >> 3;
+    const bitOffset = bitPos & 7;
+    const hi = bytes[bytePos];
+    const lo = bytePos + 1 < bytes.length ? bytes[bytePos + 1] : 0;
+    // Pull the 6 bits starting at `bitOffset` out of the 16-bit [hi|lo] window.
+    const bits = (hi << 8) | lo;
+    lastRandChars[i] = (bits >> (10 - bitOffset)) & 0x3f;
+  }
+}
+
+/**
+ * Generate a new Firebase-push-ID-compatible 20-character key.
+ *
+ * @returns A 20-char key whose lexicographic order matches creation order.
+ */
+function generatePushID(): string {
+  let now = Date.now();
+  const duplicateTime = now === lastPushTime;
+  lastPushTime = now;
+
+  const timeStampChars = new Array<string>(8);
+  for (let i = 7; i >= 0; i--) {
+    timeStampChars[i] = PUSH_CHARS.charAt(now % 64);
+    now = Math.floor(now / 64);
+  }
+  if (now !== 0) {
+    throw new Error('generatePushID: timestamp did not fully convert');
+  }
+
+  let id = timeStampChars.join('');
+
+  if (!duplicateTime) {
+    rerollRandChars();
+  } else {
+    // Same millisecond as the previous ID: increment the 72-bit random suffix by
+    // one (with carry) so the new ID still sorts strictly after the last one.
+    let i = 11;
+    for (; i >= 0 && lastRandChars[i] === 63; i--) {
+      lastRandChars[i] = 0;
+    }
+    if (i >= 0) {
+      lastRandChars[i]++;
+    } else {
+      // Astronomically unlikely (>2^72 IDs in one ms): every digit rolled over.
+      // Reroll rather than emit a wrapped, non-monotonic suffix.
+      rerollRandChars();
+    }
+  }
+
+  for (let i = 0; i < 12; i++) {
+    id += PUSH_CHARS.charAt(lastRandChars[i]);
+  }
+
+  if (id.length !== 20) {
+    throw new Error('generatePushID: generated id length is not 20');
+  }
+
+  return id;
+}
+
+export default generatePushID;


### PR DESCRIPTION
## What

Severs the **last** `firebase/database` value-import + `db`-handle dependency on the drinking-session **write path**, without changing the key format. Closes out category **A** (`generateDatabaseKey`) from the RTDB migration audit.

`generateDatabaseKey(db, refString)` did `push(child(ref(db), refString)).key` — it performs **no network call** (`push().key` derives a Firebase push ID locally), but it still needed the `db` handle. It's replaced by a new local generator, `src/libs/generatePushID.ts`, a faithful port of Michael Lehenbauer's canonical `generatePushID` algorithm:

- **20 chars** over the 64-char, sort-order-preserving alphabet `-0-9A-Z_a-z`
- first **8 chars** encode `Date.now()` (ms) big-endian → keys sort chronologically
- last **12 chars** encode **72 bits** of secure randomness via `expo-crypto` `getRandomBytes(9)` (not `Math.random()`)
- module-level `lastPushTime` / `lastRandChars` preserve **strict same-millisecond monotonic ordering** (the random suffix is incremented, not re-rolled)

New keys stay **format-compatible and co-sortable** with every existing Firebase push ID already in the DB/Onyx. A UUID was explicitly **not** used (wrong length/charset, not time-sortable) — per the audit's requirement.

## Changes

- **new** `src/libs/generatePushID.ts` — local push-ID generator (secure RNG)
- **new** `__tests__/unit/generatePushID.test.ts` — asserts length 20, in-alphabet charset, strict lexicographic (time-sortable) ordering, and same-ms ordering
- `DrinkingSession.ts` — both call sites now use `generatePushID()`; `db`/`DBPATHS`/`Database` plumbing dropped from `startLiveDrinkingSession` / `generateDrinkingSessionId` / `getNewSessionToEdit`
- `useStartEditSessionForDate.ts`, `StartSessionButtonAndPopover.tsx` — drop the now-unused `db` arg/`Database` import
- `baseFunctions.ts` — dead `generateDatabaseKey` removed (with its `child`/`push` imports); `readDataOnce` retained for the remaining category-C reads
- `DrinkingSession.test.ts` — mock repointed from `@database/baseFunctions` to `@libs/generatePushID`
- `REALTIME_MIGRATION_AUDIT.md` — category-A note updated to mark the handle severed

After this, `FirebaseContext.tsx`, `baseFunctions.ts` (`readDataOnce`), and `User.ts` (category-C OAuth read) are the only remaining `firebase/database` value importers in `src/`.

## Stacking

Stacked on **#1010** (`chore/realtime-final-rtdb-audit`) — that PR introduces the audit doc and the `baseFunctions.ts` dead-code cleanup this builds on. Base will auto-retarget to `master` when #1010 merges; review/merge **#1010 first**.

## Verification

- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `npm run lint-changed` ✅
- `npx prettier --check` ✅
- `jest __tests__/unit/generatePushID.test.ts __tests__/actions/DrinkingSession.test.ts` → 15 passed ✅

Refs #778, #809, #810.