### PR TITLE
feat(block): client foundation for one-way user block

### DIFF
--- a/__tests__/actions/Block.test.ts
+++ b/__tests__/actions/Block.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-in-views -- this is a test that asserts on the mocked API.write, not a view */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this is a test that asserts on the mocked Onyx.merge, not app code */
+
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import * as Block from '@userActions/Block';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+// Stub Onyx so importing the action under test doesn't start real Onyx.connect
+// timers, which otherwise fire after the jest environment is torn down.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+// jest.mock factories are hoisted above the const declarations below, so they
+// must inline literals rather than reference out-of-scope variables.
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({currentUser: {uid: 'user-1'}}),
+}));
+
+jest.mock('@libs/API', () => ({write: jest.fn()}));
+
+// Isolate the action's Onyx-shaping from the Localize/Onyx-backed error builder.
+jest.mock('@libs/ErrorUtils', () => ({
+  getMicroSecondOnyxErrorWithTranslationKey: (key: string) => ({
+    '1700000000000000': key,
+  }),
+}));
+
+const ME = 'user-1';
+const OTHER = 'friend-2';
+const ERROR_KEY = '1700000000000000';
+const {DELETE} = CONST.RED_BRICK_ROAD_PENDING_ACTION;
+
+const mockedWrite = jest.mocked(API.write);
+
+function lastWrite() {
+  const call = mockedWrite.mock.calls.at(-1);
+  return {command: call?.[0], params: call?.[1], onyxData: call?.[2]};
+}
+
+const metaPatch = (uid: string, value: unknown) => ({
+  onyxMethod: 'merge',
+  key: ONYXKEYS.FRIENDS_METADATA,
+  value: {[uid]: value},
+});
+
+const userDataPatch = (uid: string, value: unknown) => ({
+  onyxMethod: 'merge',
+  key: ONYXKEYS.USER_DATA_LIST,
+  value: {[uid]: value},
+});
+
+describe('Block actions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('blockUser: keep-and-dim DELETE, removes friend + pending request on success only', () => {
+    Block.blockUser(OTHER);
+    const {command, params, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.BLOCK_USER);
+    expect(params).toEqual({otherUserId: OTHER});
+    // Optimistic only marks pending — the friend is NOT dropped yet.
+    expect(onyxData?.optimisticData).toEqual([
+      metaPatch(OTHER, {pendingAction: DELETE, errors: null}),
+    ]);
+    // Block implies unfriend: drop the friend and clear any pending request
+    // between the two on the caller's own record once the server confirms.
+    expect(onyxData?.successData).toEqual([
+      userDataPatch(ME, {
+        friends: {[OTHER]: null},
+        friend_requests: {[OTHER]: null},
+      }),
+      metaPatch(OTHER, null),
+    ]);
+    // Failure keeps the row and only marks it errored.
+    expect(onyxData?.failureData).toEqual([
+      metaPatch(OTHER, {
+        errors: {[ERROR_KEY]: 'friendAction.error.couldNotBlockUser'},
+      }),
+    ]);
+  });
+
+  it('unblockUser: fire-and-forget command with no optimistic Onyx data', () => {
+    Block.unblockUser(OTHER);
+    const {command, params, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.UNBLOCK_USER);
+    expect(params).toEqual({otherUserId: OTHER});
+    // Unblock does not re-friend, and the blocked list is server-hydrated.
+    expect(onyxData).toBeUndefined();
+  });
+});

