### PR TITLE
fix(theme): sync native interface style with the app theme

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -34,6 +34,7 @@ import UpdateAppModal from './components/UpdateAppModal';
 import ForceUpdateModal from './components/Modals/ForceUpdateModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import useNativeAppearanceSync from './hooks/useNativeAppearanceSync';
 import colors from './styles/theme/colors';
 import CONST from './CONST';
 
@@ -76,6 +77,12 @@ function Kiroku() {
   const [preferredTheme, preferredThemeMetadata] = useOnyx(
     ONYXKEYS.PREFERRED_THEME,
   );
+
+  // Keep the native interface style in sync with the chosen theme so native,
+  // system-drawn surfaces (most visibly the iOS Liquid Glass tab bar's moving
+  // selection capsule) don't render their light variant over the dark theme.
+  useNativeAppearanceSync();
+
   const {config} = useConfig();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authenticationChecked, setAuthenticationChecked] = useState(false);

--- a/src/hooks/useNativeAppearanceSync.ts
+++ b/src/hooks/useNativeAppearanceSync.ts
@@ -1,0 +1,53 @@
+import {useContext, useEffect} from 'react';
+import {Appearance, Platform} from 'react-native';
+import {PreferredThemeContext} from '@components/OnyxProvider';
+import CONST from '@src/CONST';
+
+/**
+ * Propagates the user's selected app theme to the *native* interface style
+ * (`UIUserInterfaceStyle` on iOS, night mode on Android) via
+ * `Appearance.setColorScheme`.
+ *
+ * Kiroku's theme is otherwise JS-only, so native, system-drawn surfaces keep
+ * following the *device* appearance and look light while the app paints dark.
+ * The most visible offender is the iOS 26 Liquid Glass tab bar: its moving
+ * selection capsule picks its light/dark variant from the native interface
+ * style, so in dark theme over a light device it shows a bright hue while
+ * switching tabs. Native alerts, action sheets and the keyboard share the same
+ * gap. Syncing the native style keeps them consistent with the chosen theme.
+ *
+ * Resolution mirrors `useThemePreference`: an explicit light/dark choice forces
+ * that style; following the system clears the override (`null`) so the native
+ * side keeps tracking the device and `useColorScheme()` stays reactive (no
+ * feedback loop, no stuck override when the device appearance later changes).
+ *
+ * Android note: `MainActivity` declares `uiMode` in `configChanges`, so the
+ * underlying `setDefaultNightMode` delivers `onConfigurationChanged` rather
+ * than recreating the activity — no JS reload.
+ */
+function useNativeAppearanceSync() {
+  const preferredTheme = useContext(PreferredThemeContext);
+
+  useEffect(() => {
+    // Native-only: this drives the native interface style (UIKit on iOS, night
+    // mode on Android). Web has no equivalent and renders its own JS tab bar.
+    if (Platform.OS === 'web') {
+      return;
+    }
+
+    if (preferredTheme === CONST.THEME.SYSTEM) {
+      // Follow the device appearance.
+      Appearance.setColorScheme(null);
+      return;
+    }
+
+    Appearance.setColorScheme(
+      preferredTheme === CONST.THEME.DARK
+        ? CONST.COLOR_SCHEME.DARK
+        : // LIGHT, or unset (defaults to light, mirroring useThemePreference).
+          CONST.COLOR_SCHEME.LIGHT,
+    );
+  }, [preferredTheme]);
+}
+
+export default useNativeAppearanceSync;

