### PR TITLE
fix(reads): refetch cross-user data on five screens when connectivity resumes

### DIFF
--- a/src/hooks/useFriendsData/index.ts
+++ b/src/hooks/useFriendsData/index.ts
@@ -1,6 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
+import useNetwork from '@hooks/useNetwork';
 import * as Profile from '@userActions/Profile';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ProfileList, UserStatusList} from '@src/types/onyx';
@@ -84,6 +85,26 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
       });
     }, [friendIDs]),
   );
+
+  // Re-issue the batched read when connectivity resumes. `fetchUsersData` goes
+  // through `makeRequestWithSideEffects`, which DISCARDS a read while offline
+  // instead of queueing it (unlike `API.write`). `useFocusEffect` only recovers
+  // a tab switch, so a stay-on-screen reconnect would leave the list stale —
+  // mirror the focus-effect body here (same latest-wins token) so going back
+  // online refreshes `USER_DATA_LIST` in place without a tab switch.
+  useNetwork({
+    onReconnect: () => {
+      if (friendIDs.length === 0) {
+        return;
+      }
+      const token = ++currentTokenRef.current;
+      Profile.fetchUsersData(friendIDs).finally(() => {
+        if (token === currentTokenRef.current) {
+          setHasResolvedInitial(true);
+        }
+      });
+    },
+  });
 
   return {profileList, userStatusList, isLoading};
 }

