### PR TITLE
fix(auth): OAuth sign-up redirect + cold-start session persistence

### DIFF
--- a/__tests__/actions/UserOAuth.test.ts
+++ b/__tests__/actions/UserOAuth.test.ts
@@ -8,9 +8,11 @@
 
 import {signInWithCredential, updateProfile} from 'firebase/auth';
 import type {Auth, AuthCredential} from 'firebase/auth';
+import Onyx from 'react-native-onyx';
 import * as API from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import HttpsError from '@libs/Errors/HttpsError';
+import ONYXKEYS from '@src/ONYXKEYS';
 import * as Session from '@userActions/Session';
 import * as UserActions from '@userActions/User';
 
@@ -101,6 +103,7 @@ const mockedSignIn = jest.mocked(signInWithCredential);
 const mockedUpdateProfile = jest.mocked(updateProfile);
 const mockedProvision = jest.mocked(API.makeRequestWithSideEffects);
 const mockedClearSignInData = jest.mocked(Session.clearSignInData);
+const mockedOnyxUpdate = jest.mocked(Onyx.update);
 
 const fakeAuth = {} as Auth;
 const fakeCredential = {} as AuthCredential;
@@ -144,6 +147,29 @@ describe('signInWithOAuth', () => {
     expect(mockedClearSignInData).toHaveBeenCalledTimes(1);
   });
 
