### PR TITLE
fix(onboarding): stop re-prompting onboarded users after the Onyx/API migration

### DIFF
--- a/__tests__/unit/OnboardingSelectors.test.ts
+++ b/__tests__/unit/OnboardingSelectors.test.ts
@@ -31,23 +31,43 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 
 describe('OnboardingSelectors', () => {
   describe('hasCompletedOnboarding', () => {
-    test('returns false for undefined userData (brand-new account)', () => {
+    test('returns false for undefined userData', () => {
       expect(hasCompletedOnboarding(undefined)).toBe(false);
     });
 
-    test('returns false when onboarding node is missing', () => {
-      expect(hasCompletedOnboarding(makeUserData())).toBe(false);
+    test('returns true when onboarding node is missing (undefined → completed)', () => {
+      // A returning/legacy account whose record predates the stamp, or whose
+      // record has not finished hydrating, must not be re-prompted.
+      expect(hasCompletedOnboarding(makeUserData())).toBe(true);
     });
 
-    test('returns false for empty object onboarding', () => {
+    test('returns true for empty array onboarding (RTDB serialization → absent)', () => {
+      const userData = makeUserData({
+        onboarding: [] as unknown as UserData['onboarding'],
+      });
+      expect(hasCompletedOnboarding(userData)).toBe(true);
+    });
+
+    test('returns false when username_chosen is false (mid-signup), even with no onboarding node', () => {
+      const userData = makeUserData({
+        profile: {
+          display_name: 'placeholder',
+          photo_url: '',
+          username_chosen: false,
+        },
+      });
+      expect(hasCompletedOnboarding(userData)).toBe(false);
+    });
+
+    test('returns false for empty object onboarding (in progress, no stamp)', () => {
       expect(hasCompletedOnboarding(makeUserData({onboarding: {}}))).toBe(
         false,
       );
     });
 
-    test('returns false for empty array onboarding (RTDB serialization)', () => {
+    test('returns false when only last_visited_path is set (in progress)', () => {
       const userData = makeUserData({
-        onboarding: [] as unknown as UserData['onboarding'],
+        onboarding: {last_visited_path: '/onboarding/terms'},
       });
       expect(hasCompletedOnboarding(userData)).toBe(false);
     });
@@ -57,13 +77,6 @@ describe('OnboardingSelectors', () => {
         onboarding: {completed_at: 1_700_000_000_000},
       });
       expect(hasCompletedOnboarding(userData)).toBe(true);
-    });
-
-    test('returns false when only last_visited_path is set (in progress)', () => {
-      const userData = makeUserData({
-        onboarding: {last_visited_path: '/onboarding/terms'},
-      });
-      expect(hasCompletedOnboarding(userData)).toBe(false);
     });
   });
 

--- a/__tests__/unit/useOnboardingFlow.test.ts
+++ b/__tests__/unit/useOnboardingFlow.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 import {renderHook} from '@testing-library/react-native';
+import {useOnyx} from 'react-native-onyx';
+import type * as RNOnyx from 'react-native-onyx';
 import {useConfig} from '@context/global/ConfigContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useOnboardingFlow from '@hooks/useOnboardingFlow';
 import CONFIG from '@src/CONFIG';
+import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Config, UserData} from '@src/types/onyx';
 
@@ -21,9 +24,18 @@ jest.mock('@hooks/useCurrentUserData', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('react-native-onyx', () => {
+  const actual = jest.requireActual<typeof RNOnyx>('react-native-onyx');
+  return {
+    ...actual,
+    useOnyx: jest.fn(),
+  };
+});
+
 const mockedUseFirebase = jest.mocked(useFirebase);
 const mockedUseConfig = jest.mocked(useConfig);
 const mockedUseCurrentUserData = jest.mocked(useCurrentUserData);
+const mockedUseOnyx = jest.mocked(useOnyx);
 
 const TEST_UID = 'user-123';
 
@@ -31,6 +43,17 @@ function setAuth(uid: string | undefined): void {
   mockedUseFirebase.mockReturnValue({
     auth: uid ? {currentUser: {uid}} : {currentUser: null},
   } as unknown as ReturnType<typeof useFirebase>);
+}
+
+// `IS_LOADING_APP` is `true` while the OpenApp bootstrap is in flight and
+// `false` once it settles; the readiness gate requires the explicit `false`.
+function setIsLoadingApp(value: boolean | undefined): void {
+  mockedUseOnyx.mockImplementation(((key: string) => {
+    if (key === ONYXKEYS.IS_LOADING_APP) {
+      return [value, {status: 'loaded'}];
+    }
+    return [undefined, {status: 'loaded'}];
+  }) as unknown as typeof useOnyx);
 }
 
 // `userData` comes from `useCurrentUserData` (Onyx), which returns {} (not
@@ -55,6 +78,7 @@ describe('useOnboardingFlow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (CONFIG as {SKIP_ONBOARDING: boolean}).SKIP_ONBOARDING = false;
+    setIsLoadingApp(false);
     setUserData(undefined);
   });
 
@@ -75,6 +99,70 @@ describe('useOnboardingFlow', () => {
     const {result} = renderHook(() => useOnboardingFlow());
 
     expect(result.current.isReady).toBe(false);
+    expect(result.current.shouldFireOnboarding).toBe(false);
+  });
+
+  test('authenticated + OpenApp still in flight (isLoadingApp true) → not ready, no fire', () => {
+    setAuth(TEST_UID);
+    setIsLoadingApp(true);
+    // Even a complete, already-onboarded record must not be acted on until the
+    // bootstrap settles — the record may still be mid-assembly.
+    setUserData(
+      makeUserData({
+        agreed_to_terms_at: 1_700_000_000_000,
+        onboarding: {completed_at: 1_700_000_000_000},
+        profile: {
+          display_name: 'name',
+          photo_url: '',
+          username_chosen: true,
+        },
+      }),
+    );
+
+    const {result} = renderHook(() => useOnboardingFlow());
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.shouldFireOnboarding).toBe(false);
+  });
+
+  test('established user, no completed_at, username chosen, terms current → no fire (undefined onboarding = completed)', () => {
+    setAuth(TEST_UID);
+    setUserData(
+      makeUserData({
+        agreed_to_terms_at: 1_700_000_000_000,
+        // No `onboarding` node at all — a returning account that predates the
+        // completed_at stamp.
+        profile: {
+          display_name: 'name',
+          photo_url: '',
+          username_chosen: true,
+        },
+      }),
+    );
+
+    const {result} = renderHook(() => useOnboardingFlow());
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.shouldFireOnboarding).toBe(false);
+  });
+
+  test('returning record missing onboarding AND terms but username chosen → no fire (re-prompt regression guard)', () => {
+    setAuth(TEST_UID);
+    setUserData(
+      makeUserData({
+        // Neither completed_at, nor agreed_to_terms_at — the exact shape that
+        // used to fall through both selectors and re-fire onboarding.
+        profile: {
+          display_name: 'name',
+          photo_url: '',
+          username_chosen: true,
+        },
+      }),
+    );
+
+    const {result} = renderHook(() => useOnboardingFlow());
+
+    expect(result.current.isReady).toBe(true);
     expect(result.current.shouldFireOnboarding).toBe(false);
   });
 

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import {useConfig} from '@context/global/ConfigContext';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
@@ -10,6 +11,7 @@ import {
 } from '@libs/OnboardingSelectors';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import CONFIG from '@src/CONFIG';
+import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 
@@ -34,6 +36,7 @@ function useOnboardingFlow(): OnboardingFlowState {
   const {auth} = useFirebase();
   const userID = auth?.currentUser?.uid;
   const {config} = useConfig();
+  const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
   // `useCurrentUserData` returns {} (truthy) while loading / after the Onyx
   // record is wiped on account close; the readiness gate and selectors below
   // expect `undefined` to mean "not loaded yet", so map empty → undefined.
@@ -43,15 +46,17 @@ function useOnboardingFlow(): OnboardingFlowState {
   return useMemo<OnboardingFlowState>(() => {
     const skipOnboarding = CONFIG.SKIP_ONBOARDING;
     const isAuthenticated = !!userID;
-    // Treat both `undefined` (listener not yet emitted) and `null` (RTDB node
-    // missing — either pre-write during signup or post-delete during account
-    // closure) as "not enough info, defer." Without this, account deletion
-    // briefly flashes the T&C screen: account closure wipes the RTDB node
-    // before `signOut` runs, the listener emits `null`, and the onboarding
-    // selectors interpret that as "needs onboarding" while the user is still
-    // authenticated.
+    // Defer the decision until the OpenApp bootstrap has fully completed
+    // (`IS_LOADING_APP` flips to `false` in its finallyData) AND the user's
+    // record is present. `USER_DATA_LIST` is assembled incrementally — the
+    // app/open snapshot, Pusher deltas, and optimistic writes each land
+    // separately — so "the record is non-empty" does NOT imply "fully loaded".
+    // A partial record observed mid-bootstrap would otherwise be read as "needs
+    // onboarding" (and the one-way OnboardingGuard would then strand the user).
+    // Gating on the explicit bootstrap-complete signal restores the
+    // all-or-nothing guarantee the old Firebase listener gave implicitly.
     const isReady =
-      !isAuthenticated || (userData !== undefined && userData !== null);
+      !isAuthenticated || (isLoadingApp === false && userData !== undefined);
 
     if (skipOnboarding || !isAuthenticated || !isReady) {
       return {
@@ -92,7 +97,7 @@ function useOnboardingFlow(): OnboardingFlowState {
       lastVisitedPath: getOnboardingLastVisitedPath(userData),
       skipOnboarding,
     };
-  }, [userID, userData, config]);
+  }, [userID, userData, config, isLoadingApp]);
 }
 
 export default useOnboardingFlow;

--- a/src/libs/Navigation/guards/TermsReConsentGuard.tsx
+++ b/src/libs/Navigation/guards/TermsReConsentGuard.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
+import {useOnyx} from 'react-native-onyx';
 import Modal from '@components/Modal';
 import SafeAreaConsumer from '@components/SafeAreaConsumer';
 import TermsScreenContent from '@components/TermsScreenContent';
@@ -13,6 +14,7 @@ import {
 } from '@libs/OnboardingSelectors';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import {View} from 'react-native';
 
 /**
@@ -29,19 +31,25 @@ function TermsReConsentGuard() {
   // expect `undefined` to mean "not loaded yet", so map empty → undefined.
   const currentUserData = useCurrentUserData();
   const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
+  const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
 
   const shouldPrompt = useMemo(() => {
     if (!auth?.currentUser) {
       return false;
     }
-    if (userData === undefined) {
+    // Defer until the OpenApp bootstrap completes and the record is present.
+    // `USER_DATA_LIST` hydrates incrementally, so a partial record (e.g. a
+    // profile-only batch merge that lacks `agreed_to_terms_at`) would otherwise
+    // flash this modal at a returning user before their real terms-acceptance
+    // has loaded.
+    if (isLoadingApp !== false || userData === undefined) {
       return false;
     }
     if (!hasCompletedOnboarding(userData)) {
       return false;
     }
     return !hasAcceptedCurrentTerms(userData, config);
-  }, [auth?.currentUser, userData, config]);
+  }, [auth?.currentUser, isLoadingApp, userData, config]);
 
   const handleAccept = useCallback(() => {
     Onboarding.acceptTerms();

--- a/src/libs/OnboardingSelectors.ts
+++ b/src/libs/OnboardingSelectors.ts
@@ -3,24 +3,32 @@ import type {Config, UserData} from '@src/types/onyx';
 /**
  * Returns whether the user has completed the onboarding flow.
  *
- * `completed_at` is the sole source of truth. Brand-new accounts — whose
- * Firebase record has no `onboarding` node yet — return `false` here. The
- * legacy grandfathering policy lives in `isLegacyGrandfatheredUser` so this
- * selector stays small and unambiguous.
+ * Treats an absent/undefined `onboarding` node as **completed**, so a returning
+ * user is never re-prompted while their record lacks the stamp — whether
+ * because the account predates the `completed_at` field (legacy) or because the
+ * record is still hydrating from `app/open` (`USER_DATA_LIST` is assembled
+ * incrementally, so a not-yet-loaded node looks the same as a missing one).
+ *
+ * The single "still onboarding" signal is an account explicitly pending the
+ * username step (`username_chosen === false`, written at signup). That check is
+ * robust to partial hydration: a not-yet-loaded `username_chosen` is
+ * `undefined`, never `false`, so a partial record never reads as "needs
+ * onboarding". A node that is present but carries no `completed_at` (e.g. only
+ * `last_visited_path`) is an in-progress flow → `false`.
  */
 function hasCompletedOnboarding(userData: UserData | undefined): boolean {
   if (!userData) {
+    return false;
+  }
+  if (userData.profile?.username_chosen === false) {
     return false;
   }
   const onboarding = userData.onboarding as
     | UserData['onboarding']
     | []
     | undefined;
-  if (!onboarding) {
-    return false;
-  }
-  if (Array.isArray(onboarding)) {
-    return false;
+  if (!onboarding || Array.isArray(onboarding)) {
+    return true;
   }
   return onboarding.completed_at !== undefined;
 }


### PR DESCRIPTION
## Problem

Since the client RTDB → Onyx/kiroku-api migration, users who have **already completed onboarding** are re-prompted with the onboarding flow on login.

## Root cause

The onboarding decision in `useOnboardingFlow` treated "the user's `USER_DATA_LIST` record is non-empty" as "data is loaded, decide now." That was correct under the **old Firebase listener**, where `userData` was atomically either `undefined` or the _complete_ `/users/$uid` node — there was no in-between.

The read migration (`ba5d2d643`) repointed `userData` to the Onyx `USER_DATA_LIST[uid]` key, which is **assembled incrementally**: the `app/open` snapshot, Pusher `/v1/updates` deltas, and optimistic action writes each land separately. So a record can be observed **present but incomplete** — missing `onboarding.completed_at` / `agreed_to_terms_at`. The gate read that as "needs onboarding," and because `OnboardingGuard` is **one-way** (it routes _into_ onboarding and never back out), a single such render stranded the user in the flow.

A contributing factor: an earlier commit (`6ffeac5f3`) had dropped the `IS_LOADING_APP` half of the readiness gate back when `App.openApp()` wasn't wired. `openApp()` **is** wired now and already maintains `IS_LOADING_APP` (true optimistically, false in `finallyData`) — the gate just wasn't consulting it.

## Fix

Two complementary changes (no server changes — kiroku-api's `app/open`, `/complete`, `/accept-terms` are already correct):

**1. Readiness — gate on bootstrap completion.** `useOnboardingFlow` (and `TermsReConsentGuard`) now require `IS_LOADING_APP === false` before any decision, restoring the all-or-nothing guarantee the listener gave implicitly. No decision is made against a half-assembled record.

**2. Selector — "undefined onboarding = completed."** `hasCompletedOnboarding` now treats an absent / serialization-empty `onboarding` node as **completed**, so legacy accounts (predating the `completed_at` stamp) and not-yet-hydrated records are never re-prompted. The single "still onboarding" signal is `username_chosen === false` (written at signup), which is inherently robust to partial hydration — a not-yet-loaded `username_chosen` is `undefined`, never `false`. A node that's present but carries no `completed_at` (e.g. only `last_visited_path`) is still treated as in-progress.

`TermsReConsentGuard` gets the same bootstrap gate so the new selector semantics can't flash the re-consent modal against a profile-only partial record.

## Tests

- `useOnboardingFlow.test.ts`: re-added the `IS_LOADING_APP` mock; added cases for **OpenApp in-flight** (complete record, still deferred), **established user with no `completed_at`** (no fire), and a **direct regression guard** for the record shape (no `completed_at`, no `agreed_to_terms_at`, username chosen) that used to re-fire.
- `OnboardingSelectors.test.ts`: updated `hasCompletedOnboarding` cases to the new contract (absent node → completed; `username_chosen === false` → not completed; node-without-stamp → in progress).
- All onboarding suites green locally (`useOnboardingFlow`, `OnboardingSelectors`, `OnboardingGuard`, `actions/Onboarding`); `typecheck-tsgo`, `lint-changed`, and React Compiler compliance pass.

## Follow-up (operational, not in this PR)

Re-run the idempotent `#358` onboarding backfill (now in **kiroku-cli**) against staging + production RTDB so legacy users gain `completed_at`. The code is correct without it, but it's cheap insurance. Tracked alongside the `isLegacyGrandfatheredUser` removal in [#645](https://github.com/PetrCala/Kiroku/issues/645) — note that `hasCompletedOnboarding` now subsumes the grandfather logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
