### PR TITLE
feat(web): React Navigation linking for browser URLs (#933)

### DIFF
--- a/__tests__/unit/libs/LinkingConfig.test.ts
+++ b/__tests__/unit/libs/LinkingConfig.test.ts
@@ -1,0 +1,90 @@
+import {
+  findFocusedRoute,
+  getPathFromState,
+  getStateFromPath,
+} from '@react-navigation/native';
+import config from '@libs/Navigation/linkingConfig/config';
+import prefixes from '@libs/Navigation/linkingConfig/prefixes';
+import CONST from '@src/CONST';
+import SCREENS from '@src/SCREENS';
+
+/**
+ * These tests pin the browser-URL <-> screen mapping that powers web linking
+ * (epic #925, issue #933). They exercise the same `getStateFromPath` /
+ * `getPathFromState` pair React Navigation uses on web to resolve a shareable
+ * URL into navigation state and to serialize state back into the address bar.
+ */
+
+type RouteCase = {
+  /** Path as it appears in the browser address bar (no leading slash). */
+  path: string;
+  /** Screen the URL should focus. */
+  screen: string;
+  /** Params expected on the focused route, if the route is parameterized. */
+  params?: Record<string, string>;
+};
+
+const ROUTE_CASES: RouteCase[] = [
+  {path: 'home', screen: SCREENS.HOME},
+  {path: 'statistics', screen: SCREENS.STATISTICS.ROOT},
+  {path: 'settings/preferences', screen: SCREENS.SETTINGS.PREFERENCES.ROOT},
+  {path: 'badges', screen: SCREENS.BADGES.ROOT},
+  {path: 'profile/123', screen: SCREENS.PROFILE.ROOT, params: {userID: '123'}},
+  {
+    path: 'day-overview/123/2024-01-15',
+    screen: SCREENS.DAY_OVERVIEW.ROOT,
+    params: {userID: '123', date: '2024-01-15'},
+  },
+  {
+    path: 'drinking-session/abc/edit',
+    screen: SCREENS.DRINKING_SESSION.EDIT,
+    params: {sessionId: 'abc'},
+  },
+];
+
+describe('linkingConfig prefixes', () => {
+  it('keeps the native deep-link schemes', () => {
+    expect(prefixes).toContain('app://-/');
+    expect(prefixes).toContain(CONST.DEEPLINK_BASE_URL);
+  });
+
+  it('adds the web origins (production + local dev server)', () => {
+    expect(prefixes).toContain('https://app.kiroku.cz');
+    expect(prefixes).toContain('http://localhost:8082');
+  });
+});
+
+describe('linkingConfig route resolution (getStateFromPath)', () => {
+  it.each(ROUTE_CASES)(
+    'resolves /$path to the $screen screen',
+    ({path, screen, params}) => {
+      const state = getStateFromPath(path, config);
+      if (!state) {
+        throw new Error(`Expected /${path} to resolve to a navigation state`);
+      }
+
+      const focused = findFocusedRoute(state);
+      expect(focused?.name).toBe(screen);
+
+      if (params) {
+        expect(focused?.params).toMatchObject(params);
+      }
+    },
+  );
+});
+
+describe('linkingConfig path serialization (getPathFromState)', () => {
+  it.each(ROUTE_CASES)(
+    'serializes the $screen screen back to /$path',
+    ({path}) => {
+      const state = getStateFromPath(path, config);
+      if (!state) {
+        throw new Error(`Expected /${path} to resolve to a navigation state`);
+      }
+
+      // The browser address bar is always rooted at "/", so the round-trip
+      // adds the leading slash back onto the canonical path.
+      expect(getPathFromState(state, config)).toBe(`/${path}`);
+    },
+  );
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     '^.+\\.svg?$': 'jest-transformer-svg',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|expo-modules-core|react-native-gesture-handler|react-native-reanimated|react-native-worklets|react-native-nitro-sqlite|react-native-nitro-modules))',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|expo-modules-core|react-native-gesture-handler|react-native-reanimated|react-native-worklets|react-native-nitro-sqlite|react-native-nitro-modules))',
   ],
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/.claude/'],
   watchPathIgnorePatterns: ['<rootDir>/.claude/'],

--- a/src/libs/Navigation/linkingConfig/index.ts
+++ b/src/libs/Navigation/linkingConfig/index.ts
@@ -4,6 +4,7 @@ import type {RootStackParamList} from '@navigation/types';
 import config from './config';
 import customGetPathFromState from './customGetPathFromState';
 import getAdaptedStateFromPath from './getAdaptedStateFromPath';
+import prefixes from './prefixes';
 import subscribe from './subscribe';
 
 const linkingConfig: LinkingOptions<RootStackParamList> = {
@@ -16,7 +17,7 @@ const linkingConfig: LinkingOptions<RootStackParamList> = {
   },
   subscribe,
   getPathFromState: customGetPathFromState,
-  prefixes: ['app://-/'],
+  prefixes,
   config,
 };
 