+  it('seeds the default user data into Onyx for a brand-new account so the redirect is deterministic', async () => {
+    mockedProvision.mockResolvedValue(undefined);
+
+    await UserActions.signInWithOAuth(fakeAuth, fakeCredential, 'Jane Doe');
+
+    // The OnboardingGuard gates on `userData !== undefined`; without this local
+    // write a brand-new OAuth account is stranded on the auth screen on native.
+    expect(mockedOnyxUpdate).toHaveBeenCalledTimes(1);
+    const updates = mockedOnyxUpdate.mock.calls[0][0];
+    const userDataUpdate = updates.find(
+      update => update.key === ONYXKEYS.USER_DATA_LIST,
+    );
+    expect(userDataUpdate?.value).toEqual({
+      'oauth-uid': expect.objectContaining({
+        profile: {
+          display_name: 'Jane Doe',
+          photo_url: '',
+          username_chosen: false,
+        },
+      }),
+    });
+  });
+
   it('swallows a 409 (returning account) and does not re-set the display name', async () => {
     mockedProvision.mockRejectedValue(
       new HttpsError({message: 'Conflict', status: '409'}),
@@ -156,6 +182,8 @@ describe('signInWithOAuth', () => {
     expect(mockedProvision).toHaveBeenCalledTimes(1);
     // A returning user already has their Firebase Auth profile — must not be touched.
     expect(mockedUpdateProfile).not.toHaveBeenCalled();
+    // Their real Onyx data must NOT be clobbered with brand-new defaults.
+    expect(mockedOnyxUpdate).not.toHaveBeenCalled();
     // Sign-in still proceeds.
     expect(mockedClearSignInData).toHaveBeenCalledTimes(1);
   });

--- a/__tests__/unit/FirebaseAuthInit.test.ts
+++ b/__tests__/unit/FirebaseAuthInit.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- jest mock factory keys (__esModule) are dictated by Node module shape, and this test exercises the real FirebaseApp.native module via isolateModules + dynamic require() */
+
+// `firebase/auth`, `firebase/app`, and AsyncStorage are already mocked globally
+// in jest/setup.ts. Mock the remaining direct deps of FirebaseApp.native so we
+// can drive its init paths and assert the loud Crashlytics signal.
+jest.mock('@react-native-firebase/crashlytics', () => ({
+  getCrashlytics: jest.fn(() => ({})),
+  log: jest.fn(),
+  recordError: jest.fn(),
+}));
+
+jest.mock('@src/CONFIG', () => ({
+  __esModule: true,
+  default: {SEND_CRASH_REPORTS: true},
+}));
+
+jest.mock('@libs/Firebase/FirebaseConfig', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    alert: jest.fn(),
+    hmmm: jest.fn(),
+  },
+}));
+
+describe('FirebaseApp.native auth initialization', () => {
+  test('initializes auth once with AsyncStorage persistence and reuses the singleton', () => {
+    jest.isolateModules(() => {
+      const auth = require('firebase/auth');
+      auth.getReactNativePersistence.mockReturnValue('rn-persistence');
+      const instance = {tag: 'async-auth'};
+      auth.initializeAuth.mockReturnValue(instance);
+
+      const mod = require('@libs/Firebase/FirebaseApp.native');
+      const first = mod.initFirebaseAuth();
+
+      // The AsyncStorage-backed persistence is what survives a cold start.
+      expect(auth.getReactNativePersistence).toHaveBeenCalledTimes(1);
+      expect(auth.initializeAuth).toHaveBeenCalledTimes(1);
+      expect(auth.initializeAuth).toHaveBeenCalledWith(undefined, {
+        persistence: 'rn-persistence',
+      });
+      expect(first).toBe(instance);
+
+      // getFirebaseAuth returns the same instance and does NOT re-initialize.
+      const second = mod.getFirebaseAuth();
+      expect(second).toBe(instance);
+      expect(auth.initializeAuth).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('reports the failure to Crashlytics (loud, not silent) and falls back to memory persistence', () => {
+    jest.isolateModules(() => {
+      const auth = require('firebase/auth');
+      const crashlytics = require('@react-native-firebase/crashlytics');
+      auth.getReactNativePersistence.mockReturnValue('rn-persistence');
+      const memoryInstance = {tag: 'memory-auth'};
+      auth.initializeAuth
+        .mockImplementationOnce(() => {
+          throw new Error('AsyncStorage not ready');
+        })
+        .mockImplementationOnce(() => memoryInstance);
+
+      const mod = require('@libs/Firebase/FirebaseApp.native');
+      const result = mod.initFirebaseAuth();
+
+      // Fell back to memory persistence so the app still runs...
+      expect(auth.initializeAuth).toHaveBeenCalledTimes(2);
+      expect(result).toBe(memoryInstance);
+      // ...but the AsyncStorage failure was surfaced, not swallowed.
+      expect(crashlytics.recordError).toHaveBeenCalledTimes(1);
+      expect(crashlytics.log).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('session will NOT persist'),
+      );
+    });
+  });
+});

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -28,6 +28,16 @@ jest.mock('firebase/auth', () => ({
 
 jest.mock('@react-native-async-storage/async-storage', () => ({}));
 
+// FirebaseApp.native (transitively imported by many modules via getFirebaseAuth)
+// imports the modular crashlytics surface, which would otherwise pull in the real
+// native @react-native-firebase/app and crash under jest.
+jest.mock('@react-native-firebase/crashlytics', () => ({
+  getCrashlytics: jest.fn(() => ({})),
+  log: jest.fn(),
+  recordError: jest.fn(),
+  setCrashlyticsCollectionEnabled: jest.fn(),
+}));
+
 // Mock react-native-onyx storage layer because the SQLite storage layer doesn't work in jest.
 // Mocking this file in __mocks__ does not work because jest doesn't support mocking files that are not directly used in the testing project,
 // and we only want to mock the storage layer, not the whole Onyx module.

--- a/src/libs/Firebase/FirebaseApp.native.ts
+++ b/src/libs/Firebase/FirebaseApp.native.ts
@@ -1,3 +1,8 @@
+import {
+  getCrashlytics,
+  log,
+  recordError,
+} from '@react-native-firebase/crashlytics';
 import type {FirebaseApp as FirebaseAppProps} from 'firebase/app';
 import {initializeApp, getApp, getApps} from 'firebase/app';
 import type {Auth} from 'firebase/auth';
@@ -9,6 +14,7 @@ import {
 } from 'firebase/auth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Log from '@libs/Log';
+import CONFIG from '@src/CONFIG';
 import FirebaseConfig from './FirebaseConfig';
 
 const currentApps = getApps();
@@ -24,73 +30,108 @@ const FirebaseApp: FirebaseAppProps =
   currentApps.length === 0 ? initializeApp(FirebaseConfig) : getApp();
 
 /**
- * Lazy auth instance - initialized on first access to avoid accessing AsyncStorage
- * (a native module) before React Native's native bridge is ready.
- *
- * CRITICAL: In production builds with Hermes bytecode + inlineRequires: true,
- * all module imports execute immediately. If we initialize auth at import time
- * with AsyncStorage persistence, it will crash because native modules aren't
- * ready yet during RCTJSThreadManager initialization.
+ * Single auth instance for the process. Assigned only on a SUCCESSFUL
+ * `initializeAuth`/`getAuth` call, so a thrown attempt leaves it `null` and the
+ * next call retries (self-heals) rather than caching a broken instance.
  */
 let firebaseAuth: Auth | null = null;
 
 /**
- * Get Firebase Auth instance with lazy initialization.
+ * Surface a persistence-init failure in production. Native `Log.*` only reaches
+ * the Metro/Xcode console (its network sink is a stub), so an AsyncStorage
+ * persistence failure — which silently logs the user out on every cold start —
+ * would otherwise be invisible. Crashlytics is the real production sink (already
+ * wired in `platformSetup`). Gated + wrapped so reporting can never break auth init.
+ */
+function reportPersistenceFailure(message: string, error: unknown): void {
+  if (!CONFIG.SEND_CRASH_REPORTS) {
+    return;
+  }
+  try {
+    const crashlytics = getCrashlytics();
+    log(crashlytics, message);
+    recordError(
+      crashlytics,
+      error instanceof Error ? error : new Error(message),
+    );
+  } catch {
+    // Never let crash reporting itself break auth initialization.
+  }
+}
+
+/**
+ * Initialize Firebase Auth with AsyncStorage persistence so the session survives
+ * a cold start. Idempotent: returns the existing instance if already created.
  *
- * This function defers auth initialization until first access, ensuring React Native's
- * native bridge is ready. It attempts AsyncStorage persistence first, falling back to
- * memory persistence if AsyncStorage is unavailable.
+ * Call this ONCE, eagerly, from `setup()` after the native bridge is up (see
+ * `src/setup/index.ts`) rather than relying on whichever module happens to call
+ * `getFirebaseAuth()` first — initializing before AsyncStorage is ready pins auth
+ * to a non-persistent instance for the whole process, which is exactly the
+ * "logged out on every relaunch" bug this guards against.
  *
- * @returns Firebase Auth instance
- *
- * @example
- * // In a React component (after mount):
- * const auth = getFirebaseAuth();
+ * AsyncStorage persistence is the one that matters; the in-memory / `getAuth`
+ * fallbacks keep the app running but do NOT persist, so each is reported loudly.
+ */
+function initFirebaseAuth(): Auth {
+  if (firebaseAuth) {
+    return firebaseAuth;
+  }
+
+  try {
+    firebaseAuth = initializeAuth(FirebaseApp, {
+      persistence: getReactNativePersistence(AsyncStorage),
+    });
+    Log.info('[Firebase] Auth initialized with AsyncStorage persistence');
+    return firebaseAuth;
+  } catch (error) {
+    // Severe: without AsyncStorage persistence the session is never written on
+    // sign-in nor restored on relaunch, so the user is silently logged out on
+    // every cold start. Make it observable instead of degrading quietly.
+    Log.warn(
+      '[Firebase] AsyncStorage persistence unavailable, falling back to memory. Error:',
+      {error},
+    );
+    reportPersistenceFailure(
+      '[Firebase] AsyncStorage persistence FAILED - session will NOT persist across relaunch',
+      error,
+    );
+  }
+
+  try {
+    firebaseAuth = initializeAuth(FirebaseApp, {
+      persistence: inMemoryPersistence,
+    });
+    Log.info('[Firebase] Auth initialized with memory persistence (fallback)');
+    return firebaseAuth;
+  } catch (fallbackError) {
+    // Even in-memory init failed. `getAuth` keeps the app from crashing but
+    // returns a no-persistence instance (strictly worse), so record it as a
+    // hard error rather than landing there silently.
+    Log.alert(
+      '[Firebase] Failed to initialize auth with persistence, using getAuth:',
+      {fallbackError},
+    );
+    reportPersistenceFailure(
+      '[Firebase] initializeAuth failed entirely - using no-persistence getAuth()',
+      fallbackError,
+    );
+    firebaseAuth = getAuth(FirebaseApp);
+    return firebaseAuth;
+  }
+}
+
+/**
+ * Get the Firebase Auth instance. Returns the eagerly-initialized singleton
+ * (see `initFirebaseAuth`), initializing on demand as a fallback for any caller
+ * that runs before `setup()`.
  *
  * @example
  * // Via FirebaseContext (recommended):
  * const {auth} = useFirebase();
  */
 function getFirebaseAuth(): Auth {
-  // Return existing instance if already initialized
-  if (firebaseAuth) {
-    return firebaseAuth;
-  }
-
-  try {
-    // Try to initialize with AsyncStorage persistence
-    // This will work if called after React Native bridge is ready
-    firebaseAuth = initializeAuth(FirebaseApp, {
-      persistence: getReactNativePersistence(AsyncStorage),
-    });
-    Log.info('[Firebase] Auth initialized with AsyncStorage persistence');
-  } catch (error) {
-    // Fallback to memory persistence if AsyncStorage not available
-    // This ensures the app doesn't crash even if native modules have issues
-    Log.warn(
-      '[Firebase] AsyncStorage not available, using memory persistence. Error:',
-      {error},
-    );
-
-    try {
-      firebaseAuth = initializeAuth(FirebaseApp, {
-        persistence: inMemoryPersistence,
-      });
-      Log.info(
-        '[Firebase] Auth initialized with memory persistence (fallback)',
-      );
-    } catch (fallbackError) {
-      // If even memory persistence fails, try getAuth as last resort
-      Log.alert(
-        '[Firebase] Failed to initialize auth with persistence, using getAuth:',
-        {fallbackError},
-      );
-      firebaseAuth = getAuth(FirebaseApp);
-    }
-  }
-
-  return firebaseAuth;
+  return firebaseAuth ?? initFirebaseAuth();
 }
 
-export {FirebaseApp, getFirebaseAuth};
+export {FirebaseApp, getFirebaseAuth, initFirebaseAuth};
 export type {FirebaseAppProps};

--- a/src/libs/Firebase/FirebaseApp.ts
+++ b/src/libs/Firebase/FirebaseApp.ts
@@ -26,27 +26,22 @@ const FirebaseApp: FirebaseAppProps =
   currentApps.length === 0 ? initializeApp(FirebaseConfig) : getApp();
 
 /**
- * Lazy auth instance - initialized on first access to keep the export surface
- * identical to the native module (`getFirebaseAuth`).
+ * Single auth instance for the page. Assigned only on a SUCCESSFUL
+ * `initializeAuth`/`getAuth` call, so a thrown attempt leaves it `null` and the
+ * next call retries rather than caching a broken instance.
  */
 let firebaseAuth: Auth | null = null;
 
 /**
- * Get Firebase Auth instance with lazy initialization.
+ * Initialize Firebase Auth for web. Idempotent: returns the existing instance if
+ * already created. Mirrors the native `initFirebaseAuth` export surface so the
+ * shared `setup()` can call it without platform branching.
  *
- * On web the session is persisted via IndexedDB so it survives a full page
- * reload, falling back to localStorage when IndexedDB is unavailable (e.g.
- * private browsing or older browsers). Memory persistence is the last resort so
- * the app never crashes during auth init.
- *
- * @returns Firebase Auth instance
- *
- * @example
- * // Via FirebaseContext (recommended):
- * const {auth} = useFirebase();
+ * The session is persisted via IndexedDB so it survives a full page reload,
+ * falling back to localStorage when IndexedDB is unavailable (e.g. private
+ * browsing). Memory persistence is the last resort so auth init never crashes.
  */
-function getFirebaseAuth(): Auth {
-  // Return existing instance if already initialized
+function initFirebaseAuth(): Auth {
   if (firebaseAuth) {
     return firebaseAuth;
   }
@@ -58,32 +53,43 @@ function getFirebaseAuth(): Auth {
       persistence: [indexedDBLocalPersistence, browserLocalPersistence],
     });
     Log.info('[Firebase] Auth initialized with browser persistence');
+    return firebaseAuth;
   } catch (error) {
     // Fallback to memory persistence if both browser persistence layers fail.
     Log.warn(
       '[Firebase] Browser persistence unavailable, using memory persistence. Error:',
       {error},
     );
-
-    try {
-      firebaseAuth = initializeAuth(FirebaseApp, {
-        persistence: inMemoryPersistence,
-      });
-      Log.info(
-        '[Firebase] Auth initialized with memory persistence (fallback)',
-      );
-    } catch (fallbackError) {
-      // If even memory persistence fails, try getAuth as last resort
-      Log.alert(
-        '[Firebase] Failed to initialize auth with persistence, using getAuth:',
-        {fallbackError},
-      );
-      firebaseAuth = getAuth(FirebaseApp);
-    }
   }
 
-  return firebaseAuth;
+  try {
+    firebaseAuth = initializeAuth(FirebaseApp, {
+      persistence: inMemoryPersistence,
+    });
+    Log.info('[Firebase] Auth initialized with memory persistence (fallback)');
+    return firebaseAuth;
+  } catch (fallbackError) {
+    // If even memory persistence fails, try getAuth as last resort.
+    Log.alert(
+      '[Firebase] Failed to initialize auth with persistence, using getAuth:',
+      {fallbackError},
+    );
+    firebaseAuth = getAuth(FirebaseApp);
+    return firebaseAuth;
+  }
 }
 
-export {FirebaseApp, getFirebaseAuth};
+/**
+ * Get the Firebase Auth instance, initializing on demand for any caller that
+ * runs before `setup()`.
+ *
+ * @example
+ * // Via FirebaseContext (recommended):
+ * const {auth} = useFirebase();
+ */
+function getFirebaseAuth(): Auth {
+  return firebaseAuth ?? initFirebaseAuth();
+}
+
+export {FirebaseApp, getFirebaseAuth, initFirebaseAuth};
 export type {FirebaseAppProps};

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -121,17 +121,23 @@ const getDefaultUserData = (profileData: Profile): UserData => {
  *   mis-route them into onboarding) with no way to undo it: the `409` surfaces as
  *   a thrown HTTP rejection that never reaches `SaveResponseInOnyx`, so neither
  *   `onyxData` nor `failureData` is applied. A brand-new OAuth user is
- *   unaffected — the server's `200` response carries the same `onyxData`, applied
- *   when this promise resolves (before the sign-in overlay drops).
+ *   unaffected: `signInWithOAuth` writes the same defaults imperatively on the
+ *   `200` success path (see `getNewUserOnyxData`), so the post-auth redirect
+ *   does not depend on the server echoing `onyxData`.
  */
-function provisionUser(
+/**
+ * The Onyx writes that seed a brand-new account's default user data,
+ * preferences, and theme. Shared by `provisionUser`'s optimistic update (the
+ * email/password path) and `signInWithOAuth`'s success path, which applies
+ * them imperatively once the server confirms the account is genuinely new.
+ */
+function getNewUserOnyxData(
   userID: string,
   profileData: Profile,
-  {applyOptimisticData = true}: {applyOptimisticData?: boolean} = {},
-): Promise<void | Response> {
+): OnyxUpdate[] {
   const userData = getDefaultUserData(profileData);
   const preferences = getDefaultPreferences();
-  const optimisticData: OnyxUpdate[] = [
+  return [
     {
       onyxMethod: Onyx.METHOD.MERGE,
       key: ONYXKEYS.USER_DATA_LIST,
@@ -148,12 +154,23 @@ function provisionUser(
       value: preferences.theme ?? CONST.THEME.SYSTEM,
     },
   ];
+}
+
+function provisionUser(
+  userID: string,
+  profileData: Profile,
+  {applyOptimisticData = true}: {applyOptimisticData?: boolean} = {},
+): Promise<void | Response> {
+  const userData = getDefaultUserData(profileData);
+  const preferences = getDefaultPreferences();
 
   // eslint-disable-next-line rulesdir/no-api-side-effects-method
   return API.makeRequestWithSideEffects(
     WRITE_COMMANDS.PROVISION_USER,
     {profile: profileData, timezone: userData.timezone, preferences},
-    applyOptimisticData ? {optimisticData} : {},
+    applyOptimisticData
+      ? {optimisticData: getNewUserOnyxData(userID, profileData)}
+      : {},
   );
 }
 
@@ -485,8 +502,20 @@ async function signInWithOAuth(
     // `provisionUser`) because a returning user reaches this on every sign-in
     // and the defaults would briefly overwrite their real data with no rollback.
     await provisionUser(user.uid, profileData, {applyOptimisticData: false});
-    // Brand-new account only — a `409` jumps to the catch and skips this, since a
-    // returning user already has their Firebase Auth display name.
+    // Brand-new account only — a `409` jumps to the catch and skips everything
+    // below, since a returning user already has their data and display name.
+    //
+    // Seed the default user data into Onyx now that the `200` has confirmed a
+    // genuinely new account. Without a local write the post-auth OnboardingGuard
+    // has no `userData` to gate on (its readiness check is
+    // `isLoadingApp === false && userData !== undefined`) and depends entirely on
+    // the server echoing `onyxData` winning a race against `openApp` — on native
+    // that race is routinely lost, leaving the new account stranded on the auth
+    // screen instead of being redirected into onboarding. This mirrors the
+    // synchronous optimistic write the email/password signup already does, making
+    // the OAuth redirect deterministic. The returning-user path must never reach
+    // here (it would clobber their real prefs/theme); the 409 catch guarantees it.
+    await Onyx.update(getNewUserOnyxData(user.uid, profileData));
     await updateProfile(user, {displayName: name});
   } catch (error) {
     // `409 Conflict` = the account already exists (returning user). That is the

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -5,6 +5,7 @@ import * as Subscriptions from '@userActions/Subscriptions';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import intlPolyfill from '@libs/IntlPolyfill';
+import {initFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import StartupMetrics from '@libs/StartupMetrics';
 import initializeLastVisitedPath from './initializeLastVisitedPath';
 import platformSetup from './platformSetup';
@@ -73,6 +74,14 @@ export default function () {
 
   // Perform any other platform-specific setup
   platformSetup();
+
+  // Initialize Firebase Auth once, here, where native modules are proven ready
+  // (platformSetup() above already touches @react-native-firebase). Doing it at
+  // this single, post-bridge point - instead of racing on whichever module hits
+  // getFirebaseAuth() first - guarantees auth is created with persistence
+  // (AsyncStorage on native, IndexedDB on web) so the session survives a cold
+  // start. Resolves by platform extension, so no platform branching is needed.
+  initFirebaseAuth();
 
   // Capture native cold-start marks (process spawn → first content visible)
   // and log them in the same `Timing:` format as Timing.ts so Grafana picks


### PR DESCRIPTION
This branch bundles two related auth-flow fixes (same session branch).

---

## 1. OAuth sign-up redirect (commit 1)

A successful **Google/Apple sign-up on native** frequently failed to redirect the new account off the auth flow — the user signed in (Firebase account created) but never advanced into onboarding.

Post-auth routing is owned by the reactive `OnboardingGuard`, gated on `isLoadingApp === false && userData !== undefined`. Email/password signup writes the new user's data to Onyx **synchronously** (`applyOptimisticData: true`), but OAuth provisions speculatively (`applyOptimisticData: false`, so a returning user's data isn't clobbered before the 409 is known) and writes **nothing** locally — so the new account's `userData` only appears if the server's echoed `onyxData` wins a race against `openApp` and the guard's single, non-retrying `navigate()`. On native that race is routinely lost.

**Fix:** on the OAuth `200` success path (genuinely new account only — a returning user's `409` throws first and skips it), imperatively seed the default user data/preferences/theme into Onyx via the shared `getNewUserOnyxData`, mirroring the email/password path. A test asserts the new account seeds and the `409` account does not.

## 2. Cold-start session persistence (commit 2)

After fix 1 made sign-in work, a follow-up surfaced: on a true **cold start (quit & relaunch)** an already-signed-in user landed on the public `InitialScreen` — effectively logged out. The app relies solely on Firebase to restore the session (the stored `encryptedAuthToken` only signs image URLs), so a restore failure has no fallback.

**Root cause:** Firebase auth was created lazily by "whichever module calls `getFirebaseAuth()` first," inside a try/catch that **silently** degrades to `inMemoryPersistence` (which doesn't survive relaunch). If that first call lands before the native bridge/AsyncStorage are ready, auth is pinned to a non-persistent instance for the whole process — the session is never written on sign-in nor restored on relaunch. In-session sign-in still worked because in-memory holds it until the process dies, which is why this only surfaced once sign-in itself worked.

**Fix:**
- Split `FirebaseApp.native` into `initFirebaseAuth()` (idempotent; assigns the singleton only on success so a thrown attempt self-heals) and `getFirebaseAuth()` (returns the singleton, init-on-demand fallback); mirror the split in the web `FirebaseApp`.
- Call `initFirebaseAuth()` once from `setup()` right after `platformSetup()` — the proven-safe point where native `@react-native-firebase` modules are already touched — instead of racing on the first arbitrary caller.
- Make the degradation **observable**: route the AsyncStorage-persistence failure to Crashlytics (native `Log.*` has a stubbed network sink), gated on `SEND_CRASH_REPORTS` and wrapped so reporting can't break init; the no-persistence `getAuth()` last resort is now recorded as a hard error rather than reached silently.

## Testing

- `__tests__/actions/UserOAuth.test.ts` — new account seeds Onyx, `409` does not.
- `__tests__/unit/FirebaseAuthInit.test.ts` — single-instance guarantee + loud-on-failure (Crashlytics).
- Full `__tests__/unit` + `__tests__/actions`: **756 passed**. Typecheck/eslint/prettier clean.

### Device verification for fix 2 (decisive)
Static analysis says persistence *should* resolve, so the existing log line is the confirmation: on next native launch the console shows `[Firebase] Auth initialized with AsyncStorage persistence` (healthy) vs `…memory persistence` + the new Crashlytics marker (still broken — now with the recorded error explaining *why*). Acceptance: sign in → fully quit → relaunch → lands on Home, never `InitialScreen`.

https://claude.ai/code/session_015hRc1ynV5pJSsVWhkWgP3Q