### PR TITLE
fix(android): pin NDK to runner-preinstalled 27.3.13750724

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 36
         targetSdkVersion = 36
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "27.3.13750724"
 
         androidXCore = "1.0.2"
         multiDexEnabled = true


### PR DESCRIPTION
## Problem

The staging/production Android deploy ([example run](https://github.com/PetrCala/Kiroku/actions/runs/27208045233)) has been failing consistently in the **Build and deploy Android** job. Gradle dies while configuring `:app`:

```
Checking the license for package NDK (Side by side) 27.1.12297006 ... accepted.
Preparing "Install NDK (Side by side) 27.1.12297006".
Warning: An error occurred while preparing SDK package NDK 27.1.12297006:
         Error on ZipFile unknown archive.
> Failed to apply plugin 'com.facebook.react.rootproject'.
  > com.android.builder.sdk.InstallFailedException: Failed to install ndk;27.1.12297006
```

`Error on ZipFile unknown archive` = the NDK archive gradle downloaded from Google's CDN is corrupt/truncated. The license is accepted; only the download is bad.

## Root cause

This is **not a code regression** — the previous release built fine on the same `ubuntu-24.04` runner with the same config. The issue is that we pin `ndkVersion = "27.1.12297006"`, but the `ubuntu-24.04` GitHub runner only preinstalls NDK `27.3.13750724` (default), `28.2.13676358`, and `29.0.14206865`. So **every** Android build has to download `27.1.12297006` fresh from Google, and that download started returning a corrupt archive. The gradle step is already wrapped in a retry and exhausted it.

## Fix

Pin `ndkVersion` to `27.3.13750724`, which is preinstalled on the runner (same NDK 27 major, compatible with RN 0.81). Gradle now uses the local copy and never touches the CDN, removing the per-build download that was the source of fragility.

One-line change in `android/build.gradle`. No other references to the old version exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)