### PR TITLE
chore(claude): cap skill-listing description length to trim per-turn context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,5 +22,6 @@
     },
     "enabledPlugins": {
         "react-native-best-practices@callstack-agent-skills": true
-    }
+    },
+    "skillListingMaxDescChars": 512
 }


### PR DESCRIPTION
## What
Adds `skillListingMaxDescChars: 512` to the project `.claude/settings.json` (Claude Code config). Default is 1536; this caps each skill's description in the per-turn skill listing sent to the model.

## Why
The skill listing is re-read into context on **every** assistant turn, so verbose descriptions (document-tooling skills, the Claude API reference, etc.) inflate the standing context across all Kiroku sessions. Capping the description length trims that without removing or disabling any skill — shorter descriptions are unaffected and every skill stays fully invocable.

Verified against the installed Claude Code build (v2.1.170): `skillListingMaxDescChars` is read from **merged** settings, so committing it here propagates to all sessions in the repo, **including git worktrees** (where most coding happens). A personal `settings.local.json` would not reach worktree checkouts.

## Notes
- Purely a context/cost optimization — no behavioral change to the app or CI.
- Reversible: remove the key to restore the default (1536).
- New worktrees inherit it automatically; existing worktrees pick it up after rebasing onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)