### PR TITLE
feat(fab): Apple Reminders-style FAB with Liquid Glass on iOS 26

### DIFF
--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,5 +1,8 @@
+import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
 import type {ForwardedRef} from 'react';
 import React, {forwardRef, useEffect, useRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
+import {StyleSheet} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {GestureResponderEvent, Role, Text, View} from 'react-native';
 import Animated, {
@@ -14,6 +17,10 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
 import {PressableWithoutFeedback} from './Pressable';
+
+// iOS 26 ships the native Liquid Glass material; older iOS and Android do not.
+// The value is fixed for the session, so it's evaluated once at module load.
+const SUPPORTS_LIQUID_GLASS = isLiquidGlassAvailable();
 
 type FloatingActionButtonProps = {
   /* Callback to fire on request to toggle the FloatingActionButton */
@@ -33,9 +40,9 @@ function FloatingActionButton(
   {onPress, isActive, accessibilityLabel, role}: FloatingActionButtonProps,
   ref: ForwardedRef<HTMLDivElement | View | Text>,
 ) {
-  const {appColor, buttonDefaultBG, textLight} = useTheme();
+  const theme = useTheme();
+  const {appColor, buttonDefaultBG, textLight, colorScheme} = theme;
   const styles = useThemeStyles();
-  const borderRadius = styles.floatingActionButton.borderRadius;
   const fabPressable = useRef<HTMLDivElement | View | Text | null>(null);
   const sharedValue = useSharedValue(isActive ? 1 : 0);
   const buttonRef = ref;
@@ -48,19 +55,43 @@ function FloatingActionButton(
     });
   }, [isActive, sharedValue]);
 
-  const animatedStyle = useAnimatedStyle(() => {
-    const backgroundColor = interpolateColor(
+  // Rotation only — wraps just the icon. The disc is rotationally symmetric, so
+  // rotating the icon looks identical to rotating the whole button and lets the
+  // glass path keep the rotation without spinning the native glass view.
+  const iconAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{rotate: `${sharedValue.value * 135}deg`}],
+  }));
+
+  // Fallback (non-glass) circle: interpolate the fill from brand yellow to the
+  // "close" gray as the popover opens.
+  const fallbackAnimatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(
       sharedValue.value,
       [0, 1],
       [appColor, buttonDefaultBG],
-    );
+    ),
+  }));
 
-    return {
-      transform: [{rotate: `${sharedValue.value * 135}deg`}],
-      backgroundColor,
-      borderRadius,
-    };
-  });
+  // Glass path: `tintColor` is a plain native prop (not worklet-drivable), so
+  // the open state is signalled by cross-fading an opaque gray overlay in over
+  // the glass — visually identical to the fallback's color interpolation.
+  const overlayAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: sharedValue.value,
+  }));
+
+  const icon = (
+    <Animated.View style={iconAnimatedStyle}>
+      <Svg
+        width={variables.iconSizeNormal}
+        height={variables.iconSizeNormal}
+        viewBox="0 0 20 20">
+        <Path
+          fill={textLight}
+          d="M12,3c0-1.1-0.9-2-2-2C8.9,1,8,1.9,8,3v5H3c-1.1,0-2,0.9-2,2c0,1.1,0.9,2,2,2h5v5c0,1.1,0.9,2,2,2c1.1,0,2-0.9,2-2v-5h5c1.1,0,2-0.9,2-2c0-1.1-0.9-2-2-2h-5V3z"
+        />
+      </Svg>
+    </Animated.View>
+  );
 
   const toggleFabAction = (
     event: GestureResponderEvent | KeyboardEvent | undefined,
@@ -83,17 +114,28 @@ function FloatingActionButton(
       onLongPress={() => {}}
       role={role}
       shouldUseHapticsOnLongPress={false}>
-      <Animated.View style={[styles.floatingActionButton, animatedStyle]}>
-        <Svg
-          width={variables.iconSizeNormal}
-          height={variables.iconSizeNormal}
-          viewBox="0 0 20 20">
-          <Path
-            fill={textLight}
-            d="M12,3c0-1.1-0.9-2-2-2C8.9,1,8,1.9,8,3v5H3c-1.1,0-2,0.9-2,2c0,1.1,0.9,2,2,2h5v5c0,1.1,0.9,2,2,2c1.1,0,2-0.9,2-2v-5h5c1.1,0,2-0.9,2-2c0-1.1-0.9-2-2-2h-5V3z"
+      {SUPPORTS_LIQUID_GLASS ? (
+        <GlassView
+          glassEffectStyle="regular"
+          tintColor={appColor}
+          colorScheme={colorScheme}
+          style={styles.floatingActionButtonGlass}>
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              StyleSheet.absoluteFill,
+              styles.floatingActionButtonGlassOverlay,
+              overlayAnimatedStyle,
+            ]}
           />
-        </Svg>
-      </Animated.View>
+          {icon}
+        </GlassView>
+      ) : (
+        <Animated.View
+          style={[styles.floatingActionButton, fallbackAnimatedStyle]}>
+          {icon}
+        </Animated.View>
+      )}
     </PressableWithoutFeedback>
   );
 }

