### PR TITLE
fix(offline): home screen skeletons never finish loading offline (#1097)

### DIFF
--- a/__tests__/unit/getHomeContentState.test.ts
+++ b/__tests__/unit/getHomeContentState.test.ts
@@ -1,0 +1,54 @@
+import getHomeContentState from '@screens/getHomeContentState';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+
+const PREFS = {} as unknown as Preferences;
+const EMPTY_SESSIONS: DrinkingSessionList = {};
+// `getHomeContentState` only checks emptiness, so a single keyed entry is all a
+// "has sessions" fixture needs — its contents are irrelevant.
+const SOME_SESSIONS = {s1: {}} as unknown as DrinkingSessionList;
+
+describe('getHomeContentState', () => {
+  describe('unresolved snapshot (preferences or sessions still undefined)', () => {
+    test.each<
+      [string, Preferences | undefined, DrinkingSessionList | undefined]
+    >([
+      ['both undefined', undefined, undefined],
+      ['preferences resolved, sessions undefined', PREFS, undefined],
+      ['sessions resolved, preferences undefined', undefined, EMPTY_SESSIONS],
+    ])('online → loading (%s)', (_label, prefs, sessions) => {
+      expect(getHomeContentState(prefs, sessions, false)).toBe('loading');
+    });
+
+    test.each<
+      [string, Preferences | undefined, DrinkingSessionList | undefined]
+    >([
+      ['both undefined', undefined, undefined],
+      ['preferences resolved, sessions undefined', PREFS, undefined],
+      ['sessions resolved, preferences undefined', undefined, EMPTY_SESSIONS],
+    ])('offline → offlineUnavailable (%s)', (_label, prefs, sessions) => {
+      expect(getHomeContentState(prefs, sessions, true)).toBe(
+        'offlineUnavailable',
+      );
+    });
+  });
+
+  describe('resolved snapshot', () => {
+    test('empty sessions → empty (online)', () => {
+      expect(getHomeContentState(PREFS, EMPTY_SESSIONS, false)).toBe('empty');
+    });
+
+    test('empty sessions → empty even when offline (warm cache confirmed no sessions)', () => {
+      // Resolved-empty is authoritative regardless of network: a user the cache
+      // says has no sessions must see the welcome state, not the offline notice.
+      expect(getHomeContentState(PREFS, EMPTY_SESSIONS, true)).toBe('empty');
+    });
+
+    test('populated sessions → data (online)', () => {
+      expect(getHomeContentState(PREFS, SOME_SESSIONS, false)).toBe('data');
+    });
+
+    test('populated sessions → data when offline (warm cache)', () => {
+      expect(getHomeContentState(PREFS, SOME_SESSIONS, true)).toBe('data');
+    });
+  });
+});

--- a/__tests__/unit/useCurrentUserDrinkingSessions.test.ts
+++ b/__tests__/unit/useCurrentUserDrinkingSessions.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+import {renderHook} from '@testing-library/react-native';
+import {useOnyx} from 'react-native-onyx';
+import {useFirebase} from '@context/global/FirebaseContext';
+import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
+import type {DrinkingSessionList} from '@src/types/onyx';
+import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  useOnyx: jest.fn(),
+  default: {},
+}));
+
+jest.mock('@context/global/FirebaseContext', () => ({
+  useFirebase: jest.fn(),
+}));
+
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedUseFirebase = jest.mocked(useFirebase);
+
+const USER_ID = 'u1';
+
+function makeSessions(): DrinkingSessionList {
+  return {
+    s1: {
+      start_time: 1_700_000_000_000,
+      end_time: 1_700_000_900_000,
+      drinks: {1_700_000_000_000: {beer: 1}},
+    },
+  };
+}
+
+function setAuth(uid: string | undefined): void {
+  mockedUseFirebase.mockReturnValue({
+    auth: uid ? {currentUser: {uid}} : {currentUser: null},
+  } as unknown as ReturnType<typeof useFirebase>);
+}
+
+// The hook reads only the value (the entry's presence is the whole contract);
+// the status metadata is intentionally not consulted — see the hook's docblock.
+function setOnyx(value: UserDrinkingSessionsList | null | undefined): void {
+  mockedUseOnyx.mockReturnValue([value, {status: 'loaded'}] as ReturnType<
+    typeof useOnyx
+  >);
+}
+
+describe('useCurrentUserDrinkingSessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setAuth(USER_ID);
+  });
+
+  test('no signed-in user returns undefined', () => {
+    setAuth(undefined);
+    setOnyx({[USER_ID]: makeSessions()});
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('whole key null (post sign-out) returns undefined — entry not delivered', () => {
+    // `cleanupSession` does `Onyx.set(CACHED_DRINKING_SESSIONS, null)`. There's
+    // no entry for the user, so the snapshot is "not resolved" — HomeScreen,
+    // not this hook, decides loading-vs-offline from the network state.
+    setOnyx(null);
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('key present but no entry for any user returns undefined', () => {
+    setOnyx({});
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('an entry for another user only returns undefined for this user', () => {
+    setOnyx({otherUser: makeSessions()});
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('a null entry for this user (loaded, no sessions) returns {}', () => {
+    setOnyx({[USER_ID]: null} as unknown as UserDrinkingSessionsList);
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual({});
+  });
+
+  test('an empty-object entry (app/open seed for a no-session user) passes through as {}', () => {
+    setOnyx({[USER_ID]: {}});
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toEqual({});
+  });
+
+  test('a populated entry passes through unchanged', () => {
+    const sessions = makeSessions();
+    setOnyx({[USER_ID]: sessions});
+
+    const {result} = renderHook(() => useCurrentUserDrinkingSessions());
+
+    expect(result.current).toBe(sessions);
+  });
+
+  test('the null-entry empty result is a stable reference across renders', () => {
+    setOnyx({[USER_ID]: null} as unknown as UserDrinkingSessionsList);
+
+    const {result, rerender} = renderHook(() =>
+      useCurrentUserDrinkingSessions(),
+    );
+    const first = result.current;
+
+    rerender(undefined);
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/components/NoSessionsInfo.tsx
+++ b/src/components/NoSessionsInfo.tsx
@@ -9,12 +9,16 @@ type NoSessionsInfoProps = {
   /** The message to display to the user */
   message?: string;
 
-  /** The text to display on the button */
-  buttonText?: string;
+  /** The heading to display above the message */
+  title?: string;
 };
 
-/** A View shown on the home screen when the user has no drinking sessions yet */
-function NoSessionsInfo({message, buttonText}: NoSessionsInfoProps) {
+/**
+ * A centered hero View shown on the home screen for the no-content states:
+ * the default welcome ("no sessions yet"), or, with `title`/`message` overrides,
+ * the offline "can't load your sessions" notice.
+ */
+function NoSessionsInfo({message, title}: NoSessionsInfoProps) {
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
   const {translate} = useLocalize();
@@ -27,7 +31,7 @@ function NoSessionsInfo({message, buttonText}: NoSessionsInfoProps) {
           styles.loginHeroHeader,
           StyleUtils.getFontSizeStyle(variables.fontSizeSignInHeroXSmall),
         ]}>
-        {buttonText ?? translate('homeScreen.welcomeToKiroku')}
+        {title ?? translate('homeScreen.welcomeToKiroku')}
       </Text>
       <Text style={styles.textHomeScreenNoSessions}>
         {message ?? translate('homeScreen.startNewSessionByClickingPlus')}

--- a/src/hooks/useCurrentUserDrinkingSessions.ts
+++ b/src/hooks/useCurrentUserDrinkingSessions.ts
@@ -13,10 +13,17 @@ const EMPTY_SESSIONS: DrinkingSessionList = {};
  * session-write `onyxData` + Pusher / `/v1/updates` (kiroku-api), not a Firebase
  * listener.
  *
- * The cache stores `null` for "loaded, no sessions"; we surface that as an empty
- * object so consumers treat it as ready-but-empty (matching the old windowed
- * listener, which seeded `{}`), and `undefined` only while the cache is still
- * resolving.
+ * The entry is `undefined` precisely until `app/open` delivers it: kiroku-api
+ * *always* seeds `CACHED_DRINKING_SESSIONS = {[uid]: sessions ?? {}}` on open, so
+ * after open the entry is always present — real data, or `{}` for a user with no
+ * sessions. We surface a `null` entry as an empty object (consumers treat that as
+ * ready-but-empty), and `undefined` while the snapshot is still resolving.
+ *
+ * Note `undefined` does NOT distinguish "loading" from "loaded, but offline with
+ * no cached entry" (after sign-out, which sets the key to `null`, `app/open` can
+ * never run to seed it). That distinction needs the network state and so is made
+ * by the consumer (see `HomeScreen`'s `getHomeContentState`), not here — the hook
+ * reports only the raw cache truth.
  */
 function useCurrentUserDrinkingSessions(): DrinkingSessionList | undefined {
   const {auth} = useFirebase();

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1283,6 +1283,11 @@ export default {
     welcomeToKiroku: 'Vítejte v Kiroku!',
     startNewSessionByClickingPlus:
       'Spusťte novou relaci kliknutím na tlačítko plus v dolní části obrazovky',
+    offlineNoData: {
+      title: 'Jste offline',
+      message:
+        'Nepodařilo se nám načíst vaše relace. Připojte se a zobrazí se tady.',
+    },
     banners: {
       inSession: {
         label: 'Probíhá relace',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1279,6 +1279,11 @@ export default {
     welcomeToKiroku: 'Welcome to Kiroku!',
     startNewSessionByClickingPlus:
       'Start a new session by clicking the plus button at the bottom of your screen',
+    offlineNoData: {
+      title: "You're offline",
+      message:
+        "We couldn't load your sessions. Reconnect and they'll show up here.",
+    },
     banners: {
       inSession: {
         label: 'In session',

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -43,7 +43,9 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import Button from '@components/Button';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import NoSessionsInfo from '@components/NoSessionsInfo';
+import useNetwork from '@hooks/useNetwork';
 import HomeHeaderSkeleton from './HomeScreenSkeleton';
+import getHomeContentState from './getHomeContentState';
 
 type HomeScreenProps = StackScreenProps<
   BottomTabNavigatorParamList,
@@ -67,6 +69,7 @@ function HomeScreen({route}: HomeScreenProps) {
   const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
   const preferences = useCurrentUserPreferences();
   const drinkingSessionData = useCurrentUserDrinkingSessions();
+  const {isOffline} = useNetwork();
   const [localVisibleDate, setLocalVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),
   );
@@ -138,22 +141,25 @@ function HomeScreen({route}: HomeScreenProps) {
   }
 
   // Render the shell + skeletons immediately. Real components swap in for
-  // their skeletons as each piece of data resolves from Firebase. A
-  // brand-new user with no sessions gets a welcome/empty state instead of
-  // the calendar + stats.
-  const isPreferencesReady = !!preferences;
+  // their skeletons as each piece of data resolves. A brand-new user with no
+  // sessions gets a welcome/empty state instead of the calendar + stats.
   // Require `profile` (not just `userData`): a failed/incomplete ProvisionUser
   // can leave `userData` truthy while `profile` is still undefined. Gating the
   // header on the profile keeps it from rendering against profile-less data.
   const isUserDataReady = !!userData?.profile;
-  const isSessionsReady = drinkingSessionData !== undefined;
-  const showSkeletonContent = !isPreferencesReady || !isSessionsReady;
-  // `useCurrentUserDrinkingSessions` returns {} (truthy) for a user with no
-  // sessions, so check emptiness rather than truthiness.
-  const hasSessions = isSessionsReady && !isEmptyObject(drinkingSessionData);
+  // `preferences` / `drinkingSessionData` are undefined only until `app/open`
+  // delivers the snapshot (or a warm cache hydrates). While they're unresolved
+  // we show skeletons online, or an offline "can't load" notice when offline
+  // with nothing cached — never a false "no sessions" welcome. Once resolved,
+  // emptiness is authoritative (`app/open` always seeds the user's entry).
+  const contentState = getHomeContentState(
+    preferences,
+    drinkingSessionData,
+    isOffline,
+  );
 
   const renderMainContent = () => {
-    if (showSkeletonContent) {
+    if (contentState === 'loading') {
       return (
         <>
           <HomeBannerSkeleton />
@@ -162,8 +168,21 @@ function HomeScreen({route}: HomeScreenProps) {
         </>
       );
     }
-    if (!hasSessions) {
+    if (contentState === 'offlineUnavailable') {
+      return (
+        <NoSessionsInfo
+          title={translate('homeScreen.offlineNoData.title')}
+          message={translate('homeScreen.offlineNoData.message')}
+        />
+      );
+    }
+    if (contentState === 'empty') {
       return <NoSessionsInfo />;
+    }
+    // contentState === 'data' — both values are resolved; the guard re-narrows
+    // them for the type system (and is a harmless defensive fallback).
+    if (!preferences || drinkingSessionData === undefined) {
+      return null;
     }
     return (
       <>

--- a/src/screens/getHomeContentState.ts
+++ b/src/screens/getHomeContentState.ts
@@ -1,0 +1,41 @@
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+
+/**
+ * The four mutually-exclusive states of the HomeScreen main content.
+ *
+ * - `loading` — still waiting for `app/open` to deliver the initial snapshot,
+ *   and it can still arrive (we're online). Render skeletons.
+ * - `offlineUnavailable` — the snapshot hasn't resolved and can't: we're offline
+ *   with nothing cached for this user (e.g. after a sign-out, which nulls
+ *   `CACHED_DRINKING_SESSIONS`, while offline so `app/open` can't re-seed it).
+ *   Render a "reconnect to load" notice, never a false "no sessions" state.
+ * - `empty` — the snapshot resolved and the user genuinely has no sessions
+ *   (`app/open` always seeds `{[uid]: {}}` for them). Render the welcome state.
+ * - `data` — the snapshot resolved with sessions. Render the calendar + stats.
+ */
+type HomeContentState = 'loading' | 'offlineUnavailable' | 'empty' | 'data';
+
+/**
+ * Decide what the HomeScreen main content should render.
+ *
+ * `preferences` / `drinkingSessionData` are `undefined` only until `app/open`
+ * delivers them (or a warm cache hydrates from disk). When they haven't
+ * resolved, the network state disambiguates "still coming" (online → `loading`)
+ * from "can't come" (offline → `offlineUnavailable`). Once resolved, emptiness
+ * is authoritative because `app/open` always seeds the user's entry.
+ */
+function getHomeContentState(
+  preferences: Preferences | undefined,
+  drinkingSessionData: DrinkingSessionList | undefined,
+  isOffline: boolean,
+): HomeContentState {
+  const isReady = !!preferences && drinkingSessionData !== undefined;
+  if (!isReady) {
+    return isOffline ? 'offlineUnavailable' : 'loading';
+  }
+  return isEmptyObject(drinkingSessionData) ? 'empty' : 'data';
+}
+
+export default getHomeContentState;
+export type {HomeContentState};


### PR DESCRIPTION
## Summary

Fixes #1097. Stacked on #823 (`feature/offline-non-blocking-ux`), rebased onto its current head.

HomeScreen conflated **"data still loading"** with **"user has no sessions."** That single confusion produces both reported failures:
- Offline (or on a cold cache) the calendar/stats **skeletons spin forever** (#1097).
- Naively treating "loaded-but-empty" as ready flips it the other way and **flashes "Welcome to Kiroku" at users who do have data** — online (before `app/open` lands) and offline.

## Root cause (verified end-to-end)

The cache entry is `undefined` for exactly one reason: **`app/open` hasn't delivered it.** kiroku-api always seeds it on open (`src/routes/app/index.ts`):
```ts
// "Always seed the cache key … empty object when there are none."
set(ONYXKEYS.CACHED_DRINKING_SESSIONS, { [uid]: sessions ?? {} })
```
So after open the entry is **always present** — real data, or `{}` for a no-session user. `undefined` means "not delivered yet": online that resolves via `app/open`; offline (the key is nulled by sign-out, and `openApp` is queued with `IS_LOADING_APP` stuck `true`) it never does.

So the loading-vs-empty decision needs the **network state**, which the hook can't see. The fix moves the decision to the consumer and makes all four states explicit.

## The fix

A tested pure helper — `getHomeContentState(preferences, drinkingSessionData, isOffline)`:

| Snapshot | Network | Render |
|---|---|---|
| unresolved (`undefined`) | online | **loading** (skeletons) |
| unresolved (`undefined`) | offline | **offline notice** ("can't load, reconnect") |
| resolved, `{}` | any | **welcome** (genuinely no sessions) |
| resolved, has data | any | **calendar + stats** |

Result: "Welcome to Kiroku" shows **only** once we've confirmed zero sessions; a data-user offline gets a reconnect notice (mirroring `ProfileScreen`'s `offlineUnavailable` pattern, added in this same PR), never a false empty state; and the skeleton can no longer spin forever.

- **`useCurrentUserDrinkingSessions`** reverts to reporting raw cache truth (`undefined` until the entry exists). The previous attempt keyed it on Onyx's hydration `status`, which fired "ready" on disk-hydrate — *before* `app/open` — causing the welcome flash. That was the regression; this removes it.
- **`NoSessionsInfo`** gains a `title` prop (renamed from the misleading `buttonText`, used in one place) so the same hero renders the offline notice.
- New English copy `homeScreen.offlineNoData.{title,message}`; Czech filled via the `translate` skill (glossary register/voice).

## Tests

- `getHomeContentState` — all four states × online/offline (10 cases).
- `useCurrentUserDrinkingSessions` — the raw-truth contract (no-user, whole-key-null, no-entry, other-user-only, null entry, `{}` seed, populated, stable ref).

## Checklist

- ✅ `typecheck-tsgo` · `lint-changed` · `react-compiler-compliance-check check-changed`
- ✅ unit tests (helper, hook) + translation gates (`Translate`, `TranslationContext`)
- ⏳ on-device confirmation of the offline cold-start path

## Note

Offline + no cached data is a narrow edge (sign-out→sign-in offline, or the app killed before the first `app/open` finished) — it's the case that now shows the reconnect notice instead of a false welcome or an endless skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
