### PR TITLE
feat(web): web siblings for native-only modules (#930)

### DIFF
--- a/src/components/UploadImage.web.tsx
+++ b/src/components/UploadImage.web.tsx
@@ -1,0 +1,223 @@
+import React, {useEffect, useState} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import {Alert, View} from 'react-native';
+import type IconAsset from '@src/types/utils/IconAsset';
+import * as ErrorUtils from '@libs/ErrorUtils';
+import {uploadImage} from '@userActions/Image';
+import ERRORS from '@src/ERRORS';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+import UploadImagePopup from './Popups/UploadImagePopup';
+import Button from './Button';
+
+const OUTPUT_WIDTH = 300;
+const JPEG_QUALITY = 0.8;
+
+type UploadImageComponentProps = {
+  src: IconAsset;
+  isProfilePicture: boolean;
+  containerStyles?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Web sibling of UploadImage. Native picks through expo-image-picker and crops
+ * with expo-image-manipulator behind OS permission prompts; neither module
+ * exists on web. Here we pick via a `<input type="file">` and crop/resize on a
+ * `<canvas>` to the same target ratio (1:1 for profile, 3:4 otherwise) and width
+ * (300px JPEG). The result is fed into the same kiroku-api upload pipeline
+ * (`uploadImage`), so the upload/finalize flow is byte-for-byte identical to
+ * native from `uploadImage` onward.
+ */
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Failed to read selected file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function decodeImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Failed to decode selected image'));
+    image.src = dataUrl;
+  });
+}
+
+/**
+ * Center-crop to the target aspect ratio, then resize to OUTPUT_WIDTH (height
+ * derived proportionally), and encode as a JPEG object URL. Mirrors the native
+ * crop-then-resize math so the output is never stretched.
+ */
+async function processImage(
+  file: File,
+  isProfilePicture: boolean,
+): Promise<string> {
+  const dataUrl = await readFileAsDataURL(file);
+  const image = await decodeImage(dataUrl);
+
+  const srcWidth = image.naturalWidth;
+  const srcHeight = image.naturalHeight;
+  const [ratioW, ratioH] = isProfilePicture ? [1, 1] : [3, 4];
+  const targetRatio = ratioW / ratioH;
+  const srcRatio = srcWidth / srcHeight;
+
+  let originX = 0;
+  let originY = 0;
+  let cropWidth = srcWidth;
+  let cropHeight = srcHeight;
+
+  if (srcRatio > targetRatio) {
+    cropWidth = Math.round(srcHeight * targetRatio);
+    originX = Math.round((srcWidth - cropWidth) / 2);
+  } else if (srcRatio < targetRatio) {
+    cropHeight = Math.round(srcWidth / targetRatio);
+    originY = Math.round((srcHeight - cropHeight) / 2);
+  }
+
+  const outputHeight = Math.max(
+    1,
+    Math.round((cropHeight / cropWidth) * OUTPUT_WIDTH),
+  );
+
+  const canvas = document.createElement('canvas');
+  canvas.width = OUTPUT_WIDTH;
+  canvas.height = outputHeight;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas 2D context is unavailable');
+  }
+  context.drawImage(
+    image,
+    originX,
+    originY,
+    cropWidth,
+    cropHeight,
+    0,
+    0,
+    OUTPUT_WIDTH,
+    outputHeight,
+  );
+
+  const blob = await new Promise<Blob | null>(resolve => {
+    canvas.toBlob(resolve, 'image/jpeg', JPEG_QUALITY);
+  });
+  if (!blob) {
+    throw new Error('Failed to encode resized image');
+  }
+  return URL.createObjectURL(blob);
+}
+
+function UploadImageComponent({
+  src,
+  isProfilePicture = false,
+  containerStyles,
+}: UploadImageComponentProps) {
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const {isOffline} = useNetwork();
+  const [imageSource, setImageSource] = useState<string | null>(null);
+  const [uploadModalVisible, setUploadModalVisible] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<string | null>(null);
+  const [uploadOngoing, setUploadOngoing] = useState(false);
+
+  const resetIndicators = () => {
+    setUploadOngoing(false);
+    setUploadProgress(null);
+  };
+
+  const chooseImage = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    // No `change` event fires when the user cancels the native file dialog, so
+    // a cancellation is simply a silent no-op (no upload is triggered).
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        return;
+      }
+      processImage(file, isProfilePicture)
+        .then(uri => setImageSource(uri)) // Triggers upload
+        .catch(error =>
+          ErrorUtils.raiseAppError(ERRORS.IMAGE_UPLOAD.CHOICE_FAILED, error),
+        );
+    };
+    input.click();
+  };
+
+  const handleChooseImagePress = () => {
+    // The image upload goes straight to the bucket, which the offline request
+    // queue can't defer or replay. Guard up front rather than letting the user
+    // pick an image and watch the upload fail.
+    if (isOffline) {
+      Alert.alert(
+        translate('common.youAppearToBeOffline'),
+        translate('common.thisFeatureRequiresInternet'),
+      );
+      return;
+    }
+    // No OS permission step on web — the file picker prompts the user itself.
+    resetIndicators();
+    chooseImage();
+  };
+
+  useEffect(() => {
+    const handleUpload = async (sourceURI: string | null) => {
+      if (!sourceURI) {
+        return;
+      }
+
+      setUploadModalVisible(true);
+      setUploadOngoing(true);
+      try {
+        await uploadImage('avatar', sourceURI, setUploadProgress);
+      } catch (error) {
+        setImageSource(null);
+        ErrorUtils.raiseAppError(ERRORS.IMAGE_UPLOAD.UPLOAD_FAILED, error);
+        setUploadModalVisible(false);
+      }
+      setUploadOngoing(false);
+      // The object URL was only needed to read the bytes for the upload;
+      // release it once the upload settles (success or error) to avoid leaking
+      // blobs. A `finally` block would do this more tidily, but the React
+      // Compiler can't yet lower try/finally, so we fall through instead.
+      if (sourceURI.startsWith('blob:')) {
+        URL.revokeObjectURL(sourceURI);
+      }
+    };
+
+    handleUpload(imageSource);
+  }, [imageSource]);
+
+  return (
+    <View
+      style={[
+        styles.alignItemsCenter,
+        styles.justifyContentCenter,
+        containerStyles,
+      ]}>
+      <Button
+        onPress={handleChooseImagePress}
+        icon={src}
+        style={[styles.border, styles.borderRadiusNormal, styles.appBG]}
+      />
+
+      {imageSource && (
+        <UploadImagePopup
+          visible={uploadModalVisible}
+          onRequestClose={() => setUploadModalVisible(false)}
+          uploadProgress={uploadProgress}
+          uploadOngoing={uploadOngoing}
+          onUploadFinish={() => setUploadOngoing(false)}
+        />
+      )}
+    </View>
+  );
+}
+
+export default UploadImageComponent;

