### PR TITLE
fix(offline): clear the offline indicator on "Go back online"

### DIFF
--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -14,31 +14,40 @@ export default function useNetwork({
   const callback = useRef(onReconnect);
   callback.current = onReconnect;
 
-  const {isOffline, networkStatus} = useContext(NetworkContext) ?? {
-    ...CONST.DEFAULT_NETWORK_DATA,
-    networkStatus: CONST.NETWORK.NETWORK_STATUS.UNKNOWN,
-  };
-  const prevOfflineStatusRef = useRef(isOffline);
+  const network = useContext(NetworkContext);
+  const networkStatus =
+    network?.networkStatus ?? CONST.NETWORK.NETWORK_STATUS.UNKNOWN;
+  const isOffline = network?.isOffline ?? CONST.DEFAULT_NETWORK_DATA.isOffline;
+  const shouldForceOffline = network?.shouldForceOffline ?? false;
+
+  // The dev-menu "Force offline"/"Go back online" toggles only flip the
+  // `shouldForceOffline` flag, so the offline UI has to honor it symmetrically.
+  // Reading it here (instead of relying on a side-channel that writes
+  // `isOffline`) keeps the indicator in lock-step with the toggle in both
+  // directions and mirrors NetworkStore.isOffline() (`shouldForceOffline ||
+  // isOffline`). When the real network status is still UNKNOWN we don't treat it
+  // as offline.
+  const isOfflineEffective =
+    shouldForceOffline ||
+    (networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN
+      ? false
+      : isOffline);
+
+  const prevOfflineStatusRef = useRef(isOfflineEffective);
   useEffect(() => {
     // If we were offline before and now we are not offline then we just reconnected
-    const didReconnect = prevOfflineStatusRef.current && !isOffline;
+    const didReconnect = prevOfflineStatusRef.current && !isOfflineEffective;
     if (!didReconnect) {
       return;
     }
 
     callback.current();
-  }, [isOffline]);
+  }, [isOfflineEffective]);
 
   useEffect(() => {
     // Used to store previous prop values to compare on next render
-    prevOfflineStatusRef.current = isOffline;
-  }, [isOffline]);
+    prevOfflineStatusRef.current = isOfflineEffective;
+  }, [isOfflineEffective]);
 
