### PR TITLE
fix(ios): retry TestFlight upload on transient App Store Connect 500

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -264,10 +264,37 @@ platform :ios do
         }
     )
 
-    upload_to_testflight(
-        api_key_path: "./ios/ios-fastlane-json-key.json",
-        distribute_external: false,
-    )
+    # App Store Connect's TestFlight ingestion (altool / the "ContentDelivery"
+    # pipeline) intermittently returns a transient HTTP 500 on the final
+    # "CHANGE UPLOAD STATE TO COMPLETE (ASSET_UPLOAD)" call *after* the binary
+    # has already been delivered ("UPLOAD SUCCEEDED with no errors"), failing
+    # the whole deploy even though the build is on its way into processing.
+    # Retry to ride out the flake. The upload is effectively idempotent: if an
+    # earlier attempt's binary did register, a later attempt reports it as a
+    # duplicate, which we treat as success.
+    testflight_upload_attempts = 0
+    max_testflight_upload_attempts = 3
+    begin
+      testflight_upload_attempts += 1
+      upload_to_testflight(
+          api_key_path: "./ios/ios-fastlane-json-key.json",
+          distribute_external: false,
+      )
+    rescue => e
+      message = e.message.to_s
+
+      if message.match?(/already been used|already exists|already been uploaded|redundant binary/i)
+        UI.important("Build already present on App Store Connect; treating the TestFlight upload as successful (#{message.strip})")
+      elsif testflight_upload_attempts < max_testflight_upload_attempts &&
+            message.match?(/status code 5\d\d|internal server error|CHANGE UPLOAD STATE TO COMPLETE|Could not download\/upload|Error uploading ipa|timed out|connection reset/i)
+        UI.error("TestFlight upload attempt #{testflight_upload_attempts}/#{max_testflight_upload_attempts} failed: #{message.strip}")
+        UI.important("Retrying in 30s after a transient App Store Connect error...")
+        sleep(30)
+        retry
+      else
+        raise
+      end
+    end
 
     begin
       upload_symbols_to_crashlytics(


### PR DESCRIPTION
## Problem

The [staging deploy run](https://github.com/PetrCala/Kiroku/actions/runs/27148595341) (`Deploy code to staging or production`, release `0.3.15-12`) failed in the iOS **`upload_to_testflight`** step.

Crucially, the failure was **not** a build or signing problem. The IPA was built and uploaded successfully. From the logs:

```
[altool] UPLOAD SUCCEEDED with no errors
[altool] Delivery UUID: 797d9936-ae21-44aa-9896-98553272d7d5
[altool] Transferred 32557001 bytes in 0.731 seconds (44.6MB/s, ...)
[altool] No errors uploading archive ...
```

…but immediately after, App Store Connect's ingestion pipeline returned a transient server error on the final state-transition call:

```
[ContentDelivery.Uploader] CHANGE UPLOAD STATE TO COMPLETE (ASSET_UPLOAD):
received status code 500; internal server error. (...) (500)
Could not download/upload from App Store Connect!
Error uploading ipa file
```

fastlane surfaced that HTTP 500 as a hard failure and failed the entire deploy (`💥 upload_to_testflight`), even though the binary was already delivered and on its way into TestFlight processing. This is a well-known, intermittent Apple-side flake.

## Why not just wrap the whole lane in `nick-fields/retry`?

The Android job already retries its Fastlane step, but a full-lane retry is the wrong tool here:
- It re-runs the ~25-minute native build on every attempt.
- The retry would re-upload the **same** build number; if Apple did register the binary on the failing attempt, the re-upload fails with "build already exists", so the retry stays red and the fix is ineffective.

## Fix

Wrap the `beta` lane's `upload_to_testflight` in a bounded, targeted retry (3 attempts, 30s backoff) that:

1. Retries only on transient upload/5xx errors (`status code 5xx`, `internal server error`, `CHANGE UPLOAD STATE TO COMPLETE`, `Could not download/upload`, etc.).
2. Treats a "build already exists / already uploaded / redundant binary" result as **success**, since the binary may have registered on the attempt that 500'd. This makes the operation idempotent and avoids the redundant-binary trap above.
3. Re-raises anything else unchanged, so genuine signing/build failures still fail fast.

Only the `beta` (staging) lane is touched, which is exactly the path that failed. The `production` lane's upload has different external-distribution semantics and is left as-is.

## Testing

- `ruby -c fastlane/Fastfile` → Syntax OK.
- Logic verified against the captured failure output; the duplicate-detection and transient-error regexes match the real altool messages from the failing run.

https://claude.ai/code/session_01MMLLHmKbd2BMWqoRZEoU2t

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMLLHmKbd2BMWqoRZEoU2t)_