### PR TITLE
chore(lint): adapt eslint heap + concurrency to system RAM

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -205,6 +205,11 @@ export default defineConfig([
     languageOptions: {
       parser: tsParser,
       parserOptions: {
+        // Type-aware linting: every ESLint run (even a single-file
+        // `lint-changed`) builds the FULL TypeScript program from this
+        // tsconfig, so each invocation costs ~a `tsc` run in memory. That is
+        // why scripts/lint.sh adapts `--concurrency` and the Node heap ceiling
+        // to total RAM -- see the RESOURCE POLICY note there before tuning.
         project: path.resolve(dirname, './tsconfig.json'),
         tsconfigRootDir: dirname,
       },

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Run ESLint with the repo's standard flags (memory ceiling, shared content
-# cache, auto concurrency). Delegate target selection to the caller:
+# Run ESLint with the repo's standard flags (adaptive heap + concurrency, see
+# the RESOURCE POLICY note below; shared content cache). Delegate target
+# selection to the caller:
 #
 #   ./scripts/lint.sh                      -> lint the whole repo
 #   ./scripts/lint.sh src/foo.ts ...       -> lint just the given paths
@@ -37,6 +38,53 @@ if [[ "${#PASSTHROUGH_ARGS[@]}" -eq 0 ]]; then
     PASSTHROUGH_ARGS=(.)
 fi
 
+# ---------------------------------------------------------------------------
+# RESOURCE POLICY  --  read before changing the concurrency / heap defaults
+# ---------------------------------------------------------------------------
+# ESLint here runs type-aware rules (`recommendedTypeChecked` +
+# `parserOptions.project` in eslint.config.mjs), so EVERY invocation builds the
+# full TypeScript program -- even `lint-changed` on a single file pays a
+# ~tsc-sized memory cost. With `--concurrency=auto` each worker thread builds
+# its OWN copy of that program, so peak RAM scales with the worker count.
+#
+# On a low-RAM dev machine that overruns physical memory and pushes the whole
+# system into swap (the machine beachballs, not just a slow lint). So we pick
+# concurrency and the Node heap ceiling from total system RAM:
+#
+#   >= 12 GB RAM (CI runners, beefy laptops): --concurrency=auto, 8 GB heap
+#   <  12 GB RAM (e.g. an 8 GB laptop):       --concurrency=off,  RAM/2 heap
+#
+# DO NOT hard-code `--concurrency=auto` or `--max_old_space_size=8192` back in
+# unconditionally -- that's exactly what makes an 8 GB box thrash. Override for
+# a single run instead, e.g.:
+#   LINT_CONCURRENCY=auto NODE_OPTIONS='--max_old_space_size=8192 --experimental-require-module' npm run lint-changed
+# ---------------------------------------------------------------------------
+
+# Total physical RAM in MB (0 if we can't tell).
+detect_ram_mb() {
+    if [[ -r /proc/meminfo ]]; then
+        awk '/^MemTotal:/ {printf "%d", $2 / 1024; exit}' /proc/meminfo
+    elif command -v sysctl >/dev/null 2>&1; then
+        local bytes
+        bytes="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+        echo $(( bytes / 1024 / 1024 ))
+    else
+        echo 0
+    fi
+}
+
+RAM_MB="$(detect_ram_mb)"
+# Unknown RAM -> assume a capable machine so CI never regresses.
+if [[ "$RAM_MB" -eq 0 || "$RAM_MB" -ge 12288 ]]; then
+    DEFAULT_CONCURRENCY=auto
+    DEFAULT_HEAP_MB=8192
+else
+    DEFAULT_CONCURRENCY=off
+    DEFAULT_HEAP_MB=$(( RAM_MB / 2 ))
+    [[ "$DEFAULT_HEAP_MB" -lt 2048 ]] && DEFAULT_HEAP_MB=2048
+fi
+LINT_CONCURRENCY="${LINT_CONCURRENCY:-$DEFAULT_CONCURRENCY}"
+
 # Build ESLint args
 ESLINT_ARGS=()
 if [[ "$USE_CACHE" == "true" ]]; then
@@ -49,16 +97,19 @@ fi
 if [[ "$SHOW_WARNINGS" == "false" ]]; then
     ESLINT_ARGS+=(--quiet)
 fi
+# `--concurrency` / `--no-warn-ignored` go before PASSTHROUGH_ARGS so a caller
+# can still override concurrency for one run (last value on the line wins).
 ESLINT_ARGS+=(
-    --concurrency=auto
+    "--concurrency=${LINT_CONCURRENCY}"
     --no-warn-ignored
     "${PASSTHROUGH_ARGS[@]}"
 )
 
-# Run ESLint with the repo's default memory ceiling and seatbelt behavior.
-# `--experimental-require-module` lets CJS plugins (notably `eslint-plugin-rulesdir`)
-# require() ESM rule files shipped by `eslint-config-expensify`. Enabled by default
-# in Node 22.12+; we set it explicitly so Node 20.x continues to work.
-NODE_OPTIONS="${NODE_OPTIONS:---max_old_space_size=8192 --experimental-require-module}" \
+# Run ESLint with the RAM-adaptive heap ceiling (see RESOURCE POLICY) and
+# seatbelt behavior. `--experimental-require-module` lets CJS plugins (notably
+# `eslint-plugin-rulesdir`) require() ESM rule files shipped by
+# `eslint-config-expensify`. Enabled by default in Node 22.12+; we set it
+# explicitly so Node 20.x continues to work.
+NODE_OPTIONS="${NODE_OPTIONS:---max_old_space_size=${DEFAULT_HEAP_MB} --experimental-require-module}" \
 SEATBELT_FROZEN="${SEATBELT_FROZEN:-0}" \
     exec npx eslint "${ESLINT_ARGS[@]}"


### PR DESCRIPTION
## Why

`scripts/lint.sh` hard-coded `--concurrency=auto` and an 8 GB Node heap for every invocation. Because `eslint.config.mjs` uses **type-aware** rules (`recommendedTypeChecked` + `parserOptions.project`), every run -- even a single-file `lint-changed` -- builds the **full TypeScript program**, and with `--concurrency=auto` each worker thread builds its **own** copy. On an 8 GB dev machine that overruns physical RAM and swaps the whole system, so even a trivial `lint-changed` beachballs the box.

## What

`lint.sh` now selects concurrency and the Node heap ceiling from total system RAM:

| Total RAM | Concurrency | Heap |
|-----------|-------------|------|
| ≥ 12 GB (CI's 16 GB `ubuntu-latest`, beefy laptops) | `auto` | 8 GB |
| < 12 GB (e.g. an 8 GB laptop) | `off` | RAM/2 (floor 2 GB) |
| Unknown (detection fails) | `auto` | 8 GB |

- **CI is unchanged** -- the 16 GB runner takes the fast path; unknown RAM also falls back to fast so CI can never silently regress.
- **Low-RAM dev boxes** get one TS program instead of N, and a heap ceiling that isn't the entire machine.
- Per-run overrides still work (callers append after the defaults, last value wins):
  ```bash
  LINT_CONCURRENCY=auto NODE_OPTIONS='--max_old_space_size=8192 --experimental-require-module' npm run lint-changed
  ```
- RAM detection is cross-platform: `/proc/meminfo` on Linux, `sysctl hw.memsize` on macOS.

## Keeping it from being reverted

- A boxed **`RESOURCE POLICY`** note in `lint.sh` explains the type-aware cost and warns against hard-coding `auto`/8 GB back in.
- A pointer comment at the `parserOptions.project` line in `eslint.config.mjs` -- the actual cause -- links back to the policy.

## Note on scope

This makes the run *gentle*, not *cheap*: type-aware linting still builds the TS program once, so single-file `lint-changed` still costs ~a `tsc` run. `--concurrency=off` just stops the box from building several copies at once and swapping.

## Test plan

- [x] `bash -n scripts/lint.sh` passes.
- [x] Branch-selection dry-run on an 8 GB Mac resolves to `--concurrency=off`, 4096 MB heap.
- [x] `npx prettier --check eslint.config.mjs` clean.
- [ ] CI lint workflow (16 GB runner) stays on `--concurrency=auto` / 8 GB heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)