### PR TITLE
feat(offline): surface offline state on auth/sign-up screens

### DIFF
--- a/src/screens/SignUp/AuthScreen.tsx
+++ b/src/screens/SignUp/AuthScreen.tsx
@@ -181,6 +181,7 @@ function AuthScreen({route}: AuthScreenProps) {
           submitButtonText={submitButtonText}
           submitButtonStyles={styles.pb5}
           submitFlexEnabled={false}
+          isSubmitDisabled={!isOnline}
           isSubmitButtonVisible={!isLoading}
           shouldUseScrollView={false}>
           <InputWrapper

--- a/src/screens/SignUp/ForgotPasswordScreen.tsx
+++ b/src/screens/SignUp/ForgotPasswordScreen.tsx
@@ -5,6 +5,7 @@ import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import * as ValidationUtils from '@libs/ValidationUtils';
@@ -26,6 +27,7 @@ function ForgotPasswordScreen() {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const {auth} = useFirebase();
+  const {isOffline} = useNetwork();
   const [serverErrorMessage, setServerErrorMessage] = React.useState('');
   const [successMessage, setSuccessMessage] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
@@ -34,6 +36,11 @@ function ForgotPasswordScreen() {
     values: FormOnyxValues<typeof ONYXKEYS.FORMS.FORGOT_PASSWORD_FORM>,
   ) => {
     (async () => {
+      // Sending the reset email needs the network; bail when offline. The
+      // disabled submit button and OfflineIndicator already explain why.
+      if (isOffline) {
+        return;
+      }
       setIsLoading(true);
       setSuccessMessage('');
 
@@ -99,7 +106,7 @@ function ForgotPasswordScreen() {
           validate={validate}
           onSubmit={onSubmit}
           submitButtonText={translate('forgotPasswordScreen.submit')}
-          isSubmitDisabled={!!successMessage}
+          isSubmitDisabled={!!successMessage || isOffline}
           style={[styles.flexGrow1, styles.mh5]}>
           <View style={[styles.flexGrow1]}>
             <Text>{translate('forgotPasswordScreen.prompt')}</Text>

--- a/src/screens/SignUp/SignUpScreenLayout/SignUpScreenContent.tsx
+++ b/src/screens/SignUp/SignUpScreenLayout/SignUpScreenContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import FormElement from '@components/FormElement';
-// import OfflineIndicator from '@components/OfflineIndicator';
+import OfflineIndicator from '@components/OfflineIndicator';
 import Text from '@components/Text';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -86,16 +86,20 @@ function SignUpScreenContent({
               )}
             </View>
           </FormElement>
-          {/* <View
+          {/* Surfaces the offline state within the sign-up safe area (these
+          screens opt out of the ScreenWrapper default because of the custom
+          layout). Renders nothing while online. */}
+          <View
             style={[
-              styles.mb8,
               styles.signUpScreenWelcomeTextContainer,
-              styles.alignSelfCenter,
+              shouldUseNarrowLayout
+                ? styles.alignItemsCenter
+                : styles.alignSelfStart,
             ]}>
             <OfflineIndicator
               style={[styles.m0, styles.pl0, styles.alignItemsStart]}
             />
-          </View> */}
+          </View>
         </View>
         <View
           pointerEvents="box-none"


### PR DESCRIPTION
Follow-up to #823 (offline non-blocking UX). The sign-up / login screens are network-dependent but gave **no offline feedback**: while offline the submit button silently did nothing, so it looked broken.

This does **not** try to make auth work offline (authentication intrinsically needs the network) — it just surfaces the offline state so the user understands why they can't proceed.

## Changes

- **`SignUpScreenContent.tsx`** — re-enable the previously commented-out `OfflineIndicator` inside the custom `SignUpScreenLayout`. These screens (`AuthScreen`, `InitialScreen`) pass `shouldShowOfflineIndicator={false}` to `ScreenWrapper` because they use a custom safe-area layout (`useStyledSafeAreaInsets` / `getSignUpSafeAreaPadding`), so the indicator has to live *inside* that layout to render within the sign-up safe area (not under the gesture bar). Aligned it with the welcome-text container (left on wide, centered on narrow). Renders nothing while online. Covers both the auth/login and initial screens since both go through this layout.
- **`AuthScreen.tsx`** — disable the submit button while offline (`isSubmitDisabled={!isOnline}`) so the disabled state is *visible* rather than a silent no-op. The existing `if (!isOnline || isLoading) return;` guard stays as the safety net.
- **`ForgotPasswordScreen.tsx`** — same gap: bail out of `onSubmit` when offline and disable its submit button. This screen uses the default `ScreenWrapper`, so it already shows the `OfflineIndicator`.

## Consistency note

`OfflineIndicator` reads `useNetwork().isOffline` (NETWORK Onyx key); `AuthScreen`'s submit guard keeps reading `useUserConnection().isOnline` (context value). Both are driven by the same `UserConnectionProvider` bridge, so they agree. `ForgotPasswordScreen` uses `useNetwork().isOffline` to match its own (ScreenWrapper-default) indicator.

## Copy

No new strings needed — the indicator reuses the existing `common.youAppearToBeOffline` key (already present in `en.ts` and mirrored in `cs_cz.ts`).

## Base branch

Opened against `feature/offline-non-blocking-ux` (#823), which is still **open / not merged**, since it introduces `OfflineIndicator`, the NetInfo→NETWORK bridge, and the `ScreenWrapper` wiring this builds on. Mirrors the earlier #1070 workflow. **Do not merge before #823.**

## Verification

- ✅ `prettier`, `lint-changed`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed` all pass.
- ⚠️ Visual/behavioral change — **on-device confirmation of indicator placement (within safe area, not under the gesture bar) and the disabled-button states is still pending.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)