### PR TITLE
feat(home): minimal card surface (no gray boxes)

### DIFF
--- a/src/components/Charts/KpiCard/KpiCard.tsx
+++ b/src/components/Charts/KpiCard/KpiCard.tsx
@@ -31,6 +31,14 @@ type KpiCardDelta = {
   label: string;
 };
 
+/**
+ * Card surface. `fill` (default) is the standard highlighted card used on the
+ * Statistics screen. `plain` drops the card chrome (background, radius,
+ * min-height, side padding) so the content sits flat on the page background —
+ * used by the home screen's minimal treatment.
+ */
+type KpiCardSurface = 'fill' | 'plain';
+
 type KpiCardProps = {
   label: string;
   value: string | number;
@@ -56,6 +64,8 @@ type KpiCardProps = {
   headerRight?: ReactNode;
   /** Optional chart rendered below the value/delta (and any sparkline). */
   chart?: ReactNode;
+  /** Card surface treatment. Defaults to the filled card. */
+  surface?: KpiCardSurface;
 };
 
 const ARROW: Record<KpiCardDelta['direction'], string> = {
@@ -86,6 +96,7 @@ function KpiCard({
   isLoading,
   headerRight,
   chart,
+  surface = 'fill',
 }: KpiCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -125,14 +136,18 @@ function KpiCard({
 
   const body = (
     <View
-      style={[
-        styles.p3,
-        {
-          backgroundColor: theme.highlightBG,
-          borderRadius: 12,
-          minHeight: 96,
-        },
-      ]}>
+      style={
+        surface === 'plain'
+          ? [styles.pv3]
+          : [
+              styles.p3,
+              {
+                backgroundColor: theme.highlightBG,
+                borderRadius: 12,
+                minHeight: 96,
+              },
+            ]
+      }>
       {headerRight ? (
         <View
           style={[
@@ -209,4 +224,10 @@ function KpiCard({
 }
 
 export default KpiCard;
-export type {KpiCardProps, KpiCardTone, KpiCardPolarity, KpiCardDelta};
+export type {
+  KpiCardProps,
+  KpiCardTone,
+  KpiCardPolarity,
+  KpiCardDelta,
+  KpiCardSurface,
+};

--- a/src/components/Charts/KpiCard/KpiCardGroup.tsx
+++ b/src/components/Charts/KpiCard/KpiCardGroup.tsx
@@ -45,6 +45,7 @@ function KpiCardGroup({cards, isLoading}: KpiCardGroupProps): ReactElement {
             polarity={card.polarity}
             onPress={card.onPress}
             accessibilityLabel={card.accessibilityLabel}
+            surface={card.surface}
             isLoading={isLoading}
           />
         </View>

--- a/src/components/Info/HomeBanner.tsx
+++ b/src/components/Info/HomeBanner.tsx
@@ -49,11 +49,10 @@ function HomeBanner({
       onPress={onPress}
       style={[
         styles.mv2,
-        styles.p4,
+        styles.pv3,
         styles.flexRow,
         styles.alignItemsCenter,
         styles.justifyContentBetween,
-        {backgroundColor: theme.highlightBG, borderRadius: 12},
       ]}>
       <View
         style={[styles.flexRow, styles.alignItemsCenter, styles.flexShrink1]}>

--- a/src/components/Items/HomeStatsOverview.tsx
+++ b/src/components/Items/HomeStatsOverview.tsx
@@ -73,6 +73,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
       value: current.sessions,
       delta: makeDelta(current.sessions, previous.sessions),
       polarity: 'lower-is-supportive',
+      surface: 'plain',
     },
     {
       label: translate('homeScreen.stats.alcoholFree'),
@@ -81,6 +82,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
       delta: makeDelta(current.afDays, previous.afDays),
       tone: 'celebratory',
       polarity: 'higher-is-supportive',
+      surface: 'plain',
     },
   ];
 
@@ -96,6 +98,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
           value={formatUnits(totalUnits)}
           delta={makeDelta(totalUnits, previous.totalUnits)}
           polarity="lower-is-supportive"
+          surface="plain"
           headerRight={statisticsLink}
           chart={
             <View>


### PR DESCRIPTION
## Summary

**Stacked on #1079** (divider-alignment base). One of two card-background experiments — this is the **minimal** direction: drop the gray card fill so the home banner + Units block sit flat on the page, leaving the calendar's own borders as the only framed element.

**Home-only** — the Statistics screen keeps its filled cards.

## Changes

- `KpiCard`: new optional `surface` prop — `'fill'` (default, unchanged) or `'plain'` (no background / radius / min-height / side padding). Defaulting to `'fill'` means the Statistics screen is untouched.
- `KpiCardGroup`: forwards each card's `surface`.
- `HomeStatsOverview`: passes `surface="plain"` to the hero + the supporting pair.
- `HomeBanner`: transparent, no radius; padding trimmed to vertical so its text aligns to the page gutter.

## Notes

- Sibling of the **softer-tint** PR (also stacked on #1079) — pick one. Review #1079 first; whichever variant you choose then rebases onto master.
- Base #1079 must merge first (or this rebases onto master after).

## Test plan

- [ ] Home: no gray boxes; banner + Units content align to the same gutter as the calendar.
- [ ] In-session vs last-session banner still share footprint (calendar doesn't shift).
- [ ] Statistics screen unchanged (still filled cards).
- [ ] Light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)