### PR TITLE
feat(profile): make monthly overview card non-interactive on friends' profiles

### DIFF
--- a/src/components/Items/MonthlyOverviewCard.tsx
+++ b/src/components/Items/MonthlyOverviewCard.tsx
@@ -100,7 +100,7 @@ function MetricColumn({
 type MonthlyOverviewCardProps = {
   /** Month stats from `useHomeStats` (self) or `useUserMonthlyStats` (profile). */
   stats: MonthlyStats;
-  /** Show the card's title row text. The arrow shortcut stays either way. */
+  /** Show the card's title row text. */
   showTitle?: boolean;
   /** Title text; defaults to the localized "This month". */
   title?: string;
@@ -108,15 +108,23 @@ type MonthlyOverviewCardProps = {
   showWeeklyUnits?: boolean;
   /** Show the month-over-month comparison (trend arrow + previous value). */
   showMonthComparison?: boolean;
+  /**
+   * When true (default), the whole card is tappable and opens the Statistics
+   * screen. Set false (e.g. on a friend's profile) to render static content.
+   */
+  interactive?: boolean;
+  /** Show the right-arrow shortcut affordance. Defaults to true. */
+  showArrow?: boolean;
 };
 
 /**
  * Reusable "This month" stats card: three columns (Units, Sessions,
  * Alcohol-free) for a month. Each column shows the current value and, when
  * `showMonthComparison` is on, a trend arrow + the previous month's value. An
- * optional per-week bar chart sits below when `showWeeklyUnits` is on. The
- * whole card is tappable and opens the Statistics screen. Presentational — the
- * caller supplies `stats` (home or profile), so it works for self and others.
+ * optional per-week bar chart sits below when `showWeeklyUnits` is on. When
+ * `interactive` is on (default), the whole card is tappable and opens the
+ * Statistics screen. Presentational — the caller supplies `stats` (home or
+ * profile), so it works for self and others.
  */
 function MonthlyOverviewCard({
   stats,
@@ -124,6 +132,8 @@ function MonthlyOverviewCard({
   title,
   showWeeklyUnits = true,
   showMonthComparison = true,
+  interactive = true,
+  showArrow = true,
 }: MonthlyOverviewCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -145,18 +155,16 @@ function MonthlyOverviewCard({
   const sessionsDir = directionOf(current.sessions, previous.sessions);
   const afDir = directionOf(current.afDays, previous.afDays);
 
-  return (
-    <PressableWithFeedback
-      accessibilityLabel={translate('homeScreen.stats.viewStatistics')}
-      accessibilityRole="button"
-      onPress={() => Navigation.navigate(ROUTES.STATISTICS)}
-      style={[
-        styles.mv2,
-        styles.p3,
-        styles.flexRow,
-        styles.alignItemsCenter,
-        {backgroundColor: theme.cardSoftBG, borderRadius: 12},
-      ]}>
+  const cardStyle = [
+    styles.mv2,
+    styles.p3,
+    styles.flexRow,
+    styles.alignItemsCenter,
+    {backgroundColor: theme.cardSoftBG, borderRadius: 12},
+  ];
+
+  const content = (
+    <>
       <View style={styles.flex1}>
         {showTitle ? (
           <Text
@@ -215,14 +223,30 @@ function MonthlyOverviewCard({
         ) : null}
       </View>
 
-      <View style={styles.ml2}>
-        <Icon
-          src={KirokuIcons.ArrowRight}
-          width={16}
-          height={16}
-          fill={theme.icon}
-        />
-      </View>
+      {showArrow ? (
+        <View style={styles.ml2}>
+          <Icon
+            src={KirokuIcons.ArrowRight}
+            width={16}
+            height={16}
+            fill={theme.icon}
+          />
+        </View>
+      ) : null}
+    </>
+  );
+
+  if (!interactive) {
+    return <View style={cardStyle}>{content}</View>;
+  }
+
+  return (
+    <PressableWithFeedback
+      accessibilityLabel={translate('homeScreen.stats.viewStatistics')}
+      accessibilityRole="button"
+      onPress={() => Navigation.navigate(ROUTES.STATISTICS)}
+      style={cardStyle}>
+      {content}
     </PressableWithFeedback>
   );
 }

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -45,6 +45,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const {auth} = useFirebase();
   const {userID} = route.params;
   const user = auth.currentUser;
+  const isSelf = user?.uid === userID;
   // Friend data now comes from the kiroku-api (privacy-enforced) instead of
   // direct Firebase reads: profile + friends via `useFriendProfile`, rendering
   // preferences via `useFriendPreferences`, and the windowed sessions via
@@ -261,6 +262,8 @@ function ProfileScreen({route}: ProfileScreenProps) {
               stats={profileStats}
               showWeeklyUnits={false}
               showMonthComparison
+              interactive={isSelf}
+              showArrow={isSelf}
             />
           ) : (
             <MonthlyOverviewCardSkeleton />


### PR DESCRIPTION
### Details

The reusable `MonthlyOverviewCard` ("This month" stats card) is rendered on the home screen and on `ProfileScreen` (which serves both your own profile and a friend's profile). Today the whole card is always a button: it's wrapped in `PressableWithFeedback` and navigates to `ROUTES.STATISTICS`, and it always shows a right-arrow affordance.

That navigation only makes sense for the current user. Tapping it on a friend's profile would open the *viewer's* own Statistics screen, not the friend's, so the card should be static there.

This PR adds two props to `MonthlyOverviewCard`, both defaulting to `true` so the home screen and self profile are unchanged:

- `interactive` — when `false`, the card renders as a plain `View` (no press, no navigation, no `accessibilityRole="button"`) instead of `PressableWithFeedback`.
- `showArrow` — when `false`, the right-arrow icon is hidden.

`ProfileScreen` now passes `interactive={isSelf}` and `showArrow={isSelf}`, so a friend's card is static with no arrow, while your own profile keeps the home-screen behavior. The visual card (background, padding, layout) is unchanged in all cases.

### Tests

1. Open the **home screen**. Verify the "This month" card still shows the right arrow, gives press feedback, and opens the Statistics screen on tap.
2. Open **your own profile** (tap your avatar / profile). Verify the card behaves exactly like the home screen: arrow shown, tappable, opens Statistics.
3. Open a **friend's profile**. Verify the card shows the same stats but is **not** tappable (no press feedback / no navigation) and the right arrow is **gone**.

- [x] Verify that no errors appear in the JS console

### Offline tests

This change is purely presentational (props toggling pressability + an icon); it adds no network calls and is unaffected by network state. The card renders identically offline.

### QA Steps

1. On staging, open the home screen and confirm the "This month" card is tappable (arrow visible) and opens Statistics.
2. Open your own profile and confirm the card matches the home screen behavior.
3. Open a friend's profile and confirm the card is static (no tap response) and the arrow is hidden.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified all code is DRY (shared `cardStyle`/`content` extracted; both render branches reuse them)
- [x] I followed proper code patterns
- [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string
- [x] No new copy/text was added, so no localization changes are needed
- [x] If the PR modifies a generic component, I verified usages are unaffected (home screen relies on the new `true` defaults, so its behavior is preserved)

### Notes for reviewer

- `MonthlyOverviewCard` is shared: the only other usage is `HomeScreen`, which is untouched and relies on the `interactive`/`showArrow` defaults (`true`), preserving current behavior.
- Local checks run: `typecheck-tsgo` (clean), `react-compiler-compliance-check check-changed` (passed), Prettier (clean).
