### PR TITLE
fix(offline): dock OfflineIndicator correctly on offline screens

### DIFF
--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -16,7 +16,7 @@ import type {EdgeInsets} from 'react-native-safe-area-context';
 import useEnvironment from '@hooks/useEnvironment';
 import useInitialDimensions from '@hooks/useInitialWindowDimensions';
 import useKeyboardState from '@hooks/useKeyboardState';
-// import useNetwork from '@hooks/useNetwork';
+import useNetwork from '@hooks/useNetwork';
 import useTackInputFocus from '@hooks/useTackInputFocus';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
@@ -159,7 +159,7 @@ function ScreenWrapper(
   const styles = useThemeStyles();
   const keyboardState = useKeyboardState();
   const {isDevelopment} = useEnvironment();
-  // const {isOffline} = useNetwork();
+  const {isOffline} = useNetwork();
   const [didScreenTransitionEnd, setDidScreenTransitionEnd] = useState(false);
   const maxHeight = shouldEnableMaxHeight ? windowHeight : undefined;
   const minHeight =
@@ -266,8 +266,10 @@ function ScreenWrapper(
         }
 
         // We always need the safe area padding bottom if we're showing the offline indicator since it is bottom-docked.
-        // if (includeSafeAreaPaddingBottom || (isOffline && shouldShowOfflineIndicator)) {
-        if (includeSafeAreaPaddingBottom) {
+        if (
+          includeSafeAreaPaddingBottom ||
+          (isOffline && shouldShowOfflineIndicator)
+        ) {
           paddingStyle.paddingBottom = paddingBottom;
         }
 

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -1,4 +1,5 @@
 import type {ListRenderItemInfo} from 'react-native';
+import {View} from 'react-native';
 import React, {useCallback, useMemo, useState} from 'react';
 import type {
   FriendRequestList,
@@ -148,10 +149,15 @@ function FriendSearchScreen() {
     // User search needs a live server read, so offline we show a notice rather
     // than a perpetual spinner or an error.
     if (isOffline) {
+      // Fill the available space so the ScreenWrapper's trailing offline
+      // indicator stays docked at the bottom instead of sitting right below
+      // this notice.
       return (
-        <Text style={[styles.noResultsText, styles.pt4]}>
-          {translate('common.thisFeatureRequiresInternet')}
-        </Text>
+        <View style={styles.flex1}>
+          <Text style={[styles.noResultsText, styles.pt4]}>
+            {translate('common.thisFeatureRequiresInternet')}
+          </Text>
+        </View>
       );
     }
     if (searching) {


### PR DESCRIPTION
## Summary

Follow-up to #823 fixing two OfflineIndicator placement bugs found during on-device offline testing. Mirrors the earlier #1070 SocialScreen fix in spirit (opt-out + manual placement), but here both fixes are made in the shared layer where possible.

### 1. Indicator rendered *below* the bottom safe area (Settings / ReportBug / Feedback / Account profile details)

On screens that pass `includeSafeAreaPaddingBottom={false}` to `ScreenWrapper`, the default trailing `<OfflineIndicator />` rendered underneath the home-indicator / gesture bar, because the bottom safe-area inset was never applied.

**Root-cause fix in the shared `ScreenWrapper`:** apply the bottom safe-area padding whenever the offline indicator is actually showing, regardless of `includeSafeAreaPaddingBottom`. This restores the upstream Expensify condition (`includeSafeAreaPaddingBottom || (isOffline && shouldShowOfflineIndicator)`) — the branch had it commented out along with the `useNetwork` import.

This is a no-op when:
- online (no indicator, `isOffline === false`), so screens keep their intended no-bottom-padding layout, and
- the screen already includes bottom padding (Home, Social, Day Overview) — the first term short-circuits true as before.

So it fixes all affected opt-out screens (Settings, ReportBug, Feedback, the Account profile-details screen, and the other `Account/` sub-screens) without regressing the screens that already looked correct.

### 2. Indicator floating mid-screen on Friend Search

When offline, `FriendSearchScreen` short-circuits to the "this feature requires an active internet connection" notice. That notice was a bare `<Text>` (no flex), so it didn't fill the vertical space and the ScreenWrapper's trailing indicator sat directly below it, mid-screen. Wrapped the notice in a `flex1` container (the `FlatList` branch already flexes), so the indicator docks at the bottom.

## Testing

Gates pass locally: `prettier`, `lint-changed`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed`.

⚠️ These are visual fixes — **on-device verification is still pending.** This PR carries `Ready To Build - iOS` to produce an ad-hoc build for confirmation across the affected screens (Settings, Report Bug, Feedback, Account, Friend Search) and a regression check on Home / Social / Day Overview.

> [!NOTE]
> Base branch is `feature/offline-non-blocking-ux` (#823), which is still open. Do **not** merge this into `master`; it should land on / with the offline-UX branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)