--- a/src/components/FloatingActionSurface.tsx
+++ b/src/components/FloatingActionSurface.tsx
@@ -1,6 +1,6 @@
 import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
 import React from 'react';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
@@ -14,11 +14,17 @@ type FloatingActionSurfaceProps = {
 };
 
 /**
- * The visual circle of a static-icon floating action button: Liquid Glass
- * tinted with the brand color on iOS 26, a solid brand-colored circle with a
- * soft drop shadow elsewhere. Purely presentational — wrap it in a Pressable
- * and place an icon inside. For the animated start-session FAB (rotation +
- * active-state color), see FloatingActionButton instead.
+ * The visual circle of a static-icon floating action button: Liquid Glass over
+ * a brand-colored fill on iOS 26, a solid brand-colored circle with a soft drop
+ * shadow elsewhere. Purely presentational — wrap it in a Pressable and place an
+ * icon inside. For the animated start-session FAB (rotation + active-state
+ * color), see FloatingActionButton instead.
+ *
+ * Unlike the start-session FAB (which sits on the dark bottom tab bar, where a
+ * translucent glass tint reads as the brand color), this surface floats over
+ * arbitrary light screen content, so it lays an opaque brand fill behind the
+ * glass — the glass rim and adaptive shadow still render, but the brand color
+ * no longer washes out against a light backdrop.
  */
 function FloatingActionSurface({children}: FloatingActionSurfaceProps) {
   const theme = useTheme();
@@ -30,6 +36,10 @@ function FloatingActionSurface({children}: FloatingActionSurfaceProps) {
       tintColor={theme.appColor}
       colorScheme={theme.colorScheme}
       style={styles.floatingActionButtonGlass}>
+      <View
+        pointerEvents="none"
+        style={[StyleSheet.absoluteFill, styles.floatingActionButtonGlassTint]}
+      />
       {children}
     </GlassView>
   ) : (

--- a/src/components/FloatingActionSurface.tsx
+++ b/src/components/FloatingActionSurface.tsx
@@ -1,0 +1,42 @@
+import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import React from 'react';
+import {View} from 'react-native';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+// iOS 26 ships the native Liquid Glass material; older iOS and Android do not.
+// The value is fixed for the session, so it's evaluated once at module load.
+const SUPPORTS_LIQUID_GLASS = isLiquidGlassAvailable();
+
+type FloatingActionSurfaceProps = {
+  /* The icon (or other content) centered inside the circle */
+  children: React.ReactNode;
+};
+
+/**
+ * The visual circle of a static-icon floating action button: Liquid Glass
+ * tinted with the brand color on iOS 26, a solid brand-colored circle with a
+ * soft drop shadow elsewhere. Purely presentational — wrap it in a Pressable
+ * and place an icon inside. For the animated start-session FAB (rotation +
+ * active-state color), see FloatingActionButton instead.
+ */
+function FloatingActionSurface({children}: FloatingActionSurfaceProps) {
+  const theme = useTheme();
+  const styles = useThemeStyles();
+
+  return SUPPORTS_LIQUID_GLASS ? (
+    <GlassView
+      glassEffectStyle="regular"
+      tintColor={theme.appColor}
+      colorScheme={theme.colorScheme}
+      style={styles.floatingActionButtonGlass}>
+      {children}
+    </GlassView>
+  ) : (
+    <View style={styles.floatingActionButton}>{children}</View>
+  );
+}
+
+FloatingActionSurface.displayName = 'FloatingActionSurface';
+
+export default FloatingActionSurface;

--- a/src/screens/Social/SocialScreen.tsx
+++ b/src/screens/Social/SocialScreen.tsx
@@ -6,8 +6,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import {InteractionManager, StyleSheet, View} from 'react-native';
-import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated';
+import {Animated, InteractionManager, StyleSheet, View} from 'react-native';
 import {SceneMap, TabView} from 'react-native-tab-view';
 import type {
   NavigationState,
@@ -21,6 +20,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import OfflineIndicator from '@components/OfflineIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
+import FloatingActionSurface from '@components/FloatingActionSurface';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import {PressableWithFeedback} from '@components/Pressable';
@@ -105,6 +105,31 @@ function FriendRequestsBadge({count}: {count: number}) {
   );
 }
 
+type PagerPositionCaptureProps = {
+  /* The pager's continuous swipe-progress value (tab index space) */
+  position: Animated.AnimatedInterpolation<number>;
+
+  /* Called with the position value on mount and whenever its identity changes */
+  onPositionChange: (position: Animated.AnimatedInterpolation<number>) => void;
+};
+
+/**
+ * Surfaces the TabView pager's `position` animated value (only exposed via
+ * `renderTabBar` props) to the parent screen. Effect-based on purpose: the web
+ * pager (PanResponderAdapter) recreates `position` on layout changes, so a
+ * capture-once ref would go stale, and capturing during render would set
+ * parent state mid-render.
+ */
+function PagerPositionCapture({
+  position,
+  onPositionChange,
+}: PagerPositionCaptureProps) {
+  useEffect(() => {
+    onPositionChange(position);
+  }, [position, onPositionChange]);
+  return null;
+}
+
 function SocialScreen() {
   const userData = useCurrentUserData();
   const theme = useTheme();
@@ -113,6 +138,8 @@ function SocialScreen() {
   const {windowWidth} = useWindowDimensions();
   const bottomTabBarHeight = useBottomTabBarHeight();
   const [index, setIndex] = useState(0);
+  const [pagerPosition, setPagerPosition] =
+    useState<Animated.AnimatedInterpolation<number> | null>(null);
 
   // Warm the lazily imported Friend Requests module in the background once the
   // Friend List tab is interactive, so first tap of the Requests tab renders it
@@ -160,7 +187,15 @@ function SocialScreen() {
         navigationState: NavigationState<TopTabRoute>;
         options: Record<string, TabDescriptor<TopTabRoute>> | undefined;
       },
-    ) => <TopTabBar tabBarProps={tabBarProps} />,
+    ) => (
+      <>
+        <PagerPositionCapture
+          position={tabBarProps.position}
+          onPositionChange={setPagerPosition}
+        />
+        <TopTabBar tabBarProps={tabBarProps} />
+      </>
+    ),
     [],
   );
 
@@ -174,14 +209,23 @@ function SocialScreen() {
     [bottomTabBarHeight],
   );
 
-  // The friend-search FAB belongs to the Friend Requests tab only. Keep it
-  // mounted and cross-fade its opacity on tab change (rather than mount/unmount)
-  // so it eases in/out instead of popping. `withTiming` inside the worklet
-  // animates whenever the captured `isFriendRequestsTab` flips.
+  // The friend-search FAB belongs to the Friend Requests tab only. Its opacity
+  // tracks the pager's continuous swipe progress (0 = Friend List, 1 = Friend
+  // Requests) instead of the settled index, so it starts dimming the instant a
+  // swipe back toward Friend List begins and starts appearing during the swipe
+  // (or tab-tap slide) toward Friend Requests — not only after the transition
+  // settles. The static fallback only covers the first render, before the tab
+  // bar has surfaced the position value (initial tab is Friend List → hidden).
   const isFriendRequestsTab = routes[index]?.key === 'friendRequests';
-  const fabAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(isFriendRequestsTab ? 1 : 0, {duration: 200}),
-  }));
+  const fabOpacity = useMemo(
+    () =>
+      pagerPosition?.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+        extrapolate: 'clamp',
+      }) ?? (isFriendRequestsTab ? 1 : 0),
+    [pagerPosition, isFriendRequestsTab],
+  );
 
   return (
     <ScreenWrapper
@@ -208,27 +252,28 @@ function SocialScreen() {
           ScreenWrapper level (a sibling of the TabView/OfflineIndicator),
           exactly like the Home start-session FAB, so it's anchored to the
           screen and isn't shifted upward by the offline indicator's reserved
-          bottom margin the way an in-scene button would be. Reuses the Home
-          FAB's container + circle styles so the two line up. Kept mounted and
-          cross-faded via opacity; `pointerEvents` is dropped while hidden so it
-          can't be tapped on the Friend List tab. */}
+          bottom margin the way an in-scene button would be. Kept mounted with
+          its opacity bound to the pager's swipe progress (see `fabOpacity`);
+          `pointerEvents` stays gated on the settled index so a half-faded
+          button can't be tapped mid-swipe or from the Friend List tab. */}
       <Animated.View
         pointerEvents={isFriendRequestsTab ? 'auto' : 'none'}
         style={[
           styles.floatingActionButtonContainer,
           {bottom: bottomTabBarHeight + 16},
-          fabAnimatedStyle,
+          {opacity: fabOpacity},
         ]}>
         <PressableWithFeedback
           accessibilityLabel="search-screen-button"
-          style={styles.floatingActionButton}
           onPress={() => Navigation.navigate(ROUTES.SOCIAL_FRIEND_SEARCH)}>
-          <Icon
-            src={KirokuIcons.Search}
-            width={28}
-            height={28}
-            fill={theme.textLight}
-          />
+          <FloatingActionSurface>
+            <Icon
+              src={KirokuIcons.Search}
+              width={28}
+              height={28}
+              fill={theme.textLight}
+            />
+          </FloatingActionSurface>
         </PressableWithFeedback>
       </Animated.View>
     </ScreenWrapper>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1121,6 +1121,17 @@ const styles = (theme: ThemeColors) =>
       backgroundColor: theme.buttonDefaultBG,
     },
 
+    // Opaque brand fill laid behind a glass FAB's content. `glassEffectStyle`
+    // "regular" only tints translucently, so a glass FAB reads as the brand
+    // color over a dark backdrop (the bottom tab bar) but washes out over light
+    // screen content. For a FAB that floats over arbitrary content (the social
+    // search button) this fill emulates Apple's more opaque `.glassProminent`
+    // look, keeping the glass rim and adaptive shadow while guaranteeing the
+    // brand-color background everywhere.
+    floatingActionButtonGlassTint: {
+      backgroundColor: theme.appColor,
+    },
+
     // Anchors the start-session FAB to the bottom-right of a screen. The
     // `bottom` offset is applied by the caller (= bottom tab bar height + a
     // margin) so the FAB floats clearly above the native tab bar.

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1094,9 +1094,31 @@ const styles = (theme: ThemeColors) =>
       backgroundColor: theme.appColor,
       height: variables.componentSizeLarge,
       width: variables.componentSizeLarge,
-      borderRadius: 999,
+      borderRadius: variables.componentSizeLarge / 2,
       alignItems: 'center',
       justifyContent: 'center',
+      // Apple-style soft drop shadow (the pre-iOS-26 tinted-button look). A
+      // `boxShadow` string is the established pattern here (see boxShadowNone)
+      // and renders on iOS, Android, and web under RN 0.81.
+      boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)',
+    },
+
+    // Liquid Glass variant of the FAB (iOS 26+). No backgroundColor (the glass
+    // tintColor supplies the brand yellow) and no manual shadow — Liquid Glass
+    // draws its own adaptive shadow, so stacking one would double the depth cue.
+    floatingActionButtonGlass: {
+      height: variables.componentSizeLarge,
+      width: variables.componentSizeLarge,
+      borderRadius: variables.componentSizeLarge / 2,
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+    },
+
+    // Fades in over the glass to signal the "close" (X) state; mirrors the
+    // fallback button's appColor -> buttonDefaultBG interpolation.
+    floatingActionButtonGlassOverlay: {
+      backgroundColor: theme.buttonDefaultBG,
     },
 
     // Anchors the start-session FAB to the bottom-right of a screen. The


