### PR TITLE
fix(offline): home content resolves offline instead of spinning forever

### DIFF
--- a/__tests__/unit/useCurrentUserDrinkingSessions.test.ts
+++ b/__tests__/unit/useCurrentUserDrinkingSessions.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+import {renderHook} from '@testing-library/react-native';
+import {useOnyx} from 'react-native-onyx';
+import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  useOnyx: jest.fn(),
+  default: {},
+}));
+
+jest.mock('@context/global/FirebaseContext', () => ({
+  useFirebase: jest.fn(),
+}));
+
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedUseFirebase = jest.mocked(useFirebase);
+
+function setAuth(uid: string | undefined): void {
+  mockedUseFirebase.mockReturnValue({
+    auth: uid ? {currentUser: {uid}} : {currentUser: null},
+  } as unknown as ReturnType<typeof useFirebase>);
+}
+
+function setOnyx(
+  value: UserDrinkingSessionsList | null | undefined,
+  status: 'loading' | 'loaded',
+): void {
+  mockedUseOnyx.mockReturnValue([value, {status}] as unknown as ReturnType<
+    typeof useOnyx
+  >);
+}
+
+const SESSIONS_FOR_U1: UserDrinkingSessionsList = {
+  u1: {
+    s1: {
+      start_time: 1,
+      end_time: 2,
+      timezone: 'Africa/Abidjan',
+      drinks: {1: {beer: 1}},
+    },
+  },
+} as unknown as UserDrinkingSessionsList;
+
+describe('useCurrentUserDrinkingSessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setAuth('u1');
+  });
+
+  test('no signed-in user → undefined regardless of cache', () => {
+    setAuth(undefined);
+    setOnyx(SESSIONS_FOR_U1, 'loaded');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('still loading from disk → undefined (genuinely "not ready")', () => {
+    setOnyx(undefined, 'loading');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('loaded with this user`s sessions → returns them', () => {
+    setOnyx(SESSIONS_FOR_U1, 'loaded');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual(SESSIONS_FOR_U1.u1);
+  });
+
+  // Regression: the offline home-skeleton hang. The cache key has finished
+  // hydrating but holds no entry for this user — a brand-new account, a
+  // post-sign-out reset (`Onyx.set(CACHED_DRINKING_SESSIONS, null)`), or an
+  // offline cold start where `app/open` never reached the network. This must
+  // resolve to a ready-but-empty object, NOT stay undefined (which the home
+  // readiness gate reads as "still loading" → skeletons forever).
+  test('loaded but no entry for this user → ready-but-empty object', () => {
+    setOnyx({u2: {}}, 'loaded');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual({});
+    expect(result.current).not.toBeUndefined();
+  });
+
+  test('loaded with the whole cache null (post sign-out) → ready-but-empty', () => {
+    setOnyx(null, 'loaded');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual({});
+    expect(result.current).not.toBeUndefined();
+  });
+
+  test('loaded with this user`s entry explicitly null → ready-but-empty', () => {
+    setOnyx({u1: null} as unknown as UserDrinkingSessionsList, 'loaded');
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual({});
+    expect(result.current).not.toBeUndefined();
+  });
+
+  test('the empty-state object keeps a stable reference across renders', () => {
+    setOnyx(null, 'loaded');
+
+    const {result, rerender} = renderHook(() =>
+      useCurrentUserDrinkingSessions(),
+    );
+    const first = result.current;
+    rerender(undefined);
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -736,6 +736,17 @@ const CONST = {
   // a warm listener (typically <500 ms) and shorter than the safety net.
   BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS: 3 * 1000,
 
+  // Deterministic backstop for HomeScreen's readiness gates. The home content
+  // is gated on Onyx values (preferences, the cached drinking sessions) that
+  // are normally hydrated by `app/open`. Offline — and especially on a cold
+  // start with no persisted snapshot for this user — one of those can stay
+  // `undefined` indefinitely, which would otherwise leave the calendar/stats
+  // skeletons up forever. Past this point HomeScreen stops waiting and renders
+  // real content (or the empty state) with whatever it has, defaulting
+  // preferences. Longer than the splash gate above so the common warm-cache
+  // path resolves on its own first and this only fires as a true fallback.
+  HOME_CONTENT_READY_TIMEOUT_MS: 5 * 1000,
+
   KEYBOARD_TYPE: {
     VISIBLE_PASSWORD: 'visible-password',
     ASCII_CAPABLE: 'ascii-capable',

--- a/src/hooks/useCurrentUserDrinkingSessions.ts
+++ b/src/hooks/useCurrentUserDrinkingSessions.ts
@@ -17,16 +17,29 @@ const EMPTY_SESSIONS: DrinkingSessionList = {};
  * object so consumers treat it as ready-but-empty (matching the old windowed
  * listener, which seeded `{}`), and `undefined` only while the cache is still
  * resolving.
+ *
+ * "Resolving" is keyed on Onyx's hydration `status`, NOT on the value being
+ * `undefined`. The two are not the same: once the key has finished loading from
+ * disk it can legitimately hold no entry for this user (a brand-new account; a
+ * post-sign-out reset, which writes `null`; or an offline cold start where
+ * `app/open` never reached the network). All of those are "loaded, no sessions"
+ * — surfacing them as `undefined` would read as "still loading" and leave the
+ * home skeletons spinning forever offline, since no network fetch can ever
+ * arrive to flip the gate. Only `status === 'loading'` means undefined.
  */
 function useCurrentUserDrinkingSessions(): DrinkingSessionList | undefined {
   const {auth} = useFirebase();
   const userID = auth?.currentUser?.uid;
-  const [cachedByUser] = useOnyx(ONYXKEYS.CACHED_DRINKING_SESSIONS);
+  const [cachedByUser, {status}] = useOnyx(ONYXKEYS.CACHED_DRINKING_SESSIONS);
   if (!userID) {
     return undefined;
   }
   const cached = cachedByUser?.[userID];
-  return cached === null ? EMPTY_SESSIONS : cached;
+  if (cached) {
+    return cached;
+  }
+  // Hydration finished but there's no entry for this user → ready-but-empty.
+  return status === 'loaded' ? EMPTY_SESSIONS : undefined;
 }
 
 export default useCurrentUserDrinkingSessions;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,7 +4,7 @@ import SessionsCalendar from '@components/SessionsCalendar';
 import type {DateData} from 'react-native-calendars';
 import {dateToDateData, dateStringToDate} from '@libs/DataHandling';
 import OfflineIndicator from '@components/OfflineIndicator';
-import {syncUserStatus} from '@userActions/User';
+import {syncUserStatus, getDefaultPreferences} from '@userActions/User';
 import {useFirebase} from '@context/global/FirebaseContext';
 import ProfileImage from '@components/ProfileImage';
 import {SupporterBadgeForUser} from '@components/SupporterBadge';
@@ -68,6 +68,21 @@ function HomeScreen({route}: HomeScreenProps) {
     dateToDateData(new Date()),
   );
   const hasMarkedReadyRef = useRef(false);
+  // Deterministic backstop for the readiness gates below. They wait on Onyx
+  // values normally hydrated by `app/open`; offline (especially a cold start
+  // with no persisted snapshot for this user) one of those can never resolve,
+  // which would otherwise leave the skeletons up forever. After a bounded
+  // window we stop waiting and render real content (or the empty state) with
+  // whatever we have. Mounted once — the home tab stays mounted for the
+  // session, and once flipped we never want to drop back to a skeleton.
+  const [readyTimedOut, setReadyTimedOut] = useState(false);
+  useEffect(() => {
+    const timeoutId = setTimeout(
+      () => setReadyTimedOut(true),
+      CONST.HOME_CONTENT_READY_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timeoutId);
+  }, []);
   // Most recent completed session, for the "last session" banner (null when
   // there's no history — a brand-new user shows no banner).
   const lastSession = useLastSession();
@@ -84,6 +99,15 @@ function HomeScreen({route}: HomeScreenProps) {
         ? dateToDateData(dateStringToDate(lastViewedCalendarDate))
         : localVisibleDate,
     [lastViewedCalendarDate, localVisibleDate],
+  );
+
+  // Preferences to render against. When the fallback fires before preferences
+  // hydrate (offline), fall back to defaults rather than blocking the
+  // calendar/stats on a value that won't arrive. Memoized so the default
+  // object keeps a stable reference across renders.
+  const effectivePreferences = useMemo(
+    () => preferences ?? getDefaultPreferences(),
+    [preferences],
   );
 
   // Manual month navigation overrides the synced value.
@@ -136,15 +160,18 @@ function HomeScreen({route}: HomeScreenProps) {
   // their skeletons as each piece of data resolves from Firebase. A
   // brand-new user with no sessions gets a welcome/empty state instead of
   // the calendar + stats.
-  const isPreferencesReady = !!preferences;
+  // `readyTimedOut` forces the gates open so the offline fallback can paint
+  // even if a value never hydrates (see the timeout effect above).
+  const isPreferencesReady = !!preferences || readyTimedOut;
   // Require `profile` (not just `userData`): a failed/incomplete ProvisionUser
   // can leave `userData` truthy while `profile` is still undefined. Gating the
   // header on the profile keeps it from rendering against profile-less data.
   const isUserDataReady = !!userData?.profile;
-  const isSessionsReady = drinkingSessionData !== undefined;
+  const isSessionsReady = drinkingSessionData !== undefined || readyTimedOut;
   const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
   // `useCurrentUserDrinkingSessions` returns {} (truthy) for a user with no
-  // sessions, so check emptiness rather than truthiness.
+  // sessions, so check emptiness rather than truthiness. A fallback-forced
+  // ready state with still-undefined sessions is treated as "no sessions".
   const hasSessions = isSessionsReady && !isEmptyObject(drinkingSessionData);
 
   const renderMainContent = () => {
@@ -166,7 +193,7 @@ function HomeScreen({route}: HomeScreenProps) {
           visibleDate={visibleDate}
           onDateChange={onDateChange}
           drinkingSessionData={drinkingSessionData}
-          preferences={preferences}
+          preferences={effectivePreferences}
         />
         <HomeStatsOverview visibleDate={visibleDate} />
       </>


### PR DESCRIPTION
## Problem

From on-device offline testing of #823 (offline UX). Intermittently, while offline, the home screen's data **never finishes loading** — the calendar + stats skeletons stay up indefinitely. It doesn't happen every time, which pointed at a readiness gate that occasionally waits on something only the network can deliver.

## Root cause

`HomeScreen` gates its content on:

```ts
const isPreferencesReady = !!preferences;
const isSessionsReady = drinkingSessionData !== undefined;
const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
```

`useCurrentUserDrinkingSessions` returned `cachedByUser?.[userID]` (mapping `null → {}`) and **could not distinguish two states**:

1. `CACHED_DRINKING_SESSIONS` still hydrating from disk → value `undefined` (genuinely "not ready")
2. The key **loaded**, but holds **no entry for this user** → `cachedByUser?.[userID]` is also `undefined`

Case 2 happens offline routinely: `app/open` (network) is what populates `CACHED_DRINKING_SESSIONS[userID]`, and sign-out explicitly does `Onyx.set(CACHED_DRINKING_SESSIONS, null)` (`src/libs/actions/Session/index.ts`). With no entry for the user, the hook returned `undefined` forever, so `isSessionsReady` never flipped and the skeleton spun indefinitely.

It was **intermittent** because it depended entirely on whether a warm persisted snapshot for that user already existed on disk (from a prior online session). Fresh install, post sign-out, or a cold start before the snapshot was written → hang.

## Fix (layered)

1. **Root cause — `useCurrentUserDrinkingSessions` keys "resolving" on Onyx's hydration `status`, not on `value === undefined`.** Once `status === 'loaded'`, a missing/null entry is surfaced as a ready-but-empty object. This mirrors the pattern already used by `useDrinkEvents` (`allSessionsMeta.status === 'loaded'`). `undefined` now means *only* "still loading".

2. **Deterministic backstop in `HomeScreen` (`CONST.HOME_CONTENT_READY_TIMEOUT_MS`, 5s).** If any gated Onyx value never hydrates (e.g. preferences genuinely absent on an offline cold start), the screen stops waiting after a bounded window and renders real content (or the real empty state) with whatever it has, defaulting preferences via `getDefaultPreferences()`. Belt-and-suspenders so home can never spin forever regardless of which gate is implicated. It's longer than the splash gate so the common warm-cache path resolves on its own first.

3. **Regression test** (`__tests__/unit/useCurrentUserDrinkingSessions.test.ts`) covering loading vs loaded-but-empty: loaded-with-no-entry, whole-cache-`null` (post sign-out), and explicit-`null` entry all resolve to ready-but-empty; `status: 'loading'` stays `undefined`.

## Test plan

- [x] `npx prettier --check` on changed files
- [x] `lint` (seatbelt-aware) on changed files — clean
- [x] `typecheck-tsgo` — clean
- [x] `react-compiler-compliance-check check-changed` — passed
- [x] New regression test — 7/7 pass
- [ ] **On-device confirmation needed**: offline cold start (no persisted snapshot for the user / after sign-out) should now resolve to the calendar/empty-state within a bounded time instead of spinning.

## Notes

- Base is `feature/offline-non-blocking-ux`. **Do not merge** — needs on-device confirmation first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)