--- a/src/libs/Permissions/checkPermission.web.ts
+++ b/src/libs/Permissions/checkPermission.web.ts
@@ -1,0 +1,45 @@
+import type {PermissionKey} from './types';
+
+/**
+ * Web sibling of checkPermission. react-native-permissions has no web build, so
+ * we answer from the browser's own permission surfaces instead:
+ *  - location → the Permissions API (`navigator.permissions`) when available.
+ *  - notifications → the Notification API's current grant.
+ *  - photo/camera reads → always granted: the web pickers (`<input type=file>`,
+ *    getUserMedia) drive their own prompts at use time, so there is nothing to
+ *    pre-check.
+ *
+ * Never rejects; an unsupported API resolves to false. Because nothing here
+ * imports react-native-permissions, the web bundle drops the native module
+ * entirely.
+ */
+async function checkPermission(
+  permissionType: PermissionKey,
+): Promise<boolean> {
+  if (permissionType === 'location') {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.permissions?.query) {
+        const status = await navigator.permissions.query({
+          name: 'geolocation',
+        });
+        return status.state === 'granted';
+      }
+    } catch {
+      // Permissions API unsupported or threw — treat as not granted.
+    }
+    return false;
+  }
+
+  if (permissionType === 'notifications') {
+    return (
+      typeof Notification !== 'undefined' &&
+      Notification.permission === 'granted'
+    );
+  }
+
+  // read_photos / write_photos / camera: the browser prompts inline when the
+  // picker is opened, so there is no separate grant to verify here.
+  return true;
+}
+
+export default checkPermission;

