### PR TITLE
fix(social): add search-bar top gap + lazy-load Friend Requests tab

### DIFF
--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -1,5 +1,12 @@
-import React, {useCallback, useMemo, useState} from 'react';
-import {StyleSheet, View} from 'react-native';
+import React, {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {InteractionManager, StyleSheet, View} from 'react-native';
 import {SceneMap, TabView} from 'react-native-tab-view';
 import type {
   NavigationState,
@@ -10,6 +17,7 @@ import {getReceivedRequestsCount} from '@libs/FriendUtils';
 import ScreenWrapper from '@components/ScreenWrapper';
 import OfflineIndicator from '@components/OfflineIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import Text from '@components/Text';
 import TopTabBar, {TOP_TAB_COMMON_OPTIONS} from '@components/TopTabBar';
 import type {TopTabRoute} from '@components/TopTabBar';
@@ -19,18 +27,21 @@ import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import FriendListScreen from './FriendListScreen';
-import FriendRequestScreen from './FriendRequestScreen';
 
-// The Friend List / Friend Requests tabs render at the TOP of the screen via
-// `react-native-tab-view`, mirroring the Statistics layout (shared `TopTabBar`).
-// Each scene owns its own data via `useCurrentUserData`, so SceneMap can render
-// them directly.
-const renderScene = SceneMap({
-  friendList: FriendListScreen,
-  friendRequests: FriendRequestScreen,
-});
+// Friend List is the default tab, so it stays statically imported and paints on
+// mount. Friend Requests is lazily imported — and prefetched once Friend List is
+// interactive (see the effect in SocialScreen) — so its module evaluation and
+// mount-time effects/fetch stay off the tab-switch frame. This mirrors the
+// Statistics screen's treatment of its non-default tabs.
+const loadFriendRequestScreen = () => import('./FriendRequestScreen');
+const FriendRequestScreen = lazy(loadFriendRequestScreen);
 
 const localStyles = StyleSheet.create({
+  placeholder: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   badge: {
     minWidth: 18,
     height: 18,
@@ -45,6 +56,37 @@ const localStyles = StyleSheet.create({
     fontWeight: '700',
     textAlign: 'center',
   },
+});
+
+// Shown while the lazily imported Friend Requests tab resolves and mounts on its
+// first activation; also the TabView placeholder for the not-yet-rendered tab.
+function TabLazyPlaceholder(): React.ReactNode {
+  return (
+    <View style={localStyles.placeholder}>
+      <FlexibleLoadingIndicator />
+    </View>
+  );
+}
+
+function renderLazyPlaceholder(): React.ReactNode {
+  return <TabLazyPlaceholder />;
+}
+
+function FriendRequestScene() {
+  return (
+    <Suspense fallback={<TabLazyPlaceholder />}>
+      <FriendRequestScreen />
+    </Suspense>
+  );
+}
+
+// The Friend List / Friend Requests tabs render at the TOP of the screen via
+// `react-native-tab-view`, mirroring the Statistics layout (shared `TopTabBar`).
+// Friend List is statically imported (default tab); Friend Requests is lazy +
+// Suspense so it stays off the tab-switch frame until first activated.
+const renderScene = SceneMap({
+  friendList: FriendListScreen,
+  friendRequests: FriendRequestScene,
 });
 
 function FriendRequestsBadge({count}: {count: number}) {
@@ -62,6 +104,19 @@ function SocialScreen() {
   const {windowWidth} = useWindowDimensions();
   const bottomTabBarHeight = useBottomTabBarHeight();
   const [index, setIndex] = useState(0);
+
+  // Warm the lazily imported Friend Requests module in the background once the
+  // Friend List tab is interactive, so first tap of the Requests tab renders it
+  // without the dynamic-import stall. Errors are swallowed — the real lazy
+  // render surfaces them on tap as usual.
+  useEffect(() => {
+    const handle = InteractionManager.runAfterInteractions(() => {
+      loadFriendRequestScreen().catch(() => undefined);
+    });
+    return () => {
+      handle.cancel?.();
+    };
+  }, []);
 
   const routes = useMemo<TopTabRoute[]>(
     () => [
@@ -124,6 +179,8 @@ function SocialScreen() {
         renderScene={renderScene}
         renderTabBar={renderTabBar}
         initialLayout={{width: windowWidth}}
+        lazy
+        renderLazyPlaceholder={renderLazyPlaceholder}
         commonOptions={commonOptions}
         options={sceneOptions}
       />

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1814,6 +1814,10 @@ const styles = (theme: ThemeColors) =>
       flexDirection: 'row',
       height: variables.searchWindowHeight,
       ...spacing.gap2,
+      // Gap above the search bar so it isn't flush against the top tab bar /
+      // header. `marginTop` (not `paddingTop`) because the container has a fixed
+      // height — padding would shrink the input instead of adding space above.
+      ...spacing.mt3,
       ...spacing.ph2,
       ...spacing.pb2,
     },


### PR DESCRIPTION
### Details

Two Friends-screen (`SocialScreen`) issues, both surfaced by the recent native bottom-tab migration:

**1. No gap between the top tab bar and the search bar.** The `SearchWindow` sat flush against the `TopTabBar`'s hairline border, so the rounded search box read as glued to the tabs.

- Added a 12px top margin (`...spacing.mt3`) to the shared `searchWindowContainer` style.
- Uses `marginTop`, **not** `paddingTop`, on purpose: the container has a fixed `height: variables.searchWindowHeight` (50px), so padding would shrink the input instead of adding space above it.
- The shared style means the same gap is applied consistently under the bar/header on all three `SearchWindow` screens (Friend List, Friend Search, Friends-of-Friends). I verified none of those screens had compensating top-spacing above the search bar to remove (the small `pt1`/`mt2` paddings that exist sit *below* the bar and space the result list — unrelated, left untouched).

**2. The Friends tab loaded slowly.** `SocialScreen`'s `react-native-tab-view` `TabView` ran without `lazy`, so **both** inner tabs mounted synchronously on the tab-switch frame: Friend Requests fired its own effects, a `USER_DATA_LIST` read, a `Profile.fetchUserProfiles` fetch, and a non-virtualized `.map()` render — all while the user was on Friend List, with no placeholder so the screen appeared frozen until everything completed.

The Statistics screen uses the identical `TabView`/`TopTabBar` shell but is fast because it opts into `lazy` + `renderLazyPlaceholder` + `React.lazy`/`Suspense` + an `InteractionManager` prefetch. This PR mirrors that proven pattern on `SocialScreen`:

- `FriendRequestScreen` is now `React.lazy(() => import('./FriendRequestScreen'))`, wrapped in a `Suspense` scene. Friend List stays statically imported (it's the default tab).
- The `TabView` gets `lazy` + `renderLazyPlaceholder`, so Friend Requests mounts only when its tab is first tapped — off the Friend List paint frame.
- An `InteractionManager.runAfterInteractions` effect prefetches the Friend Requests module once Friend List is interactive, so the first Requests tap has no dynamic-import stall.
- The Friend Requests tab **badge count** is unaffected (computed in `SocialScreen` from `userData`, independent of the lazy scene).

A pre-existing per-row `useOnyx(FRIENDS_METADATA)` subscription in `FriendOfflineFeedback` (~20 subscriptions for a full list) is a known follow-up — it predates the migration and is not the regression cause, so it's intentionally out of scope here.

### Tests

1. Open the **Friends** tab → confirm a clear gap between the Friend List / Friend Requests top tab bar and the search box, and that the search input itself is **not** shrunk.
2. Type in the search box → confirm filtering still works and the input height/look is unchanged.
3. From a cold launch, tap the **Friends** bottom tab → confirm the Friend List paints without a long freeze.
4. Tap the **Friend Requests** top tab the first time → confirm a brief loading placeholder, then the requests list renders.
5. While on **Friend List**, confirm the pending-request **badge count** still shows on the Friend Requests tab.
6. Open the **Add friend / search** screen and the **Friends of friends** screen → confirm the search bar there also has the gap under the header and their result lists below are unchanged.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, open Friends → Friend List shows cached friends (or the offline notice) as before; the search-bar gap is present.
2. Tap Friend Requests offline → placeholder then the cached/empty state; no crash.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. On staging, navigate to the Friends tab and confirm the search-bar top gap (steps 1–2 above).
2. Confirm the Friends tab no longer stalls on open, and the Friend Requests tab loads on first tap (steps 3–5 above).
3. Confirm the gap and unchanged lists on the friend-search and friends-of-friends screens (step 6).

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified any new or modified comments were clear, correct English, and explained "why" the code was doing something
- [x] I verified all code is DRY (reuses the existing Statistics `lazy`/`Suspense`/`renderLazyPlaceholder`/`InteractionManager` pattern and the shared `searchWindowContainer` style)
- [x] If a new CSS style is added I verified a similar style doesn't already exist (reused the shared `searchWindowContainer`; `spacing.mt3` is an existing utility)
- [x] If the PR modifies a generic component (shared `SearchWindow` style), I considered usages across all three screens that consume it
- [ ] If the PR modifies the UI (padding/spacing): added `design` label and/or tagged the design team

> Local verification done: `prettier` (clean), `typecheck-tsgo` (clean), `react-compiler-compliance-check check-changed` (passed for both files). Manual on-device Android/iOS runs not performed in this environment.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>
