### PR TITLE
fix(display-name): validate "unchanged" against optimistic Onyx name, not stale Firebase Auth

### DIFF
--- a/src/screens/Settings/Account/DisplayNameScreen.tsx
+++ b/src/screens/Settings/Account/DisplayNameScreen.tsx
@@ -58,9 +58,13 @@ function DisplayNameScreen({route}: DisplayNameScreenProps) {
   ) => {
     const errors: FormInputErrors<typeof ONYXKEYS.FORMS.DISPLAY_NAME_FORM> = {};
 
+    // Compare against the optimistic Onyx profile name (what Home and this
+    // form's default value read) rather than the Firebase Auth profile. The
+    // Auth display-name sync is best-effort and fails silently offline, so it
+    // can lag behind Onyx and wrongly reject reverting to a previous name.
     const errorKey = ValidationUtils.validateUsername(
       values.displayName,
-      auth.currentUser?.displayName,
+      profileData?.display_name,
     );
 
     if (errorKey) {


### PR DESCRIPTION
## Problem

Found during on-device offline testing of #823. Repro:

1. Change your display name (nickname) from **A** → **B**. Works locally: Home and the form both show **B**.
2. Try to change it back **B** → **A**. The form rejects it with _"this nickname is the same as your current one"_, even after going back online.

## Root cause

`src/screens/Settings/Account/DisplayNameScreen.tsx` `validate()` compared the new value against the **Firebase Auth** profile:

```ts
ValidationUtils.validateUsername(values.displayName, auth.currentUser?.displayName)
```

But `changeDisplayName` (`src/libs/actions/User.ts`) optimistically updates Onyx `userDataList[uid].profile.display_name` (what Home and the form's `defaultValue` read via `useCurrentUserData`), and only best-effort-syncs Firebase Auth via `updateProfile(...).catch(() => {})`. That Auth sync **fails silently offline and isn't retried on reconnect**, so `auth.currentUser.displayName` stays stale at **A** while Onyx already says **B**. Reverting to **A** then matches the stale Auth value and is wrongly rejected as unchanged.

## Fix

Compare the "unchanged" check against `profileData?.display_name` — the optimistic Onyx value already read in this screen and used everywhere else in the app. Same source of truth as Home and the form's default value.

## Scope check

- **`UserNameScreen.tsx`** — does not pass a "current" value into `validateUsername` (no "same as current" check). No bug, no change.
- **`Onboarding/DisplayNameScreen.tsx`** — calls `validateUsername(values.username)` with no second arg. No "same as current" check. No bug, no change.

Only the Settings display-name screen had the pattern.

## Deeper inconsistency (not addressed here)

The underlying issue is that the Firebase Auth display-name sync in `changeDisplayName` is best-effort (`updateProfile(...).catch()`) and never retried on reconnect, so Auth and Onyx can permanently diverge. This PR fixes the user-visible validation bug by treating Onyx as the source of truth; reconciling the Auth profile is left as a follow-up.

## Sequencing

Builds on #823 (`feature/offline-non-blocking-ux`), which is not yet merged, so this PR is based on that branch. Independent of the other offline follow-up bugs. **Do not merge before #823.**

## Verification

- A → B, then B → A is accepted ✅
- Typing the genuinely-current value is still correctly rejected as unchanged ✅
- `prettier`, `lint-changed`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)