--- a/src/libs/Permissions/requestPermission.web.ts
+++ b/src/libs/Permissions/requestPermission.web.ts
@@ -1,0 +1,53 @@
+import type {PermissionKey} from './types';
+
+const LOCATION_REQUEST_TIMEOUT_MS = 10000;
+
+/**
+ * Trigger the browser's geolocation prompt and resolve to whether access was
+ * granted. A successful fix means granted; an error (including the user denying
+ * the prompt) means not granted.
+ */
+function requestLocationPermission(): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) {
+    return Promise.resolve(false);
+  }
+  return new Promise<boolean>(resolve => {
+    navigator.geolocation.getCurrentPosition(
+      () => resolve(true),
+      () => resolve(false),
+      {timeout: LOCATION_REQUEST_TIMEOUT_MS, maximumAge: 0},
+    );
+  });
+}
+
+/**
+ * Web sibling of requestPermission. react-native-permissions has no web build,
+ * so we trigger the matching browser prompt and resolve to whether access was
+ * granted:
+ *  - location → navigator.geolocation (browser shows the prompt).
+ *  - notifications → Notification.requestPermission().
+ *  - photo/camera reads → true: the web pickers prompt at use time, so an
+ *    explicit request step is a no-op grant here.
+ *
+ * Never rejects. Unlike the native sibling it shows no fallback Alert: the
+ * browser surfaces its own denial UI.
+ */
+async function requestPermission(
+  permissionType: PermissionKey,
+): Promise<boolean> {
+  if (permissionType === 'location') {
+    return requestLocationPermission();
+  }
+
+  if (permissionType === 'notifications') {
+    if (typeof Notification === 'undefined') {
+      return false;
+    }
+    const result = await Notification.requestPermission();
+    return result === 'granted';
+  }
+
+  return true;
+}
+
+export default requestPermission;

--- a/src/libs/actions/Subscriptions.web.ts
+++ b/src/libs/actions/Subscriptions.web.ts
@@ -1,0 +1,82 @@
+import type {
+  CustomerInfo,
+  PurchasesOffering,
+  PurchasesPackage,
+} from 'react-native-purchases';
+
+/**
+ * Web sibling of the Subscriptions action module. RevenueCat
+ * (react-native-purchases) is a native-only IAP SDK with no web build, so every
+ * entry point here is a no-op that mirrors the native module's shape:
+ *  - boot/login hooks (initialize/identify/forget) do nothing.
+ *  - fetchCurrentOffering resolves to null, so the paywall renders its
+ *    "unavailable" state and never shows a (non-functional) purchase button.
+ *  - purchase/restore resolve to an error outcome.
+ *
+ * The `import type` above is erased at build time, so this file pulls no
+ * react-native-purchases runtime code into the web bundle.
+ */
+
+/**
+ * RevenueCat entitlement identifier — kept identical to the native module so
+ * any shared consumer reads the same constant on every platform.
+ */
+const SUPPORTER_ENTITLEMENT_ID = 'supporter';
+
+/** Mirrors the native PurchaseOutcome union. */
+type PurchaseOutcome =
+  | {status: 'success'; customerInfo: CustomerInfo}
+  | {status: 'cancelled'}
+  | {status: 'error'; message: string};
+
+/** Mirrors the native RestoreOutcome union. */
+type RestoreOutcome =
+  | {status: 'success'; granted: boolean; customerInfo: CustomerInfo}
+  | {status: 'error'; message: string};
+
+const WEB_UNAVAILABLE_MESSAGE = 'In-app purchases are not available on web';
+
+function initialize(): void {
+  // No RevenueCat SDK on web — nothing to configure.
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function identify(_userId: string): void {
+  // No RevenueCat SDK on web — nothing to reconcile.
+}
+
+function forget(): void {
+  // No RevenueCat SDK on web — nothing to log out.
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function syncSupporterStatusFromCustomerInfo(_info: CustomerInfo): void {
+  // The web build never receives CustomerInfo updates.
+}
+
+function fetchCurrentOffering(): Promise<PurchasesOffering | null> {
+  return Promise.resolve(null);
+}
+
+function purchaseSupporterPackage(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _pkg: PurchasesPackage,
+): Promise<PurchaseOutcome> {
+  return Promise.resolve({status: 'error', message: WEB_UNAVAILABLE_MESSAGE});
+}
+
+function restoreSupporterPurchases(): Promise<RestoreOutcome> {
+  return Promise.resolve({status: 'error', message: WEB_UNAVAILABLE_MESSAGE});
+}
+
+export {
+  fetchCurrentOffering,
+  forget,
+  identify,
+  initialize,
+  purchaseSupporterPackage,
+  restoreSupporterPurchases,
+  syncSupporterStatusFromCustomerInfo,
+  SUPPORTER_ENTITLEMENT_ID,
+};
+export type {PurchaseOutcome, RestoreOutcome};

--- a/src/libs/getCurrentLocation.web.ts
+++ b/src/libs/getCurrentLocation.web.ts
@@ -1,0 +1,53 @@
+import type {DrinkLocation} from '@src/types/onyx';
+
+const LOCATION_TIMEOUT_MS = 5000;
+
+/**
+ * Web sibling of getCurrentLocation. Native uses expo-location; the browser has
+ * no such module, so we resolve the current fix through `navigator.geolocation`
+ * instead. Returns a DrinkLocation, or null when geolocation is unavailable,
+ * denied, or times out. Never rejects — the caller (a fire-and-forget capture
+ * path) must not block on this.
+ *
+ * Unlike native, the browser owns the permission prompt: a prior
+ * checkPermission('location') grant is not required and a denial simply yields
+ * null here.
+ */
+function getCurrentLocation(): Promise<DrinkLocation | null> {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) {
+    return Promise.resolve(null);
+  }
+  return new Promise<DrinkLocation | null>(resolve => {
+    let settled = false;
+    const settle = (value: DrinkLocation | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+    // Guard the worst case where neither callback fires. getCurrentPosition's
+    // own `timeout` covers the success/error path, but this mirrors the native
+    // race so a hung lookup can never block the caller.
+    setTimeout(() => settle(null), LOCATION_TIMEOUT_MS);
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const location: DrinkLocation = {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+          capturedAt: position.timestamp ?? Date.now(),
+        };
+        // Only attach accuracy when the browser reported a number, mirroring
+        // native: the server rejects writes containing `undefined`.
+        if (typeof position.coords.accuracy === 'number') {
+          location.accuracy = position.coords.accuracy;
+        }
+        settle(location);
+      },
+      () => settle(null),
+      {enableHighAccuracy: false, timeout: LOCATION_TIMEOUT_MS, maximumAge: 0},
+    );
+  });
+}
+
+export default getCurrentLocation;


