### PR TITLE
test(generatePushID): fix timing-flaky same-millisecond ordering test

### DIFF
--- a/__tests__/unit/generatePushID.test.ts
+++ b/__tests__/unit/generatePushID.test.ts
@@ -73,15 +73,25 @@ describe('generatePushID', () => {
   });
 
   it('keeps strict ordering for keys minted in the same millisecond', () => {
-    // No timer advance → identical Date.now() → exercises the monotonic-increment
-    // path (random suffix incremented, not re-rolled).
-    const a = generatePushID();
-    const b = generatePushID();
-    const c = generatePushID();
-    expect(a < b).toBe(true);
-    expect(b < c).toBe(true);
-    // Same-millisecond keys share the 8-char timestamp prefix.
-    expect(b.slice(0, 8)).toBe(a.slice(0, 8));
-    expect(c.slice(0, 8)).toBe(a.slice(0, 8));
+    // Pin Date.now() directly rather than leaning on jest.setSystemTime: the global
+    // setup (jest/setupAfterEnv.ts) calls jest.useRealTimers(), which defeats the
+    // file's fake clock, so Date.now() would otherwise return real wall-clock time.
+    // Three synchronous calls could then straddle a millisecond boundary on a loaded
+    // CI runner, flipping the timestamp prefix and failing the prefix assertions.
+    // Freezing Date.now() guarantees an identical millisecond and exercises the
+    // monotonic-increment path (random suffix incremented, not re-rolled).
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(START_MS);
+    try {
+      const a = generatePushID();
+      const b = generatePushID();
+      const c = generatePushID();
+      expect(a < b).toBe(true);
+      expect(b < c).toBe(true);
+      // Same-millisecond keys share the 8-char timestamp prefix.
+      expect(b.slice(0, 8)).toBe(a.slice(0, 8));
+      expect(c.slice(0, 8)).toBe(a.slice(0, 8));
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
### Details

Fixes a pre-existing CI flake in `__tests__/unit/generatePushID.test.ts`: the test **"keeps strict ordering for keys minted in the same millisecond"** intermittently failed on loaded runners (observed: expected `-OuadiHZ`, received `-OuadiH_`).

**Root cause (subtler than it looks).** The test asserts that three synchronous `generatePushID()` calls share an identical 8-char timestamp prefix. It tried to freeze the clock via `jest.setSystemTime(START_MS)` in `beforeEach`, and `jest.config.js` even sets `fakeTimers.enableGlobally: true`. But [`jest/setupAfterEnv.ts`](https://github.com/PetrCala/Kiroku/blob/master/jest/setupAfterEnv.ts) calls `jest.useRealTimers()` at module top level, which **overrides** that global config for every test file. So `setSystemTime`/`advanceTimersByTime` are silent no-ops here and `Date.now()` returns real wall-clock time. On a loaded CI runner the three calls can straddle a millisecond boundary, flipping the prefix by one char and failing the assertion. (The observed `-OuadiHZ`/`-OuadiH_` decode to `2026-06-08T09:53:35.908`/`.909Z` — real time, 1ms apart — not the frozen `START_MS`, which encodes to `-OhqqeV-`.) The other three tests survive because the generator's monotonic-increment path guarantees strict ordering even with identical/real timestamps; only this test pins an exact prefix.

**Fix.** Pin `Date.now()` directly in this test with `jest.spyOn(Date, 'now').mockReturnValue(START_MS)`, restored in a `finally`. Unlike `setSystemTime`, this is independent of the global `useRealTimers()` policy, guarantees an identical millisecond across all three calls, and still exercises the monotonic-increment path (suffix incremented, not re-rolled). Deliberately scoped to this one test — I did not re-enable fake timers file-wide, since the global `useRealTimers()` is an intentional infra policy. A comment documents the `setupAfterEnv` interaction so the spy isn't "consolidated" back to `setSystemTime`.

Test-only change; no production code, UI, or copy touched.

### Tests

1. `npx jest __tests__/unit/generatePushID.test.ts` → 4/4 pass.
2. Ran the suite 15× in a loop → 0 failures (no spy leakage / regression).
3. Adversarial proof: with `Date.now()` mocked to advance 1ms per call (simulating a ms-boundary straddle), the **unpinned** path reproduces the exact flake (prefixes differ), while the **pinned** fix stays immune (all three prefixes equal, strict ordering holds).
4. `npm run typecheck-tsgo` → clean. Prettier → clean.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — unit-test-only change, no runtime behavior affected.

### QA Steps

N/A — unit-test-only change. CI's `test.yml` exercises it.

- [x] Verify that no errors appear in the JS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)