### PR TITLE
fix(offline): degrade avatar download failures silently (no stacked alerts)

### DIFF
--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -10,8 +10,8 @@ import {Image} from 'expo-image';
 import type {FirebaseStorage} from 'firebase/storage';
 import getProfilePictureURL from '@src/storage/storageProfile';
 import CONST from '@src/CONST';
-import * as ErrorUtils from '@libs/ErrorUtils';
-import ERRORS from '@src/ERRORS';
+import Log from '@libs/Log';
+import useNetwork from '@hooks/useNetwork';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as KirokuIcons from './Icon/KirokuIcons';
@@ -109,6 +109,12 @@ function ProfileImage({
     undefined,
   );
 
+  // Bumped on reconnect to re-resolve avatars that failed to download while
+  // offline, mirroring `Avatar`'s `useNetwork` retry. We keep the current
+  // placeholder visible during the retry instead of flashing a spinner.
+  const [reconnectTrigger, setReconnectTrigger] = useState(0);
+  useNetwork({onReconnect: () => setReconnectTrigger(prev => prev + 1)});
+
   // Resolve the Firebase Storage download URL once per source change. Image
   // caching is delegated to expo-image's `cachePolicy`, so no custom layer is
   // needed here.
@@ -132,7 +138,11 @@ function ProfileImage({
             setImageUrl(url && url !== CONST.NO_IMAGE ? url : null);
           }
         } catch (error) {
-          ErrorUtils.raiseAppError(ERRORS.IMAGE_UPLOAD.FETCH_FAILED, error);
+          // A background avatar download can fail for benign reasons (offline,
+          // flaky network). Degrade silently to the placeholder instead of
+          // raising a blocking, stackable app-error alert; the `useNetwork`
+          // retry above re-resolves the real avatar once back online.
+          Log.warn('Failed to resolve profile picture URL', {error});
           if (isActive) {
             setImageUrl(null);
           }
@@ -150,7 +160,7 @@ function ProfileImage({
     return () => {
       isActive = false;
     };
-  }, [storage, userID, downloadPath, refreshTrigger]);
+  }, [storage, userID, downloadPath, refreshTrigger, reconnectTrigger]);
 
   const expectsPhoto =
     !!downloadPath &&


### PR DESCRIPTION
## Problem

On-device offline testing of #823 surfaced a pre-existing bug: when offline, **multiple "Image upload failed — could not fetch the image, please try again" alerts stack on top of each other**, even on screens unrelated to image upload (e.g. the Sessions screen).

### Root cause

In `src/components/ProfileImage.tsx`, the `useEffect` that resolves a Firebase Storage `downloadPath` via `getProfilePictureURL(...)` had a catch that called `ErrorUtils.raiseAppError(ERRORS.IMAGE_UPLOAD.FETCH_FAILED, error)`, which fires a global blocking `Alert.alert`.

Offline (or on any flaky download), **every** `ProfileImage` with a Storage `downloadPath` fails and raises its own alert — the header avatar, friend rows, etc. — so they stack. This is pre-existing; #823 newly exposes it by making screens reachable offline (the old blocking offline modal previously hid them).

## Fix

A background avatar download failure should degrade silently to the existing placeholder, not raise a user-facing alert:

- Replace `raiseAppError(...)` on the fetch-failure path with a non-blocking `Log.warn`, keeping `setImageUrl(null)` so the component renders its existing placeholder/fallback avatar (the `expectsPhoto` + `imageUrl` logic already handles this).
- Add `useNetwork({onReconnect})` retry trigger (mirroring `Avatar.tsx`, which already resets image-load errors on reconnect) so failed avatars re-resolve to the real image once back online. The placeholder stays visible during the retry rather than flashing a spinner.

## Verification

- `npx prettier --write` ✅
- `npm run lint-changed` ✅ (exit 0)
- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- Manual (offline): navigating across Home / Sessions / Social shows placeholder avatars and **zero** alert popups; back online, real avatars resolve.

## Sequencing

Builds on #823 (`feature/offline-non-blocking-ux`) and is **based off that branch**, so this PR targets it. Once #823 merges, retarget to `master`. Independent of the other three offline follow-up bugs. **Do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)