### PR TITLE
fix(HomeScreen): guard against missing/partial user profile

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -211,7 +211,10 @@ function HomeScreen({route}: HomeScreenProps) {
   // calendar renders even when the user has no sessions yet — empty days
   // are still a valid view of their history.
   const isPreferencesReady = !!preferences;
-  const isUserDataReady = !!userData;
+  // Require `profile` (not just `userData`): a failed/incomplete ProvisionUser
+  // can leave `userData` truthy while `profile` is still undefined. Gating the
+  // header on the profile keeps it from rendering against profile-less data.
+  const isUserDataReady = !!userData?.profile;
   const isSessionsReady = drinkingSessionData !== undefined;
   const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
 
@@ -255,7 +258,7 @@ function HomeScreen({route}: HomeScreenProps) {
               <ProfileImage
                 storage={storage}
                 userID={user.uid}
-                downloadPath={userData.profile.photo_url}
+                downloadPath={userData?.profile?.photo_url}
                 style={styles.avatarMedium}
                 // refreshTrigger={refreshCounter}
                 refreshTrigger={0}


### PR DESCRIPTION
## Problem

`HomeScreen` hard-crashes the error boundary with `TypeError: Cannot read property 'photo_url' of undefined` whenever a user's profile is missing (e.g. a failed/incomplete `ProvisionUser`). `useCurrentUserData` can return a truthy value (`{}`) while `userData.profile` is still `undefined`, and the header read `userData.profile.photo_url` unguarded.

## Change

Harden the header so a missing/partial profile degrades gracefully instead of crashing:

- Optional-chain the photo read: `userData?.profile?.photo_url` (`ProfileImage`'s `downloadPath` already accepts `string | null | undefined`).
- Gate `isUserDataReady` on `userData?.profile` (not just `userData`), so the header renders the skeleton instead of against profile-less data.
- `display_name` was already optional-chained (`userData?.profile?.display_name ?? ''`), left as-is.

## Context

This surfaced while diagnosing a production outage where kiroku-api 500'd `ProvisionUser` (separately fixed in kiroku-api #85). This client guard is defense-in-depth so a future provisioning hiccup can't hard-crash the home screen.

## Gates

- `npx prettier --write` — clean (unchanged)
- `npm run lint-changed` — pass
- `npm run typecheck-tsgo` — pass
- `npm run react-compiler-compliance-check check-changed` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)