### PR TITLE
fix(offline): graceful profile state when a friend's data is unavailable

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -981,6 +981,9 @@ export default {
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
       `${hasCommonFriends ? 'Společní přátelé:' : 'Přátelé:'}`,
     profileImage: 'Profilový obrázek',
+    offlineUnavailableTitle: 'Profil se nepodařilo načíst',
+    offlineUnavailableMessage:
+      'Tento profil se nepodařilo načíst v režimu offline. Pro zobrazení se znovu připojte.',
   },
   statistics: {
     title: 'Statistiky',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -976,6 +976,9 @@ export default {
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
       `${hasCommonFriends ? 'Common friends:' : 'Friends:'}`,
     profileImage: 'Profile Image',
+    offlineUnavailableTitle: "Couldn't load this profile",
+    offlineUnavailableMessage:
+      "We couldn't load this profile while offline. Reconnect to view it.",
   },
   statistics: {
     title: 'Statistics',

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -35,7 +35,6 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
-import OfflineIndicator from '@components/OfflineIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Button from '@components/Button';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -205,8 +204,9 @@ function ProfileScreen({route}: ProfileScreenProps) {
 
   // A cross-user profile read can't be queued while offline, so a friend whose
   // data isn't already cached resolves with nothing. Keep the screen chrome
-  // (header + offline indicator) and show a graceful loading/empty state rather
-  // than the blank dark screen an early `return` produced.
+  // (ScreenWrapper renders its own OfflineIndicator) and show a graceful
+  // loading/empty state rather than the blank dark screen an early `return`
+  // produced.
   if (isLoading) {
     return (
       <ScreenWrapper
@@ -221,7 +221,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
           ]}>
           <FlexibleLoadingIndicator />
         </View>
-        <OfflineIndicator />
       </ScreenWrapper>
     );
   }
@@ -251,7 +250,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
             {translate('profileScreen.offlineUnavailableMessage')}
           </Text>
         </View>
-        <OfflineIndicator />
       </ScreenWrapper>
     );
   }
@@ -318,7 +316,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
         onClose={() => setManageFriendModalVisible(false)}
         friendId={userID}
       />
-      <OfflineIndicator />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -34,7 +34,8 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
-import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
+import OfflineIndicator from '@components/OfflineIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Button from '@components/Button';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -191,25 +192,75 @@ function ProfileScreen({route}: ProfileScreenProps) {
     setUnitsConsumed(thisMonthUnits);
   }, [drinkingSessionData, preferences, visibleDateData]);
 
+  const header = (
+    <HeaderWithBackButton
+      title={
+        user?.uid === userID
+          ? translate('profileScreen.title')
+          : translate('profileScreen.titleNotSelf')
+      }
+      onBackButtonPress={Navigation.goBack}
+    />
+  );
+
+  // A cross-user profile read can't be queued while offline, so a friend whose
+  // data isn't already cached resolves with nothing. Keep the screen chrome
+  // (header + offline indicator) and show a graceful loading/empty state rather
+  // than the blank dark screen an early `return` produced.
   if (isLoading) {
-    return <FullScreenLoadingIndicator />;
+    return (
+      <ScreenWrapper
+        testID={ProfileScreen.displayName}
+        onEntryTransitionEnd={onEntryTransitionEnd}>
+        {header}
+        <View
+          style={[
+            styles.flex1,
+            styles.justifyContentCenter,
+            styles.alignItemsCenter,
+          ]}>
+          <FlexibleLoadingIndicator />
+        </View>
+        <OfflineIndicator />
+      </ScreenWrapper>
+    );
   }
   if (!profileData || !preferences || !userData) {
-    return;
+    return (
+      <ScreenWrapper
+        testID={ProfileScreen.displayName}
+        onEntryTransitionEnd={onEntryTransitionEnd}>
+        {header}
+        <View
+          style={[
+            styles.flex1,
+            styles.justifyContentCenter,
+            styles.alignItemsCenter,
+            styles.ph5,
+          ]}>
+          <Text style={[styles.textHeadlineH1, styles.textAlignCenter]}>
+            {translate('profileScreen.offlineUnavailableTitle')}
+          </Text>
+          <Text
+            style={[
+              styles.textNormal,
+              styles.textSupporting,
+              styles.textAlignCenter,
+              styles.mt2,
+            ]}>
+            {translate('profileScreen.offlineUnavailableMessage')}
+          </Text>
+        </View>
+        <OfflineIndicator />
+      </ScreenWrapper>
+    );
   }
 
   return (
     <ScreenWrapper
       testID={ProfileScreen.displayName}
       onEntryTransitionEnd={onEntryTransitionEnd}>
-      <HeaderWithBackButton
-        title={
-          user?.uid === userID
-            ? translate('profileScreen.title')
-            : translate('profileScreen.titleNotSelf')
-        }
-        onBackButtonPress={Navigation.goBack}
-      />
+      {header}
       <ScrollView
         style={[styles.flexGrow1, styles.mnw100]}
         showsVerticalScrollIndicator={false}>
@@ -267,6 +318,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
         onClose={() => setManageFriendModalVisible(false)}
         friendId={userID}
       />
+      <OfflineIndicator />
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## Problem

From on-device offline testing of #823: opening a **friend's profile while offline** renders a **fully blank screen** (dark in dark mode) — no content, no header, no spinner. Most likely for friends whose profile data isn't already in the local Onyx cache (e.g. a just-accepted friend), since a cross-user profile read can't be queued offline.

Root cause is in [`ProfileScreen.tsx`](src/screens/Profile/ProfileScreen.tsx): when the other user's data is unavailable the component early-returned a bare `return;`, rendering nothing at all — not even the `ScreenWrapper`/header. #823's description claimed these reads "show a loading spinner until reconnect; never blocks the screen," but in practice the screen was blank.

## Fix

Keep the screen chrome mounted in **every** state:

- `ScreenWrapper` + `HeaderWithBackButton` + `OfflineIndicator` render in all branches.
- **Loading:** centered `FlexibleLoadingIndicator` (instead of the chrome-less full-screen overlay).
- **Unavailable:** a short, graceful message — *"Couldn't load this profile while offline. Reconnect to view it."*
- **Cached data available:** renders normally, unchanged.

The goal: never a blank dark screen.

### Locales
- Adds `profileScreen.offlineUnavailableTitle` / `offlineUnavailableMessage` to `src/languages/en.ts`.
- Mirrors the key structure in `src/languages/cs_cz.ts`.
- Other locales to be filled via the `translate` skill (not hand-written here). No em-dashes in the copy, per repo style.

## Testing
- `npm run typecheck-tsgo` ✅
- `npm run lint-changed` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- ⚠️ **Needs on-device confirmation** of the offline friend-profile flow (the original repro was on-device).

## Notes
- Based on `feature/offline-non-blocking-ux` (#823), **not** master. Do not merge ahead of its base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)