### PR TITLE
fix(offline): resolve unloaded-snapshot states for sessions and friends

### DIFF
--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -10,13 +10,14 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {View} from 'react-native';
+import {Alert, View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import * as App from '@userActions/App';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useLocalize from '@hooks/useLocalize';
 import usePrevious from '@hooks/usePrevious';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -66,8 +67,25 @@ function StartSessionButtonAndPopover(
   const {translate} = useLocalize();
   const user = auth.currentUser;
   const userData = useCurrentUserData();
+  const drinkingSessionData = useCurrentUserDrinkingSessions();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
   const [startSession] = useOnyx(ONYXKEYS.START_SESSION_GLOBAL_CREATE);
+  // The user's session snapshot is `undefined` until `app/open` delivers it (or
+  // a warm cache hydrates from disk). Creating a session before then would write
+  // onto a never-loaded base: the home "couldn't load" notice flips into a
+  // misleading one-session calendar, and the server snapshot discards the local
+  // session on reconnect. Gate new-session creation until the snapshot resolves.
+  // `{}` (resolved-empty, e.g. a brand-new user) is allowed; only `undefined` is
+  // blocked. This is the snapshot itself, NOT `IS_LOADING_APP`, so an
+  // offline-with-warm-cache user can still log sessions.
+  const isSessionDataLoaded = drinkingSessionData !== undefined;
+
+  const showSessionsUnavailableAlert = (): void => {
+    Alert.alert(
+      translate('startSession.unavailableTitle'),
+      translate('startSession.unavailableMessage'),
+    );
+  };
   const [isCreateMenuActive, setIsCreateMenuActive] = useState(false);
   const fabRef = useRef<HTMLDivElement>(null);
   const {windowHeight} = useWindowDimensions();
@@ -77,8 +95,15 @@ function StartSessionButtonAndPopover(
 
   const startLiveDrinkingSession = async (): Promise<void> => {
     try {
+      const isStartingNewSession = !ongoingSessionData?.ongoing;
+      // Resuming an already-ongoing session is always allowed; only starting a
+      // brand-new one requires the snapshot to have loaded.
+      if (isStartingNewSession && !isSessionDataLoaded) {
+        showSessionsUnavailableAlert();
+        return;
+      }
       await App.setLoadingText(translate('liveSessionScreen.loading'));
-      if (!ongoingSessionData?.ongoing) {
+      if (isStartingNewSession) {
         await DS.startLiveDrinkingSession(user, userData?.timezone?.selected);
       }
       DS.navigateToOngoingSessionScreen();
@@ -88,6 +113,10 @@ function StartSessionButtonAndPopover(
   };
 
   const createEditDrinkingSession = async (): Promise<void> => {
+    if (!isSessionDataLoaded) {
+      showSessionsUnavailableAlert();
+      return;
+    }
     try {
       await App.setLoadingText(translate('common.loading'));
       await DS.setIsCreatingNewSession(true);

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -855,6 +855,9 @@ export default {
     newSessionExplained: 'Spustit relaci (plovoucí tlačítko)',
     sessionFrom: ({startTime}: SessionStartTimeParams) =>
       `Relace od ${startTime}`,
+    unavailableTitle: 'Relace se nenačetly',
+    unavailableMessage:
+      'Nepodařilo se načíst vaše relace. Připojte se k internetu a zkuste to znovu.',
   },
   userNameScreen: {
     headerTitle: 'Uživatelské jméno',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -511,6 +511,8 @@ export default {
   friendListScreen: {
     searchYourFriendList: 'Prohledat seznam přátel',
     userList: 'List vašich přátel',
+    offlineNoData:
+      'Jste offline. Nepodařilo se načíst vaše přátele. Připojte se a zobrazí se zde.',
   },
   friendAction: {
     error: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -850,6 +850,9 @@ export default {
     newSessionExplained: 'Start a session (Floating action)',
     sessionFrom: ({startTime}: SessionStartTimeParams) =>
       `A session from ${startTime}`,
+    unavailableTitle: 'Sessions not loaded',
+    unavailableMessage:
+      'We could not load your sessions. Reconnect to the internet, then try again.',
   },
   userNameScreen: {
     headerTitle: 'User name',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -509,6 +509,8 @@ export default {
   friendListScreen: {
     searchYourFriendList: 'Search your friend list',
     userList: 'The list of your friends',
+    offlineNoData:
+      "You're offline. We couldn't load your friends. Reconnect and they'll show up here.",
   },
   friendAction: {
     error: {

--- a/src/screens/Social/FriendListScreen.tsx
+++ b/src/screens/Social/FriendListScreen.tsx
@@ -1,4 +1,5 @@
 import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
 import SearchWindow from '@components/Social/SearchWindow';
 import type {UserIDToNicknameMapping} from '@src/types/various/Search';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -13,12 +14,16 @@ import useFriendsData from '@hooks/useFriendsData';
 import NoFriendInfo from '@components/Social/NoFriendInfo';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useNetwork from '@hooks/useNetwork';
+import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
 
 function FriendListScreen() {
   const userData = useCurrentUserData();
   const {translate} = useLocalize();
   const styles = useThemeStyles();
+  const {isOffline} = useNetwork();
+  const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
   const [friends, setFriends] = useState<UserArray>([]);
   const [friendsToDisplay, setFriendsToDisplay] = useState<UserArray>([]);
   const [userHasFriends, setUserHasFriends] = useState<boolean>(false);
@@ -28,6 +33,17 @@ function FriendListScreen() {
     isLoading: isLoadingFriends,
   } = useFriendsData(friends);
   const [isSearching, setIsSearching] = useState<boolean>(false);
+
+  // `friends` is empty until app/open delivers the friend list (or a warm cache
+  // hydrates). `IS_LOADING_APP === false` marks that bootstrap as settled, but it
+  // only flips in app/open's finallyData, which is deferred while offline, so it
+  // stays `true` offline. Online with nothing yet: keep the list loading so the
+  // first-boot "no friends" flash never shows. Offline with nothing cached:
+  // bootstrap can't settle, so show an offline notice rather than spinning
+  // forever or falsely claiming the user has no friends.
+  const isBootstrapPending = isLoadingApp !== false && friends.length === 0;
+  const isInitialFriendsLoad = isBootstrapPending && !isOffline;
+  const isFriendsUnavailableOffline = isBootstrapPending && isOffline;
 
   const localSearch = useCallback(
     (searchText: string): void => {
@@ -57,6 +73,13 @@ function FriendListScreen() {
   };
 
   const emptyListComponent = useMemo(() => {
+    if (isFriendsUnavailableOffline) {
+      return (
+        <Text style={styles.noResultsText}>
+          {translate('friendListScreen.offlineNoData')}
+        </Text>
+      );
+    }
     if (!userHasFriends) {
       return <NoFriendInfo />;
     }
@@ -65,7 +88,12 @@ function FriendListScreen() {
         {`${translate('userList.noFriendsFound')}\n\n${translate('userList.tryModifyingSearch')}`}
       </Text>
     );
-  }, [userHasFriends, styles.noResultsText, translate]);
+  }, [
+    isFriendsUnavailableOffline,
+    userHasFriends,
+    styles.noResultsText,
+    translate,
+  ]);
 
   useEffect(() => {
     const friendsArray = objKeys(userData?.friends);
@@ -90,7 +118,7 @@ function FriendListScreen() {
         emptyListComponent={emptyListComponent}
         userSubset={friendsToDisplay}
         orderUsers
-        isLoading={isLoadingFriends || isSearching}
+        isLoading={isLoadingFriends || isSearching || isInitialFriendsLoad}
       />
     </View>
   );


### PR DESCRIPTION
Follow-up to the offline epic (#823). Two screens render a broken state when their data snapshot **couldn't be loaded** (offline with nothing cached, e.g. signed out while offline, or a cold start offline). Both stem from the same root cause and are fixed together.

## 1. Sessions — block creation until the snapshot has loaded

When `CACHED_DRINKING_SESSIONS[uid]` is `undefined` and the user is offline, Home correctly shows a "couldn't load / reconnect" notice (`getHomeContentState` → `offlineUnavailable`). But the start-session FAB stayed active, so the user could still create a session — which was harmful:

- **Misleading UI:** the optimistic merge (`cachedSessionPatch`) flips the cache from `undefined` to `{oneSession}`; `getHomeContentState` keys "ready" on `!== undefined`, so it re-reads as `data` and renders a calendar showing **only the new session**, hiding the unloaded ones and the notice.
- **Data loss:** on reconnect, `app/open` re-seeds the snapshot with server truth, **discarding** the local-only session.

**Fix:** gate new-session creation (live + edit) in `StartSessionButtonAndPopover` on `useCurrentUserDrinkingSessions() !== undefined`. Resolved-empty (`{}`, a brand-new user) is allowed; only the unresolved `undefined` base is blocked, with a clear "reconnect, then try again" alert. Resuming an ongoing session is unaffected.

## 2. Friends — resolve the list offline instead of spinning or lying

The friend list derives its loaded state from `IS_LOADING_APP`, which only flips to `false` in `app/open`'s `finallyData`. That request is **deferred while offline**, so the flag stays `true` offline. A user offline with nothing cached can't resolve the list:
- gating the spinner on `IS_LOADING_APP !== false` alone (as #1104 does) → **spins forever offline**;
- not gating it → falls through to a **false "no friends"** empty state.

**Fix:** `FriendListScreen` now has three states — keep loading only while a real load can still arrive (online bootstrap, which fixes the first-boot "no friends" flash); show an offline "couldn't load your friends, reconnect" notice when offline with nothing cached; resolve normally otherwise. A warm cache renders immediately regardless of network. **This supersedes #1104** (which fixed only the online flash and would have introduced the offline spinner) — #1104 can be closed.

### Why gate on the snapshot, not `IS_LOADING_APP`, for sessions

`IS_LOADING_APP` stays `true` while offline (the `app/open` write is deferred), so gating *creation* on it would block an offline-with-warm-cache user from logging sessions — exactly the offline-first behaviour the epic added. The snapshot itself (`!== undefined`) is the precise "is the base loaded?" signal. (The friend list does use `IS_LOADING_APP`, but only as the *spinner* signal, paired with an explicit offline branch so it never hangs.)

## Testing

`prettier`, `lint-changed`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed`, and the `TranslationContext` unit test all pass. New `en`/`cs_cz` keys mirror. On-device confirmation pending — repro for each: sign out while offline (or cold-start offline with no cache), then (1) tap + on Home → reconnect alert instead of a phantom session; (2) open the Friends tab → offline notice instead of a spinner or false "no friends".

🤖 Generated with [Claude Code](https://claude.com/claude-code)