### PR TITLE
feat(web): Firebase Hosting site/target for app.kiroku.cz

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -9,6 +9,11 @@
       "hosting": {
         "app": ["kiroku-app-prod"]
       }
+    },
+    "dev-alcohol-tracker-db": {
+      "hosting": {
+        "app": ["kiroku-app-dev"]
+      }
     }
   }
 }

--- a/.firebaserc
+++ b/.firebaserc
@@ -3,5 +3,12 @@
     "default": "alcohol-tracker-db",
     "dev": "dev-alcohol-tracker-db",
     "prod": "alcohol-tracker-db"
+  },
+  "targets": {
+    "alcohol-tracker-db": {
+      "hosting": {
+        "app": ["kiroku-app-prod"]
+      }
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ bun.lockb
 
 # Firebase
 **/database.rules.test.json
+.firebase/
 
 # Bundle artifact
 *.jsbundle

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,17 @@
 {
+  "hosting": [
+    {
+      "target": "app",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  ],
   "emulators": {
     "singleProjectMode": false,
     "auth": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "web": "tsx ./node_modules/.bin/webpack-cli serve --config config/webpack/webpack.dev.ts --env file=.env.development",
     "web:framed": "echo '▶ Device simulator: http://localhost:8082/simulator.html' && npm run web",
     "build-web": "tsx ./node_modules/.bin/webpack-cli --config config/webpack/webpack.common.ts --env file=.env.production",
+    "build-web-dev": "tsx ./node_modules/.bin/webpack-cli --config config/webpack/webpack.common.ts --env file=.env.development",
     "web-server": "http-server ./dist -c-1 --port 8080"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Phase 2 of the web revival epic #925. Closes #935.

Adds Firebase Hosting config so the web SPA can be deployed to dedicated hosting sites — prod **and dev** — separate from the kiroku.cz landing page.

### Infra (already created, outside this repo)

- New hosting site **`kiroku-app-prod`** under `alcohol-tracker-db` and **`kiroku-app-dev`** under `dev-alcohol-tracker-db` (naming follows the existing `kiroku-{web,api,admin}-{prod,dev}` sites; the issue suggested `kiroku-app`, adjusted for consistency).
- Custom domain **app.kiroku.cz** flow started on `kiroku-app-prod` via the Hosting API — pending two DNS records at WEDOS (see below).

### Repo changes

- `firebase.json`: `hosting` block (array form) — target `app`, `public: dist`, SPA rewrite `**` → `/index.html`, standard ignore globs. One block serves both projects; the target resolves per project.
- `.firebaserc`: target mapping `app` → `kiroku-app-prod` (prod project) and `app` → `kiroku-app-dev` (dev project).
- `package.json`: new `build-web-dev` script (same webpack config, `--env file=.env.development`) so the dev site gets a build wired to the dev Firebase project.
- `.gitignore`: ignore the `.firebase/` deploy cache.

### Deploy commands

```
# prod
npm run build-web
firebase deploy --only hosting:app --project alcohol-tracker-db

# dev
npm run build-web-dev
firebase deploy --only hosting:app --project dev-alcohol-tracker-db
```

Never run a bare `firebase deploy` from this repo — always scope to `hosting:app`.

## Verification

- ✅ Prod: https://kiroku-app-prod.web.app — index, deep links (SPA rewrite), all bundles, `canvaskit.wasm`, `css/fonts.css` return 200; headless Chrome renders the signup/login screen
- ✅ Dev: https://kiroku-app-dev.web.app — same checks pass; login screen renders **with the DEV logo badge**, and the served bundle contains the `dev-alcohol-tracker-db` config (correct env baked in)
- ✅ kiroku.cz landing page checked before and after each deploy: unchanged (separate `kiroku-web-prod` site; its `kiroku.cz` + `www.kiroku.cz` custom domains untouched)

## Pending manual steps

**1. DNS at WEDOS** — Firebase is waiting for these records (prod domain `app.kiroku.cz` on `kiroku-app-prod`, dev domain `app-dev.kiroku.cz` on `kiroku-app-dev`, mirroring `api.kiroku.cz` / `api-dev.kiroku.cz`):

| Type | Host | Value |
|------|------|-------|
| CNAME | `app.kiroku.cz` | `kiroku-app-prod.web.app` |
| TXT | `_acme-challenge.app.kiroku.cz` | `SSy_9heiCxN9LUx3flgMlZ5dyvoi_g6sXbCHO_hVCMg` |
| CNAME | `app-dev.kiroku.cz` | `kiroku-app-dev.web.app` |
| TXT | `_acme-challenge.app-dev.kiroku.cz` | `9AetArSh3-hzt5WusHlegJa2GOAjlkh5NpaNNqoJQJo` |

The CNAMEs prove ownership and route traffic; the TXTs let the TLS certs issue immediately. After propagation Firebase verifies and provisions TLS automatically. Until then the apps are fully served at the `.web.app` URLs.

**2. Google sign-in on the new domains** — email/password login works as-is; the Google button additionally needs:
- Firebase console → Authentication → Settings → Authorized domains: add `kiroku-app-prod.web.app` (prod project) and `kiroku-app-dev.web.app` (dev project); later also `app.kiroku.cz` (prod) and `app-dev.kiroku.cz` (dev).
- GCP console → Credentials → the web OAuth client of each project: add the same URLs (with `https://`) to **Authorized JavaScript origins** (the web flow uses Google Identity Services, which validates the page origin against the client).

Follow-up: CI deploy workflow is #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
