### PR TITLE
fix(home): keep FAB above the bottom tab bar during loading

### DIFF
--- a/src/hooks/useBottomTabBarHeight/index.native.ts
+++ b/src/hooks/useBottomTabBarHeight/index.native.ts
@@ -11,9 +11,15 @@ import variables from '@src/styles/variables';
  * Reads the context directly (rather than the library's `useBottomTabBarHeight`,
  * which throws without a provider) so it degrades gracefully to the static bar
  * height if ever rendered outside the tab navigator.
+ *
+ * `||` (not `??`): the library seeds the context with `0` and only reports the
+ * real height once the native bar measures itself a frame or two after mount.
+ * Treating that `0` as unmeasured (and falling back to the static height) keeps
+ * tab-bar insets correct from the first frame, so the Home FAB never starts out
+ * behind the bar and then pops above it once the measurement lands.
  */
 function useBottomTabBarHeight(): number {
-  return useContext(BottomTabBarHeightContext) ?? variables.bottomTabHeight;
+  return useContext(BottomTabBarHeightContext) || variables.bottomTabHeight;
 }
 
 export default useBottomTabBarHeight;

--- a/src/hooks/useBottomTabBarHeight/index.native.ts
+++ b/src/hooks/useBottomTabBarHeight/index.native.ts
@@ -12,14 +12,19 @@ import variables from '@src/styles/variables';
  * which throws without a provider) so it degrades gracefully to the static bar
  * height if ever rendered outside the tab navigator.
  *
- * `||` (not `??`): the library seeds the context with `0` and only reports the
- * real height once the native bar measures itself a frame or two after mount.
- * Treating that `0` as unmeasured (and falling back to the static height) keeps
- * tab-bar insets correct from the first frame, so the Home FAB never starts out
- * behind the bar and then pops above it once the measurement lands.
+ * The library seeds the context with `0` and only reports the real height once
+ * the native bar measures itself a frame or two after mount. We treat that `0`
+ * (and a missing provider, `undefined`) as "unmeasured" and fall back to the
+ * static height — note a plain `??` would not, since `0` is non-nullish. This
+ * keeps tab-bar insets correct from the first frame, so the Home FAB never
+ * starts out behind the bar and then pops above it once the measurement lands.
  */
 function useBottomTabBarHeight(): number {
-  return useContext(BottomTabBarHeightContext) || variables.bottomTabHeight;
+  const measuredHeight = useContext(BottomTabBarHeightContext);
+  if (!measuredHeight) {
+    return variables.bottomTabHeight;
+  }
+  return measuredHeight;
 }
 
 export default useBottomTabBarHeight;


### PR DESCRIPTION
## Problem

During app loading on the Home screen (while skeletons are shown), the start-session FAB briefly renders **behind** the bottom tab bar, then pops up above it once the app is ready.

## Root cause

The FAB is positioned to clear the native tab bar via `bottom: bottomTabBarHeight + 16` (it can't be z-ordered above the natively-composited bar — `react-native-bottom-tabs` renders the scene as a child of the native tab controller, with the bar as a native sibling drawn on top, so lifting the FAB out of the bar's band is the only way to keep it visible).

`useBottomTabBarHeight()` returned `0` during the first frames of loading:

- The library seeds its height context with `useState(0)` and only reports the real height once the native bar measures itself a frame or two after mount (`onTabBarMeasured`).
- The hook fell back to the static height with `??`, but `0 ?? 72` is `0` (`??` only catches `null`/`undefined`), so the fallback never kicked in during the unmeasured window.

Result: the FAB landed at `bottom: 16` — inside the bar's band, behind it — then jumped to `bottom ≈ 88` once the measurement landed. The same `0` also briefly zeroed the `ScrollView` `paddingBottom` and the offline-indicator margin.

## Fix

Use `||` instead of `??` so the unmeasured `0` falls back to the static `variables.bottomTabHeight` (72). Tab-bar insets are then correct from the first frame, and the FAB never starts behind the bar. Once the native bar measures itself, the value refines to the exact inset-aware height. This matches the hook's documented intent ("degrades gracefully to the static bar height").

One-line change, plus a comment explaining why `||` over `??`.

## Testing

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — pass
- Prettier — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)