### PR TITLE
feat(settings): bury delete-account behind a Manage account screen

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -124,6 +124,7 @@ const ROUTES = {
   SETTINGS_SUBSCRIPTION_TERMS: 'settings/subscription-terms',
   SETTINGS_REPORT_BUG: 'settings/report-bug',
   SETTINGS_FEEDBACK: 'settings/feedback',
+  SETTINGS_MANAGE_ACCOUNT: 'settings/manage-account',
   SETTINGS_DELETE: 'settings/delete',
   SETTINGS_ADMIN: 'settings/admin',
   SETTINGS_ADMIN_FEEDBACK: 'settings/admin/feedback',

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -93,6 +93,7 @@ const SCREENS = {
     SUBSCRIPTION_TERMS: 'Settings_SubscriptionTerms',
     REPORT_BUG: 'Settings_ReportBug',
     FEEDBACK: 'Settings_Feedback',
+    MANAGE_ACCOUNT: 'Settings_ManageAccount',
     DELETE: 'Settings_Delete',
   },
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -595,6 +595,13 @@ export default {
       success: 'Vaše historie polohy byla vymazána.',
       error: 'Nepodařilo se vymazat historii polohy. Zkuste to prosím znovu.',
     },
+    accountSection: {
+      title: 'Účet',
+    },
+    manageAccount: {
+      label: 'Správa účtu',
+      description: 'Možnosti účtu, včetně smazání vašeho účtu.',
+    },
     error: {
       save: 'Nepodařilo se uložit nastavení soukromí. Zkuste to prosím znovu.',
     },
@@ -952,6 +959,16 @@ export default {
     sent: 'Zpětná vazba odeslána!',
     sending: 'Odesílám zpětnou vazbu…',
     error: 'Došlo k chybě při odesílání zpětné vazby. Zkuste to prosím znovu.',
+  },
+  manageAccountScreen: {
+    title: 'Správa účtu',
+    dangerZone: {
+      title: 'Nebezpečná zóna',
+      subtitle: 'Tyto akce jsou trvalé a nelze je vrátit zpět.',
+    },
+    deleteAccount: {
+      title: 'Smazat účet',
+    },
   },
   deleteAccountScreen: {
     deleteAccount: 'Smazat účet',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -590,6 +590,13 @@ export default {
       success: 'Your location history has been cleared.',
       error: "We couldn't clear your location history. Please try again.",
     },
+    accountSection: {
+      title: 'Account',
+    },
+    manageAccount: {
+      label: 'Manage account',
+      description: 'Account options, including deleting your account.',
+    },
     error: {
       save: "We couldn't save your privacy preferences. Please try again.",
     },
@@ -947,6 +954,16 @@ export default {
     sent: 'Feedback sent!',
     sending: 'Sending feedback...',
     error: 'There was an error sending your feedback. Please try again.',
+  },
+  manageAccountScreen: {
+    title: 'Manage account',
+    dangerZone: {
+      title: 'Danger zone',
+      subtitle: 'These actions are permanent and cannot be undone.',
+    },
+    deleteAccount: {
+      title: 'Delete account',
+    },
   },
   deleteAccountScreen: {
     deleteAccount: 'Delete account',

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -204,6 +204,9 @@ const SettingsModalStackNavigator =
       require<ReactComponentModule>('@screens/Settings/FeedbackScreen').default,
     [SCREENS.SETTINGS.ABOUT]: () =>
       require<ReactComponentModule>('@screens/Settings/AboutScreen').default,
+    [SCREENS.SETTINGS.MANAGE_ACCOUNT]: () =>
+      require<ReactComponentModule>('@screens/Settings/Account/ManageAccountScreen')
+        .default,
     [SCREENS.SETTINGS.DELETE]: () =>
       require<ReactComponentModule>('@screens/Settings/DeleteAccountScreen')
         .default,

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -182,6 +182,10 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
             [SCREENS.SETTINGS.REPORT_BUG]: ROUTES.SETTINGS_REPORT_BUG,
             [SCREENS.SETTINGS.FEEDBACK]: ROUTES.SETTINGS_FEEDBACK,
             [SCREENS.SETTINGS.ABOUT]: ROUTES.SETTINGS_ABOUT,
+            [SCREENS.SETTINGS.MANAGE_ACCOUNT]: {
+              path: ROUTES.SETTINGS_MANAGE_ACCOUNT,
+              exact: true,
+            },
             [SCREENS.SETTINGS.DELETE]: {
               path: ROUTES.SETTINGS_DELETE,
               exact: true,

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -135,6 +135,7 @@ type SettingsNavigatorParamList = {
   [SCREENS.SETTINGS.REPORT_BUG]: undefined;
   [SCREENS.SETTINGS.FEEDBACK]: undefined;
   [SCREENS.SETTINGS.ABOUT]: undefined;
+  [SCREENS.SETTINGS.MANAGE_ACCOUNT]: undefined;
   [SCREENS.SETTINGS.DELETE]: undefined;
 };
 

--- a/src/screens/Settings/Account/ManageAccountScreen.tsx
+++ b/src/screens/Settings/Account/ManageAccountScreen.tsx
@@ -1,0 +1,66 @@
+import type {StackScreenProps} from '@react-navigation/stack';
+import React from 'react';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import MenuItem from '@components/MenuItem';
+import MenuItemGroup from '@components/MenuItemGroup';
+import ScreenWrapper from '@components/ScreenWrapper';
+import ScrollView from '@components/ScrollView';
+import Section from '@components/Section';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@libs/Navigation/Navigation';
+import type {SettingsNavigatorParamList} from '@navigation/types';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+import type SCREENS from '@src/SCREENS';
+
+type ManageAccountScreenProps = StackScreenProps<
+  SettingsNavigatorParamList,
+  typeof SCREENS.SETTINGS.MANAGE_ACCOUNT
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function ManageAccountScreen({route}: ManageAccountScreenProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+
+  return (
+    <ScreenWrapper
+      testID={ManageAccountScreen.displayName}
+      includeSafeAreaPaddingBottom={false}
+      shouldShowOfflineIndicatorInWideScreen>
+      <HeaderWithBackButton
+        title={translate('manageAccountScreen.title')}
+        onBackButtonPress={Navigation.goBack}
+      />
+      <ScrollView style={styles.pt3}>
+        <MenuItemGroup>
+          <Section
+            title={translate('manageAccountScreen.dangerZone.title')}
+            subtitle={translate('manageAccountScreen.dangerZone.subtitle')}
+            isCentralPane
+            subtitleMuted
+            childrenStyles={styles.pt3}
+            titleStyles={styles.generalSectionTitle}>
+            <MenuItem
+              title={translate('manageAccountScreen.deleteAccount.title')}
+              icon={KirokuIcons.Delete}
+              iconType={CONST.ICON_TYPE_ICON}
+              iconFill={theme.danger}
+              titleStyle={styles.textDanger}
+              wrapperStyle={styles.sectionMenuItemTopDescription}
+              shouldShowRightIcon
+              onPress={() => Navigation.navigate(ROUTES.SETTINGS_DELETE)}
+            />
+          </Section>
+        </MenuItemGroup>
+      </ScrollView>
+    </ScreenWrapper>
+  );
+}
+
+ManageAccountScreen.displayName = 'Manage Account Screen';
+export default ManageAccountScreen;

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -15,8 +15,6 @@ import Text from '@components/Text';
 import Button from '@components/Button';
 import ConfirmModal from '@components/ConfirmModal';
 import MenuItem from '@components/MenuItem';
-import * as KirokuIcons from '@components/Icon/KirokuIcons';
-import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import * as Preferences from '@userActions/Preferences';
 import * as Privacy from '@userActions/Privacy';
@@ -282,8 +280,6 @@ function PrivacyScreen() {
           <MenuItem
             title={translate('privacyScreen.manageAccount.label')}
             description={translate('privacyScreen.manageAccount.description')}
-            icon={KirokuIcons.Profile}
-            iconType={CONST.ICON_TYPE_ICON}
             wrapperStyle={styles.sectionMenuItemTopDescription}
             shouldShowRightIcon
             onPress={() => Navigation.navigate(ROUTES.SETTINGS_MANAGE_ACCOUNT)}

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -14,6 +14,10 @@ import Switch from '@components/Switch';
 import Text from '@components/Text';
 import Button from '@components/Button';
 import ConfirmModal from '@components/ConfirmModal';
+import MenuItem from '@components/MenuItem';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
 import * as Preferences from '@userActions/Preferences';
 import * as Privacy from '@userActions/Privacy';
 import * as SessionLocations from '@userActions/SessionLocations';
@@ -269,6 +273,21 @@ function PrivacyScreen() {
               />
             </View>
           </View>
+        </Section>
+        <Section
+          title={translate('privacyScreen.accountSection.title')}
+          titleStyles={styles.generalSectionTitle}
+          isCentralPane
+          childrenStyles={styles.pt3}>
+          <MenuItem
+            title={translate('privacyScreen.manageAccount.label')}
+            description={translate('privacyScreen.manageAccount.description')}
+            icon={KirokuIcons.Profile}
+            iconType={CONST.ICON_TYPE_ICON}
+            wrapperStyle={styles.sectionMenuItemTopDescription}
+            shouldShowRightIcon
+            onPress={() => Navigation.navigate(ROUTES.SETTINGS_MANAGE_ACCOUNT)}
+          />
         </Section>
         <ConfirmModal
           danger

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -211,11 +211,6 @@ function SettingsScreen() {
           icon: KirokuIcons.Exit,
           action: onSignOut,
         },
-        {
-          translationKey: 'settingsScreen.deleteAccount',
-          icon: KirokuIcons.Delete,
-          routeName: ROUTES.SETTINGS_DELETE,
-        },
         ...(userIsAdmin
           ? [
               {


### PR DESCRIPTION
### Details

The **Delete account** action used to sit on the top-level Settings screen, right next to **Sign out** — one of the most prominent spots in the app and a one-tap path to an irreversible action.

This PR makes it intentionally harder to reach by accident, without removing the capability. The entry is now three taps deep, behind a new intermediate screen:

```
Settings > Account > Privacy > Manage account > Delete account
```

What changed:

- Removed the "Delete account" item from `SettingsScreen`'s authentication section (it no longer appears on the main Settings screen).
- Added a "Manage account" navigation row at the bottom of the **Privacy** screen.
- Added a new `ManageAccountScreen` with a "Danger zone" section whose red **Delete account** row navigates to the existing delete flow.
- Wired the new `SETTINGS_MANAGE_ACCOUNT` screen/route through `SCREENS`, `ROUTES`, navigation types, the modal stack navigator, and the linking config (mirroring the existing `SETTINGS.DELETE` pattern in all five places).
- Added English copy (`manageAccountScreen.*`, `privacyScreen.accountSection`, `privacyScreen.manageAccount`) and the mirrored Czech translations via the `translate` skill.

**The actual deletion flow is untouched** — `DeleteAccountScreen` keeps the same route, re-auth (password / OAuth), and confirm modal. Only the entry point moved. The old `settings/delete` deep link still works and now also reachable from the new Manage account screen.

### Tests

1. Open **Settings** and verify there is **no** "Delete account" item in the bottom (Authentication) section anymore.
2. Go to **Settings > Account > Privacy**, scroll to the bottom, and verify a new **Account** section with a **Manage account** row (chevron on the right).
3. Tap **Manage account** and verify the new screen opens with a **Danger zone** section containing a red **Delete account** row.
4. Tap **Delete account** and verify the existing delete flow opens (reason field, password / provider re-auth, and the "Deleting your account cannot be undone." confirm modal).
5. Switch the app language to Czech and repeat steps 2–4, verifying the new strings are localized (Správa účtu / Nebezpečná zóna / Smazat účet).
6. Verify the `settings/manage-account` and `settings/delete` deep links resolve correctly.

- [ ] Verify that no errors appear in the JS console

### Offline tests

- The change is navigation/UI only; no new network calls. The delete flow's existing offline behavior (confirm button disabled while offline) is unchanged.

### QA Steps

1. Confirm "Delete account" is no longer on the main Settings screen.
2. Navigate Settings > Account > Privacy > Manage account > Delete account and confirm each step renders correctly on Android and iOS.
3. Complete an account deletion from the new path on a test account and verify it still works end to end.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method of the `LocaleContextProvider`
- [x] If a new screen is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the screen.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
