### PR TITLE
feat(statistics): add monthly average tile to Overview Load section

### DIFF
--- a/__tests__/unit/libs/Statistics/overview.test.ts
+++ b/__tests__/unit/libs/Statistics/overview.test.ts
@@ -66,6 +66,7 @@ describe('buildPeriodSummary', () => {
     expect(s.totalUnits).toBe(0);
     expect(s.drinkingDays).toBe(0);
     expect(s.avgUnitsPerDrinkingDay).toBe(0);
+    expect(s.monthlyAvgUnits).toBe(0);
     expect(s.sessions).toBe(0);
   });
 
@@ -106,6 +107,35 @@ describe('buildPeriodSummary', () => {
     expect(s.longestDryStreak).toBe(14);
     expect(s.drinkingDays).toBe(2);
     expect(s.afDays).toBe(29);
+  });
+
+  it('projects a full month to ~30.44 units/month at that rate', () => {
+    // 31 units across a fully-elapsed 31-day month → ~AVG_DAYS_PER_MONTH.
+    const s = buildPeriodSummary(
+      [event('2026-01-02', 31)],
+      JAN_START,
+      JAN_END,
+      AFTER_JAN,
+      THRESHOLDS,
+    );
+    expect(s.elapsedDays).toBe(31);
+    expect(s.totalUnits).toBe(31);
+    expect(s.monthlyAvgUnits).toBeCloseTo(365.25 / 12); // (31 / 31) * 30.44
+  });
+
+  it('interpolates a short window up to a monthly projection', () => {
+    // 7 units over a 7-day elapsed window → ~30, not the raw weekly 7.
+    const now = new Date(2026, 0, 7, 23, 59, 59);
+    const s = buildPeriodSummary(
+      [event('2026-01-03', 7)],
+      JAN_START,
+      JAN_END,
+      now,
+      THRESHOLDS,
+    );
+    expect(s.elapsedDays).toBe(7);
+    expect(s.totalUnits).toBe(7);
+    expect(s.monthlyAvgUnits).toBeCloseTo(365.25 / 12); // (7 / 7) * 30.44
   });
 
   it('clamps elapsed days and totals to `now` for a partial period', () => {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -987,6 +987,7 @@ export default {
           sessions: {label: 'Sessions'},
           heaviestDay: {label: 'Heaviest day', unit: 'units'},
           avgPerDrinkingDay: {label: 'Avg / drinking day', unit: 'units'},
+          monthlyAvg: {label: 'Avg / month', unit: 'units'},
           daysOverYellow: {
             label: ({threshold}: StatsThresholdParams) =>
               `Days over ${threshold}`,

--- a/src/libs/Statistics/overview/periodSummary.ts
+++ b/src/libs/Statistics/overview/periodSummary.ts
@@ -6,6 +6,13 @@ import collectWindowAggregates from './windowAggregates';
 type Thresholds = {yellow: number; orange: number};
 
 /**
+ * Average Gregorian month length (365.25 / 12). Normalizes the range's unit
+ * rate into a per-month projection, so short windows extrapolate up to a month
+ * and long windows collapse to a true units-per-month average.
+ */
+const AVG_DAYS_PER_MONTH = 365.25 / 12;
+
+/**
  * Count of elapsed days falling in each severity band. Sums to
  * `elapsedDays`. `green` is the alcohol-free count by definition.
  */
@@ -42,6 +49,13 @@ type PeriodSummary = {
   heaviestDay: number;
   /** totalUnits / drinkingDays, or 0 when there were no drinking days. */
   avgUnitsPerDrinkingDay: number;
+  /**
+   * Units per month, projected from the range's rate
+   * (`totalUnits / elapsedDays * AVG_DAYS_PER_MONTH`), or 0 for an empty
+   * window. Short ranges extrapolate up; long ranges read as the real
+   * monthly average.
+   */
+  monthlyAvgUnits: number;
   /** Days with units strictly over the yellow threshold (orange + red bands). */
   daysOverYellow: number;
   /** Days with units strictly over the orange threshold (red band). */
@@ -58,6 +72,7 @@ const EMPTY_SUMMARY: PeriodSummary = {
   longestDryStreak: 0,
   heaviestDay: 0,
   avgUnitsPerDrinkingDay: 0,
+  monthlyAvgUnits: 0,
   daysOverYellow: 0,
   daysOverOrange: 0,
   distribution: {green: 0, yellow: 0, orange: 0, red: 0},
@@ -116,6 +131,10 @@ function summarizePeriod(
     longestDryStreak,
     heaviestDay,
     avgUnitsPerDrinkingDay: drinkingDays > 0 ? totalUnits / drinkingDays : 0,
+    monthlyAvgUnits:
+      dayKeys.length > 0
+        ? (totalUnits / dayKeys.length) * AVG_DAYS_PER_MONTH
+        : 0,
     daysOverYellow: distribution.orange + distribution.red,
     daysOverOrange: distribution.red,
     distribution,

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -140,6 +140,15 @@ function OverviewTab() {
         : undefined,
       polarity: 'lower-is-supportive',
     },
+    {
+      label: translate('statistics.tabs.overview.kpi.monthlyAvg.label'),
+      value: formatUnits(current.monthlyAvgUnits),
+      unit: translate('statistics.tabs.overview.kpi.monthlyAvg.unit'),
+      delta: previous
+        ? makeDelta(current.monthlyAvgUnits, previous.monthlyAvgUnits)
+        : undefined,
+      polarity: 'lower-is-supportive',
+    },
   ];
 
   const pctOver =


### PR DESCRIPTION
### Details

Adds a fourth **Avg / month** tile to the Statistics → Overview tab's **Load** section, filling the previously empty slot in the 2×2 KPI block.

The value projects the selected range's unit rate to a per-month figure, normalizing by the average Gregorian month (`365.25 / 12 ≈ 30.44` days):

```
monthlyAvgUnits = elapsedDays > 0 ? (totalUnits / elapsedDays) * 30.44 : 0
```

- Short ranges **extrapolate up**: 7 units logged in a 7-day week → **~30**, not the raw weekly 7.
- Long ranges read as the **true monthly average**: 120 units over a year → **10**.

**Why this shape:** the metric (`monthlyAvgUnits`) is derived inside the existing `summarizePeriod` pass rather than as a new aggregation. As a result both the current range *and* the comparison window get it for free, so the delta chip works exactly like the sibling Load tiles with no changes to `buildOverviewModel`, `windowAggregates`, the barrel, or the hook. It reuses `totalUnits` and `elapsedDays` (already clamped to `now`), so a partial current period extrapolates from the days actually elapsed.

**Localization note:** only the English key (`statistics.tabs.overview.kpi.monthlyAvg`) was added, per the project policy of filling other locales via the `translate` skill. The `cs_cz` `statistics.tabs.overview` subtree is separately stale (it predates the Overview rewrite and is missing all current `kpi` siblings), so the new tile falls back to English for Czech users today — identical to every other current Overview tile, no regression. A dedicated re-translation of that whole section is tracked separately.

**Files**
- `src/libs/Statistics/overview/periodSummary.ts` — new `monthlyAvgUnits` field + `AVG_DAYS_PER_MONTH` constant
- `src/screens/Statistics/tabs/OverviewTab.tsx` — fourth Load card (reuses `formatUnits` / `makeDelta`, `polarity: 'lower-is-supportive'`)
- `src/languages/en.ts` — `monthlyAvg: {label: 'Avg / month', unit: 'units'}`
- `__tests__/unit/libs/Statistics/overview.test.ts` — coverage for the new field

### Tests

Automated:
- `npx jest __tests__/unit/libs/Statistics/overview.test.ts` — **19 passed**, including new cases: full-month projection (~30.44), short-window interpolation (7-in-a-week → ~30), and empty-window (0).
- `npm run typecheck-tsgo` — clean.
- `npm run react-compiler-compliance-check check-changed` — passed.

Manual:
1. Open **Statistics → Overview**.
2. Verify the **Load** section now shows four tiles in a 2×2 block (narrow phone): Sessions, Heaviest day, Avg / drinking day, **Avg / month**.
3. Switch the range (W / M / 6M / Y / All) and confirm **Avg / month** rescales sensibly — on a **Week** range it reads ~4.3× the weekly total; on a fully-elapsed month it ≈ that month's total.
4. Enable a comparison (previous period) and verify the delta chip appears on the new tile and is colored as "lower is supportive".

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed. The tile is derived entirely from already-loaded drink events; it renders identically offline.

### QA Steps

1. On staging, open **Statistics → Overview**.
2. Confirm the **Load** section shows the new **Avg / month** tile filling the 2×2 grid.
3. Cycle through every range preset and confirm the value is reasonable (short ranges show a projected monthly figure, not the raw range total).
4. Turn on the previous-period comparison and confirm the delta renders.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified any copy / text shown in the product is localized (English key added in `src/languages/en.ts`, rendered via `translate`; other locales filled via the `translate` skill per CLAUDE.md).
- [x] I verified copy is grammatically correct and follows sentence-case label conventions ("Avg / month").
- [x] I verified all code is DRY (metric reuses the existing `summarizePeriod` pass; tile reuses `formatUnits` / `makeDelta`).
- [x] I verified constants are defined as such (`AVG_DAYS_PER_MONTH`).
- [x] I added comments explaining "why" (the normalization rationale on the constant and the field).

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)