### PR TITLE
feat(home): softer card fill (lower-contrast cards)

### DIFF
--- a/src/components/Charts/KpiCard/KpiCard.tsx
+++ b/src/components/Charts/KpiCard/KpiCard.tsx
@@ -31,6 +31,13 @@ type KpiCardDelta = {
   label: string;
 };
 
+/**
+ * Card fill. `fill` (default) is the standard highlighted card used on the
+ * Statistics screen. `soft` keeps the same card shape but uses a lighter,
+ * lower-contrast background — used by the home screen's softer treatment.
+ */
+type KpiCardSurface = 'fill' | 'soft';
+
 type KpiCardProps = {
   label: string;
   value: string | number;
@@ -56,6 +63,8 @@ type KpiCardProps = {
   headerRight?: ReactNode;
   /** Optional chart rendered below the value/delta (and any sparkline). */
   chart?: ReactNode;
+  /** Card fill treatment. Defaults to the standard filled card. */
+  surface?: KpiCardSurface;
 };
 
 const ARROW: Record<KpiCardDelta['direction'], string> = {
@@ -86,6 +95,7 @@ function KpiCard({
   isLoading,
   headerRight,
   chart,
+  surface = 'fill',
 }: KpiCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -128,7 +138,8 @@ function KpiCard({
       style={[
         styles.p3,
         {
-          backgroundColor: theme.highlightBG,
+          backgroundColor:
+            surface === 'soft' ? theme.cardSoftBG : theme.highlightBG,
           borderRadius: 12,
           minHeight: 96,
         },
@@ -209,4 +220,10 @@ function KpiCard({
 }
 
 export default KpiCard;
-export type {KpiCardProps, KpiCardTone, KpiCardPolarity, KpiCardDelta};
+export type {
+  KpiCardProps,
+  KpiCardTone,
+  KpiCardPolarity,
+  KpiCardDelta,
+  KpiCardSurface,
+};

--- a/src/components/Charts/KpiCard/KpiCardGroup.tsx
+++ b/src/components/Charts/KpiCard/KpiCardGroup.tsx
@@ -45,6 +45,7 @@ function KpiCardGroup({cards, isLoading}: KpiCardGroupProps): ReactElement {
             polarity={card.polarity}
             onPress={card.onPress}
             accessibilityLabel={card.accessibilityLabel}
+            surface={card.surface}
             isLoading={isLoading}
           />
         </View>

--- a/src/components/Info/HomeBanner.tsx
+++ b/src/components/Info/HomeBanner.tsx
@@ -53,7 +53,7 @@ function HomeBanner({
         styles.flexRow,
         styles.alignItemsCenter,
         styles.justifyContentBetween,
-        {backgroundColor: theme.highlightBG, borderRadius: 12},
+        {backgroundColor: theme.cardSoftBG, borderRadius: 12},
       ]}>
       <View
         style={[styles.flexRow, styles.alignItemsCenter, styles.flexShrink1]}>

--- a/src/components/Items/HomeStatsOverview.tsx
+++ b/src/components/Items/HomeStatsOverview.tsx
@@ -73,6 +73,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
       value: current.sessions,
       delta: makeDelta(current.sessions, previous.sessions),
       polarity: 'lower-is-supportive',
+      surface: 'soft',
     },
     {
       label: translate('homeScreen.stats.alcoholFree'),
@@ -81,6 +82,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
       delta: makeDelta(current.afDays, previous.afDays),
       tone: 'celebratory',
       polarity: 'higher-is-supportive',
+      surface: 'soft',
     },
   ];
 
@@ -96,6 +98,7 @@ function HomeStatsOverview({visibleDate}: HomeStatsOverviewProps) {
           value={formatUnits(totalUnits)}
           delta={makeDelta(totalUnits, previous.totalUnits)}
           polarity="lower-is-supportive"
+          surface="soft"
           headerRight={statisticsLink}
           chart={
             <View>

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -24,6 +24,7 @@ const colors: Record<string, Color> = {
   // Dark Mode Theme Colors
   // productDark100: '#010409', // black
   productDark100: '#0D1117', // appBG
+  productDark150: '#11161D', // soft card (between appBG and card)
   productDark200: '#151B23', // card
   productDark300: '#212830', // search
   productDark350: '#262D36', // skeleton base
@@ -36,6 +37,7 @@ const colors: Record<string, Color> = {
 
   // Light Mode Theme Colors
   productLight100: '#FFFFFF', // appBG
+  productLight150: '#FAFBFC', // soft card (between appBG and card)
   productLight200: '#F6F8FA', // card
   productLight300: '#F6F8FA', // search // TODO
   productLight350: '#E5E9ED', // skeleton base

--- a/src/styles/theme/themes/dark.ts
+++ b/src/styles/theme/themes/dark.ts
@@ -8,6 +8,7 @@ const darkTheme = {
   appBG: colors.productDark100,
   splashBG: colors.yellowStrong,
   highlightBG: colors.productDark200,
+  cardSoftBG: colors.productDark150,
   calendarRangeBG: `${colors.yellowStrong}33`,
   darkBG: colors.productLight900,
   appColor: colors.yellowStrong,

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -8,6 +8,7 @@ const lightTheme = {
   appBG: colors.productLight100,
   splashBG: colors.yellowStrong,
   highlightBG: colors.productLight200,
+  cardSoftBG: colors.productLight150,
   calendarRangeBG: `${colors.yellowStrong}38`,
   darkBG: colors.productLight900,
   appColor: colors.yellowStrong,

--- a/src/styles/theme/types.ts
+++ b/src/styles/theme/types.ts
@@ -15,6 +15,8 @@ type ThemeColors = {
   appBG: Color;
   splashBG: Color;
   highlightBG: Color;
+  /** A softer card fill, a touch closer to `appBG` than `highlightBG`. */
+  cardSoftBG: Color;
   calendarRangeBG: Color;
   darkBG: Color;
   appColor: Color;


### PR DESCRIPTION
## Summary

**Stacked on #1079** (divider-alignment base). The other card-background experiment — the **softer-tint** direction: keep the home cards (banner + Units block) but swap their gray fill for a lighter, lower-contrast tint to dial down the visual noise, without losing the carded look.

**Home-only** — the Statistics screen keeps its standard fill.

## Changes

- New `cardSoftBG` theme token (light `#FAFBFC`, dark `#11161D` — each a step closer to `appBG` than `highlightBG`).
- `KpiCard`: new optional `surface` prop — `'fill'` (default, unchanged) or `'soft'` (same card shape, `cardSoftBG` fill). Defaulting to `'fill'` leaves the Statistics screen untouched.
- `KpiCardGroup`: forwards each card's `surface`.
- `HomeStatsOverview` + `HomeBanner`: use the soft fill.

## Notes

- Sibling of the **minimal** PR (#1081, also stacked on #1079) — pick one. Review #1079 first; whichever variant you choose then rebases onto master.

## Test plan

- [ ] Home cards read as cards but noticeably lighter/quieter than before.
- [ ] In-session vs last-session banner still share footprint.
- [ ] Statistics screen unchanged.
- [ ] Light + dark (the dark soft tint is very subtle by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)