### PR TITLE
feat(i18n): re-translate cs_cz statistics Overview tab to parity with en

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -23,8 +23,8 @@ import type {
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
   SessionWindowIdParams,
-  StatsAfDaysParams,
   StatsDrillDownTitleParams,
+  StatsThresholdParams,
   SupporterCancelledStatusParams,
   SupporterPriceParams,
   SupporterPurchaseCtaParams,
@@ -974,47 +974,61 @@ export default {
       overview: {
         label: 'Přehled',
         hero: {
-          afDays: {
-            label: 'Dny bez alkoholu tento měsíc',
-            a11yLabel: ({value, total}: StatsAfDaysParams) =>
-              `${value} z ${total} dnů bez alkoholu tento měsíc`,
-          },
+          label: 'Jednotky za období',
+          unit: 'jednotek',
+        },
+        delta: {
+          vsPrevious: 'vs předchozí',
+        },
+        sections: {
+          highlights: 'Hlavní body',
+          load: 'Zátěž',
+          risk: 'Riziko',
         },
         kpi: {
-          sessionsThisWeek: {
-            label: 'Relace tento týden',
-            delta: 'vs minulý týden',
+          afDays: {label: 'Dny bez alkoholu'},
+          dryStreak: {label: 'Nejdelší série bez alkoholu', unit: 'dní'},
+          sessions: {label: 'Relace'},
+          heaviestDay: {label: 'Nejtěžší den', unit: 'jednotek'},
+          avgPerDrinkingDay: {label: 'Průměr / den pití', unit: 'jednotek'},
+          monthlyAvg: {label: 'Průměr / měsíc', unit: 'jednotek'},
+          daysOverYellow: {
+            label: ({threshold}: StatsThresholdParams) =>
+              `Dny nad ${threshold}`,
           },
-          quietDaysThisWeek: {
-            label: 'Klidné dny tento týden',
-            delta: 'vs minulý týden',
+          daysOverOrange: {
+            label: ({threshold}: StatsThresholdParams) =>
+              `Dny nad ${threshold}`,
           },
-          unitsThisWeek: {
-            label: 'Jednotky tento týden',
-            delta: 'vs minulý týden',
+          pctOver: {
+            label: ({threshold}: StatsThresholdParams) =>
+              `% dní nad ${threshold}`,
           },
         },
-        trend: {
-          title: '8týdenní trend',
-          bandCaption:
-            'Stínovaný pás je tam, kde se odehrála většina vašich posledních 8 týdnů.',
-          chip: {
-            down: 'Vaše týdenní jednotky postupně klesají.',
-            up: 'Vaše týdenní jednotky postupně rostou.',
-            none: 'Vaše týdny se proměňují jako obvykle.',
+        texture: {
+          series: {
+            title: 'Jednotky podle období',
+            a11y: 'Jednotky za dílčí období',
           },
-          a11yLabel: 'Posledních 8 týdnů týdenních jednotek, vyhlazeno',
+          distribution: {
+            title: 'Dny podle intenzity',
+            a11y: 'Rozložení dní podle intenzity pití',
+            af: 'Bez alk.',
+            light: 'Mírná',
+            moderate: 'Střední',
+            heavy: 'Těžká',
+          },
         },
         empty: {
           neverLogged: {
-            title: 'Zatím není co zobrazit',
-            body: 'Až zaznamenáte relaci, objeví se zde týdenní trendy a měsíční přehled.',
+            title: 'Zatím není co zaznamenat',
+            body: 'Až zaznamenáte relaci, objeví se zde váš přehled za období.',
           },
           noDataInRange:
             'Žádné relace v tomto období. Každý uplynulý den byl bez alkoholu.',
         },
         sparseFooter:
-          'Zatím jen pár týdnů historie. Vaše trendy se vyjasní, jak budete přidávat data.',
+          'Zatím jen málo historie. Tato čísla se zpřesní, jak budete přidávat další záznamy.',
       },
       trends: {
         label: 'Trendy',
@@ -1060,11 +1074,13 @@ export default {
           sliceCaption: ({label, units, share}: BreakdownSliceCaptionParams) =>
             `${label}: ${units} jednotek (${share} %)`,
           a11y: 'Koláč složení podle druhu drinku',
+          current: 'Aktuální',
+          previous: 'Předchozí',
         },
         multiples: {
           title: 'Týdenní trend podle druhu',
           subtitle: 'Malý graf pro každý druh s daty v tomto období.',
-          empty: 'Zatím žádné trendy podle druhu. Zkus širší období.',
+          empty: 'Zatím žádné trendy podle druhu. Zkuste širší období.',
           tileSubtitle: ({units}: BreakdownTileSubtitleParams) =>
             `${units} jednotek za období`,
           a11yTile: ({label}: BreakdownDrinkLabelParams) =>

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -50,11 +50,6 @@ type SessionWindowIdParams = {
   sessionId: DrinkingSessionId;
 };
 
-type StatsAfDaysParams = {
-  value: number;
-  total: number;
-};
-
 type StatsThresholdParams = {
   threshold: number;
 };
@@ -135,7 +130,6 @@ export type {
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
   SessionWindowIdParams,
-  StatsAfDaysParams,
   StatsDrillDownTitleParams,
   StatsThresholdParams,
   SupporterCancelledStatusParams,


### PR DESCRIPTION
### Details

The Czech (`cs_cz`) `statistics.tabs.overview` subtree predated the Statistics **Overview** tab rewrite. Its structure no longer matched the English source of truth in `src/languages/en.ts`, so every Overview tile silently fell back to English for Czech users.

This re-translates the entire `overview` subtree into structural parity with `en.ts` (same nesting, key order, and value shape: string→string, function→function with the same param types), translated against the Czech glossary in `src/languages/context/cs_cz.md` (vykání, sentence case, `… `space-before-`%`, no em-dashes).

**`overview` (full rewrite):**
- `hero` → `{label: 'Jednotky za období', unit: 'jednotek'}`
- `delta.vsPrevious` → `vs předchozí`
- `sections` → Hlavní body / Zátěž / Riziko
- `kpi` (9 tiles): afDays, dryStreak, sessions, heaviestDay, avgPerDrinkingDay, **monthlyAvg ("Avg / month" → `Průměr / měsíc`)**, and the three `StatsThresholdParams` function labels (`Dny nad …` / `% dní nad …`)
- `texture.series` + `texture.distribution` (Bez alk. / Mírná / Střední / Těžká)
- `empty` + `sparseFooter` retranslated; `noDataInRange` was already correct and kept verbatim

**Other out-of-sync items fixed while in the file:**
- `breakdown.donut`: added missing `current` / `previous` legend labels (`Aktuální` / `Předchozí`)
- `breakdown.multiples.empty`: fixed tykání `Zkus` → vykání `Zkuste` (register drift per the glossary)
- `params.ts`: removed the now-orphaned `StatsAfDaysParams` type/export; `cs_cz` now imports `StatsThresholdParams` for the threshold KPI labels

The `monthlyAvg` key was added to `en.ts` on master in #f19d084d (English-only); this PR fills its Czech translation. `trends`, `patterns`, `charts`, `drilldown`, `filters`, and `legend` were already in parity and left untouched. No `en.ts` changes (source of truth untouched).

### Tests

1. Open the app with the Czech locale.
2. Go to **Statistics → Overview** tab.
3. Verify every tile renders in Czech (no English fallback): the hero "Jednotky za období", the Hlavní body / Zátěž / Riziko sections, all KPI tiles including the "Avg / month" → `Průměr / měsíc` tile, the threshold tiles ("Dny nad …", "% dní nad …"), and the intensity distribution chips (Bez alk. / Mírná / Střední / Těžká).
4. Go to **Statistics → Breakdown** tab and verify the donut comparison legend shows `Aktuální` / `Předchozí`, and the per-type empty state reads `Zkuste širší období.`

Automated:
- `npm run test -- __tests__/unit/Translate.test.ts` → 6/6 pass (translation key-parity gate)
- `npm run typecheck-tsgo` → clean (cs_cz typed against en's `TranslationPaths`; confirms structural parity + correct param types)

- [x] Verify that no errors appear in the JS console

### Offline tests

Translation strings are bundled; no network dependency. Behavior is identical offline.

### QA Steps

1. Switch the app language to Czech.
2. Navigate to Statistics → Overview and confirm all tiles/sections/labels are Czech (no English text).
3. Confirm the "Avg / month" Load tile shows `Průměr / měsíc`.
4. Navigate to Statistics → Breakdown and confirm the donut legend (`Aktuální` / `Předchozí`) and the multiples empty state (`Zkuste širší období.`).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified any copy / text shown in the product is localized via `src/languages/*` (this PR fills `cs_cz`; `en.ts` is unchanged)
- [x] Czech translations were produced via the `translate` skill against the curated `cs_cz` glossary (not hand-written ad hoc)
- [x] I verified all code is DRY and follows existing patterns in the file
- [ ] Manual on-device run on Android / iOS (verified via unit test + typecheck instead; recommend a quick visual check)

### Screenshots/Videos

<details>
<summary>Android</summary>

N/A (string-only change; verify per Tests steps)

</details>

<details>
<summary>iOS</summary>

N/A (string-only change; verify per Tests steps)

</details>