--- a/src/libs/Navigation/linkingConfig/prefixes.ts
+++ b/src/libs/Navigation/linkingConfig/prefixes.ts
@@ -1,0 +1,26 @@
+import type {LinkingOptions} from '@react-navigation/native';
+import type {RootStackParamList} from '@navigation/types';
+import CONST from '@src/CONST';
+
+/**
+ * URL prefixes that React Navigation strips before resolving a path to a screen.
+ *
+ * On native these are matched against incoming deep-link URLs (`extractPathFromURL`).
+ * On web, React Navigation reads `window.location` directly and ignores this list,
+ * but we keep the web origins here so the config documents every surface the app is
+ * reachable from and so any full-URL resolution stays consistent across platforms.
+ */
+const prefixes: LinkingOptions<RootStackParamList>['prefixes'] = [
+  // Native deep-link schemes. `app://-/` is the historical scheme inherited from the
+  // upstream template; `kiroku://` (CONST.DEEPLINK_BASE_URL) is the scheme registered in
+  // the iOS Info.plist and AndroidManifest.
+  'app://-/',
+  CONST.DEEPLINK_BASE_URL,
+
+  // Web origins. Production lives at https://app.kiroku.cz; the dev server serves on
+  // http://localhost:8082 (see config/webpack/webpack.dev.ts BASE_PORT).
+  'https://app.kiroku.cz',
+  'http://localhost:8082',
+];
+
+export default prefixes;


### PR DESCRIPTION
## Web epic #925 · Phase 1 · #933 — React Navigation linking for browser URLs

Makes shareable browser URLs resolve to the correct screen and makes browser back/forward work on react-native-web, by giving the React Navigation linking config explicit web URL prefixes (while keeping the native scheme prefixes).

### What changed
- **`src/libs/Navigation/linkingConfig/prefixes.ts`** (new) — extracts the linking `prefixes` into a dedicated module, mirroring upstream Expensify's structure. Contents:
  - Native deep-link schemes: `app://-/` (historical, kept) and `kiroku://` (`CONST.DEEPLINK_BASE_URL` — the scheme actually registered in `ios/kiroku/Info.plist` and `AndroidManifest.xml`).
  - Web origins: `https://app.kiroku.cz` (production) and `http://localhost:8082` (dev server, see `config/webpack/webpack.dev.ts` `BASE_PORT`).
- **`src/libs/Navigation/linkingConfig/index.ts`** — imports the new `prefixes` module instead of the inline `prefixes: ['app://-/']`.
- **`__tests__/unit/libs/LinkingConfig.test.ts`** (new) — pins the URL↔screen mapping and the `getStateFromPath`/`getPathFromState` round-trip for representative routes, plus asserts the prefix list.
- **`jest.config.js`** — lets Jest transform `@react-navigation` (adds it to the `transformIgnorePatterns` allowlist, matching upstream Expensify). Required so the linking config can be imported in a unit test.

### Note on web vs. native prefixes
React Navigation's web `useLinking` reads `window.location.pathname + search` directly and does **not** consult `prefixes` (prefixes are used by `extractPathFromURL` on native). The web origins are included for parity/documentation and full-URL consistency; the behavioural win on web comes from the existing `getStateFromPath`/`getPathFromState` config, which this PR verifies.

### Verified
**Live on web** (`npm run web` → http://localhost:8082):
- App boots; `/` → login screen.
- `/forgot-password` resolves to the ForgotPassword screen.*
- Browser **back** (popstate) `/forgot-password` → `/` re-renders login; **forward** `/` → `/forgot-password`. ✅

\* The ForgotPassword screen then hits a pre-existing `findDOMNode is not a function` crash from `@react-ng/bounds-observer` (React 19 web shim) — **unrelated to linking**, belongs to the shims chip (#930). The route *resolution* worked.

**Unit test** (`LinkingConfig.test.ts`, 16 cases) confirms the URL↔screen mapping and round-trip:

| URL | Screen | `getPathFromState` round-trip |
|-----|--------|------|
| `/home` | `Home` | `/home` |
| `/statistics` | `Statistics_Root` | `/statistics` |
| `/settings/preferences` | `Settings_Preferences` | `/settings/preferences` |
| `/badges` | `Badges_Root` | `/badges` |
| `/profile/123` | `Profile_Root` (userID=123) | `/profile/123` |
| `/day-overview/123/2024-01-15` | `DayOverview_Root` (userID, date) | `/day-overview/123/2024-01-15` |
| `/drinking-session/abc/edit` | `DrinkingSession_Edit` (sessionId=abc) | `/drinking-session/abc/edit` |

### Checklist
- [x] Prettier, `typecheck-tsgo`, `react-compiler-compliance-check check-changed`, `lint-changed` — all clean
- [x] New + existing navigation/unit tests pass locally
- [ ] CI green

Refs #925
Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)