### PR TITLE
Fix offline indicator position on Social screen

### DIFF
--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -9,6 +9,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import {PressableWithFeedback} from '@components/Pressable';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import ScreenWrapper from '@components/ScreenWrapper';
+import OfflineIndicator from '@components/OfflineIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
@@ -137,7 +138,9 @@ function SocialScreen(_: SocialScreenProps) {
   ];
 
   return (
-    <ScreenWrapper testID={SocialScreen.displayName}>
+    <ScreenWrapper
+      testID={SocialScreen.displayName}
+      shouldShowOfflineIndicator={false}>
       <HeaderWithBackButton
         title={translate('socialScreen.title')}
         onBackButtonPress={Navigation.goBack}
@@ -149,6 +152,7 @@ function SocialScreen(_: SocialScreenProps) {
         onSwipeBeyondStart={() => Navigation.goBack()}
         renderScene={renderScene}
       />
+      <OfflineIndicator />
       <View style={styles.bottomTabBarContainer}>
         {footerButtons.map(button => (
           <SocialFooterButton


### PR DESCRIPTION
## Problem

During on-device offline testing of #823, the bottom **"You appear to be offline"** `OfflineIndicator` banner on the Social/friends screen renders **below** the footer tab buttons (friend list / friend requests), which looks wrong. It should appear **above** the footer tabs.

### Root cause

`src/screens/Social/SocialScreen.tsx` wraps its content in `<ScreenWrapper>` and renders a custom footer `<View style={styles.bottomTabBarContainer}>` as the **last child**. `ScreenWrapper` renders its default `<OfflineIndicator />` *after* its children, so the banner lands below the footer.

## Fix

Mirror what `src/screens/HomeScreen.tsx` already does:

- Pass `shouldShowOfflineIndicator={false}` to the `<ScreenWrapper>`.
- Render `<OfflineIndicator />` (from `@components/OfflineIndicator`) manually, just **before** the `bottomTabBarContainer` footer `<View>`.

This places the banner above the tabs. No other screens are affected.

## Notes

- Builds on #823 (`feature/offline-non-blocking-ux`), which introduced the `OfflineIndicator` / `ScreenWrapper` wiring this fix relies on. Based on that branch since #823 has not yet merged; should be retargeted to `master` once #823 lands.
- Independent of the other offline follow-up bugs.

## Checks

- [x] `prettier --write` (no changes)
- [x] `lint` (eslint-seatbelt, clean)
- [x] `typecheck-tsgo` (clean)
- [x] `react-compiler-compliance-check check-changed` (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)