--- a/src/ERRORS.ts
+++ b/src/ERRORS.ts
@@ -64,6 +64,7 @@ const ERRORS = {
   },
   USER: {
     BUG_SUBMISSION_FAILED: 'user/bug-submission-failed',
+    COULD_NOT_BLOCK_USER: 'user/could-not-block-user',
     COULD_NOT_UNFRIEND: 'user/could-not-unfriend',
     DATA_FETCH_FAILED: 'user/data-fetch-failed',
     FEEDBACK_REMOVAL_FAILED: 'user/feedback-removal-failed',

--- a/src/components/ManageFriendPopover.tsx
+++ b/src/components/ManageFriendPopover.tsx
@@ -1,5 +1,6 @@
 import React, {useRef} from 'react';
 import {View} from 'react-native';
+import * as Block from '@userActions/Block';
 import * as Friends from '@userActions/Friends';
 import * as Privacy from '@userActions/Privacy';
 import {useFirebase} from '@src/context/global/FirebaseContext';
@@ -39,6 +40,7 @@ function ManageFriendPopover({
   const fabRef = useRef<HTMLDivElement>(null);
   const {windowHeight} = useWindowDimensions();
   const [unfriendModalVisible, setUnfriendModalVisible] = React.useState(false);
+  const [blockModalVisible, setBlockModalVisible] = React.useState(false);
 
   const isHidden = dataVisibility?.hidden_from?.[friendId] === true;
 
@@ -64,6 +66,13 @@ function ManageFriendPopover({
         setUnfriendModalVisible(true);
       },
     },
+    {
+      text: translate('profileScreen.blockUser'),
+      icon: KirokuIcons.Lock,
+      onSelected: () => {
+        setBlockModalVisible(true);
+      },
+    },
   ];
 
   const handleUnfriend = () => {
@@ -77,6 +86,22 @@ function ManageFriendPopover({
         ErrorUtils.raiseAppError(ERRORS.USER.COULD_NOT_UNFRIEND, error);
       } finally {
         setUnfriendModalVisible(false);
+        Navigation.goBack();
+      }
+    })();
+  };
+
+  const handleBlock = () => {
+    (async () => {
+      if (!user) {
+        return;
+      }
+      try {
+        Block.blockUser(friendId);
+      } catch (error) {
+        ErrorUtils.raiseAppError(ERRORS.USER.COULD_NOT_BLOCK_USER, error);
+      } finally {
+        setBlockModalVisible(false);
         Navigation.goBack();
       }
     })();
@@ -103,6 +128,16 @@ function ManageFriendPopover({
           setUnfriendModalVisible(false);
         }}
         onConfirm={handleUnfriend}
+        danger
+      />
+      <ConfirmModal
+        isVisible={blockModalVisible}
+        title={translate('profileScreen.blockUserTitle')}
+        prompt={translate('profileScreen.blockUserPrompt')}
+        onCancel={() => {
+          setBlockModalVisible(false);
+        }}
+        onConfirm={handleBlock}
         danger
       />
     </View>

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -521,6 +521,7 @@ export default {
       couldNotRemoveRequest:
         'Could not remove the friend request. Please try again.',
       couldNotUnfriend: 'Could not remove this friend. Please try again.',
+      couldNotBlockUser: 'Could not block this user. Please try again.',
     },
   },
   notFoundScreen: {
@@ -994,6 +995,10 @@ export default {
     manageFriend: 'Manage Friend',
     unfriendPrompt: 'Do you really want to unfriend this user?',
     unfriend: 'Unfriend',
+    blockUser: 'Block user',
+    blockUserTitle: 'Block this user?',
+    blockUserPrompt:
+      'Blocking removes your friendship and hides each of you from the other. They will not be able to find you or send you a friend request. You can unblock them later.',
     hideDataFromFriend: 'Hide my data from this friend',
     showDataToFriend: 'Show my data to this friend',
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
@@ -1794,6 +1799,11 @@ export default {
       bugSubmissionFailed: {
         title: 'Bug Submission Failed',
         message: 'There was an issue submitting the bug. Please try again.',
+      },
+      couldNotBlockUser: {
+        title: 'Could Not Block User',
+        message:
+          'There was an issue trying to block this user. Please try again.',
       },
       couldNotUnfriend: {
         title: 'Could Not Unfriend',

--- a/src/libs/API/parameters/BlockUserParams.ts
+++ b/src/libs/API/parameters/BlockUserParams.ts
@@ -1,0 +1,5 @@
+type BlockUserParams = {
+  otherUserId: string;
+};
+
+export default BlockUserParams;

--- a/src/libs/API/parameters/UnblockUserParams.ts
+++ b/src/libs/API/parameters/UnblockUserParams.ts
@@ -1,0 +1,5 @@
+type UnblockUserParams = {
+  otherUserId: string;
+};
+
+export default UnblockUserParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -4,6 +4,8 @@ export type {default as SendFriendRequestParams} from './SendFriendRequestParams
 export type {default as AcceptFriendRequestParams} from './AcceptFriendRequestParams';
 export type {default as DeleteFriendRequestParams} from './DeleteFriendRequestParams';
 export type {default as UnfriendParams} from './UnfriendParams';
+export type {default as BlockUserParams} from './BlockUserParams';
+export type {default as UnblockUserParams} from './UnblockUserParams';
 export type {default as UpdateSessionParams} from './UpdateSessionParams';
 export type {default as DeleteSessionParams} from './DeleteSessionParams';
 export type {default as CaptureSessionLocationParams} from './CaptureSessionLocationParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -35,6 +35,8 @@ const WRITE_COMMANDS = {
   ACCEPT_FRIEND_REQUEST: 'AcceptFriendRequest',
   DELETE_FRIEND_REQUEST: 'DeleteFriendRequest',
   UNFRIEND: 'Unfriend',
+  BLOCK_USER: 'BlockUser',
+  UNBLOCK_USER: 'UnblockUser',
   UPDATE_SESSION: 'UpdateSession',
   DELETE_SESSION: 'DeleteSession',
   UPDATE_PREFERENCES: 'UpdatePreferences',
@@ -86,6 +88,8 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.ACCEPT_FRIEND_REQUEST]: Parameters.AcceptFriendRequestParams;
   [WRITE_COMMANDS.DELETE_FRIEND_REQUEST]: Parameters.DeleteFriendRequestParams;
   [WRITE_COMMANDS.UNFRIEND]: Parameters.UnfriendParams;
+  [WRITE_COMMANDS.BLOCK_USER]: Parameters.BlockUserParams;
+  [WRITE_COMMANDS.UNBLOCK_USER]: Parameters.UnblockUserParams;
   [WRITE_COMMANDS.UPDATE_SESSION]: Parameters.UpdateSessionParams;
   [WRITE_COMMANDS.DELETE_SESSION]: Parameters.DeleteSessionParams;
   [WRITE_COMMANDS.UPDATE_PREFERENCES]: Parameters.UpdatePreferencesParams;

--- a/src/libs/Errors/ERROR_MAPPING.ts
+++ b/src/libs/Errors/ERROR_MAPPING.ts
@@ -48,6 +48,7 @@ const ERROR_MAPPING: ErrorMapping = {
   [ERRORS.SESSION.SAVE_FAILED]: 'errors.session.saveFailed',
   [ERRORS.SESSION.START_FAILED]: 'errors.session.startFailed',
   [ERRORS.USER.BUG_SUBMISSION_FAILED]: 'errors.user.bugSubmissionFailed',
+  [ERRORS.USER.COULD_NOT_BLOCK_USER]: 'errors.user.couldNotBlockUser',
   [ERRORS.USER.COULD_NOT_UNFRIEND]: 'errors.user.couldNotUnfriend',
   [ERRORS.USER.DATA_FETCH_FAILED]: 'errors.user.dataFetchFailed',
   [ERRORS.USER.FEEDBACK_REMOVAL_FAILED]: 'errors.user.feedbackRemovalFailed',

--- a/src/libs/actions/Block.ts
+++ b/src/libs/actions/Block.ts
@@ -1,0 +1,113 @@
+import Onyx from 'react-native-onyx';
+import type {OnyxUpdate} from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import * as ErrorUtils from '@libs/ErrorUtils';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {TranslationPaths} from '@src/languages/types';
+import type {FriendActionMetadata} from '@src/types/onyx/FriendsMetadata';
+
+/**
+ * Block actions built on the kiroku-api `API.write` pattern. A one-way block:
+ * when the caller blocks `otherUserId`, the server atomically severs the
+ * friendship both ways, clears any pending friend requests in either direction,
+ * and hides each user from the other; neither can then find or send a request to
+ * the other. Authority is server-side (the caller's Firebase ID token), so
+ * callers pass only the counterpart id; the caller's own uid is used solely for
+ * the optimistic Onyx update.
+ *
+ * The blocked-user list itself is server-authoritative and hydrates into Onyx via
+ * `app/open` + `/v1/updates` (like data-visibility in `Privacy.ts`), so we do NOT
+ * guess at its Onyx shape here. The only optimistic change is the local unfriend
+ * effect (block implies unfriend): `blockUser` mirrors `unfriend`'s keep-and-dim
+ * — it dims the friend row while the write is queued (`FRIENDS_METADATA`), drops
+ * the friend (and any pending request) from the signed-in user's `userDataList`
+ * record only once the server confirms, and surfaces a dismissible error on
+ * failure without losing the row. `unblockUser` does NOT re-friend, and the
+ * blocked list is server-hydrated, so it carries no optimistic Onyx data.
+ *
+ * The helpers below mirror `Friends.ts`, which is the canonical source for this
+ * pattern; they are duplicated rather than shared to keep this addition isolated
+ * from the friend flow.
+ */
+
+const {DELETE} = CONST.RED_BRICK_ROAD_PENDING_ACTION;
+
+function getCurrentUserID(): string | undefined {
+  return getFirebaseAuth().currentUser?.uid ?? undefined;
+}
+
+/** Optimistic `merge userDataList { [uid]: patch }`. */
+function userDataPatch(
+  uid: string,
+  patch: Record<string, unknown>,
+): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.USER_DATA_LIST,
+    value: {[uid]: patch},
+  };
+}
+
+/** `merge friendsMetadata { [otherUserId]: meta }` (null removes the entry). */
+function metaPatch(
+  otherUserId: string,
+  meta: FriendActionMetadata | null,
+): OnyxUpdate {
+  return {
+    onyxMethod: Onyx.METHOD.MERGE,
+    key: ONYXKEYS.FRIENDS_METADATA,
+    value: {[otherUserId]: meta},
+  };
+}
+
+function errorMeta(message: TranslationPaths): FriendActionMetadata {
+  return {
+    errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey(message),
+  };
+}
+
+/**
+ * Block a user. The server severs the friendship and clears pending requests
+ * both ways and hides each user from the other; the client keeps-and-dims the
+ * friend row, then removes the friend and any pending request from the caller's
+ * own `userDataList` record once the server confirms.
+ */
+function blockUser(otherUserId: string) {
+  const uid = getCurrentUserID();
+  if (!uid) {
+    return;
+  }
+  // Keep-and-dim: don't drop the friend until the server confirms the teardown.
+  const optimisticData: OnyxUpdate[] = [
+    metaPatch(otherUserId, {pendingAction: DELETE, errors: null}),
+  ];
+  const successData: OnyxUpdate[] = [
+    userDataPatch(uid, {
+      friends: {[otherUserId]: null},
+      friend_requests: {[otherUserId]: null},
+    }),
+    metaPatch(otherUserId, null),
+  ];
+  const failureData: OnyxUpdate[] = [
+    metaPatch(otherUserId, errorMeta('friendAction.error.couldNotBlockUser')),
+  ];
+  API.write(
+    WRITE_COMMANDS.BLOCK_USER,
+    {otherUserId},
+    {optimisticData, successData, failureData},
+  );
+}
+
+/**
+ * Unblock a user the caller previously blocked. This does NOT re-establish the
+ * friendship. The blocked-user list is server-authoritative and hydrates into
+ * Onyx via app updates, so there is no optimistic Onyx data to apply here.
+ */
+function unblockUser(otherUserId: string) {
+  API.write(WRITE_COMMANDS.UNBLOCK_USER, {otherUserId});
+}
+
+export {blockUser, unblockUser};


### PR DESCRIPTION
## What

Client-side foundation for the **Block user** feature (epic `feature/block`). One-way block: when A blocks B, the server atomically severs the friendship both ways, clears pending requests in both directions, hides each user from the other, and prevents either from finding or re-requesting the other. A owns the block and can undo it; unblock does **not** re-friend.

This PR is the client leg only: the command + optimistic UI + the entry point in the friend popover. The authoritative atomic teardown lives in **kiroku-api** (separate, parallel work item — not in this repo).

## ⚠️ Corrected architecture (issues are stale)

Issues #755/#756 describe building block on **Firebase RTDB security rules** (`database.rules.json`) mirroring `src/database/friends.ts` / `privacy.ts`. **That architecture no longer exists** — the client→API migration is complete (`src/database/` only has `updates.ts`; `git grep firebase/database src` = 0). This PR builds on the kiroku-api `API.write` pattern instead, mirroring `Friends.unfriend`.

## Changes

- **Write commands**: `WRITE_COMMANDS.BLOCK_USER = 'BlockUser'` and `UNBLOCK_USER = 'UnblockUser'`, registered in the param-type map (`src/libs/API/types.ts`).
- **Param types**: `BlockUserParams` / `UnblockUserParams` (`{otherUserId: string}`), exported from `parameters/index.ts` (mirror `UnfriendParams`).
- **`src/libs/actions/Block.ts`** mirroring `Friends.ts`:
  - `blockUser(otherUserId)` — keep-and-dim on the friend row (`FRIENDS_METADATA`), and on **success** drops the friend *and* any pending request between the two from the caller's own `userDataList` record (block implies unfriend). Surfaces a dismissible error on failure without losing the row.
  - `unblockUser(otherUserId)` — fire-and-forget `API.write`; no optimistic Onyx data (unblock does not re-friend, and the blocked list is server-hydrated, so its Onyx shape is not guessed at here).
- **`ManageFriendPopover.tsx`**: new **"Block user"** item (alongside hide/show/unfriend) behind a destructive `ConfirmModal` explaining it removes the friendship and hides each user from the other; on confirm it calls `blockUser`, closes the popover, and navigates back.
- **English copy only** (`en.ts`): `profileScreen.blockUser` / `blockUserTitle` / `blockUserPrompt`, the keep-and-dim error `friendAction.error.couldNotBlockUser`, and the error-modal copy `errors.user.couldNotBlockUser` (+ `ERRORS.USER.COULD_NOT_BLOCK_USER` and its `ERROR_MAPPING` entry). No em-dashes. Non-English locales are intentionally **not** hand-written — that's a follow-up via the `translate` skill (per CLAUDE.md); the always-on `TranslationContext` gate still passes (it checks context-file existence, not key parity, and locales are loosely typed).
- **Unit test** `__tests__/actions/Block.test.ts` mirroring `Friends.test.ts`.

## Verification

- `npm run typecheck-tsgo` ✅
- `npm run lint-changed` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `npx jest __tests__/actions/Block.test.ts` ✅ (2/2); Friends + TranslationContext tests still pass.

## Out of scope (next increments)

- **kiroku-api server enforcement** — the authoritative atomic block teardown (separate chip/repo).
- **#759** — exclude blocked users from search & disable requests.
- **#760** — filter blocked users from friend list / profile / sessions.
- **#761** — Settings → Privacy "Blocked users" management screen (the eventual consumer of `unblockUser`).
- **#762** — full `translate`-skill run for non-English locales.

Refs #756, #758, #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)