--- a/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
@@ -48,6 +48,12 @@ function BottomTabNavigator() {
         initialRouteName={SCREENS.HOME}
         tabBarActiveTintColor={theme.appColor}
         tabBarInactiveTintColor={theme.icon}
+        // Android Material tab bar only: theme the active-indicator "pill" and
+        // touch ripple. Otherwise they fall back to Material's default light
+        // `colorSecondaryContainer`, which shows as a bright hue behind the
+        // selected tab in the dark theme. Both are no-ops on iOS.
+        activeIndicatorColor={theme.activeComponentBG}
+        rippleColor={theme.hoverComponentBG}
         // On iOS 26, let the system render its native Liquid Glass tab bar: it
         // gives the items the roomier, vertically-centered spacing of modern iOS
         // (the legacy opaque appearance looked vertically squashed). On older iOS


### PR DESCRIPTION
### Details

On iOS 26 the native Liquid Glass bottom tab bar draws a translucent **selection capsule** that slides between tabs. Its light/dark variant is chosen from the **native** interface style (`UIUserInterfaceStyle`), not from Kiroku's in-app theme. Kiroku's theme is **JS-only** and was never propagated to the native side, so when the device was in light mode while the user picked Kiroku's **dark** theme, the system drew a _light_ capsule over the dark app background, producing the light hues seen while switching tabs. In the light theme the light capsule blends into the light background, which is why the issue only ever surfaced in dark mode.

A library patch was ruled out: iOS 26's glass capsule has no public API to recolor it. The correct fix is to make the native interface style follow the chosen theme, which React Native supports out of the box.

**Changes**

- **`src/hooks/useNativeAppearanceSync.ts` (new):** mirrors the selected theme to the native interface style via `Appearance.setColorScheme` (`UIUserInterfaceStyle` on iOS, night mode on Android). An explicit light/dark choice forces that style; following the system clears the override (`null`) so native keeps tracking the device and `useColorScheme()` stays reactive (no feedback loop, no stuck override). Skipped on web.
- **`src/Kiroku.tsx`:** mounts the hook once at the app root (inside `OnyxProvider`, and not subject to the per-screen static `ThemeProvider` overrides like the always-dark sign-in page), so it is driven by the persistent preference.
- **`src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx`:** Android's Material active-indicator pill ignores night mode (the app ships no `values-night/` resources), so it is themed explicitly via the supported `activeIndicatorColor` / `rippleColor` props.

**Side effect (intended):** other native, system-drawn surfaces (alerts, action sheets, the keyboard) now also follow the app theme, which is the correct behavior for an app whose dark theme the user explicitly chose. `MainActivity` already declares `uiMode` in `configChanges`, so the Android night-mode change does not recreate the activity (no JS reload).

### Tests

1. On an **iOS 26** device, set the system appearance to **Light** (Settings → Display & Brightness), then set Kiroku's theme to **Dark** in app settings.
2. Switch between the bottom tabs (Home / Friends / Statistics / Settings) and verify the moving selection bubble is **dark** and shows **no light hue** during the transition.
3. Set Kiroku's theme to **System**, then toggle the device appearance (Control Center). Verify both the app content **and** the native tab bar track the change, and that switching back works (no stuck mode).
4. Switch Kiroku to the **Light** theme and verify the tab bar looks unchanged / correct.
5. On **Android** (dark theme), verify the active-indicator pill behind the selected tab is a subtle dark surface, not a bright pill.
6. Open a native alert and the keyboard in the dark theme and verify they render dark (intended side effect).
7. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

The theme preference is local (Onyx) and this change only mirrors the already-resolved theme to the native interface style; there is no network interaction. Behavior is identical offline and online.

- [ ] With the device offline, switch theme and verify the tab bar updates exactly as it does online.

### QA Steps

1. On staging, repeat the **Tests** steps 1–6 above on an iOS 26 device and an Android device.
2. Confirm there is no white/light flash on the tab bar selection bubble when switching tabs in the dark theme.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified that comments were added to code that is not self explanatory, and explain "why" rather than "what".
- [x] Any new file has a description of what it does / why it is needed at the top.
- [x] I verified all code is DRY and that constants are defined as such (`CONST.THEME` / `CONST.COLOR_SCHEME`).
- [x] Local gates pass: `prettier`, `lint` (eslint-seatbelt), `typecheck-tsgo`, and the React Compiler compliance check.
- [x] No user-facing copy was added (no localization needed).
- [ ] I ran the tests on **all platforms** & verified they passed on Android and iOS (device verification in progress).

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>