### PR DESCRIPTION
### Details

Restyles the floating action buttons to mimic the iOS 26 Reminders bottom-right plus button, while keeping the Kiroku brand yellow (`theme.appColor`) instead of Apple blue.

**Commit 1 — Home start-session FAB:**

- **All platforms (Android, web, iOS < 26):** the solid yellow circle now carries an Apple-style soft drop shadow it previously lacked, and uses a real radius (`componentSizeLarge / 2`) instead of `999` (UIVisualEffectView doesn't clamp the way RN Views do).
- **iOS 26+:** the FAB background renders as native **Liquid Glass** via `expo-glass-effect` (already a dependency; pod already installed). The glass is tinted brand yellow and follows the in-app theme via `colorScheme`. Gated by a module-level `isLiquidGlassAvailable()` constant, mirroring the existing `BottomTabNavigator` precedent.
- The 135° rotate-to-X is split into its own worklet wrapping just the SVG icon; the yellow → gray "close" signal is kept via `interpolateColor` on the fallback circle and reproduced on the glass path by cross-fading an opaque gray overlay (`tintColor` is a plain native prop, not worklet-drivable). The `onPress` / popover / ref / blur wiring is unchanged; `isInteractive` is intentionally omitted so native glass gestures can't swallow the popover toggle.

**Commit 2 — Social friend-search FAB + swipe-driven show/hide:**

- New `FloatingActionSurface` component: the visual circle of a static-icon FAB (Liquid Glass on iOS 26, the solid shadowed circle elsewhere). The Social screen's search button now uses it instead of a directly-styled pressable.
- The FAB's opacity is now bound to the tab pager's continuous `position` value instead of a post-settle 200 ms fade: it starts dimming the instant a swipe back toward Friend List begins, and starts appearing during the swipe (or tab-tap slide) toward Friend Requests. The position value is surfaced from `renderTabBar` props by an effect-based capture component (the web pager recreates it on layout changes, so a capture-once ref would go stale). `pointerEvents` stays gated on the settled index so a half-faded button can't be tapped.

**Commit 3 — Opaque brand fill behind the glass search FAB:**

- `glassEffectStyle="regular"` only tints *translucently*, so a glass FAB reads as brand yellow over a dark backdrop (the start-session FAB sits on the bottom tab bar) but washes out over the light Friend Requests content. The search FAB now lays an opaque brand-color fill behind the glass — emulating Apple's more opaque `.glassProminent` look (which `expo-glass-effect` doesn't expose) — so the glass rim and adaptive shadow still render while the brand-color background shows on any backdrop. The non-glass fallback was already a solid brand circle, so this only affects the iOS 26 glass path; the start-session FAB is unchanged.

