### PR TITLE
fix(profile): refetch a friend's data when connectivity resumes

### DIFF
--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -6,6 +6,7 @@ import type {UserID} from '@src/types/onyx/OnyxCommon';
 import {startOfMonth, subMonths} from 'date-fns';
 import {useEffect, useRef, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
+import useNetwork from '@hooks/useNetwork';
 
 type UseDrinkingSessionsFetchReturn = {
   /** Last-good snapshot of the windowed session list. Stays populated across
@@ -109,6 +110,26 @@ function useDrinkingSessionsFetch(
 
     DrinkingSession.openFriendDrinkingSessions(userID, from).finally(finalize);
   }, [userID, sessionsMonthsBack, monthsLoadedMeta.status]);
+
+  // Re-issue the windowed read when connectivity resumes.
+  // `openFriendDrinkingSessions` goes through `makeRequestWithSideEffects`,
+  // which DISCARDS a read while offline instead of queueing it (unlike
+  // `API.write`), and the effect above only re-runs when `userID` /
+  // `sessionsMonthsBack` change — so an offline mount leaves the calendar empty
+  // even after going back online. Re-fetch the SAME window (no token/loading
+  // bookkeeping needed: the carry-no-optimistic-data read just refreshes
+  // `cachedDrinkingSessions[userID]` in place when it lands).
+  useNetwork({
+    onReconnect: () => {
+      if (!userID || monthsLoadedMeta.status !== 'loaded') {
+        return;
+      }
+      const from = startOfMonth(
+        subMonths(new Date(), sessionsMonthsBack),
+      ).getTime();
+      DrinkingSession.openFriendDrinkingSessions(userID, from);
+    },
+  });
 
   return {data, isLoading, isFetchingOlderMonths};
 }

--- a/src/hooks/useFriendPreferences/index.ts
+++ b/src/hooks/useFriendPreferences/index.ts
@@ -4,6 +4,7 @@ import type {Preferences as PreferencesType} from '@src/types/onyx';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import {useEffect, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
+import useNetwork from '@hooks/useNetwork';
 
 type UseFriendPreferencesReturn = {
   /** The friend's rendering preferences, or `undefined` until loaded / when the
@@ -46,6 +47,20 @@ function useFriendPreferences(userID: UserID): UseFriendPreferencesReturn {
       isActive = false;
     };
   }, [userID]);
+
+  // Re-issue the read when connectivity resumes. `openFriendPreferences` goes
+  // through `makeRequestWithSideEffects`, which DISCARDS a read while offline
+  // instead of queueing it (unlike `API.write`), and the effect above is keyed
+  // on `userID` so it never re-runs on reconnect — without this the profile
+  // calendar's units/colors stay missing after going back online.
+  useNetwork({
+    onReconnect: () => {
+      if (!userID) {
+        return;
+      }
+      Preferences.openFriendPreferences(userID);
+    },
+  });
 
   const isLoading = !!userID && loadedUserID !== userID;
 

--- a/src/hooks/useFriendProfile/index.ts
+++ b/src/hooks/useFriendProfile/index.ts
@@ -4,6 +4,7 @@ import type UserData from '@src/types/onyx/UserData';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import {useEffect, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
+import useNetwork from '@hooks/useNetwork';
 
 type UseFriendProfileReturn = {
   /** The viewed user's public data (profile, public_data, is_supporter, friends),
@@ -47,6 +48,23 @@ function useFriendProfile(userID: UserID): UseFriendProfileReturn {
       isActive = false;
     };
   }, [userID]);
+
+  // Re-issue the reads when connectivity resumes. `openPublicProfile` /
+  // `openFriendList` go through `makeRequestWithSideEffects`, which DISCARDS a
+  // read while offline instead of queueing it (unlike `API.write`), so an
+  // offline mount leaves the profile screen stuck on its empty "go online"
+  // state — the `useEffect` above is keyed on `userID` and never re-runs on
+  // reconnect. The reads carry no optimistic data, so this refreshes
+  // `userDataList[userID]` in place without flashing a loader over cached data.
+  useNetwork({
+    onReconnect: () => {
+      if (!userID) {
+        return;
+      }
+      Profile.openPublicProfile(userID);
+      Profile.openFriendList(userID);
+    },
+  });
 
   const isLoading = !!userID && loadedUserID !== userID;
 


### PR DESCRIPTION
## Problem

While **offline**, opening another user's **Profile** shows the empty "go online to see data" state. Going **back online does not refetch** the friend's data, so the screen stays stuck on the empty state until you navigate away and back (which re-mounts it).

This only affects a **friend's** profile. Home and Statistics "work" because they render the **current user's** data, which `app/open` persists into Onyx at launch and is served from the offline disk cache regardless of connectivity, not because they refetch on reconnect.

## Root cause

The three friend-data hooks fetch from a `useEffect` keyed only on `userID`, with no dependency on network state and no reconnect handler:

- `useFriendProfile` → `Profile.openPublicProfile` + `Profile.openFriendList`
- `useFriendPreferences` → `Preferences.openFriendPreferences`
- `useDrinkingSessionsFetch` → `DrinkingSession.openFriendDrinkingSessions`

All four calls go through `API.makeRequestWithSideEffects`, whose contract is: *"not persisted to disk. If there is no network connectivity, the request is ignored and discarded."* Unlike `API.write` (queued in `SequentialQueue` and replayed on reconnect), these reads are fire-and-forget.

So on the offline→online edge:
- the `useEffect` does not re-run (`userID` is unchanged), and
- nothing else re-issues the read — the global `reconnectApp`/`openApp`-on-reconnect is commented out in `AuthScreens`; the only registered reconnect callback is `SequentialQueue.flush`, which replays **writes** only.

## Fix

Add a `useNetwork({onReconnect})` handler to each of the three hooks that re-issues the same read(s) when connectivity resumes. The reads carry no optimistic data, so they refresh `userDataList[userID]` / `cachedDrinkingSessions[userID]` in place — the screen flips from the empty state to data without flashing a loader over already-cached data. `useNetwork`'s `onReconnect` fires precisely on the offline→online edge and already honors the dev-menu force-offline toggle.

## Changed files

- `src/hooks/useFriendProfile/index.ts`
- `src/hooks/useFriendPreferences/index.ts`
- `src/hooks/useDrinkingSessionsFetch/index.ts`

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed
- `npm run lint-changed` — clean
- `npx prettier --write` — no changes

### Manual QA suggestion

1. Go offline, open a friend's profile → empty "go online" state.
2. Go back online → profile, friend count, monthly overview, and calendar now populate without navigating away.
3. Sanity-check the happy path (online the whole time) and an online network blip — cached data should not flash a loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)