-  // If the network status is undefined, we don't treat it as offline. Otherwise, we utilize the isOffline prop.
-  return {
-    isOffline:
-      networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN
-        ? false
-        : isOffline,
-  };
+  return {isOffline: isOfflineEffective};
 }

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -27,11 +27,10 @@ export default function useNetwork({
   // directions and mirrors NetworkStore.isOffline() (`shouldForceOffline ||
   // isOffline`). When the real network status is still UNKNOWN we don't treat it
   // as offline.
+  const isNetworkStatusUnknown =
+    networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN;
   const isOfflineEffective =
-    shouldForceOffline ||
-    (networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN
-      ? false
-      : isOffline);
+    shouldForceOffline || (!isNetworkStatusUnknown && isOffline);
 
   const prevOfflineStatusRef = useRef(isOfflineEffective);
   useEffect(() => {

--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -64,7 +64,18 @@ function setOfflineStatus(isCurrentlyOffline: boolean, reason = ''): void {
   isOffline = isCurrentlyOffline;
 }
 
-// Update the offline status in response to changes in shouldForceOffline
+// Mirror the `shouldForceOffline` flag (driven by the dev-menu "Force
+// offline"/"Go back online" toggles) so the NetInfo subscription guard below
+// can honor it if `subscribeToNetInfo()` is ever re-enabled.
+//
+// We deliberately do NOT write `isOffline`/`networkStatus` from this listener.
+// UserConnectionProvider is the single writer of the NETWORK key's connectivity
+// fields, and the offline UI reads `shouldForceOffline` directly (see
+// useNetwork / NetworkStore). Writing here would re-introduce a double-writer
+// race: on "Go back online" the old NetInfo.fetch() path frequently observed
+// `isInternetReachable === null` on-device, treated null as unreachable, and
+// re-asserted `isOffline: true` — leaving the offline indicator stuck until a
+// full app reload.
 let shouldForceOffline = false;
 Onyx.connect({
   key: ONYXKEYS.NETWORK,
@@ -72,35 +83,7 @@ Onyx.connect({
     if (!network) {
       return;
     }
-    const currentShouldForceOffline = !!network.shouldForceOffline;
-    if (currentShouldForceOffline === shouldForceOffline) {
-      return;
-    }
-    shouldForceOffline = currentShouldForceOffline;
-    if (shouldForceOffline) {
-      setOfflineStatus(
-        true,
-        'shouldForceOffline was detected in the Onyx data',
-      );
-      Log.info(
-        `[NetworkStatus] Setting "offlineStatus" to "true" because user is under force offline`,
-      );
-    } else {
-      // If we are no longer forcing offline fetch the NetInfo to set isOffline appropriately
-      NetInfo.fetch().then(state => {
-        const isInternetUnreachable =
-          (state.isInternetReachable ?? false) === false;
-        setOfflineStatus(
-          isInternetUnreachable || !isServerUp,
-          'NetInfo checked if the internet is reachable',
-        );
-        Log.info(
-          `[NetworkStatus] The force-offline mode was turned off. Getting the device network status from NetInfo. Network state: ${JSON.stringify(
-            state,
-          )}. Setting the offline status to: ${isInternetUnreachable}.`,
-        );
-      });
-    }
+    shouldForceOffline = !!network.shouldForceOffline;
   },
 });
 

--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -74,7 +74,7 @@ function setOfflineStatus(isCurrentlyOffline: boolean, reason = ''): void {
 // useNetwork / NetworkStore). Writing here would re-introduce a double-writer
 // race: on "Go back online" the old NetInfo.fetch() path frequently observed
 // `isInternetReachable === null` on-device, treated null as unreachable, and
-// re-asserted `isOffline: true` — leaving the offline indicator stuck until a
+// re-asserted `isOffline: true`, leaving the offline indicator stuck until a
 // full app reload.
 let shouldForceOffline = false;
 Onyx.connect({


### PR DESCRIPTION
## Problem

On device (dev menu → cmd+D): **Force offline** shows the `OfflineIndicator` banner immediately (good), but **Go back online** does **not** hide it. Only a full app reload clears the banner. The offline→online transition wasn't reaching the indicator.

This sits at the intersection of #1091 (dev-menu Force offline / Go back online toggles, merged to master) and this branch's NetInfo→`NETWORK` Onyx bridge (`UserConnectionProvider`) that drives `OfflineIndicator`.

## Root cause — writer conflict on the `NETWORK` Onyx key

The dev toggles only flip `shouldForceOffline` on the `NETWORK` key (`setShouldForceOffline`). They never touch `isOffline`/`networkStatus`.

- `OfflineIndicator` reads `useNetwork()`, which only consulted `isOffline` (gated by `networkStatus`) — it ignored `shouldForceOffline` entirely.
- The reason the banner appeared at all was a **second writer**: `NetworkConnection.ts`'s top-level `Onyx.connect` listener translated `shouldForceOffline` → `isOffline` via `setOfflineStatus`. That module is imported (PusherUtils / middleware), so the listener is live.
- On **Go back online**, that listener ran `NetInfo.fetch()` and computed `(state.isInternetReachable ?? false) === false`. On device `isInternetReachable` is frequently `null` right after toggling, so it was treated as **unreachable** and the listener **re-asserted `isOffline: true`** — keeping the banner up. A full reload re-ran the bridge (`UserConnectionProvider`), which keys off the more reliable `state.isConnected`, so it cleared.

So the toggle's `shouldForceOffline` flag was consulted asymmetrically: it effectively showed the banner (via the side-channel writer) but the online path couldn't clear the same flag.

Per project design, `UserConnectionProvider` is meant to be the **single writer** of the `NETWORK` key's connectivity fields (and `subscribeToNetInfo()` stays disabled). The `NetworkConnection` listener was a conflicting second writer.

## Fix (one writer, symmetric reader)

- **`src/hooks/useNetwork.ts`** — read `shouldForceOffline` directly and OR it into the effective offline state, mirroring `NetworkStore.isOffline()` (`shouldForceOffline || isOffline`). The indicator now responds to the toggle symmetrically in both directions, with no dependence on anything writing `isOffline`.
- **`src/libs/NetworkConnection.ts`** — the `Onyx.connect` listener no longer writes `isOffline`/`networkStatus`. It only mirrors `shouldForceOffline` into a local var so the (still-disabled) `subscribeToNetInfo()` guard keeps working if it's ever re-enabled. `UserConnectionProvider` remains the single writer of the connectivity fields, eliminating the double-writer race and the flaky `NetInfo.fetch()` re-assert.

## Why this is safe

- **Real NetInfo offline/online** is unchanged — still driven solely by the bridge (`UserConnectionProvider`), which writes both `isOffline` and `networkStatus` from `state.isConnected`.
- **Request-queue flush on reconnect** is unaffected — it's wired to `NetworkStore.onReconnection(flush)` (SequentialQueue), which fires off the bridge's `isOffline` transition. `NetworkConnection.onReconnect` has no active callers.
- Did **not** re-enable `subscribeToNetInfo()` (would reintroduce a double-writer per project memory).

## Verification

- ✅ `typecheck-tsgo`, `lint-changed`, `react-compiler-compliance-check check-changed`, prettier — all clean.
- ⚠️ **Needs on-device confirmation:**
  - Force offline → banner shows.
  - Go back online → banner hides immediately (no reload).
  - Real airplane-mode / Wi-Fi off → banner shows; back online → banner hides.

Base: `feature/offline-non-blocking-ux` (do not merge until the on-device check passes).