### PR TITLE
fix(social): align Friends search FAB with Home add-session FAB

### DIFF
--- a/src/screens/Social/FriendRequestScreen.tsx
+++ b/src/screens/Social/FriendRequestScreen.tsx
@@ -5,7 +5,6 @@ import type {
   ProfileList,
 } from '@src/types/onyx';
 import {useEffect, useRef, useState} from 'react';
-import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as Friends from '@userActions/Friends';
@@ -16,20 +15,15 @@ import GrayHeader from '@components/Header/GrayHeader';
 import {objKeys} from '@libs/DataHandling';
 import CONST from '@src/CONST';
 import useCurrentUserData from '@hooks/useCurrentUserData';
-import Navigation from '@libs/Navigation/Navigation';
-import ROUTES from '@src/ROUTES';
 import NoFriendInfo from '@components/Social/NoFriendInfo';
 import {isEmptyArray, isEmptyObject} from '@src/types/utils/EmptyObject';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
-import Icon from '@components/Icon';
-import useTheme from '@hooks/useTheme';
 import ScrollView from '@components/ScrollView';
 import Button from '@components/Button';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {PressableWithFeedback} from '@components/Pressable';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import ERRORS from '@src/ERRORS';
 
@@ -197,7 +191,6 @@ function FriendRequestItem({
 
 function FriendRequestScreen() {
   const userData = useCurrentUserData();
-  const theme = useTheme();
   const styles = useThemeStyles();
   const {translate} = useLocalize();
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
@@ -334,17 +327,6 @@ function FriendRequestScreen() {
           </View>
         )}
       </ScrollView>
-      <PressableWithFeedback
-        accessibilityLabel="search-screen-button"
-        style={styles.goToSearchScreenButton}
-        onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
-        <Icon
-          src={KirokuIcons.Search}
-          width={28}
-          height={28}
-          fill={theme.textLight}
-        />
-      </PressableWithFeedback>
     </View>
   );
 }

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import {InteractionManager, StyleSheet, View} from 'react-native';
+import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
 import {SceneMap, TabView} from 'react-native-tab-view';
 import type {
   NavigationState,
@@ -173,6 +174,15 @@ function SocialScreen() {
     [bottomTabBarHeight],
   );
 
+  // The friend-search FAB belongs to the Friend Requests tab only. Keep it
+  // mounted and cross-fade its opacity on tab change (rather than mount/unmount)
+  // so it eases in/out instead of popping. `withTiming` inside the worklet
+  // animates whenever the captured `isFriendRequestsTab` flips.
+  const isFriendRequestsTab = routes[index]?.key === 'friendRequests';
+  const fabAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(isFriendRequestsTab ? 1 : 0, {duration: 200}),
+  }));
+
   return (
     <ScreenWrapper
       testID={SocialScreen.displayName}
@@ -199,26 +209,28 @@ function SocialScreen() {
           exactly like the Home start-session FAB, so it's anchored to the
           screen and isn't shifted upward by the offline indicator's reserved
           bottom margin the way an in-scene button would be. Reuses the Home
-          FAB's container + circle styles so the two line up. */}
-      {routes[index]?.key === 'friendRequests' && (
-        <View
-          style={[
-            styles.floatingActionButtonContainer,
-            {bottom: bottomTabBarHeight + 16},
-          ]}>
-          <PressableWithFeedback
-            accessibilityLabel="search-screen-button"
-            style={styles.floatingActionButton}
-            onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
-            <Icon
-              src={KirokuIcons.Search}
-              width={28}
-              height={28}
-              fill={theme.textLight}
-            />
-          </PressableWithFeedback>
-        </View>
-      )}
+          FAB's container + circle styles so the two line up. Kept mounted and
+          cross-faded via opacity; `pointerEvents` is dropped while hidden so it
+          can't be tapped on the Friend List tab. */}
+      <Animated.View
+        pointerEvents={isFriendRequestsTab ? 'auto' : 'none'}
+        style={[
+          styles.floatingActionButtonContainer,
+          {bottom: bottomTabBarHeight + 16},
+          fabAnimatedStyle,
+        ]}>
+        <PressableWithFeedback
+          accessibilityLabel="search-screen-button"
+          style={styles.floatingActionButton}
+          onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
+          <Icon
+            src={KirokuIcons.Search}
+            width={28}
+            height={28}
+            fill={theme.textLight}
+          />
+        </PressableWithFeedback>
+      </Animated.View>
     </ScreenWrapper>
   );
 }

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -194,29 +194,31 @@ function SocialScreen() {
         options={sceneOptions}
       />
       <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
-      {/* Friend-search FAB. Rendered at the ScreenWrapper level (a sibling of
-          the TabView/OfflineIndicator), exactly like the Home start-session
-          FAB, so it's anchored to the screen and isn't shifted upward by the
-          offline indicator's reserved bottom margin the way an in-scene button
-          would be. Reuses the Home FAB's container + circle styles so the two
-          line up. */}
-      <View
-        style={[
-          styles.floatingActionButtonContainer,
-          {bottom: bottomTabBarHeight + 16},
-        ]}>
-        <PressableWithFeedback
-          accessibilityLabel="search-screen-button"
-          style={styles.floatingActionButton}
-          onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
-          <Icon
-            src={KirokuIcons.Search}
-            width={28}
-            height={28}
-            fill={theme.textLight}
-          />
-        </PressableWithFeedback>
-      </View>
+      {/* Friend-search FAB, only on the Friend Requests tab. Rendered at the
+          ScreenWrapper level (a sibling of the TabView/OfflineIndicator),
+          exactly like the Home start-session FAB, so it's anchored to the
+          screen and isn't shifted upward by the offline indicator's reserved
+          bottom margin the way an in-scene button would be. Reuses the Home
+          FAB's container + circle styles so the two line up. */}
+      {routes[index]?.key === 'friendRequests' && (
+        <View
+          style={[
+            styles.floatingActionButtonContainer,
+            {bottom: bottomTabBarHeight + 16},
+          ]}>
+          <PressableWithFeedback
+            accessibilityLabel="search-screen-button"
+            style={styles.floatingActionButton}
+            onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
+            <Icon
+              src={KirokuIcons.Search}
+              width={28}
+              height={28}
+              fill={theme.textLight}
+            />
+          </PressableWithFeedback>
+        </View>
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -14,10 +14,15 @@ import type {
   TabDescriptor,
 } from 'react-native-tab-view';
 import {getReceivedRequestsCount} from '@libs/FriendUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
 import ScreenWrapper from '@components/ScreenWrapper';
 import OfflineIndicator from '@components/OfflineIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
+import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import {PressableWithFeedback} from '@components/Pressable';
 import Text from '@components/Text';
 import TopTabBar, {TOP_TAB_COMMON_OPTIONS} from '@components/TopTabBar';
 import type {TopTabRoute} from '@components/TopTabBar';
@@ -25,6 +30,7 @@ import useBottomTabBarHeight from '@hooks/useBottomTabBarHeight';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import FriendListScreen from './FriendListScreen';
 
@@ -100,6 +106,8 @@ function FriendRequestsBadge({count}: {count: number}) {
 
 function SocialScreen() {
   const userData = useCurrentUserData();
+  const theme = useTheme();
+  const styles = useThemeStyles();
   const {translate} = useLocalize();
   const {windowWidth} = useWindowDimensions();
   const bottomTabBarHeight = useBottomTabBarHeight();
@@ -186,6 +194,29 @@ function SocialScreen() {
         options={sceneOptions}
       />
       <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
+      {/* Friend-search FAB. Rendered at the ScreenWrapper level (a sibling of
+          the TabView/OfflineIndicator), exactly like the Home start-session
+          FAB, so it's anchored to the screen and isn't shifted upward by the
+          offline indicator's reserved bottom margin the way an in-scene button
+          would be. Reuses the Home FAB's container + circle styles so the two
+          line up. */}
+      <View
+        style={[
+          styles.floatingActionButtonContainer,
+          {bottom: bottomTabBarHeight + 16},
+        ]}>
+        <PressableWithFeedback
+          accessibilityLabel="search-screen-button"
+          style={styles.floatingActionButton}
+          onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
+          <Icon
+            src={KirokuIcons.Search}
+            width={28}
+            height={28}
+            fill={theme.textLight}
+          />
+        </PressableWithFeedback>
+      </View>
     </ScreenWrapper>
   );
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1836,23 +1836,6 @@ const styles = (theme: ThemeColors) =>
       fontWeight: FontUtils.fontWeight.bold,
     },
 
-    // Mirrors the Home start-session FAB (`floatingActionButton` +
-    // `floatingActionButtonContainer`) so the two line up: same 52px size and
-    // same 16px clearance above the native tab bar. The Social scene is already
-    // inset by `bottomTabBarHeight` (see SocialScreen's `sceneStyle`), so the
-    // `bottom` here is just the margin, not the full bar height like Home.
-    goToSearchScreenButton: {
-      position: 'absolute',
-      bottom: 16,
-      right: variables.goToSearchButtonOffset,
-      width: variables.componentSizeLarge,
-      height: variables.componentSizeLarge,
-      borderRadius: variables.componentSizeLarge / 2,
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: theme.appColor,
-    },
-
     secondAvatar: {
       position: 'absolute',
       right: -18,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1836,13 +1836,18 @@ const styles = (theme: ThemeColors) =>
       fontWeight: FontUtils.fontWeight.bold,
     },
 
+    // Mirrors the Home start-session FAB (`floatingActionButton` +
+    // `floatingActionButtonContainer`) so the two line up: same 52px size and
+    // same 16px clearance above the native tab bar. The Social scene is already
+    // inset by `bottomTabBarHeight` (see SocialScreen's `sceneStyle`), so the
+    // `bottom` here is just the margin, not the full bar height like Home.
     goToSearchScreenButton: {
       position: 'absolute',
-      bottom: variables.goToSearchButtonOffset,
+      bottom: 16,
       right: variables.goToSearchButtonOffset,
-      width: variables.iconSizeSuperLarge,
-      height: variables.iconSizeSuperLarge,
-      borderRadius: variables.iconSizeSuperLarge / 2,
+      width: variables.componentSizeLarge,
+      height: variables.componentSizeLarge,
+      borderRadius: variables.componentSizeLarge / 2,
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: theme.appColor,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -231,7 +231,6 @@ export default {
   bottomTabBarCounterSize: 20,
   calendarHeaderHeight: 50,
   sessionsCalendarArrowWidth: 44,
-  goToSearchButtonOffset: 20,
   qrCodeScreenSizePercentage: 0.7,
   qrCodeMinSizeLargeScreen: 300,
 


### PR DESCRIPTION
### Details

Aligns the Friends search FAB with the Home screen's start-session `+` FAB and fixes it floating too high above the bottom tab bar.

**Root cause:** the search FAB lived *inside* the Friend Requests `TabView` scene. That scene is a flex sibling of `<OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />`, so the indicator's reserved bottom margin shrinks the scene and lifts an absolutely-positioned in-scene button well above the tab bar. The Home FAB never had this problem because it's a direct absolute child of `ScreenWrapper`, anchored to the screen rather than to flex-laid-out content.

**Fix:** render the search FAB at the `SocialScreen` level (sibling of the TabView / OfflineIndicator), reusing the Home FAB's `floatingActionButtonContainer` + `floatingActionButton` styles and the same `bottom: bottomTabBarHeight + 16` formula. The two FABs are now geometrically identical and positioned the same way, and the search FAB no longer reacts to the offline indicator.

The FAB stays scoped to the **Friend Requests** tab (gated on the active tab), matching its previous visibility; it's hidden on the Friend List tab.

Removed the in-scene button and its now-dead `goToSearchScreenButton` style and `goToSearchButtonOffset` variable.

> Earlier commits in this PR also disabled the double-counted bottom safe-area inset on the Social scene, but `master` landed that independently (`includeSafeAreaPaddingBottom={false}` + a lifted `OfflineIndicator`), so after rebasing only the FAB-positioning change remains.

### Tests

1. Open the Friends screen on iOS and switch to the Friend Requests tab.
2. Verify the search FAB sits at the same height above the bottom tab bar as the Home `+` FAB (same size, same clearance).
3. Toggle the device offline and back online; verify the search FAB does **not** move (previously it jumped up when the offline indicator appeared).
4. Switch to the Friend List tab; verify the FAB is hidden. Switch back; verify it returns and tapping it opens friend search.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline on the Friend Requests tab. The offline indicator appears above the tab bar and the search FAB stays anchored (does not shift up).

### QA Steps

1. On a notched iOS device, compare the Home `+` FAB and the Friends search FAB (Friend Requests tab) relative to the bottom tab bar; confirm they match.
2. Toggle airplane mode on the Friend Requests tab; confirm the FAB doesn't move.
3. Confirm the FAB is not shown on the Friend List tab.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I followed proper code patterns (reuses the existing Home FAB styles/positioning)
- [x] No copy/text was added or modified
- [x] I verified all code is DRY (shares the Home FAB styles; removed the duplicate style/variable)

### Screenshots/Videos

<details>
<summary>Android</summary>

N/A — layout-only change shared across platforms.

</details>

<details>
<summary>iOS</summary>

<!-- add before/after screenshots here -->

</details>
