### PR TITLE
fix(nav): lift offline indicator above the native bottom tab bar

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -316,7 +316,7 @@ function HomeScreen({route}: HomeScreenProps) {
           {renderBanner()}
           {renderMainContent()}
         </ScrollView>
-        <OfflineIndicator />
+        <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
         {/* Start-session FAB, floating bottom-right above the bottom tab bar.
             Home-only so the session modal's back-nav assumption (Home sits
             underneath the modal) stays intact. The bottom offset clears the

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -19,6 +19,7 @@ import ConfirmModal from '@components/ConfirmModal';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import * as Session from '@userActions/Session';
 import MenuItem from '@components/MenuItem';
+import OfflineIndicator from '@components/OfflineIndicator';
 import ScreenWrapper from '@components/ScreenWrapper';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
 import ScrollView from '@components/ScrollView';
@@ -347,6 +348,7 @@ function SettingsScreen() {
       style={[styles.w100, styles.pb0]}
       includePaddingTop
       includeSafeAreaPaddingBottom={false}
+      shouldShowOfflineIndicator={false}
       testID={SettingsScreen.displayName}>
       <HeaderWithBackButton
         title={translate('settingsScreen.title')}
@@ -374,6 +376,7 @@ function SettingsScreen() {
           onCancel={() => toggleSignoutConfirmModal(false)}
         />
       </ScrollView>
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -113,6 +113,7 @@ function SocialScreen() {
   return (
     <ScreenWrapper
       testID={SocialScreen.displayName}
+      includeSafeAreaPaddingBottom={false}
       shouldShowOfflineIndicator={false}>
       <HeaderWithBackButton
         title={translate('socialScreen.title')}

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -127,7 +127,7 @@ function SocialScreen() {
         commonOptions={commonOptions}
         options={sceneOptions}
       />
-      <OfflineIndicator />
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -2,8 +2,10 @@ import React, {useEffect, useState} from 'react';
 import type {ComponentType} from 'react';
 import {InteractionManager} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import OfflineIndicator from '@components/OfflineIndicator';
 import ScreenWrapper from '@components/ScreenWrapper';
 import StatsContextProvider from '@components/StatsContextProvider';
+import useBottomTabBarHeight from '@hooks/useBottomTabBarHeight';
 import useLocalize from '@hooks/useLocalize';
 import DrillDownProvider from './drilldown/DrillDownContext';
 import StatisticsScreenSkeleton from './StatisticsScreenSkeleton';
@@ -25,6 +27,7 @@ import StatsDrillDownSheet from './StatsDrillDownSheet';
  */
 function StatisticsScreen() {
   const {translate} = useLocalize();
+  const bottomTabBarHeight = useBottomTabBarHeight();
   const [isReady, setIsReady] = useState(false);
   const [Tabs, setTabs] = useState<ComponentType | null>(null);
 
@@ -59,7 +62,9 @@ function StatisticsScreen() {
   }, [isReady]);
 
   return (
-    <ScreenWrapper testID={StatisticsScreen.displayName}>
+    <ScreenWrapper
+      testID={StatisticsScreen.displayName}
+      shouldShowOfflineIndicator={false}>
       <HeaderWithBackButton
         title={translate('statistics.title')}
         shouldShowBackButton={false}
@@ -74,6 +79,7 @@ function StatisticsScreen() {
       ) : (
         <StatisticsScreenSkeleton />
       )}
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -64,6 +64,7 @@ function StatisticsScreen() {
   return (
     <ScreenWrapper
       testID={StatisticsScreen.displayName}
+      includeSafeAreaPaddingBottom={false}
       shouldShowOfflineIndicator={false}>
       <HeaderWithBackButton
         title={translate('statistics.title')}


### PR DESCRIPTION
## What

On the four root tab screens (Home, Friends, Statistics, Settings) the offline indicator ("You appear to be offline") was rendered at the bottom of the scene, but the native bottom tab bar (`react-native-bottom-tabs`, 72px) overlays the scene content, so the indicator sat **behind** the tab bar and was obscured.

This lifts the indicator by `bottomTabBarHeight` so it docks just above the tab bar.

## Why

The native `UITabBarController` / Material tab bar overlays the scene rather than reserving layout space, so anything bottom-docked needs an explicit inset. The screens already inset their scroll/scene content by `bottomTabBarHeight`; the offline indicator was the one bottom-docked element that didn't.

## How

- **Home** & **Social** — already used the explicit-render pattern (`shouldShowOfflineIndicator={false}` + a positioned `<OfflineIndicator>`); just added `style={{marginBottom: bottomTabBarHeight}}`.
- **Statistics** & **Settings** — switched off ScreenWrapper's default indicator to the same explicit, offset render. ScreenWrapper's default path adds a safe-area `paddingBottom` when offline, which would double-count against `bottomTabBarHeight` (the native tab-bar height already includes the home-indicator inset), so the explicit pattern keeps the offset consistent across all four roots.

`bottomTabBarHeight` comes from `useBottomTabBarHeight()`, which reads the measured native height (72px fallback), so it tracks the real tab-bar height including the safe-area region.

## Reviewer notes

- Worth a quick visual check on iOS that the indicator sits flush above the tab bar. It currently has no gap (flush); happy to add the FAB-style `+ 16` breathing room if preferred.
- No new strings, no behavior change when online.

## Checks

- `prettier --write` ✓
- `typecheck-tsgo` ✓
- `react-compiler-compliance-check check-changed` (4 files) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)