### PR TITLE
fix(home): unify the last-session and this-month tile headings

### DIFF
--- a/src/components/Info/HomeBanner.tsx
+++ b/src/components/Info/HomeBanner.tsx
@@ -50,7 +50,7 @@ function HomeBanner({
       onPress={onPress}
       style={[
         styles.mt2,
-        styles.p4,
+        styles.p3,
         styles.flexRow,
         styles.alignItemsCenter,
         styles.justifyContentBetween,
@@ -75,7 +75,9 @@ function HomeBanner({
           <Text
             style={[
               styles.textLabelSupporting,
-              isActive && [styles.textStrong, {color: theme.danger}],
+              styles.textStrong,
+              styles.mb1,
+              isActive && {color: theme.danger},
             ]}
             numberOfLines={1}>
             {label}
@@ -105,7 +107,7 @@ function HomeBannerSkeleton() {
   const styles = useThemeStyles();
   return (
     <View style={styles.mt2}>
-      <Skeleton height={68} radius={12} />
+      <Skeleton height={64} radius={12} />
     </View>
   );
 }


### PR DESCRIPTION
## What

The two top tiles on the Home screen drew their headings inconsistently:

| | Font | Corner inset | Heading → body gap |
|---|---|---|---|
| **Last session** (`HomeBanner`) | regular weight | `p4` (16px) | none |
| **This month** (`MonthlyOverviewCard`) | bold (`textStrong`) | `p3` (12px) | `mb1` (4px) |

This unifies the **Last session** heading to the **This month** treatment (the reference):

- **Font:** heading is now bold (`textStrong`), matching "This month". The active/in-session state keeps the danger accent, now just recoloring the already-bold label.
- **Spacing relative to the card's top-left corner:** card padding `p4` → `p3` (16px → 12px), so the heading sits the same distance from the corner as "This month".
- **Vertical gap between heading and the line below:** added `mb1` (4px) under the heading. Previously the "Last session" heading and its detail line had no gap; this matches the "This month" heading-to-Units spacing. Both tiles now share the same heading→body gap.
- Skeleton height nudged `68` → `64` to track the slightly shorter footprint (−8px padding, +4px gap).

Only `MonthlyOverviewCard` was the reference and is unchanged; all edits are in `HomeBanner`, which is also reused by the in-session banner.

## Notes on the unify-to spacing
Per the request, both tiles are unified to the existing "This month vs. Units" gap (`mb1` = 4px) first. If you want it a touch larger across both, bumping the heading to `mb2` (8px) in both components is a one-line follow-up.

## Checks
- `prettier` ✅ (unchanged)
- `typecheck-tsgo` ✅
- `react-compiler-compliance-check check-changed` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)