### PR TITLE
chore(rtdb): tear the last Firebase RTDB plumbing out of the client

### DIFF
--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -63,14 +63,6 @@ jest.mock('react-native', () => ({
   },
 }));
 
-jest.mock('firebase/database', () => ({
-  get: jest.fn(),
-  limitToFirst: jest.fn(),
-  orderByChild: jest.fn(),
-  query: jest.fn(),
-  ref: jest.fn(),
-  update: jest.fn(),
-}));
 jest.mock('@libs/generatePushID', () => ({
   __esModule: true,
   default: jest.fn(() => 'generated-id'),

--- a/contributingGuides/REALTIME_MIGRATION_AUDIT.md
+++ b/contributingGuides/REALTIME_MIGRATION_AUDIT.md
@@ -24,14 +24,46 @@ follow-ups.
 > client read/write migration is 100% complete. The inventory and gap tables below are the
 > pre-cutover (2026-06-05) snapshot, kept for historical reference.
 
+> **Update (2026-06-08, epic [#810](https://github.com/PetrCala/Kiroku/issues/810)): the
+> client is now 100% off Firebase RTDB.**
+> With every reader and writer gone, the last vestigial `db` plumbing has been removed and
+> the RTDB handle torn out of `FirebaseContext`. `getDatabase` / `connectDatabaseEmulator`
+> (and the database-emulator branch, `databaseURL` guard, and `type Database`) are deleted;
+> `FirebaseContextProps` no longer carries `db`. The two remaining `db` consumers were
+> resolved without a handle: `UserConnectionContext`'s emulator-online fallback now keys off
+> `CONFIG.IS_USING_EMULATORS` (behavior-equivalent — the DB emulator was only ever connected
+> when that flag is set), and `NoFriendUserOverview`'s always-true `!db` guard was dropped.
+> The now-orphaned `isConnectedToDatabaseEmulator` helper and the dead
+> `jest.mock('firebase/database')` in `DrinkingSession.test.ts` were removed too.
+> **`git grep "firebase/database" src` now returns zero matches** — the client has no
+> Firebase Realtime Database dependency at all. Auth + Storage are untouched and still
+> provided from `FirebaseContext`.
+>
+> **Important — this is a _client_-side migration, not an RTDB decommission.** Firebase RTDB
+> **remains** kiroku-api's server-side datastore, written via the Firebase Admin SDK (which
+> bypasses security rules). The goal was to stop the app from talking to RTDB directly and
+> route every write/read through kiroku-api, so the client gets a unified offline queue
+> (Onyx optimistic data + queued requests replayed on reconnect). Storage writes are slated
+> to move behind the API the same way later.
+>
+> The only remaining RTDB-related work is **backend/infra under
+> [#810](https://github.com/PetrCala/Kiroku/issues/810)**: now that no client touches RTDB
+> directly, lock the RTDB security rules to **deny-all client access** (the Admin SDK used by
+> kiroku-api is unaffected). `FirebaseConfig.databaseURL`, the `DATABASE_PORT` emulator
+> config, and the `DATABASE_URL` env are now unused by the client and can be retired — a
+> small build/env follow-up, intentionally not ripped out here.
+
 ---
 
 ## 1. Verdict
 
-**The RTDB migration is ~90% complete.** All writes, all change-listeners
+**The client RTDB migration is now 100% complete** (revised 2026-06-08 — see the dated
+updates above; `firebase/database` refs in `src/` are now zero). _The original 2026-06-05
+verdict read "~90% complete"; the remainder of this section describes that pre-cutover
+snapshot and is kept for historical reference._ All writes, all change-listeners
 (`onValue`/`onChild*`), all current-user reads, friend sessions/profiles/statuses,
-friend preferences, and user search are migrated to kiroku-api. What remains touching
-`firebase/database` at **runtime** is:
+friend preferences, and user search are migrated to kiroku-api. What remained touching
+`firebase/database` at **runtime** (as of 2026-06-05) was:
 
 - **1 legitimate, permanent keep** — the `db` handle provider (`FirebaseContext`).
 - **1 keep, now SEVERED** — `generateDatabaseKey` was the last RTDB-handle dependency on

--- a/src/components/Social/NoFriendUserOverview.tsx
+++ b/src/components/Social/NoFriendUserOverview.tsx
@@ -17,10 +17,10 @@ function NoFriendUserOverview({
   profileData,
   RightSideComponent,
 }: NoFriendUserOverviewProps) {
-  const {db, storage} = useFirebase();
+  const {storage} = useFirebase();
   const styles = useThemeStyles();
 
-  if (!db || !profileData) {
+  if (!profileData) {
     return;
   }
 

--- a/src/context/global/FirebaseContext.tsx
+++ b/src/context/global/FirebaseContext.tsx
@@ -2,13 +2,10 @@ import type {ReactNode} from 'react';
 import {createContext, useContext, useMemo} from 'react';
 import type {Auth} from 'firebase/auth';
 import {connectAuthEmulator} from 'firebase/auth';
-import type {Database} from 'firebase/database';
-import {connectDatabaseEmulator, getDatabase} from 'firebase/database';
 import type {FirebaseStorage} from 'firebase/storage';
 import {getStorage, connectStorageEmulator} from 'firebase/storage';
 import {
   isConnectedToAuthEmulator,
-  isConnectedToDatabaseEmulator,
   isConnectedToStorageEmulator,
 } from '@src/libs/Firebase/FirebaseUtils';
 import {FirebaseApp, getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
@@ -17,7 +14,6 @@ import CONFIG from '@src/CONFIG';
 
 type FirebaseContextProps = {
   auth: Auth;
-  db: Database;
   storage: FirebaseStorage;
 };
 
@@ -25,7 +21,7 @@ const FirebaseContext = createContext<FirebaseContextProps | null>(null);
 
 /** Fetch the FirebaseContext. If the context does not exist, throw an error.
  *
- * @example { db, storage } = useFirebase();
+ * @example { auth, storage } = useFirebase();
  */
 const useFirebase = (): FirebaseContextProps => {
   const context = useContext(FirebaseContext);
@@ -49,7 +45,6 @@ function FirebaseProvider({children}: FirebaseProviderProps) {
     // This is called in useMemo which runs after component mounts, ensuring React Native
     // bridge is fully initialized. Direct import would execute at module load time and crash.
     const auth = getFirebaseAuth();
-    const db = getDatabase(FirebaseApp);
     const storage = getStorage(FirebaseApp);
 
     // Check if emulators should be used
@@ -61,9 +56,6 @@ function FirebaseProvider({children}: FirebaseProviderProps) {
       if (!FirebaseConfig.authDomain) {
         throw new Error('Auth URL not defined in FirebaseConfig');
       }
-      if (!FirebaseConfig.databaseURL) {
-        throw new Error('Database URL not defined in FirebaseConfig');
-      }
       if (!FirebaseConfig.storageBucket) {
         throw new Error('Storage bucket not defined in FirebaseConfig');
       }
@@ -73,14 +65,6 @@ function FirebaseProvider({children}: FirebaseProviderProps) {
       }
 
       // Safety check to connect to emulators only if they are not already running
-      if (!isConnectedToDatabaseEmulator(db)) {
-        connectDatabaseEmulator(
-          db,
-          CONFIG.EMULATORS.HOST,
-          CONFIG.EMULATORS.DATABASE_PORT,
-        );
-      }
-
       if (!isConnectedToStorageEmulator(storage)) {
         connectStorageEmulator(
           storage,
@@ -89,7 +73,7 @@ function FirebaseProvider({children}: FirebaseProviderProps) {
         );
       }
     }
-    return {auth, db, storage};
+    return {auth, storage};
   }, []);
 
   return (

--- a/src/context/global/UserConnectionContext.tsx
+++ b/src/context/global/UserConnectionContext.tsx
@@ -1,8 +1,7 @@
 import type {ReactNode} from 'react';
 import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import NetInfo from '@react-native-community/netinfo';
-import {isConnectedToDatabaseEmulator} from '@libs/Firebase/FirebaseUtils';
-import {useFirebase} from './FirebaseContext';
+import CONFIG from '@src/CONFIG';
 
 type UserConnectionContextProps = {
   isOnline: boolean | undefined;
@@ -36,7 +35,6 @@ type UserConnectionProviderProps = {
  * and provide this information through a context provider.
  */
 function UserConnectionProvider({children}: UserConnectionProviderProps) {
-  const {db} = useFirebase();
   const [isOnline, setIsOnline] = useState<boolean | undefined>(true);
 
   useEffect(() => {
@@ -47,16 +45,17 @@ function UserConnectionProvider({children}: UserConnectionProviderProps) {
 
     // Check the initial network status
     NetInfo.fetch().then(state => {
-      const isUsingEmulators = isConnectedToDatabaseEmulator(db);
       const isConnected = state.isConnected as boolean | undefined;
-      setIsOnline(isConnected ?? isUsingEmulators);
+      // When running against the local emulator suite NetInfo may report an
+      // unknown status; treat that as online so dev builds aren't stuck offline.
+      setIsOnline(isConnected ?? CONFIG.IS_USING_EMULATORS);
     });
 
     // Unsubscribe to clean up the subscription
     return () => {
       unsubscribe();
     };
-  }, [db]);
+  }, []);
 
   const value = useMemo(() => {
     return {isOnline};

--- a/src/libs/Firebase/FirebaseUtils.ts
+++ b/src/libs/Firebase/FirebaseUtils.ts
@@ -2,8 +2,6 @@ import type {FirebaseStorage} from 'firebase/storage';
 import type {Auth} from 'firebase/auth';
 import CONFIG from '@src/CONFIG';
 
-/* eslint-disable @typescript-eslint/dot-notation */
-
 /**
  * Checks if the Firebase Storage instance is connected to an emulator.
  *
@@ -44,34 +42,4 @@ function isConnectedToAuthEmulator(auth: Auth): boolean {
   );
 }
 
-/**
- * Safely checks if the provided Firebase database instance is using an emulator.
- * @param database - A Firebase Database instance (or unknown).
- * @returns True if using emulator; otherwise, false.
- */
-function isConnectedToDatabaseEmulator(database: unknown): boolean {
-  if (typeof database !== 'object' || database === null) {
-    return false;
-  }
-
-  const repoInternal = (database as Record<string, unknown>)['_repoInternal'];
-  if (typeof repoInternal !== 'object' || repoInternal === null) {
-    return false;
-  }
-
-  const repoInfo = (repoInternal as Record<string, unknown>)['repoInfo_'];
-  if (typeof repoInfo !== 'object' || repoInfo === null) {
-    return false;
-  }
-
-  const isUsingEmulator = (repoInfo as Record<string, unknown>)[
-    'isUsingEmulator'
-  ];
-  return typeof isUsingEmulator === 'boolean' ? isUsingEmulator : false;
-}
-
-export {
-  isConnectedToAuthEmulator,
-  isConnectedToDatabaseEmulator,
-  isConnectedToStorageEmulator,
-};
+export {isConnectedToAuthEmulator, isConnectedToStorageEmulator};


### PR DESCRIPTION
## Summary

Final **client-side** cleanup for the Firebase RTDB → kiroku-api migration. With every reader and writer already migrated (epic #809, gaps C1–C4 all landed — the C4 signup version gate was the last live RTDB read, cut over in the preceding PR), this removes the now-vestigial Realtime Database plumbing and tears the `db` handle out of `FirebaseContext`.

**Result: `git grep "firebase/database" src` now returns zero matches.** The app no longer talks to Firebase Realtime Database directly. Auth + Storage are untouched.

> **Scope note:** this does **not** decommission RTDB. RTDB remains kiroku-api's server-side datastore (written via the Firebase Admin SDK). The migration's purpose is to stop the _client_ from talking to RTDB directly and route all writes/reads through kiroku-api, so the app gets a unified offline queue (Onyx optimistic data + queued requests). Storage writes are slated to move behind the API the same way later.

## Changes

**Remove vestigial `db` plumbing (no behavior change)**

- `FirebaseContext.tsx` — drop the `db` handle entirely: remove `getDatabase` / `connectDatabaseEmulator`, the database-emulator branch, the `databaseURL` guard, `db` from `FirebaseContextProps`, and the `type Database` imports. Fix the `useFirebase()` JSDoc example.
- `UserConnectionContext.tsx` — the only live use of `db` was the emulator-online fallback `isConnectedToDatabaseEmulator(db)`. Key it off `CONFIG.IS_USING_EMULATORS` instead. Behavior-equivalent: the DB emulator was only ever connected when that flag is set, so the two always agreed.
- `NoFriendUserOverview.tsx` — drop the always-true `!db` guard (the handle was a stable, always-defined object); keep `storage`.

**Dead-code removal unlocked by the above**

- `FirebaseUtils.ts` — remove the now-orphaned `isConnectedToDatabaseEmulator` (zero consumers) and its stale `dot-notation` eslint-disable.
- `__tests__/actions/DrinkingSession.test.ts` — remove the dead `jest.mock('firebase/database')` (the session action path no longer imports RTDB).

**Docs**

- `contributingGuides/REALTIME_MIGRATION_AUDIT.md` — revise the verdict: the **client is now 100% off Firebase RTDB**, with an explicit note that RTDB stays as the server datastore (not decommissioned). The historical (2026-06-05) inventory/gap tables are kept for reference.

> Note: the prior PR already removed `db` from `Profile.fetchUserProfiles`, `User.fetchUserNicknames`, `SearchWindow`, `FriendsFriendsScreen`, and `useFriendsData` as part of the C4 swap, so those aren't repeated here.

## Verification

- `git grep "firebase/database" src` → **0 matches** ✅
- `git grep "isConnectedToDatabaseEmulator|connectDatabaseEmulator|getDatabase" src` → 0 matches ✅
- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `npm run lint-changed` / direct `eslint` on the 5 changed files ✅
- `DrinkingSession.test.ts` passes after the dead-mock removal ✅

## Remaining work (out of scope — backend/infra under #810)

The **client** is done. RTDB is **not** going away — it stays as kiroku-api's server-side datastore. The one backend follow-up: now that no client touches RTDB directly, lock the RTDB security rules to **deny-all client access** (the Admin SDK used by kiroku-api bypasses rules, so it keeps working).

Small build/env follow-up (intentionally **not** done here): `FirebaseConfig.databaseURL`, the `DATABASE_PORT` emulator config, and the `DATABASE_URL` env are now unused by the client and can be retired.

Refs #809 #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
