### PR TITLE
fix(web): Phase 1 logged-in screen QA — clear web-only crashes (#934)

### DIFF
--- a/config/webpack/webpack.common.ts
+++ b/config/webpack/webpack.common.ts
@@ -83,7 +83,10 @@ const getCommonConfiguration = ({
     mode: isDevelopment ? 'development' : 'production',
     devtool: 'source-map',
     entry: {
-      main: './index.js',
+      // Web-specific entry: it initializes the CanvasKit WASM that
+      // `@shopify/react-native-skia` needs before booting `index.js`. Native
+      // (metro) keeps using `index.js` directly.
+      main: './index.web.js',
     },
     output: {
       // Use simple filenames in development to prevent memory leaks from contenthash changes

--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,33 @@
+/**
+ * @format
+ *
+ * Web entry point.
+ *
+ * `@shopify/react-native-skia` (used by the Statistics charts through
+ * `victory-native`) binds CanvasKit at *import* time on web — `Skia.web.ts`
+ * runs `JsiSkApi(global.CanvasKit)` the moment the module is evaluated, so the
+ * resulting `Skia` object captures whatever `global.CanvasKit` is at that
+ * instant. The chart code lives in a lazily-loaded chunk, so we must finish
+ * initializing the CanvasKit WASM *before* that chunk (and its Skia import) is
+ * evaluated, or every chart throws (`CanvasKit.XYWHRect` on `undefined`).
+ *
+ * Load CanvasKit up front, then boot the app. The ~8MB WASM is fetched once and
+ * browser-cached. Importing the dedicated `LoadSkiaWeb` module (not the `web`
+ * barrel) keeps `Skia.web.ts` out of the main bundle so it isn't evaluated
+ * early. Native links CanvasKit into the binary and uses `index.js` directly.
+ */
+// eslint-disable-next-line import/extensions
+import {LoadSkiaWeb} from '@shopify/react-native-skia/lib/module/web/LoadSkiaWeb';
+
+// The CanvasKit WASM is emitted at the web root by the webpack CopyPlugin.
+LoadSkiaWeb({locateFile: () => '/canvaskit.wasm'})
+  .catch(() => {
+    // If CanvasKit can't load, still boot — only the charts depend on it.
+  })
+  .finally(() => {
+    // Defer the app (and its transitive Skia imports) until CanvasKit is ready.
+    // The explicit `.js` extension is required so this doesn't resolve back to
+    // `index.web.js` (this file) and recurse.
+    // eslint-disable-next-line import/extensions
+    require('./index.js');
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@react-native-firebase/crashlytics": "^24.0.0",
         "@react-native-firebase/perf": "^24.0.0",
         "@react-native-google-signin/google-signin": "^10.0.1",
-        "@react-navigation/bottom-tabs": "7.17.1",
+        "@react-navigation/bottom-tabs": "7.3.14",
         "@react-navigation/native": "7.1.10",
         "@react-navigation/native-stack": "7.3.14",
         "@react-navigation/stack": "7.3.3",
@@ -9074,17 +9074,16 @@
       }
     },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.17.1.tgz",
-      "integrity": "sha512-BsN/Kokx+fAxze13xiwm3HWuJSbIuOZ9y6fGQJ6MLU4vobsaAm53kQ+3wtJg3ZF55I6uN7b68CqD932NFbsh8g==",
+      "version": "7.3.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.3.14.tgz",
+      "integrity": "sha512-s2qinJggS2HYZdCOey9A+fN+bNpWeEKwiL/FjAVOTcv+uofxPWN6CtEZUZGPEjfRjis/srURBmCmpNZSI6sQ9Q==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.21",
-        "color": "^4.2.3",
-        "sf-symbols-typescript": "^2.1.0"
+        "@react-navigation/elements": "^2.4.3",
+        "color": "^4.2.3"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.3.0",
+        "@react-navigation/native": "^7.1.10",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@react-native-firebase/crashlytics": "^24.0.0",
     "@react-native-firebase/perf": "^24.0.0",
     "@react-native-google-signin/google-signin": "^10.0.1",
-    "@react-navigation/bottom-tabs": "7.17.1",
+    "@react-navigation/bottom-tabs": "7.3.14",
     "@react-navigation/native": "7.1.10",
     "@react-navigation/native-stack": "7.3.14",
     "@react-navigation/stack": "7.3.3",

--- a/patches/@react-ng+bounds-observer+0.2.1+001+remove-PropTypes-and-findDOMNode.patch
+++ b/patches/@react-ng+bounds-observer+0.2.1+001+remove-PropTypes-and-findDOMNode.patch
@@ -1,0 +1,68 @@
+diff --git a/node_modules/@react-ng/bounds-observer/dist/index.js b/node_modules/@react-ng/bounds-observer/dist/index.js
+index b3c9cb3..4ec4327 100644
+--- a/node_modules/@react-ng/bounds-observer/dist/index.js
++++ b/node_modules/@react-ng/bounds-observer/dist/index.js
+@@ -33,11 +33,10 @@ var BoundsObserver = exports.BoundsObserver = /** @class */ (function (_super) {
+         return _this;
+     }
+     BoundsObserver.prototype.componentDidMount = function () {
+-        var childRef = this._childRef.current;
+-        if (!childRef) {
++        var childNode = this._childRef.current;
++        if (!childNode) {
+             throw new Error("Reference should have been set by the time the component is mounted");
+         }
+-        var childNode = react_dom_1.default.findDOMNode(childRef);
+         if (!(childNode instanceof Element)) {
+             throw new Error("Child's corresponding DOM node should be an Element");
+         }
+@@ -126,9 +125,6 @@ var BoundsObserver = exports.BoundsObserver = /** @class */ (function (_super) {
+         var observer = args.observer;
+         observer.disconnect();
+     };
+-    BoundsObserver.propTypes = {
+-        children: prop_types_1.default.element.isRequired,
+-    };
+     return BoundsObserver;
+ }(react_1.default.Component));
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/node_modules/@react-ng/bounds-observer/src/index.tsx b/node_modules/@react-ng/bounds-observer/src/index.tsx
+index c690fcc..b6841c7 100644
+--- a/node_modules/@react-ng/bounds-observer/src/index.tsx
++++ b/node_modules/@react-ng/bounds-observer/src/index.tsx
+@@ -1,6 +1,5 @@
+ import React, {ReactInstance, RefObject} from "react";
+ import {BoundingClientRectObserver} from "@html-ng/bounding-client-rect-observer";
+-import PropTypes from "prop-types";
+ import ReactDOM from 'react-dom';
+ 
+ interface BoundsObserverProps {
+@@ -12,10 +11,6 @@ interface BoundsObserverProps {
+ }
+ 
+ export class BoundsObserver extends React.Component<BoundsObserverProps, {}> {
+-    static propTypes = {
+-        children: PropTypes.element.isRequired,
+-    };
+-
+     private _childRef = React.createRef<ReactInstance>();
+ 
+     private _childNode: Element | null = null;
+@@ -27,14 +22,12 @@ export class BoundsObserver extends React.Component<BoundsObserverProps, {}> {
+     }
+ 
+     componentDidMount() {
+-        const childRef = this._childRef.current;
++        const childNode = this._childRef.current;
+ 
+-        if (!childRef) {
++        if (!childNode) {
+             throw new Error("Reference should have been set by the time the component is mounted");
+         }
+ 
+-        const childNode = ReactDOM.findDOMNode(childRef);
+-
+         if (!(childNode instanceof Element)) {
+             throw new Error("Child's corresponding DOM node should be an Element");
+         }

--- a/src/components/FocusTrap/FocusTrapContainerElement/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapContainerElement/index.web.tsx
@@ -1,29 +1,32 @@
-// /**
-//  * A wrapper View component allowing us to register a container element for a FocusTrap
-//  */
-// import type {ForwardedRef} from 'react';
-// import React from 'react';
-// import {View} from 'react-native';
-// import type FocusTrapContainerElementProps from './FocusTrapContainerElementProps';
+/**
+ * A wrapper View component allowing us to register a container element for a FocusTrap
+ */
+import type {ForwardedRef} from 'react';
+import React from 'react';
+import {View} from 'react-native';
+import type FocusTrapContainerElementProps from './FocusTrapContainerElementProps';
 
-// function FocusTrapContainerElement({onContainerElementChanged, ...props}: FocusTrapContainerElementProps, ref?: ForwardedRef<View>) {
-//     return (
-//         <View
-//             ref={(node) => {
-//                 const r = ref;
-//                 if (typeof r === 'function') {
-//                     r(node);
-//                 } else if (r) {
-//                     r.current = node;
-//                 }
-//                 onContainerElementChanged?.(node as unknown as HTMLElement | null);
-//             }}
-//             // eslint-disable-next-line react/jsx-props-no-spreading
-//             {...props}
-//         />
-//     );
-// }
+function FocusTrapContainerElement(
+  {onContainerElementChanged, ...props}: FocusTrapContainerElementProps,
+  ref?: ForwardedRef<View>,
+) {
+  return (
+    <View
+      ref={node => {
+        const r = ref;
+        if (typeof r === 'function') {
+          r(node);
+        } else if (r) {
+          r.current = node;
+        }
+        onContainerElementChanged?.(node as unknown as HTMLElement | null);
+      }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  );
+}
 
-// FocusTrapContainerElement.displayName = 'FocusTrapContainerElement';
+FocusTrapContainerElement.displayName = 'FocusTrapContainerElement';
 
-// export default React.forwardRef(FocusTrapContainerElement);
+export default React.forwardRef(FocusTrapContainerElement);

--- a/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
@@ -1,34 +1,29 @@
-// import FocusTrap from 'focus-trap-react';
-// import React from 'react';
-// import sharedTrapStack from '@components/FocusTrap/sharedTrapStack';
-// import ReportActionComposeFocusManager from '@libs/ReportActionComposeFocusManager';
-// import type FocusTrapForModalProps from './FocusTrapForModalProps';
+import FocusTrap from 'focus-trap-react';
+import React from 'react';
+import sharedTrapStack from '@components/FocusTrap/sharedTrapStack';
+import type FocusTrapForModalProps from './FocusTrapForModalProps';
 
-// function FocusTrapForModal({
-//   children,
-//   active,
-//   initialFocus = false,
-// }: FocusTrapForModalProps) {
-//   return (
-//     <FocusTrap
-//       active={active}
-//       focusTrapOptions={{
-//         trapStack: sharedTrapStack,
-//         clickOutsideDeactivates: true,
-//         initialFocus,
-//         fallbackFocus: document.body,
-//         setReturnFocus: element => {
-//           if (ReportActionComposeFocusManager.isFocused()) {
-//             return false;
-//           }
-//           return element;
-//         },
-//       }}>
-//       {children}
-//     </FocusTrap>
-//   );
-// }
+function FocusTrapForModal({
+  children,
+  active,
+  initialFocus = false,
+}: FocusTrapForModalProps) {
+  return (
+    <FocusTrap
+      active={active}
+      focusTrapOptions={{
+        trapStack: sharedTrapStack,
+        clickOutsideDeactivates: true,
+        initialFocus,
+        // Fall back to the document body so the trap never throws when the
+        // modal momentarily has no tabbable node (e.g. during enter/exit).
+        fallbackFocus: document.body,
+      }}>
+      {children}
+    </FocusTrap>
+  );
+}
 
-// FocusTrapForModal.displayName = 'FocusTrapForModal';
+FocusTrapForModal.displayName = 'FocusTrapForModal';
 
-// export default FocusTrapForModal;
+export default FocusTrapForModal;

--- a/src/components/FocusTrap/FocusTrapForScreen/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapForScreen/index.web.tsx
@@ -1,76 +1,69 @@
-// import {useIsFocused, useRoute} from '@react-navigation/native';
-// import FocusTrap from 'focus-trap-react';
-// import React, {useMemo} from 'react';
-// import BOTTOM_TAB_SCREENS from '@components/FocusTrap/BOTTOM_TAB_SCREENS';
-// import sharedTrapStack from '@components/FocusTrap/sharedTrapStack';
-// import TOP_TAB_SCREENS from '@components/FocusTrap/TOP_TAB_SCREENS';
-// import WIDE_LAYOUT_INACTIVE_SCREENS from '@components/FocusTrap/WIDE_LAYOUT_INACTIVE_SCREENS';
-// import useWindowDimensions from '@hooks/useWindowDimensions';
-// import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
-// import CONST from '@src/CONST';
-// import type FocusTrapProps from './FocusTrapProps';
+import {useIsFocused, useRoute} from '@react-navigation/native';
+import FocusTrap from 'focus-trap-react';
+import React, {useMemo} from 'react';
+import BOTTOM_TAB_SCREENS from '@components/FocusTrap/BOTTOM_TAB_SCREENS';
+import sharedTrapStack from '@components/FocusTrap/sharedTrapStack';
+import TOP_TAB_SCREENS from '@components/FocusTrap/TOP_TAB_SCREENS';
+import WIDE_LAYOUT_INACTIVE_SCREENS from '@components/FocusTrap/WIDE_LAYOUT_INACTIVE_SCREENS';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
+import CONST from '@src/CONST';
+import type FocusTrapProps from './FocusTrapProps';
 
-// function FocusTrapForScreen({children, focusTrapSettings}: FocusTrapProps) {
-//     const isFocused = useIsFocused();
-//     const route = useRoute();
-//     const {isSmallScreenWidth} = useWindowDimensions();
+function FocusTrapForScreen({children, focusTrapSettings}: FocusTrapProps) {
+  const isFocused = useIsFocused();
+  const route = useRoute();
+  const {shouldUseNarrowLayout} = useResponsiveLayout();
 
-//     const isActive = useMemo(() => {
-//         if (typeof focusTrapSettings?.active !== 'undefined') {
-//             return focusTrapSettings.active;
-//         }
-//         // Focus trap can't be active on bottom tab screens because it would block access to the tab bar.
-//         if (BOTTOM_TAB_SCREENS.find((screen) => screen === route.name)) {
-//             return false;
-//         }
+  const isActive = useMemo(() => {
+    if (typeof focusTrapSettings?.active !== 'undefined') {
+      return focusTrapSettings.active;
+    }
+    // Focus trap can't be active on bottom tab screens because it would block access to the tab bar.
+    if (BOTTOM_TAB_SCREENS.find(screen => screen === route.name)) {
+      return false;
+    }
 
-//         // in top tabs only focus trap for currently shown tab should be active
-//         if (TOP_TAB_SCREENS.find((screen) => screen === route.name)) {
-//             return isFocused;
-//         }
+    // in top tabs only focus trap for currently shown tab should be active
+    if (TOP_TAB_SCREENS.find(screen => screen === route.name)) {
+      return isFocused;
+    }
 
-//         // Focus trap can't be active on these screens if the layout is wide because they may be displayed side by side.
-//         if (WIDE_LAYOUT_INACTIVE_SCREENS.includes(route.name) && !isSmallScreenWidth) {
-//             return false;
-//         }
-//         return true;
-//     }, [isFocused, isSmallScreenWidth, route.name, focusTrapSettings?.active]);
+    // Focus trap can't be active on these screens if the layout is wide because they may be displayed side by side.
+    if (
+      WIDE_LAYOUT_INACTIVE_SCREENS.includes(route.name) &&
+      !shouldUseNarrowLayout
+    ) {
+      return false;
+    }
+    return true;
+  }, [isFocused, shouldUseNarrowLayout, route.name, focusTrapSettings?.active]);
 
-//     return (
-//         <FocusTrap
-//             active={isActive}
-//             paused={!isFocused}
-//             containerElements={focusTrapSettings?.containerElements?.length ? focusTrapSettings.containerElements : undefined}
-//             focusTrapOptions={{
-//                 trapStack: sharedTrapStack,
-//                 allowOutsideClick: true,
-//                 fallbackFocus: document.body,
-//                 delayInitialFocus: CONST.ANIMATED_TRANSITION,
-//                 initialFocus: (focusTrapContainers) => {
-//                     if (!canFocusInputOnScreenFocus()) {
-//                         return false;
-//                     }
+  return (
+    <FocusTrap
+      active={isActive}
+      paused={!isFocused}
+      containerElements={
+        focusTrapSettings?.containerElements?.length
+          ? focusTrapSettings.containerElements
+          : undefined
+      }
+      focusTrapOptions={{
+        trapStack: sharedTrapStack,
+        allowOutsideClick: true,
+        // Fall back to the document body so the trap never throws when the
+        // active screen has no tabbable node.
+        fallbackFocus: document.body,
+        delayInitialFocus: CONST.ANIMATED_TRANSITION,
+        // Don't steal focus into inputs on touch devices (would pop the keyboard).
+        initialFocus: () => (canFocusInputOnScreenFocus() ? undefined : false),
+        ...(focusTrapSettings?.focusTrapOptions ?? {}),
+      }}>
+      {children}
+    </FocusTrap>
+  );
+}
 
-//                     const isFocusedElementInsideContainer = focusTrapContainers?.some((container) => container.contains(document.activeElement));
-//                     if (isFocusedElementInsideContainer) {
-//                         return false;
-//                     }
-//                     return undefined;
-//                 },
-//                 setReturnFocus: (element) => {
-//                     if (document.activeElement && document.activeElement !== document.body) {
-//                         return false;
-//                     }
-//                     return element;
-//                 },
-//                 ...(focusTrapSettings?.focusTrapOptions ?? {}),
-//             }}
-//         >
-//             {children}
-//         </FocusTrap>
-//     );
-// }
+FocusTrapForScreen.displayName = 'FocusTrapForScreen';
 
-// FocusTrapForScreen.displayName = 'FocusTrapForScreen';
-
-// export default FocusTrapForScreen;
+export default FocusTrapForScreen;

--- a/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.web.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.web.tsx
@@ -1,4 +1,5 @@
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import type {BottomTabBarProps} from '@react-navigation/bottom-tabs';
 import {useNavigationState} from '@react-navigation/native';
 import React from 'react';
 import useLocalize from '@hooks/useLocalize';
@@ -23,6 +24,15 @@ import ActiveCentralPaneRouteContext from './ActiveRouteContext';
  */
 const Tab = createBottomTabNavigator();
 
+// `@react-navigation/bottom-tabs` invokes the `tabBar` prop as a plain function
+// inside a `SafeAreaInsetsContext.Consumer` render prop, so passing the bar
+// component directly would run its hooks outside a component fiber ("Invalid
+// hook call"). Render it as a real element instead, via a stable reference.
+function renderTabBar(props: BottomTabBarProps) {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <BottomTabBar {...props} />;
+}
+
 function BottomTabNavigator() {
   const {translate} = useLocalize();
   const theme = useTheme();
@@ -41,7 +51,7 @@ function BottomTabNavigator() {
           // screen through during the swap.
           sceneStyle: {backgroundColor: theme.appBG},
         }}
-        tabBar={BottomTabBar}>
+        tabBar={renderTabBar}>
         {BOTTOM_TAB_CONFIG.map(tab => (
           <Tab.Screen
             key={tab.name}

--- a/src/libs/Navigation/AppNavigator/createCustomStackNavigator/CustomRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createCustomStackNavigator/CustomRouter.ts
@@ -170,8 +170,13 @@ function CustomRouter(options: ResponsiveStackNavigatorRouterOptions) {
       partialState: StackNavigationState<RootStackParamList>,
       {routeNames, routeParamList, routeGetIdList}: RouterConfigOptions,
     ): StackNavigationState<ParamListBase> {
-      compareAndAdaptState(partialState);
-      const state = stackRouter.getRehydratedState(partialState, {
+      // `partialState` is frozen by React Navigation in dev, but
+      // `compareAndAdaptState` reassigns its top-level `routes`/`index`/`stale`
+      // fields when adapting a deep link on wide (web) layouts. Adapt a shallow
+      // copy so those reassignments don't throw on the read-only original.
+      const adaptableState = {...partialState};
+      compareAndAdaptState(adaptableState);
+      const state = stackRouter.getRehydratedState(adaptableState, {
         routeNames,
         routeParamList,
         routeGetIdList,


### PR DESCRIPTION
## What & why

Web epic #925, **Phase 1 issue #934** — the screen-by-screen logged-in QA pass. Walk each main screen on web (signed in) and fix the remaining web-only runtime crashes + console errors. Built on the merged Phase 1 prerequisites (#1118 web persistence/Google sign-in, #1111 web siblings, #1112 URL linking, #1117 text-node cleanup).

These crashes masked one another, so each fix uncovered the next: **login → bottom tabs → tooltips → router → Skia charts.**

## Fixes

1. **FocusTrap (every modal + onboarding crashed).** `FocusTrap/{FocusTrapForModal,FocusTrapForScreen,FocusTrapContainerElement}/index.web.tsx` were commented out → empty export → `{}`, so `ReanimatedModal` (and the onboarding navigator) threw *"Element type is invalid"*. Restored the real `focus-trap-react` implementations (deps already present: `focus-trap-react`, `sharedTrapStack`), dropping the Expensify-only `ReportActionComposeFocusManager` and adapting `FocusTrapForScreen` to Kiroku's `useResponsiveLayout` + the installed focus-trap's `initialFocus` signature.

2. **`@react-navigation/bottom-tabs` version mismatch.** `7.17.1` requires peer `@react-navigation/native ^7.3.0`, but the project pins native `7.1.10` → `createScreenFactory is not a function`. Web-only (native tabs use `@bottom-tabs/react-navigation`). **Downgraded to `7.3.14`** (peer `^7.1.10`).

3. **Custom web tab bar "Invalid hook call".** `BottomTabNavigator.web.tsx` passed `tabBar={BottomTabBar}`; 7.3.14 invokes `tabBar` as a plain function inside a `SafeAreaInsetsContext.Consumer` render prop, so the bar's hooks ran outside a fiber. Render it as a stable element instead (`renderTabBar`).

4. **Tooltips crashed on React 19.** `@react-ng/bounds-observer` calls the removed `ReactDOM.findDOMNode`. Added a patch (port of Expensify's, regenerated against the installed build) that uses the ref directly.

5. **Router crashed on wide layouts.** `CustomRouter` `compareAndAdaptState` mutated React Navigation's (dev-frozen) rehydrated state; only triggered on the wide web layout. Adapt a shallow copy.

6. **Skia charts (highest risk).** `@shopify/react-native-skia` binds CanvasKit at *import* time on web, so the WASM must initialize before the lazy chart chunk loads or `victory-native` throws `CanvasKit.XYWHRect` on `undefined`. Added a web entry **`index.web.js`** that `await LoadSkiaWeb()` before booting `index.js`.

## Verified on web (signed in)

| Screen / cluster | Status |
|---|---|
| Login (email + Google) | ✅ clean |
| Home + Calendar (`react-native-calendars`) | ✅ clean |
| **Statistics** — Overview/Trends/Patterns/Breakdown, incl. Skia charts (victory-native, HourPolar dial, DrinkTypeDonut, DowHourHeatmap) | ✅ clean, no console errors |
| Friends / Social — list, **SwipeablePager** (Friend List/Requests), friend profile RHP | ✅ clean |
| Settings — list + Profile Details (mobile layout) | ✅ clean |
| Drinking Session / Day Overview — entry points (calendar, FAB Live/Edit menu) | ✅ no crashes (deep session screens not exhaustively driven via automation) |
| Modals (VerifyEmailModal, FAB menu) | ✅ render/animate correctly |

## Known remaining (for a later Phase 1 increment)

- **Wide desktop layout only:** settings-detail RHP (e.g. Profile Details) content shifts off-screen-left (modal renders ~1810px wide). **Correct in the mobile / `/simulator.html` layout** (the primary target). Likely affects other settings-detail RHPs on desktop.
- **Skia startup cost:** CanvasKit (~8MB WASM) now loads before app boot (browser-cached after first load). Deferring it to chart screens via `WithSkiaWeb` is a follow-up optimization.
- Benign console noise: RNW `props.pointerEvents`/`shadow*` deprecations; an `@react-navigation/elements` `NavigationProvider` compile warning (gated behind `headerShown`, never executed).

## Gates
`prettier --check`, `typecheck-tsgo`, `react-compiler-compliance-check check-changed`, and `lint-changed` all pass locally. Touches shared screen code → will toggle **Ready To Build** to confirm iOS/Android still build.

Refs #934, #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)