### PR TITLE
ci(web): deploy, PR preview channels, and web-build guard (#936)

### DIFF
--- a/.github/workflows/deployWeb.yml
+++ b/.github/workflows/deployWeb.yml
@@ -1,0 +1,156 @@
+name: Deploy web
+
+# Deploys the react-native-web SPA to Firebase Hosting.
+#
+# - push to `production` -> build-web        -> live deploy to the prod project
+#                                                (hosting target `app` =
+#                                                 kiroku-app-prod / app.kiroku.cz)
+# - push to `staging`    -> build-web-dev     -> live deploy to the dev project
+#                                                (hosting target `app` =
+#                                                 kiroku-app-dev)
+# - PR labeled `Ready To Build - Web`         -> build-web-dev -> preview channel
+#   (or manual dispatch with a PR number)        `pr-<number>` on the dev site,
+#                                                URL commented on the PR
+#
+# Auth: a single Google service-account JSON in the FIREBASE_SERVICE_ACCOUNT
+# secret, granted Firebase Hosting Admin on BOTH Firebase projects
+# (alcohol-tracker-db and dev-alcohol-tracker-db). The firebase CLI reads it via
+# GOOGLE_APPLICATION_CREDENTIALS.
+on:
+  push:
+    branches: [staging, production]
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      PULL_REQUEST_NUMBER:
+        description: Pull request number to build a preview channel for
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deployLive:
+    name: Build and deploy web (live)
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve deploy target
+        id: target
+        run: |
+          if [[ "$GITHUB_REF_NAME" == "production" ]]; then
+            {
+              echo "PROJECT=prod"
+              echo "BUILD_SCRIPT=build-web"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "PROJECT=dev"
+              echo "BUILD_SCRIPT=build-web-dev"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      # build-web reads .env.production; build-web-dev reads .env.development.
+      # Stage the matching file from secrets (the dev/staging site is fed the
+      # staging env so it points at the staging API roots).
+      - name: Stage .env.production from secret
+        if: ${{ github.ref_name == 'production' }}
+        run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
+
+      - name: Stage .env.development from staging secret
+        if: ${{ github.ref_name == 'staging' }}
+        run: echo "${{ secrets.STAGING_ENV_FILE }}" > .env.development
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Build web
+        run: npm run ${{ steps.target.outputs.BUILD_SCRIPT }}
+
+      - name: Authenticate to Firebase
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-sa.json"
+
+      - name: Deploy to Firebase Hosting (live)
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+        run: |
+          npx --yes firebase-tools@13 deploy \
+            --only hosting:app \
+            --project ${{ steps.target.outputs.PROJECT }} \
+            --non-interactive \
+            --message "Deploy ${{ github.sha }} (${{ github.ref_name }})"
+
+  deployPreview:
+    name: Build and deploy web preview channel
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'Ready To Build - Web') }}
+    runs-on: ubuntu-latest
+    env:
+      PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
+    steps:
+      - name: Resolve PR head ref
+        id: ref
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          HEAD_SHA="$(gh pr view "$PULL_REQUEST_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq '.headRefOid')"
+          echo "REF=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || steps.ref.outputs.REF }}
+
+      # Previews are built with the dev/staging config so they exercise the
+      # staging API, and are hosted as a channel on the dev site.
+      - name: Stage .env.development from staging secret
+        run: echo "${{ secrets.STAGING_ENV_FILE }}" > .env.development
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Build web
+        run: npm run build-web-dev
+
+      - name: Authenticate to Firebase
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-sa.json"
+
+      - name: Deploy preview channel
+        id: preview
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+        run: |
+          set -e
+          npx --yes firebase-tools@13 hosting:channel:deploy "pr-${PULL_REQUEST_NUMBER}" \
+            --only app \
+            --project dev \
+            --expires 7d \
+            --json > channel.json
+          URL="$(jq -r '.result | to_entries[0].value.url' channel.json)"
+          echo "URL=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on the PR
+        uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
+        with:
+          github_token: ${{ github.token }}
+          number: ${{ env.PULL_REQUEST_NUMBER }}
+          body: |
+            :globe_with_meridians: **Web preview deployed** for this PR.
+
+            ${{ steps.preview.outputs.URL }}
+
+            _This is a dev build on a temporary Firebase Hosting channel (expires in 7 days). Re-apply the `Ready To Build - Web` label to refresh it._

