### PR TITLE
fix(offline): allow discarding/deleting a session while offline

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -258,7 +258,6 @@ function DrinkingSessionWindow({
         )}
         confirmText={translate('common.yes')}
         cancelText={translate('common.no')}
-        shouldDisableConfirmButtonWhenOffline
         shouldShowCancelButton
       />
       <ConfirmModal


### PR DESCRIPTION
## Problem

Found during on-device offline testing of PR #823. When offline, pressing **Delete/Discard** on a session opens the confirmation modal, but the **"Yes" confirm button is disabled**, so the user cannot delete or discard a session while offline. This blocks a core flow.

## Root cause

The discard `<ConfirmModal>` in `src/components/DrinkingSessionWindow/index.tsx` set `shouldDisableConfirmButtonWhenOffline`. That gate made sense before the RTDB→kiroku-api migration, when the delete couldn't be queued.

After the migration, the delete goes through `removeDrinkingSessionData` → `API.write(WRITE_COMMANDS.DELETE_SESSION, ...)` → the offline `SequentialQueue`: the session is removed optimistically and the delete replays on reconnect. So the offline gate is obsolete and wrongly blocks the flow.

## Fix

Remove the `shouldDisableConfirmButtonWhenOffline` prop from the discard `ConfirmModal`. The other `ConfirmModal` in the file (the unsaved-changes leave warning, which has no offline gate) is left untouched.

## Verification

- Offline: confirming the modal removes the session immediately (optimistic) and routes back without hanging.
- On reconnect: the delete replays via the SequentialQueue with no duplicate or resurrection.

## Notes

- Builds on #823 (branch `feature/offline-non-blocking-ux`); based on it because #823 is not yet merged. Rebase onto `master` once #823 lands.
- Independent of the other offline follow-up bugs. Do not merge ahead of #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)