### PR TITLE
fix(home): restore no-sessions empty state on home screen

### DIFF
--- a/src/components/NoSessionsInfo.tsx
+++ b/src/components/NoSessionsInfo.tsx
@@ -13,7 +13,7 @@ type NoSessionsInfoProps = {
   buttonText?: string;
 };
 
-/** A View that informs the users that they have no friends */
+/** A View shown on the home screen when the user has no drinking sessions yet */
 function NoSessionsInfo({message, buttonText}: NoSessionsInfoProps) {
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -40,6 +40,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import Button from '@components/Button';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
+import NoSessionsInfo from '@components/NoSessionsInfo';
 import {HomeHeaderSkeleton, StatOverviewSkeleton} from './HomeScreenSkeleton';
 
 type HomeScreenProps = StackScreenProps<
@@ -138,9 +139,9 @@ function HomeScreen({route}: HomeScreenProps) {
   }
 
   // Render the shell + skeletons immediately. Real components swap in for
-  // their skeletons as each piece of data resolves from Firebase. The
-  // calendar renders even when the user has no sessions yet — empty days
-  // are still a valid view of their history.
+  // their skeletons as each piece of data resolves from Firebase. A
+  // brand-new user with no sessions gets a welcome/empty state instead of
+  // the calendar + stats.
   const isPreferencesReady = !!preferences;
   // Require `profile` (not just `userData`): a failed/incomplete ProvisionUser
   // can leave `userData` truthy while `profile` is still undefined. Gating the
@@ -148,6 +149,9 @@ function HomeScreen({route}: HomeScreenProps) {
   const isUserDataReady = !!userData?.profile;
   const isSessionsReady = drinkingSessionData !== undefined;
   const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
+  // `useCurrentUserDrinkingSessions` returns {} (truthy) for a user with no
+  // sessions, so check emptiness rather than truthiness.
+  const hasSessions = isSessionsReady && !isEmptyObject(drinkingSessionData);
 
   const renderMainContent = () => {
     if (showSkeletonContent) {
@@ -157,6 +161,9 @@ function HomeScreen({route}: HomeScreenProps) {
           <StatOverviewSkeleton />
         </>
       );
+    }
+    if (!hasSessions) {
+      return <NoSessionsInfo />;
     }
     return (
       <>


### PR DESCRIPTION
## Problem

A brand-new user with no drinking sessions no longer sees the "Welcome to Kiroku" empty state on the home screen. Instead they see an empty calendar and zeroed-out stats.

## Root cause

The empty state (`NoSessionsInfo`) was **not** removed deliberately. It was lost in a merge-conflict resolution in #469 (`30334ae93`, merged 2026-05-21), which silently dropped the `NoSessionsInfo` import, the `hasSessions` variable, and the `if (hasSessions) … return <NoSessionsInfo />` branch from `HomeScreen`'s `renderMainContent()`. The component and both translation keys (`homeScreen.welcomeToKiroku`, `homeScreen.startNewSessionByClickingPlus`) survived as dead code. The later home-rework commits only touched the stats/banner, so they aren't the culprit.

## Fix

- Re-import `NoSessionsInfo` and restore the no-sessions branch in `renderMainContent()`, so the empty state **replaces** the calendar + stats view (the original behavior).
- The emptiness check now uses `isEmptyObject(drinkingSessionData)` instead of the old `!!` test: `useCurrentUserDrinkingSessions()` returns `{}` (truthy) for a user with no sessions, so the old truthiness check would never have fired correctly under the current hook.
- Updated the stale "calendar renders even when the user has no sessions" comment, and fixed an incorrect JSDoc on `NoSessionsInfo` ("informs the users that they have no friends").

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run lint-changed` — clean
- `npm run react-compiler-compliance-check check-changed` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)