### PR TITLE
fix(web): stop empty-string text node erroring on login landing

### DIFF
--- a/src/screens/SignUp/SignUpScreenLayout/SignUpScreenContent.tsx
+++ b/src/screens/SignUp/SignUpScreenLayout/SignUpScreenContent.tsx
@@ -56,7 +56,7 @@ function SignUpScreenContent({
               <KirokuLogo />
             </View>
             <View style={[styles.signUpScreenWelcomeTextContainer]}>
-              {welcomeHeader && (
+              {!!welcomeHeader && (
                 <Text
                   style={[
                     styles.loginHeroHeader,
@@ -73,7 +73,7 @@ function SignUpScreenContent({
                   {welcomeHeader}
                 </Text>
               )}
-              {welcomeText && (
+              {!!welcomeText && (
                 <Text
                   style={[
                     styles.loginHeroBody,


### PR DESCRIPTION
### Details

On the web build (epic #925), the login/landing screen logged a React DOM error to the browser console, repeated ~4x on boot:

> `Unexpected text node: . A text node cannot be a child of a <View>.`

**Root cause.** `SignUpScreenContent` rendered the welcome body with `{welcomeText && (<Text>…</Text>)}`, while `InitialScreen` passes `welcomeText=""`. The expression `"" && (...)` evaluates to the empty string `""`, and React renders an empty string as a real text node, sitting directly inside a `<View>` — which react-native-web rejects. (The empty content after `Unexpected text node:` matched the empty string, not whitespace.) It logged ~4x because the screen re-renders a few times during boot as auth-check/locale state settles.

**Fix.** Coerced both conditional guards to real booleans so a falsy string renders nothing instead of an empty text node:

```diff
-{welcomeHeader && (<Text …>{welcomeHeader}</Text>)}
+{!!welcomeHeader && (<Text …>{welcomeHeader}</Text>)}
-{welcomeText && (<Text …>{welcomeText}</Text>)}
+{!!welcomeText && (<Text …>{welcomeText}</Text>)}
```

Both guards are fixed: the header one is latent today (non-empty) but the same trap. This is exactly the "left part of a conditional rendering a React component must be a boolean, not a string" rule in the author checklist below.

This is pre-existing Phase-0 code, not introduced by the Phase-1 shims (#1111 / #930). Part of the web epic #925.

### Tests

1. Run the web build: from a fresh worktree `npm install`, copy env (`cp .env.development ./.env`), `npm run web`, open the served port.
2. Open the browser console on the login landing screen ("Track your everyday alcohol adventures" / Create account / Log in).
3. Verify the console no longer logs `Unexpected text node: . A text node cannot be a child of a <View>`.

Verified locally: built and served the web app, reloaded the landing screen, read the browser console — zero matches for `text node` / `Unexpected text` / `child of a <View>`. The landing screen renders correctly (logo, headline, Create account, "Already have an account? Log in"). Remaining console errors are pre-existing, unrelated web-shim warnings (Firebase `getReactNativePersistence`, `PermissionsAndroid`).

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — no network behavior changed; this is a render-time guard fix.

### QA Steps

1. On web, load the login/landing screen.
2. Open the browser dev console.
3. Verify no `text node ... child of a <View>` error is logged, and the screen renders normally.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors (the targeted error is gone; remaining ones are pre-existing and unrelated)
- [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`. (This is the fix.)
- [x] I verified all code is DRY
- [x] No copy / text changes (no localization impact)

### Screenshots/Videos

<details>
<summary>Web (login landing after fix)</summary>

Landing screen renders correctly; console clean of the text-node error.

</details>
