### PR TITLE
feat(badges): gate badges screen behind a feature flag (off)

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -113,6 +113,7 @@ const CONST = {
   // `@libs/FeatureFlags` — never read this object directly at call sites so the
   // backing source can later swap to Onyx/remote-config without churn.
   FEATURES: {
+    BADGES: false,
     FULLSCREEN_CALENDAR: true,
   },
   APP_UPDATE: {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -22,6 +22,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import HomeBanner, {HomeBannerSkeleton} from '@components/Info/HomeBanner';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getPlatform from '@libs/getPlatform';
+import * as FeatureFlags from '@libs/FeatureFlags';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
@@ -292,17 +293,19 @@ function HomeScreen({route}: HomeScreenProps) {
                   <SupporterBadgeForUser userID={user.uid} size="medium" />
                 </View>
               </Button>
-              <PressableWithFeedback
-                accessibilityLabel={translate('bottomTabBar.badges')}
-                role={CONST.ROLE.BUTTON}
-                onPress={() => Navigation.navigate(ROUTES.BADGES)}>
-                <Icon
-                  src={KirokuIcons.Star}
-                  fill={theme.icon}
-                  width={24}
-                  height={24}
-                />
-              </PressableWithFeedback>
+              {FeatureFlags.isEnabled('BADGES') && (
+                <PressableWithFeedback
+                  accessibilityLabel={translate('bottomTabBar.badges')}
+                  role={CONST.ROLE.BUTTON}
+                  onPress={() => Navigation.navigate(ROUTES.BADGES)}>
+                  <Icon
+                    src={KirokuIcons.Star}
+                    fill={theme.icon}
+                    width={24}
+                    height={24}
+                  />
+                </PressableWithFeedback>
+              )}
             </View>
           </View>
         ) : (

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -14,6 +14,7 @@ import {dateToDateData, dateStringToDate, objKeys} from '@libs/DataHandling';
 import SessionsCalendar from '@components/SessionsCalendar';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import {getCommonFriendsCount} from '@libs/FriendUtils';
+import * as FeatureFlags from '@libs/FeatureFlags';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
@@ -225,12 +226,14 @@ function ProfileScreen({route}: ProfileScreenProps) {
         showsVerticalScrollIndicator={false}>
         {user?.uid === userID && (
           <>
-            <Button
-              icon={KirokuIcons.Star}
-              iconFill={StyleUtils.getIconFillColor()}
-              style={[styles.profileBadgesIndicator, styles.bgTransparent]}
-              onPress={() => Navigation.navigate(ROUTES.BADGES)}
-            />
+            {FeatureFlags.isEnabled('BADGES') && (
+              <Button
+                icon={KirokuIcons.Star}
+                iconFill={StyleUtils.getIconFillColor()}
+                style={[styles.profileBadgesIndicator, styles.bgTransparent]}
+                onPress={() => Navigation.navigate(ROUTES.BADGES)}
+              />
+            )}
             <Button
               icon={KirokuIcons.Gear}
               iconFill={StyleUtils.getIconFillColor()}


### PR DESCRIPTION
### Details

Puts the **badges screen behind a feature flag**, defaulting to **off**, since badges aren't ready to ship yet.

- Adds a static `BADGES` flag to `CONST.FEATURES` (set to `false`), read through the existing `FeatureFlags.isEnabled(...)` accessor — never via direct `CONST.FEATURES` access, per the established pattern.
- Gates the two UI entry points that navigate to `ROUTES.BADGES` behind the flag:
  - The star icon in the home header (`src/screens/HomeScreen.tsx`)
  - The star button on your own profile (`src/screens/Profile/ProfileScreen.tsx`)

These were the only two call sites that navigate to the badges screen, so with the flag off it's unreachable from the UI. The route and navigator registration are intentionally left in place (inert without an entry point), so flipping `BADGES: true` later fully restores access with no further wiring.

### Tests

1. With `CONST.FEATURES.BADGES = false` (current default):
   1. Open the app and go to the Home screen — verify the star (badges) icon is **not** shown in the header.
   2. Open your own Profile screen — verify the star (badges) button is **not** shown (the gear/settings button is still present).
2. Temporarily set `CONST.FEATURES.BADGES = true` and reload:
   1. Verify the star icon reappears on Home and the star button reappears on your own Profile.
   2. Tap either — verify the badges screen opens as before.
3. Revert the flag back to `false`.

- [x] Verify that no errors appear in the JS console

### Offline tests

No network behavior changed — the flag is a static client constant. Entry points are hidden identically online and offline.

### QA Steps

1. On Home, verify there is no star/badges icon in the header.
2. On your own Profile, verify there is no star/badges button (gear/settings button still present).
3. Verify no console errors.

- [x] Verify that no errors appear in the JS console

### Notes for reviewers

- No new copy/strings added (reused existing `bottomTabBar.badges` label, which stays unused while the flag is off).
- Local checks run: `prettier` (clean), `typecheck-tsgo` (passes — also confirms `'BADGES'` is a valid flag key), `react-compiler-compliance-check check-changed` (passes on all 3 files).