--- a/.github/workflows/webBuild.yml
+++ b/.github/workflows/webBuild.yml
@@ -1,0 +1,45 @@
+name: Web build
+
+# Regression gate for the react-native-web build. Runs `npm run build-web`
+# (production webpack config, no deploy) so a web break can't merge silently.
+# Path-filtered to web-relevant changes; can also be triggered manually.
+# Forcing a full build + hosted preview for an arbitrary PR is the job of the
+# `Ready To Build - Web` label, handled by deployWeb.yml.
+on:
+  pull_request:
+    paths:
+      - src/**
+      - web/**
+      - assets/**
+      - config/webpack/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/webBuild.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  webBuild:
+    name: Build web (no deploy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # build-web runs webpack with `--env file=.env.production`; dotenv needs
+      # the file to exist. Stage it from the same secret the native production
+      # build and the screenshots workflow use.
+      - name: Stage .env.production from secret
+        run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Build web
+        run: npm run build-web

--- a/config/webpack/webpack.common.ts
+++ b/config/webpack/webpack.common.ts
@@ -48,6 +48,10 @@ const includeModules = [
   'expo-image',
   'expo-image-manipulator',
   'expo-modules-core',
+  // iOS-26 Liquid Glass. Ships untranspiled JSX in build/*.js; the cross-platform
+  // (non-.ios) files are a no-op (isLiquidGlassAvailable() === false, Glass* render
+  // a plain View), so transpiling them yields a clean web fallback.
+  'expo-glass-effect',
   'victory-native',
   '@shopify/react-native-skia',
 ].join('|');


### PR DESCRIPTION
## What

Phase 2 of the web epic (#925), issue #936 — CI for the react-native-web build.

### Workflows added
- **`webBuild.yml`** — path-filtered PR gate that runs `npm run build-web` (no deploy). Web can no longer silently regress. Triggers on PRs touching `src/**`, `web/**`, `assets/**`, `config/webpack/**`, `package.json`, `package-lock.json`, or the workflow itself; plus manual dispatch.
- **`deployWeb.yml`**
  - push to **`production`** → `build-web` → **live** deploy to the prod project (hosting target `app` = `kiroku-app-prod` / app.kiroku.cz). Same trigger model as `deploy.yml`'s production deploy.
  - push to **`staging`** → `build-web-dev` → **live** deploy to the dev project (`kiroku-app-dev`).
  - PR labeled **`Ready To Build - Web`** (or `workflow_dispatch` with a PR number) → `build-web-dev` → **`pr-<n>` preview channel** on the dev site, URL commented on the PR (7-day expiry). This is what makes the existing `Ready To Build - Web` label functional.

### Bundled fix
- **`config/webpack/webpack.common.ts`** — adds `expo-glass-effect` to the babel-loader `includeModules` allowlist. The new guard immediately caught that `npm run build-web` was **already broken on master**: the iOS-26 Liquid Glass commit (d8e72cf0a) pulled in `expo-glass-effect`, which ships untranspiled JSX, and there was no web CI to catch it. The cross-platform fallback is a no-op on web (`isLiquidGlassAvailable() === false`), so transpiling it yields a clean web build.

### Auth & secrets
- Env files staged from existing secrets: `PRODUCTION_ENV_FILE` → `.env.production`, `STAGING_ENV_FILE` → `.env.development` (matches `platformDeploy.yml` / `screenshots.yml`).
- **New secret required: `FIREBASE_SERVICE_ACCOUNT`** — a Google service-account JSON consumed by the firebase CLI via `GOOGLE_APPLICATION_CREDENTIALS`. Must be granted **Firebase Hosting Admin on BOTH** `alcohol-tracker-db` (prod) and `dev-alcohol-tracker-db` (dev/previews). Not yet set — see checklist.

### Design notes
- Previews build with the dev/staging config and host on the dev site, so they exercise the staging API (never prod) and never touch the prod hosting site.
- Preview deploy triggers on `pull_request: labeled` (not `pull_request_target`), so secrets are never exposed to fork PRs.
- Depends on #935 (already merged): `firebase.json` hosting target `app` + `.firebaserc` target mappings.

## Verification
- ✅ `actionlint` clean on both workflows.
- ✅ `webBuild` guard runs and is **green** on this PR (and proved its worth by catching the master break).
- ✅ Full CI suite (lint / typecheck / test / react-compiler) green.
- ⏳ Live deploy + preview channel paths require `FIREBASE_SERVICE_ACCOUNT` to be set, then verifiable via a preview-channel run (label this PR) and a post-merge `staging`/`production` push.

## Reviewer checklist
- [ ] Create the `FIREBASE_SERVICE_ACCOUNT` secret (service-account JSON, Firebase Hosting Admin on **both** `alcohol-tracker-db` and `dev-alcohol-tracker-db`).
- [ ] After the secret is set, label this PR `Ready To Build - Web` to verify the preview-channel path.

Closes #936. Part of #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)