### PR TITLE
revert: restore app ndkVersion to 27.1.12297006 (match React Native)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 36
         targetSdkVersion = 36
-        ndkVersion = "27.3.13750724"
+        ndkVersion = "27.1.12297006"
 
         androidXCore = "1.0.2"
         multiDexEnabled = true


### PR DESCRIPTION
## Reverts the NDK bump from #1129

#1129 changed the app `buildscript.ext.ndkVersion` to `27.3.13750724` to dodge an Android deploy failure. On closer inspection that change was **ineffective**, and this restores the original value.

### Why the bump didn't help
- The original deploy failure was a **transient corrupt NDK download** from Google's CDN (`Error on ZipFile unknown archive`). It has since **resolved on its own** — recent Android jobs install the NDK cleanly (`"Install NDK ... 27.1.12297006" ready → complete → finished`).
- The bump targeted the wrong lever. `buildscript.ext.ndkVersion` only feeds the **app** module (`android/app/build.gradle`). **React Native pins its own NDK** in `node_modules/react-native/gradle/libs.versions.toml` → `ndkVersion = "27.1.12297006"`, and that's the version AGP actually installs. Build logs after #1129 never reference `27.3` at all — the download it was meant to remove still happened.
- Net effect of #1129: app module on 27.3, RN on 27.1 — a pointless patch-level skew with no benefit.

### If we want real download-immunity later
The correct lever is the gradle **property** `ndkVersion` (honored by RN's `ReactAndroid/build.gradle.kts`: `rootProject.hasProperty("ndkVersion")`), set in `android/gradle.properties`. That forces RN + all modules onto the runner-preinstalled NDK and removes the download — but it changes the NDK RN links against, so it must be validated against a real Android build (CI's PR checks don't build Android).

One-line change; deploy is currently green either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)