### PR TITLE
feat(statistics): weekly-units chart as bars + trend line

### DIFF
--- a/contributingGuides/STATISTICS_V2.md
+++ b/contributingGuides/STATISTICS_V2.md
@@ -194,7 +194,7 @@ Each tab ships with at least one **hero chart** so no tab feels empty on day one
 
 ### 6.2 Trends — "How is this changing?"
 
-- **Hero**: weekly units line + EWMA overlay + band-of-normal
+- **Hero**: weekly units as faint bars + a prominent EWMA trend line (deeper amber), with an on-chart legend. (The percentile band-of-normal was dropped from this chart in favor of per-week bars; `percentileBand` remains as a utility.)
 - Cumulative alcohol-free days YTD (only-up line, psychologically additive)
 - Weekly drink-type stacked area
 - "vs previous period" toggle adds a dashed second series to each

--- a/src/components/Charts/BaseChart/types.ts
+++ b/src/components/Charts/BaseChart/types.ts
@@ -39,6 +39,10 @@ type ChartTheme = {
   primaryStroke: string;
   /** Translucent fill for the "band of normal" overlay. */
   bandFill: string;
+  /** Faint accent fill for raw "weekly units" bars. */
+  barFill: string;
+  /** Deeper-amber stroke for the prominent weekly trend line. */
+  trendStroke: string;
   /** Stroke color for muted comparison ("vs previous period") lines. */
   comparisonStroke: string;
   /** Five-stop intensity ramp for the heatmap, indices 0..4. */

--- a/src/components/Charts/BaseChart/useChartTheme.ts
+++ b/src/components/Charts/BaseChart/useChartTheme.ts
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import useTheme from '@hooks/useTheme';
+import colors from '@styles/theme/colors';
 import type {ChartTheme} from './types';
 
 /**
@@ -25,6 +26,12 @@ function useChartTheme(): ChartTheme {
       primaryStroke: appColor,
       // ~20% alpha suffix on the theme accent for the band-of-normal stripe.
       bandFill: `${appColor}33`,
+      // Faint accent fill (~33% alpha) for "raw weekly units" bars — context
+      // the prominent trend line reads above.
+      barFill: `${appColor}55`,
+      // A deeper amber for the weekly trend line so it pops above the faint
+      // bars. Brand-family (yellow→amber), never red — per design doc §3.
+      trendStroke: colors.yellow600,
       // Muted ~67% alpha on the supporting text color for dashed
       // "vs previous period" overlays — visible but never competes with
       // the primary series.

--- a/src/components/Charts/TrendLine/TrendLine.tsx
+++ b/src/components/Charts/TrendLine/TrendLine.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import {View} from 'react-native';
-import {DashPathEffect, Rect} from '@shopify/react-native-skia';
-import {BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
+import {DashPathEffect} from '@shopify/react-native-skia';
+import {Bar, BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
 import {
   formatWeekTick,
   roundTick,
@@ -19,8 +19,6 @@ type TrendLineProps = {
   ewma?: number[];
   /** Comparison-period units, parallel-indexed; omit to hide. */
   comparison?: number[];
-  /** P25 / P75 band; null when the underlying series is too short. */
-  band?: {p25: number; p75: number} | null;
   accessibilityLabel: string;
   emptyLabel?: string;
   height?: number;
@@ -42,10 +40,10 @@ const COMPARISON_DASH: number[] = [4, 4];
 
 /**
  * Hero chart for the Trends tab. Composes:
- *   1. translucent P25–P75 "band of normal" stripe (Skia <Rect>),
- *   2. solid weekly-units line in the brand color,
- *   3. thinner EWMA line above (hidden when < 4 weeks),
- *   4. dashed muted-color comparison line (hidden when not requested).
+ *   1. faint weekly-units bars — the raw "what happened each week",
+ *   2. a deeper-amber EWMA trend line on top — the prominent story line
+ *      (hidden when < 4 weeks of data, leaving just the bars),
+ *   3. a dashed muted-color comparison line (hidden when not requested).
  *
  * Every yKey present on `data` rows must be a real number; callers zero-fill
  * missing series upstream (in `useTrendsTabData`) so the underlying chart
@@ -58,7 +56,6 @@ function TrendLine({
   units,
   ewma,
   comparison,
-  band,
   accessibilityLabel,
   emptyLabel,
   height,
@@ -95,9 +92,8 @@ function TrendLine({
       if (showEwma && row.ewma > max) max = row.ewma;
       if (showComparison && row.cmp > max) max = row.cmp;
     }
-    if (band && band.p75 > max) max = band.p75;
     return max;
-  }, [data, band, showEwma, showComparison]);
+  }, [data, showEwma, showComparison]);
 
   const xTicks = useMemo(() => tickIndices(weeks.length), [weeks.length]);
   const yTicks = useMemo(() => valueTicks(maxY), [maxY]);
@@ -119,57 +115,31 @@ function TrendLine({
         formatYLabel: roundTick,
       }}
       loading={isLoading}>
-      {({points, chartBounds, theme}) => {
-        const top = chartBounds.top;
-        const bottom = chartBounds.bottom;
-        const yFor = (value: number) =>
-          top + (1 - value / maxY) * (bottom - top);
-
-        let bandRect = null;
-        if (band) {
-          const bandTopY = yFor(band.p75);
-          const bandBottomY = yFor(band.p25);
-          const bandHeight = Math.max(0, bandBottomY - bandTopY);
-          if (bandHeight > 0) {
-            bandRect = (
-              <Rect
-                x={chartBounds.left}
-                y={bandTopY}
-                width={chartBounds.right - chartBounds.left}
-                height={bandHeight}
-                color={theme.bandFill}
-              />
-            );
-          }
-        }
-
-        return (
-          <>
-            {bandRect}
+      {({points, chartBounds, theme}) => (
+        <>
+          <Bar
+            points={points.y}
+            chartBounds={chartBounds}
+            color={theme.barFill}
+            roundedCorners={{topLeft: 3, topRight: 3}}
+          />
+          {showComparison ? (
             <Line
-              points={points.y}
-              color={theme.primaryStroke}
-              strokeWidth={2}
+              points={points.cmp}
+              color={theme.comparisonStroke}
+              strokeWidth={1.5}>
+              <DashPathEffect intervals={COMPARISON_DASH} />
+            </Line>
+          ) : null}
+          {showEwma ? (
+            <Line
+              points={points.ewma}
+              color={theme.trendStroke}
+              strokeWidth={2.6}
             />
-            {showEwma ? (
-              <Line
-                points={points.ewma}
-                color={theme.primaryStroke}
-                strokeWidth={1.5}
-                opacity={0.6}
-              />
-            ) : null}
-            {showComparison ? (
-              <Line
-                points={points.cmp}
-                color={theme.comparisonStroke}
-                strokeWidth={1.5}>
-                <DashPathEffect intervals={COMPARISON_DASH} />
-              </Line>
-            ) : null}
-          </>
-        );
-      }}
+          ) : null}
+        </>
+      )}
     </BaseChart>
   );
 

--- a/src/components/Charts/TrendLine/WeeklyTrendLegend.tsx
+++ b/src/components/Charts/TrendLine/WeeklyTrendLegend.tsx
@@ -43,7 +43,7 @@ function WeeklyTrendLegend({
           }}
         />
         <Text style={[styles.textMicroSupporting]}>
-          {translate('statistics.tabs.trends.weeklyTrend.legend.thisPeriod')}
+          {translate('statistics.tabs.trends.weeklyTrend.legend.perWeek')}
         </Text>
       </View>
 

--- a/src/components/Charts/TrendLine/WeeklyTrendLegend.tsx
+++ b/src/components/Charts/TrendLine/WeeklyTrendLegend.tsx
@@ -1,0 +1,92 @@
+import {View} from 'react-native';
+import {useChartTheme} from '@components/Charts/BaseChart';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+type WeeklyTrendLegendProps = {
+  /** Show the "Trend" item — hidden when there's no EWMA line (sparse data). */
+  showTrend: boolean;
+  /** Show the dashed "Previous period" item — Compare mode only. */
+  showComparison: boolean;
+};
+
+/**
+ * Color key for the weekly-units chart: a faint bar swatch ("this period"), a
+ * solid deeper line ("trend"), and a dashed line ("previous period"). Pulls the
+ * same tokens from `useChartTheme` as `TrendLine`, so the swatches always match
+ * what's drawn.
+ */
+function WeeklyTrendLegend({
+  showTrend,
+  showComparison,
+}: WeeklyTrendLegendProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const {barFill, trendStroke, comparisonStroke} = useChartTheme();
+
+  return (
+    <View
+      style={[
+        styles.flexRow,
+        styles.flexWrap,
+        styles.justifyContentCenter,
+        {columnGap: 14, rowGap: 6},
+      ]}>
+      <View style={[styles.flexRow, styles.alignItemsCenter, {columnGap: 6}]}>
+        <View
+          style={{
+            width: 12,
+            height: 10,
+            borderRadius: 2,
+            backgroundColor: barFill,
+          }}
+        />
+        <Text style={[styles.textMicroSupporting]}>
+          {translate('statistics.tabs.trends.weeklyTrend.legend.thisPeriod')}
+        </Text>
+      </View>
+
+      {showTrend ? (
+        <View style={[styles.flexRow, styles.alignItemsCenter, {columnGap: 6}]}>
+          <View
+            style={{
+              width: 16,
+              height: 2.5,
+              borderRadius: 2,
+              backgroundColor: trendStroke,
+            }}
+          />
+          <Text style={[styles.textMicroSupporting]}>
+            {translate('statistics.tabs.trends.weeklyTrend.legend.trend')}
+          </Text>
+        </View>
+      ) : null}
+
+      {showComparison ? (
+        <View style={[styles.flexRow, styles.alignItemsCenter, {columnGap: 6}]}>
+          <View
+            style={[styles.flexRow, styles.alignItemsCenter, {columnGap: 2}]}>
+            <View
+              style={{width: 4, height: 2, backgroundColor: comparisonStroke}}
+            />
+            <View
+              style={{width: 4, height: 2, backgroundColor: comparisonStroke}}
+            />
+            <View
+              style={{width: 4, height: 2, backgroundColor: comparisonStroke}}
+            />
+          </View>
+          <Text style={[styles.textMicroSupporting]}>
+            {translate('statistics.tabs.trends.comparison.legend')}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+WeeklyTrendLegend.displayName = 'WeeklyTrendLegend';
+
+export default WeeklyTrendLegend;
+export type {WeeklyTrendLegendProps};

--- a/src/components/Charts/TrendLine/index.ts
+++ b/src/components/Charts/TrendLine/index.ts
@@ -1,2 +1,4 @@
 export {default as TrendLine} from './TrendLine';
 export type {TrendLineProps} from './TrendLine';
+export {default as WeeklyTrendLegend} from './WeeklyTrendLegend';
+export type {WeeklyTrendLegendProps} from './WeeklyTrendLegend';

--- a/src/hooks/useStatistics/useTrendsTabData.ts
+++ b/src/hooks/useStatistics/useTrendsTabData.ts
@@ -5,7 +5,6 @@ import {
   buildAfYtdSeries,
   buildWeeklyStackedSeries,
   buildWeeklyUnits,
-  percentileBand,
   shiftRange,
 } from '@libs/Statistics/trends';
 import type {AfYtdPoint} from '@libs/Statistics/trends';
@@ -21,7 +20,6 @@ type Hero = {
   units: number[];
   ewma?: number[];
   comparison?: number[];
-  band: {p25: number; p75: number} | null;
   captionKey: CaptionKey;
 };
 
@@ -77,7 +75,6 @@ function useTrendsTabData(): TrendsTabData {
 
     const ewmaSeries =
       units.length >= MIN_EWMA_N ? ewma(units, 0.3) : undefined;
-    const band = percentileBand(units);
 
     const comparisonUnits = comparisonRange
       ? buildWeeklyUnits(
@@ -119,7 +116,6 @@ function useTrendsTabData(): TrendsTabData {
       units,
       ewma: ewmaSeries,
       comparison: comparisonAligned,
-      band,
       captionKey,
     };
   }, [events, range.start, range.end, comparisonRange]);

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1021,8 +1021,10 @@ export default {
         weeklyTrend: {
           title: 'Týdenní jednotky',
           emptyLabel: 'Váš trend se ukáže, jak budou přibývat data.',
-          bandCaption:
-            'Stínované pásmo ukazuje, kde se pohybovala většina posledních týdnů.',
+          legend: {
+            thisPeriod: 'Toto období',
+            trend: 'Trend',
+          },
           captions: {
             trendingDown: 'Vaše týdenní jednotky mají sestupný trend.',
             trendingUp: 'Vaše týdenní jednotky mají vzestupný trend.',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1022,7 +1022,7 @@ export default {
           title: 'Týdenní jednotky',
           emptyLabel: 'Váš trend se ukáže, jak budou přibývat data.',
           legend: {
-            thisPeriod: 'Toto období',
+            perWeek: 'Za týden',
             trend: 'Trend',
           },
           captions: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1031,7 +1031,7 @@ export default {
           title: 'Weekly units',
           emptyLabel: 'Your trend will show as data builds.',
           legend: {
-            thisPeriod: 'This period',
+            perWeek: 'Per week',
             trend: 'Trend',
           },
           captions: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1030,8 +1030,10 @@ export default {
         weeklyTrend: {
           title: 'Weekly units',
           emptyLabel: 'Your trend will show as data builds.',
-          bandCaption:
-            'The shaded band is where most of your recent weeks landed.',
+          legend: {
+            thisPeriod: 'This period',
+            trend: 'Trend',
+          },
           captions: {
             trendingDown: 'Your weekly units are trending down.',
             trendingUp: 'Your weekly units are trending up.',

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -3,7 +3,7 @@ import {StyleSheet, View} from 'react-native';
 import {ChartCard} from '@components/Charts/ChartCard';
 import {CumulativeLine} from '@components/Charts/CumulativeLine';
 import {StackedArea} from '@components/Charts/StackedArea';
-import {TrendLine} from '@components/Charts/TrendLine';
+import {TrendLine, WeeklyTrendLegend} from '@components/Charts/TrendLine';
 import ScrollView from '@components/ScrollView';
 import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
@@ -37,9 +37,8 @@ function TrendsTab() {
   const {openDrillDown} = useStatsDrillDown();
 
   const heroComparisonShown = !!hero.comparison;
-  const heroSubtitle = hero.band
-    ? translate('statistics.tabs.trends.weeklyTrend.bandCaption')
-    : undefined;
+  // The trend line only draws once EWMA exists (≥4 weeks); the legend mirrors it.
+  const heroShowTrend = !!hero.ewma && hero.ewma.length === hero.weeks.length;
   const heroCaption = translate(CAPTION_KEYS[hero.captionKey]);
   const comparisonLegend = translate(
     'statistics.tabs.trends.comparison.legend',
@@ -62,20 +61,20 @@ function TrendsTab() {
         contentContainerStyle={styles.container}>
         <ChartCard
           title={translate('statistics.tabs.trends.weeklyTrend.title')}
-          subtitle={heroSubtitle}
           footer={
-            <Text style={themeStyles.textMicroSupporting}>
-              {heroComparisonShown
-                ? `${heroCaption} · ${comparisonLegend}`
-                : heroCaption}
-            </Text>
+            <View style={{rowGap: 8}}>
+              <WeeklyTrendLegend
+                showTrend={heroShowTrend}
+                showComparison={heroComparisonShown}
+              />
+              <Text style={themeStyles.textMicroSupporting}>{heroCaption}</Text>
+            </View>
           }>
           <TrendLine
             weeks={hero.weeks}
             units={hero.units}
             ewma={hero.ewma}
             comparison={hero.comparison}
-            band={hero.band}
             emptyLabel={translate(
               'statistics.tabs.trends.weeklyTrend.emptyLabel',
             )}


### PR DESCRIPTION
## Why

The Trends **"Weekly units"** hero was hard to read. It stacked three things in the *same brand hue* — a raw line, a same-colored EWMA line, and a same-colored percentile band — distinguished only by stroke width and opacity, with **no legend** and the EWMA never explained. Most users couldn't tell what they were looking at.

## What changed

Redesigned around "bars = what happened, line = your trend" (a familiar fitness-app pattern):

- **Raw weekly units → faint bars** (one per week) instead of a line — instantly reads as "each week."
- **EWMA → the single prominent trend line**, in a **deeper amber** so it pops above the bars.
- **Dropped the band-of-normal** from this chart (the bars already show every week). `percentileBand` stays as a utility; only the hero stopped rendering it.
- **On-chart legend** (`WeeklyTrendLegend`): _This period_ (bar swatch) · _Trend_ (line) · _Previous period_ (dashed, Compare mode). It pulls the same `useChartTheme` tokens as the chart, so swatches always match what's drawn.

Supporting changes: two new chart-theme tokens (`barFill`, `trendStroke`); removed the now-unused `band` plumbing from the hero data + the `bandCaption` subtitle; new `weeklyTrend.legend.{thisPeriod,trend}` keys in en + cs_cz.

The chosen design (bars + deeper trend line, no band, with legend) was picked from a rendered mockup before implementation.

## Verification

- `typecheck-tsgo` ✓ · React Compiler `check-changed` (8 files) ✓ · read-only eslint on all changed files ✓
- Statistics + Charts jest (28 suites / 240 tests) ✓ · translation parity (`Translate.test.ts`) ✓

> On-device visual confirmation (bars/line rendering, light + dark, Compare on/off, sparse-data <4 weeks → bars only) wasn't run in this environment — worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)