### PR TITLE
fix(nav): add breathing room between offline indicator and tab bar

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -316,7 +316,7 @@ function HomeScreen({route}: HomeScreenProps) {
           {renderBanner()}
           {renderMainContent()}
         </ScrollView>
-        <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
+        <OfflineIndicator style={{marginBottom: bottomTabBarHeight + 16}} />
         {/* Start-session FAB, floating bottom-right above the bottom tab bar.
             Home-only so the session modal's back-nav assumption (Home sits
             underneath the modal) stays intact. The bottom offset clears the

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -376,7 +376,7 @@ function SettingsScreen() {
           onCancel={() => toggleSignoutConfirmModal(false)}
         />
       </ScrollView>
-      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight + 16}} />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -127,7 +127,7 @@ function SocialScreen() {
         commonOptions={commonOptions}
         options={sceneOptions}
       />
-      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight + 16}} />
     </ScreenWrapper>
   );
 }

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -79,7 +79,7 @@ function StatisticsScreen() {
       ) : (
         <StatisticsScreenSkeleton />
       )}
-      <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
+      <OfflineIndicator style={{marginBottom: bottomTabBarHeight + 16}} />
     </ScreenWrapper>
   );
 }


### PR DESCRIPTION
## What

Stacked on #1122. Adds a 16px gap between the offline indicator and the native bottom tab bar on the four root tab screens, so it sits slightly above the bar instead of flush against it.

## Why

#1122 lifted the offline indicator above the tab bar but docked it flush. This adds breathing room, matching the Home FAB's existing `bottomTabBarHeight + 16` offset.

## How

Changed `marginBottom: bottomTabBarHeight` → `bottomTabBarHeight + 16` on Home, Friends, Statistics, and Settings.

## Notes

- Stacked on `claude/zealous-carson-792903` (#1122) — base will retarget to `master` automatically once #1122 merges.
- Purely a numeric offset tweak; no behavior change when online.

## Checks

- `prettier --write` ✓
- `react-compiler-compliance-check check-changed` (4 files) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)