--- a/src/screens/Profile/FriendsFriendsScreen.tsx
+++ b/src/screens/Profile/FriendsFriendsScreen.tsx
@@ -25,6 +25,7 @@ import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import useNetwork from '@hooks/useNetwork';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -161,6 +162,20 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Re-issue the friends read when connectivity resumes. `openFriendList` goes
+  // through `makeRequestWithSideEffects`, which DISCARDS a read while offline
+  // instead of queueing it (unlike `API.write`), and the mount effect above is
+  // keyed on `fetchData`/`userID` so it never re-runs on reconnect — without
+  // this an offline mount leaves the screen stuck on its empty state. Call the
+  // read directly (not `fetchData`, which toggles `isLoading`): it carries no
+  // optimistic data and refreshes `userDataList[userID].friends` in place, which
+  // cascades through the `initialSearch` effect to repaint the list.
+  useNetwork({
+    onReconnect: () => {
+      Profile.openFriendList(userID);
+    },
+  });
 
   useEffect(() => {
     const initialSearch = async (): Promise<void> => {

--- a/src/screens/Settings/Admin/SeeBugsScreen.tsx
+++ b/src/screens/Settings/Admin/SeeBugsScreen.tsx
@@ -6,6 +6,7 @@ import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import type {Bug, NicknameToId} from '@src/types/onyx';
@@ -42,6 +43,18 @@ function SeeBugsScreen() {
       isMounted = false;
     };
   }, []);
+
+  // Re-issue the read when connectivity resumes. `getBugList` goes through
+  // `makeRequestWithSideEffects`, which DISCARDS a read while offline instead of
+  // queueing it (unlike `API.write`), and the mount effect above runs once (`[]`)
+  // so it never re-runs on reconnect — without this an offline mount leaves the
+  // list empty after going back online. No loading toggle: the read carries no
+  // optimistic data and refreshes the `BUG_LIST` Onyx key in place.
+  useNetwork({
+    onReconnect: () => {
+      getBugList();
+    },
+  });
 
   useEffect(() => {
     const fetchNicknames = async () => {

--- a/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
+++ b/src/screens/Settings/Admin/SeeFeedbackScreen.tsx
@@ -6,6 +6,7 @@ import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import type {Feedback, NicknameToId} from '@src/types/onyx';
@@ -42,6 +43,18 @@ function SeeFeedbackScreen() {
       isMounted = false;
     };
   }, []);
+
+  // Re-issue the read when connectivity resumes. `getFeedbackList` goes through
+  // `makeRequestWithSideEffects`, which DISCARDS a read while offline instead of
+  // queueing it (unlike `API.write`), and the mount effect above runs once (`[]`)
+  // so it never re-runs on reconnect — without this an offline mount leaves the
+  // list empty after going back online. No loading toggle: the read carries no
+  // optimistic data and refreshes the `FEEDBACK_LIST` Onyx key in place.
+  useNetwork({
+    onReconnect: () => {
+      getFeedbackList();
+    },
+  });
 
   useEffect(() => {
     const fetchNicknames = async () => {

--- a/src/screens/Social/FriendRequestScreen.tsx
+++ b/src/screens/Social/FriendRequestScreen.tsx
@@ -4,7 +4,7 @@ import type {
   FriendRequestStatus,
   ProfileList,
 } from '@src/types/onyx';
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import {useFirebase} from '@context/global/FirebaseContext';
 import * as Friends from '@userActions/Friends';
@@ -15,6 +15,7 @@ import GrayHeader from '@components/Header/GrayHeader';
 import {objKeys} from '@libs/DataHandling';
 import CONST from '@src/CONST';
 import useCurrentUserData from '@hooks/useCurrentUserData';
+import useNetwork from '@hooks/useNetwork';
 import NoFriendInfo from '@components/Social/NoFriendInfo';
 import {isEmptyArray, isEmptyObject} from '@src/types/utils/EmptyObject';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
@@ -228,7 +229,7 @@ function FriendRequestScreen() {
   // Fetch only the request profiles we don't already have cached and aren't
   // already fetching — replacing the old "re-fetch every request on any change"
   // path. One batched call, deduped against Onyx + the in-flight set.
-  useEffect(() => {
+  const fetchMissingProfiles = useCallback(() => {
     const missingIDs = objKeys(friendRequests).filter(
       id => !userDataList?.[id]?.profile && !inFlightRef.current.has(id),
     );
@@ -245,6 +246,21 @@ function FriendRequestScreen() {
       setHasResolvedInitial(true);
     });
   }, [friendRequests, userDataList]);
+
+  useEffect(() => {
+    fetchMissingProfiles();
+  }, [fetchMissingProfiles]);
+
+  // Re-issue the missing-profile read when connectivity resumes.
+  // `fetchUserProfiles` goes through `makeRequestWithSideEffects`, which DISCARDS
+  // a read while offline instead of queueing it (unlike `API.write`), and the
+  // effect above is keyed on data identity (`friendRequests`/`userDataList`) so
+  // it never re-runs on reconnect — without this an offline mount leaves the
+  // request profiles missing after going back online. The shared dedupe (Onyx +
+  // in-flight set) means the reconnect call only fetches what's still missing.
+  useNetwork({
+    onReconnect: () => fetchMissingProfiles(),
+  });
 
   // Cold-load gate only: show the spinner just for the first load of a request
   // set with nothing cached yet — never blank the list out on a later refresh.

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -1,6 +1,6 @@
 import type {ListRenderItemInfo} from 'react-native';
 import {View} from 'react-native';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import type {
   FriendRequestList,
   FriendRequestStatus,
@@ -47,6 +47,10 @@ function FriendSearchScreen() {
   >({});
   const [noUsersFound, setNoUsersFound] = useState(false);
   const [displayData, setDisplayData] = useState<ProfileList>({});
+  // The last query the search box emitted. `SearchWindow` owns the text (it only
+  // re-calls `onSearch` when the debounced text changes), so we track it here to
+  // be able to replay it when connectivity resumes.
+  const lastSearchTextRef = useRef('');
 
   /** Having a list of users returned by the search,
    * determine the request status for each and update
@@ -83,6 +87,7 @@ function FriendSearchScreen() {
 
   const dbSearch = useCallback(
     async (searchText: string): Promise<void> => {
+      lastSearchTextRef.current = searchText;
       // User search is a live server read that can't be queued; offline it would
       // hang on a spinner or fail. Short-circuit and let the render show the
       // offline notice instead.
@@ -114,6 +119,23 @@ function FriendSearchScreen() {
     },
     [isOffline, updateRequestStatuses, resetSearch],
   );
+
+  // Replay the pending query when connectivity resumes. The offline branch of
+  // `dbSearch` short-circuits (search is a live, unqueueable read) and renders
+  // the offline notice, but nothing re-runs the query once back online — the
+  // notice clears and the result list is left blank with the typed query still
+  // in the box. Re-issue the last query the search box emitted on the
+  // offline->online edge so reconnecting recovers the results in place. (Kept as
+  // its own `useNetwork` call because the one above must read `isOffline` before
+  // `dbSearch` is defined, and this handler must call `dbSearch`.)
+  useNetwork({
+    onReconnect: () => {
+      if (!lastSearchTextRef.current.trim()) {
+        return;
+      }
+      dbSearch(lastSearchTextRef.current);
+    },
+  });
 
   useMemo(() => {
     if (!userData) {


### PR DESCRIPTION
## Root cause

Cross-user / on-demand reads (a friend's friends list, friend-request profiles, friend-list presence, admin feedback/bugs) are issued via `API.makeRequestWithSideEffects` (READ commands). Per its contract in `src/libs/API/index.ts`, such reads are **not persisted to disk and are discarded when offline** — unlike `API.write`, which is queued in `SequentialQueue` and replayed on reconnect.

These screens issue the reads from a `useEffect` keyed only on data identity (e.g. `userID`, `friendRequests`), with no dependency on network state and no reconnect handler, and the global `reconnectApp`/openApp-on-reconnect is commented out in `AuthScreens.tsx`. So if a screen mounts while offline, the read is dropped and going back online never re-issues it — the screen stays stuck on its empty state. (Home/Statistics are unaffected because they render the current user's data, which `app/open` persists into Onyx and serves from the offline disk cache.)

This is a follow-up to merged #1138, which fixed the same class of bug on the friend Profile screen. Same proven pattern: add a `useNetwork({onReconnect})` handler that re-issues the read on the offline→online edge. The reads carry no optimistic data, so they refresh the backing Onyx key in place; no `isLoading` toggle (that would flash a full loader over already-cached data on a brief blip). The existing mount-fetch effects and their guards are left untouched.

## Changed files — what recovers on reconnect

- **`src/screens/Profile/FriendsFriendsScreen.tsx`** — re-issues `Profile.openFriendList(userID)`; refreshing `userDataList[userID].friends` cascades through the existing `initialSearch` effect to repaint the list. (Calls the read directly, not `fetchData`, which would toggle `isLoading`.)
- **`src/screens/Social/FriendRequestScreen.tsx`** — extracts the missing-profile fetch into a `useCallback` (`fetchMissingProfiles`) shared by the existing effect and the reconnect handler; re-issues `Profile.fetchUserProfiles(missingIDs)`, deduped against Onyx + the in-flight set.
- **`src/screens/Settings/Admin/SeeFeedbackScreen.tsx`** — re-issues `getFeedbackList()`; refreshes the `FEEDBACK_LIST` Onyx key in place.
- **`src/screens/Settings/Admin/SeeBugsScreen.tsx`** — re-issues `getBugList()`; refreshes the `BUG_LIST` Onyx key in place.
- **`src/hooks/useFriendsData/index.ts`** — mirrors the `useFocusEffect` body (guard on empty `friendIDs`, bump the latest-wins token, `Profile.fetchUsersData(friendIDs)`); `useFocusEffect` only recovered a tab switch, so a stay-on-screen reconnect now refreshes the friend list's profile+presence batch too.

### Follow-up: friend search (same family, different mechanism)

- **`src/screens/Social/FriendSearchScreen.tsx`** — user search is a live, unqueueable server read, so `dbSearch` deliberately short-circuits while offline and renders the "requires internet" notice. But the query lives in `SearchWindow` (it only re-calls `onSearch` when the debounced text changes), so reconnecting never re-ran it: the offline notice cleared and the result list was left blank with the typed query still in the box. Now the screen tracks the last query the search box emitted and replays it via `useNetwork({onReconnect})` on the offline→online edge, recovering the results in place.

## Checks

- `npx prettier --write` (all changed files)
- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `npm run lint-changed` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)