The DayOverview date-picker FAB inherits the shadow + radius via the shared style and stays non-glass (no code changes; can adopt `FloatingActionSurface` as a follow-up).

No new dependencies. Branch rebased onto master — `expo-glass-effect` web transpilation is already provided by master (#936 follow-up `fix(web): transpile expo-glass-effect so the web build compiles`), so this PR no longer touches the webpack config.

### Tests

1. On the Home screen, observe the bottom-right start-session FAB.
2. On **iOS 26** (built with Xcode 26): verify the FAB renders as a circular Liquid Glass button tinted brand yellow, the background content refracts through it when scrolling the list beneath, and there is no doubled drop shadow.
3. On **iOS < 26 / Android / web**: verify the FAB is a solid yellow circle with a soft Apple-style drop shadow.
4. Tap the FAB: the plus rotates to an X over ~340ms (gray fades in on top) and the session-type popover opens. Tap again: it reverses and the popover closes.
5. Go to Friends → swipe (or tap) between the Friend List and Friend Requests tabs: the search FAB's opacity tracks the swipe progress continuously — it starts dimming the moment a swipe back toward Friend List begins and starts appearing during the swipe toward Friend Requests. A cancelled swipe restores it.
6. On the Friend Requests tab, tap the search FAB: it navigates to Search For New Friends. On the Friend List tab, verify the (invisible) FAB cannot be tapped. On **iOS 26**, verify the search FAB shows a solid brand-yellow background (not a washed-out clear glass) over the Friend Requests list.
7. Toggle the app light/dark theme and repeat steps 4–6 (exercises the glass `colorScheme` path on iOS 26).
8. Spot-check the DayOverview date-picker FAB: soft shadow, still circular.

- [ ] Verify that no errors appear in the JS console

### Offline tests

No network behavior is touched by this change; both FABs render identically offline.

### QA Steps

1. Open the app and go to the Home screen.
2. Confirm the bottom-right "+" FAB appears with a soft drop shadow (and, on an iOS 26 device, a glassy tinted appearance).
3. Tap it and confirm the plus animates to an X and the start-session menu opens; tap again to close.
4. Go to Friends and swipe between Friend List and Friend Requests: confirm the search button fades with the swipe (dims as soon as you start swiping back), shows a brand-yellow background, and opens friend search when tapped.
5. Repeat in both light and dark themes.

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>
