### PR TITLE
fix(friends): stop the "no friends" flash on first cold boot

### DIFF
--- a/__tests__/unit/getFriendListContentState.test.ts
+++ b/__tests__/unit/getFriendListContentState.test.ts
@@ -1,0 +1,48 @@
+import getFriendListContentState from '@screens/Social/getFriendListContentState';
+
+describe('getFriendListContentState', () => {
+  describe('unresolved list (no friends known yet, bootstrap not complete)', () => {
+    // `isLoadingApp` is `undefined` before the first openApp optimistic write
+    // and `true` while openApp is in flight — both mean "bootstrap not done".
+    test.each<[string, boolean | undefined]>([
+      ['isLoadingApp undefined', undefined],
+      ['isLoadingApp true', true],
+    ])('online → loading (%s)', (_label, isLoadingApp) => {
+      expect(getFriendListContentState(0, isLoadingApp, false)).toBe('loading');
+    });
+
+    test.each<[string, boolean | undefined]>([
+      ['isLoadingApp undefined', undefined],
+      ['isLoadingApp true', true],
+    ])('offline → offlineUnavailable (%s)', (_label, isLoadingApp) => {
+      expect(getFriendListContentState(0, isLoadingApp, true)).toBe(
+        'offlineUnavailable',
+      );
+    });
+  });
+
+  describe('resolved list (bootstrap complete)', () => {
+    test('no friends → empty (online)', () => {
+      expect(getFriendListContentState(0, false, false)).toBe('empty');
+    });
+
+    test('no friends → empty even when offline (warm cache confirmed none)', () => {
+      // Resolved-empty is authoritative regardless of network: a user the cache
+      // says has no friends sees the welcome state, not the offline notice.
+      expect(getFriendListContentState(0, false, true)).toBe('empty');
+    });
+  });
+
+  describe('has friends (data is authoritative regardless of bootstrap/network)', () => {
+    test.each<[string, boolean | undefined, boolean]>([
+      ['online, bootstrap done', false, false],
+      ['offline warm cache', false, true],
+      ['offline mid-bootstrap (cached)', true, true],
+      ['online mid-bootstrap (cached)', undefined, false],
+    ])('→ data (%s)', (_label, isLoadingApp, isOffline) => {
+      expect(getFriendListContentState(3, isLoadingApp, isOffline)).toBe(
+        'data',
+      );
+    });
+  });
+});

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -511,6 +511,11 @@ export default {
   friendListScreen: {
     searchYourFriendList: 'Prohledat seznam přátel',
     userList: 'List vašich přátel',
+    offlineNoData: {
+      title: 'Jste offline',
+      message:
+        'Nepodařilo se nám načíst vaše přátele. Připojte se a zobrazí se tady.',
+    },
   },
   friendAction: {
     error: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -509,6 +509,11 @@ export default {
   friendListScreen: {
     searchYourFriendList: 'Search your friend list',
     userList: 'The list of your friends',
+    offlineNoData: {
+      title: "You're offline",
+      message:
+        "We couldn't load your friends. Reconnect and they'll show up here.",
+    },
   },
   friendAction: {
     error: {

--- a/src/screens/Social/FriendListScreen.tsx
+++ b/src/screens/Social/FriendListScreen.tsx
@@ -11,15 +11,18 @@ import Text from '@components/Text';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import UserListComponent from '@components/Social/UserListComponent';
 import useFriendsData from '@hooks/useFriendsData';
+import useNetwork from '@hooks/useNetwork';
 import NoFriendInfo from '@components/Social/NoFriendInfo';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
+import getFriendListContentState from './getFriendListContentState';
 
 function FriendListScreen() {
   const userData = useCurrentUserData();
   const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
+  const {isOffline} = useNetwork();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const [friends, setFriends] = useState<UserArray>([]);
@@ -59,7 +62,38 @@ function FriendListScreen() {
     setFriendsToDisplay(friends);
   };
 
+  // On a cold boot `userData.friends` is briefly undefined until the `app/open`
+  // bootstrap hydrates the friend list, and `objKeys(undefined)` collapses to
+  // `[]`. Without this, the empty state would render before the list arrives.
+  // `contentState` disambiguates an empty list: still loading (online) vs.
+  // can't-load-yet (offline, nothing cached) vs. genuinely empty (bootstrap
+  // done). This mirrors HomeScreen's `getHomeContentState`. `isLoadingApp` is
+  // the same bootstrap-complete signal the onboarding/terms guards gate on.
+  const contentState = getFriendListContentState(
+    friends.length,
+    isLoadingApp,
+    isOffline,
+  );
+
   const emptyListComponent = useMemo(() => {
+    if (contentState === 'offlineUnavailable') {
+      return (
+        <View style={[styles.fullScreenCenteredContent, styles.ph5]}>
+          <Text style={[styles.textHeadlineH1, styles.textAlignCenter]}>
+            {translate('friendListScreen.offlineNoData.title')}
+          </Text>
+          <Text
+            style={[
+              styles.textNormal,
+              styles.textSupporting,
+              styles.textAlignCenter,
+              styles.mt2,
+            ]}>
+            {translate('friendListScreen.offlineNoData.message')}
+          </Text>
+        </View>
+      );
+    }
     if (!userHasFriends) {
       return <NoFriendInfo />;
     }
@@ -68,7 +102,19 @@ function FriendListScreen() {
         {`${translate('userList.noFriendsFound')}\n\n${translate('userList.tryModifyingSearch')}`}
       </Text>
     );
-  }, [userHasFriends, styles.noResultsText, translate]);
+  }, [
+    contentState,
+    userHasFriends,
+    styles.fullScreenCenteredContent,
+    styles.ph5,
+    styles.textHeadlineH1,
+    styles.textAlignCenter,
+    styles.textNormal,
+    styles.textSupporting,
+    styles.mt2,
+    styles.noResultsText,
+    translate,
+  ]);
 
   useEffect(() => {
     const friendsArray = objKeys(userData?.friends);
@@ -76,16 +122,6 @@ function FriendListScreen() {
     setFriendsToDisplay(friendsArray);
     setUserHasFriends(friendsArray.length > 0);
   }, [userData]);
-
-  // On a cold boot `userData.friends` is briefly undefined until the `app/open`
-  // bootstrap hydrates the friend list. Without this gate, `objKeys(undefined)`
-  // collapses to `[]` and the "no friends" empty state flashes before the list
-  // arrives (it then self-corrects, and a reload paints instantly from the
-  // persisted Onyx cache, so the flash is first-launch-only). Keep the list in
-  // its loading state until the bootstrap completes (`isLoadingApp === false`,
-  // the same bootstrap-complete signal the onboarding/terms guards gate on) or
-  // we already have friends to show.
-  const isInitialFriendsLoad = isLoadingApp !== false && friends.length === 0;
 
   return (
     <View style={styles.flex1}>
@@ -103,7 +139,9 @@ function FriendListScreen() {
         emptyListComponent={emptyListComponent}
         userSubset={friendsToDisplay}
         orderUsers
-        isLoading={isLoadingFriends || isSearching || isInitialFriendsLoad}
+        isLoading={
+          isLoadingFriends || isSearching || contentState === 'loading'
+        }
       />
     </View>
   );

--- a/src/screens/Social/FriendListScreen.tsx
+++ b/src/screens/Social/FriendListScreen.tsx
@@ -1,4 +1,5 @@
 import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
 import SearchWindow from '@components/Social/SearchWindow';
 import type {UserIDToNicknameMapping} from '@src/types/various/Search';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -13,10 +14,12 @@ import useFriendsData from '@hooks/useFriendsData';
 import NoFriendInfo from '@components/Social/NoFriendInfo';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
 
 function FriendListScreen() {
   const userData = useCurrentUserData();
+  const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const [friends, setFriends] = useState<UserArray>([]);
@@ -74,6 +77,16 @@ function FriendListScreen() {
     setUserHasFriends(friendsArray.length > 0);
   }, [userData]);
 
+  // On a cold boot `userData.friends` is briefly undefined until the `app/open`
+  // bootstrap hydrates the friend list. Without this gate, `objKeys(undefined)`
+  // collapses to `[]` and the "no friends" empty state flashes before the list
+  // arrives (it then self-corrects, and a reload paints instantly from the
+  // persisted Onyx cache, so the flash is first-launch-only). Keep the list in
+  // its loading state until the bootstrap completes (`isLoadingApp === false`,
+  // the same bootstrap-complete signal the onboarding/terms guards gate on) or
+  // we already have friends to show.
+  const isInitialFriendsLoad = isLoadingApp !== false && friends.length === 0;
+
   return (
     <View style={styles.flex1}>
       <SearchWindow
@@ -90,7 +103,7 @@ function FriendListScreen() {
         emptyListComponent={emptyListComponent}
         userSubset={friendsToDisplay}
         orderUsers
-        isLoading={isLoadingFriends || isSearching}
+        isLoading={isLoadingFriends || isSearching || isInitialFriendsLoad}
       />
     </View>
   );

--- a/src/screens/Social/getFriendListContentState.ts
+++ b/src/screens/Social/getFriendListContentState.ts
@@ -1,0 +1,53 @@
+/**
+ * The four mutually-exclusive states of the FriendListScreen list area.
+ *
+ * - `loading` — `app/open` hasn't delivered the friend list yet and it can still
+ *   arrive (we're online). Render the spinner.
+ * - `offlineUnavailable` — the friend list hasn't resolved and can't: we're
+ *   offline with nothing cached for this user (e.g. a first launch that never
+ *   reached the network). Render a "reconnect to load" notice, never a false
+ *   "no friends" state — the user may well have friends we simply haven't
+ *   fetched.
+ * - `empty` — the bootstrap completed and the user genuinely has no friends.
+ *   Render the welcome/empty state with the "add friends" CTA.
+ * - `data` — there are friends to render (including a warm cache while offline).
+ */
+type FriendListContentState =
+  | 'loading'
+  | 'offlineUnavailable'
+  | 'empty'
+  | 'data';
+
+/**
+ * Decide what the FriendListScreen list area should render.
+ *
+ * `app/open` is the only thing that hydrates the signed-in user's friend list,
+ * and it flips `IS_LOADING_APP` to `false` in its `finallyData` once it
+ * resolves. Until then an empty list is indistinguishable from "not loaded", so
+ * the network state disambiguates "still coming" (online → `loading`) from
+ * "can't come" (offline → `offlineUnavailable`). A non-empty list is
+ * authoritative regardless of network — a warm cache paints instantly, even
+ * offline.
+ *
+ * @param friendCount Number of friends currently known (from the hydrated list).
+ * @param isLoadingApp The `IS_LOADING_APP` bootstrap flag. `undefined` until the
+ *   first `openApp` optimistic write lands; only `false` means "bootstrap done".
+ * @param isOffline Whether the device is offline (`useNetwork`).
+ */
+function getFriendListContentState(
+  friendCount: number,
+  isLoadingApp: boolean | undefined,
+  isOffline: boolean,
+): FriendListContentState {
+  if (friendCount > 0) {
+    return 'data';
+  }
+  const isBootstrapComplete = isLoadingApp === false;
+  if (!isBootstrapComplete) {
+    return isOffline ? 'offlineUnavailable' : 'loading';
+  }
+  return 'empty';
+}
+
+export default getFriendListContentState;
+export type {FriendListContentState};


### PR DESCRIPTION
## Problem

On the **first cold launch** of the app (online), the Friends list briefly shows the **"no friends" empty state**, then self-corrects. After one reload it paints instantly from the persisted Onyx cache and never recurs. Classic boot-time hydration race.

A related gap: a user who **has friends but has never synced online** (offline first launch, nothing cached) got no indication *why* the list was empty — just a bare/indefinite loading state, unlike Home/Profile which show an explicit offline notice.

## Root cause

`FriendListScreen` derived `userHasFriends` from `objKeys(userData?.friends)`. On cold boot `userData.friends` is `undefined` until `App.openApp()` (fire-and-forget in `AuthScreens`) hydrates `USER_DATA_LIST[uid].friends`. `objKeys(undefined)` collapses to `[]`, so `userHasFriends` is `false` and `NoFriendInfo` renders before the list arrives.

`useFriendsData`'s existing `isLoading` does **not** cover this — it gates on already *knowing* the friend IDs (`friendIDs.length > 0 && !hasCachedData && !hasResolvedInitial`), so it's `false` while the friend-ID list itself is still unloaded.

## Fix

Extract `getFriendListContentState` (mirrors the established `getHomeContentState`), returning `'loading' | 'offlineUnavailable' | 'empty' | 'data'`:

```ts
function getFriendListContentState(friendCount, isLoadingApp, isOffline) {
  if (friendCount > 0) return 'data';                  // cached list is authoritative (even offline)
  const isBootstrapComplete = isLoadingApp === false;  // app/open's finallyData
  if (!isBootstrapComplete) return isOffline ? 'offlineUnavailable' : 'loading';
  return 'empty';                                       // bootstrap done, genuinely no friends
}
```

`FriendListScreen` then:
- shows the **spinner** while `contentState === 'loading'` (online bootstrap), masking the old empty-state flash,
- shows an explicit **"you're offline, reconnect to load your friends"** message while `contentState === 'offlineUnavailable'` (plain title+message, no "add friends" CTA since we don't actually know the user's friends),
- shows `NoFriendInfo` only once `contentState === 'empty'` (bootstrap complete, list authoritative),
- renders the list for `'data'` — a warm cache paints instantly even offline.

`isLoadingApp` is the same bootstrap-complete signal the onboarding (`useOnboardingFlow`) and terms (`TermsReConsentGuard`) guards already use; `isOffline` comes from `useNetwork()`, matching Home/Profile.

## Behavior

| Scenario | Before | After |
|---|---|---|
| First cold boot, online, has friends | "no friends" flash → list | spinner → list |
| First cold boot, online, no friends | "no friends" (indistinguishable from loading) | spinner → "no friends" once `app/open` done |
| Returning user (cached) | list | list (no spinner, even offline) |
| Offline, never synced, **has friends** | bare/indefinite empty, no explanation | **"you're offline, reconnect" message** |
| Offline, confirmed no friends (warm cache) | "no friends" | "no friends" (authoritative) |
| Offline → reconnect | — | queued `app/open` replays → resolves to list / `NoFriendInfo` |

## Tests
- `__tests__/unit/getFriendListContentState.test.ts` — full state-matrix coverage (mirrors `getHomeContentState.test.ts`).
- ✅ `Translate.test.ts` parity · `typecheck-tsgo` · React Compiler · Prettier — all green. Lint via CI.
- English keys added to `en.ts`; `cs_cz` filled via the `translate` skill (mirrors home's `offlineNoData`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)