### PR TITLE
feat(dev-menu): add Force offline / Go back online toggles

### DIFF
--- a/src/components/CustomDevMenu/index.native.tsx
+++ b/src/components/CustomDevMenu/index.native.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect} from 'react';
 import {DevSettings} from 'react-native';
 import Onyx from 'react-native-onyx';
+import {setShouldForceOffline} from '@userActions/Network';
 import toggleTestToolsModal from '@userActions/TestTool';
 import type CustomDevMenuElement from './types';
 
@@ -15,6 +16,17 @@ const CustomDevMenu: CustomDevMenuElement = Object.assign(
         // — useful for testing one-time-hydration paths like the
         // earliest_session_at backfill without re-doing the sign-in dance.
         Onyx.clear().finally(() => DevSettings.reload());
+      });
+      // Force the whole app offline without cutting the device's real
+      // connection. This flips the `shouldForceOffline` flag that
+      // NetworkStore, HttpUtils and Pusher all honor, so requests queue and
+      // the offline UI / optimistic-rollback behave exactly as if the network
+      // were down — the supported way to exercise the offline-first flows.
+      DevSettings.addMenuItem('Force offline', () => {
+        setShouldForceOffline(true);
+      });
+      DevSettings.addMenuItem('Go back online', () => {
+        setShouldForceOffline(false);
       });
     }, []);
     // eslint-disable-next-line react/jsx-no-useless-fragment


### PR DESCRIPTION
## What

Adds two items to the React Native dev menu (Cmd+D / shake):

- **Force offline** → `setShouldForceOffline(true)`
- **Go back online** → `setShouldForceOffline(false)`

## Why

Testing the offline-first flows (PR #823) previously meant actually cutting the network. The iOS Simulator has no airplane mode of its own (it shares the Mac's connection), so the only options were heavy-handed (Network Link Conditioner 100% loss, firewall rules) and none of them cleanly silence Pusher.

`shouldForceOffline` is OR'd into the offline check in `NetworkStore`, `HttpUtils`, `NetworkConnection` and `pusher.ts`, so flipping it makes the whole app behave as offline — request queueing, optimistic-update rollback, offline UI indicators, and Pusher silence — **without touching the device's real connection.** This is the supported, Pusher-aware way to exercise those flows.

## Notes

- Native-only: registered in `CustomDevMenu/index.native.tsx`, which `ScreenWrapper` mounts only in development. The web variant stays a no-op.
- The built-in "Configure Bundler" item was left in place — it's a native RN dev-menu built-in and `DevSettings` exposes no remove API; stripping it would require fragile native patching.

## Testing

Run a dev build, open Cmd+D, tap **Force offline** → app shows offline behavior; tap **Go back online** → reconnects. No real network change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)