### PR DESCRIPTION
## What & why

Phase 1 of the web epic (#925). Issue **#930**: add web/default siblings for native-only modules so the screens that depend on them load on web with features **gracefully degraded** instead of crashing on a missing native module.

Web resolves `*.web.ts(x)` ahead of the default; native (metro) ignores `.web.*`, so every change here is **web-only** — the native bundle is untouched.

## Shims added

| Native dep | Web sibling | Behavior on web |
|---|---|---|
| `expo-location` | `src/libs/getCurrentLocation.web.ts` | Resolves the current fix via `navigator.geolocation`; returns `null` on unavailable/denied/timeout, never rejects (mirrors the native fire-and-forget contract). |
| `expo-image-picker` + `expo-image-manipulator` | `src/components/UploadImage.web.tsx` | Picks via `<input type="file">`, center-crops + resizes on a `<canvas>` (same 1:1 / 3:4 ratio, 300px JPEG @ 0.8), then feeds the **same** kiroku-api upload pipeline (`uploadImage`). |
| `react-native-purchases` (RevenueCat) | `src/libs/actions/Subscriptions.web.ts` | No-op SDK. `fetchCurrentOffering → null` degrades the paywall to its existing "unavailable" state (no purchase button = no IAP UI on web); purchase/restore return an error outcome. `import type` only, so no RNP runtime code in the web bundle. |
| `react-native-permissions` / `PermissionsAndroid` | `checkPermission.web.ts` / `requestPermission.web.ts` | Answer from the browser's own permission surfaces (Permissions API, geolocation prompt, Notification API). Because only these two files import the RNP-touching modules, this removes `react-native-permissions` from the web bundle entirely. |

## Already covered (no change needed)

- **`react-native-fs`** — only imported by `clearCache/index.native.ts`; the default `index.ts` is already a web-safe no-op.
- **`expo-file-system`** — not imported anywhere under `src/`.

## Verification

- `npm run typecheck-tsgo` ✅, `npm run react-compiler-compliance-check check-changed` ✅ (new component compiles — avoided `try/finally`, which the compiler can't yet lower), `npm run lint-changed` ✅, prettier ✅.
- **Web build**: `npm run web` compiles with **0 errors** and the only remaining warning is the pre-existing Firebase `getReactNativePersistence` one. The ~17 `react-native-permissions` Phase-0 build warnings are **gone**, and none of `expo-location` / `expo-image-picker` / `react-native-purchases` appear in the bundle.
- **Runtime boot**: app boots to the login landing with no native-module errors; `Subscriptions.initialize()` (run at boot from `setup/index.ts`) executes the web no-op cleanly. Confirmed via the Claude Preview MCP that every browser API the shims rely on (geolocation, Permissions API, Notification, FileReader, `canvas.toBlob`, `URL.createObjectURL`, file input) is present in the runtime.
- Authenticated screens (Profile/UploadImage, SupportKiroku, Privacy) sit behind login + a live backend; their modules are all in the boot-time static import graph that executed cleanly. Live post-login visual checks pending dev credentials.

## Notes
- A pre-existing `Unexpected text node ... child of a <View>` console error fires on the **login landing screen** (Phase-0 code, not touched here) — out of scope for #930.

Part of #925. Closes #930.