### PR TITLE
feat(block): filter blocked users from discovery & consumption UI (#759, #760)

### DIFF
--- a/__tests__/unit/BlockUtils.test.ts
+++ b/__tests__/unit/BlockUtils.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+
+import {filterBlockedUsers, isBlocked} from '@libs/BlockUtils';
+import {getCommonFriends, getCommonFriendsCount} from '@libs/FriendUtils';
+import type {UserList} from '@src/types/onyx/OnyxCommon';
+
+// The signed-in user's outbound block list, as hydrated into
+// `USER_DATA_LIST[myUid].blocked` (the server writes `{[uid]: true}`).
+const BLOCKED: UserList = {bob: true, carol: true};
+
+describe('libs/BlockUtils.isBlocked', () => {
+  it('returns true for a user in the block list', () => {
+    expect(isBlocked(BLOCKED, 'bob')).toBe(true);
+  });
+
+  it('returns false for a user not in the block list', () => {
+    expect(isBlocked(BLOCKED, 'dave')).toBe(false);
+  });
+
+  it('returns false when the block list is undefined (nobody blocked)', () => {
+    expect(isBlocked(undefined, 'bob')).toBe(false);
+  });
+
+  it('returns false when the block list is empty', () => {
+    expect(isBlocked({}, 'bob')).toBe(false);
+  });
+
+  it('treats a falsy entry as not blocked (e.g. a stale {uid: false})', () => {
+    expect(isBlocked({bob: false}, 'bob')).toBe(false);
+  });
+});
+
+describe('libs/BlockUtils.filterBlockedUsers', () => {
+  it('removes blocked users while preserving order', () => {
+    expect(
+      filterBlockedUsers(['alice', 'bob', 'dave', 'carol'], BLOCKED),
+    ).toEqual(['alice', 'dave']);
+  });
+
+  it('returns the same array reference when there is no block list', () => {
+    const input = ['alice', 'bob'];
+    expect(filterBlockedUsers(input, undefined)).toBe(input);
+  });
+
+  it('returns all users when none are blocked', () => {
+    expect(filterBlockedUsers(['alice', 'dave'], BLOCKED)).toEqual([
+      'alice',
+      'dave',
+    ]);
+  });
+
+  it('returns an empty array when every user is blocked', () => {
+    expect(filterBlockedUsers(['bob', 'carol'], BLOCKED)).toEqual([]);
+  });
+
+  it('handles an empty input array', () => {
+    expect(filterBlockedUsers([], BLOCKED)).toEqual([]);
+  });
+});
+
+// FriendUtils delegates its blocked-exclusion to filterBlockedUsers; these cover
+// the wiring used by ProfileScreen / FriendsFriendsScreen (#760).
+describe('libs/FriendUtils common-friends blocked exclusion', () => {
+  it('excludes blocked users from the common-friends list', () => {
+    const mine = ['alice', 'bob', 'carol'];
+    const theirs = ['bob', 'carol', 'dave'];
+    expect(getCommonFriends(mine, theirs, BLOCKED)).toEqual([]);
+  });
+
+  it('keeps non-blocked common friends', () => {
+    const mine = ['alice', 'bob', 'dave'];
+    const theirs = ['alice', 'bob', 'erin'];
+    // alice is common and not blocked; bob is common but blocked.
+    expect(getCommonFriends(mine, theirs, BLOCKED)).toEqual(['alice']);
+  });
+
+  it('matches the legacy behaviour when no block list is passed', () => {
+    const mine = ['alice', 'bob'];
+    const theirs = ['bob', 'carol'];
+    expect(getCommonFriends(mine, theirs)).toEqual(['bob']);
+  });
+
+  it('counts only non-blocked common friends', () => {
+    const mine = ['alice', 'bob', 'carol'];
+    const theirs = ['alice', 'bob', 'carol'];
+    // alice counts; bob and carol are blocked.
+    expect(getCommonFriendsCount(mine, theirs, BLOCKED)).toBe(1);
+  });
+});

--- a/src/components/Search/SendFriendRequestButton/index.tsx
+++ b/src/components/Search/SendFriendRequestButton/index.tsx
@@ -9,6 +9,8 @@ import * as Friends from '@userActions/Friends';
 import type {TranslationPaths} from '@src/languages/types';
 import ERRORS from '@src/ERRORS';
 import useLocalize from '@hooks/useLocalize';
+import useCurrentUserData from '@hooks/useCurrentUserData';
+import {isBlocked} from '@libs/BlockUtils';
 import type SendFriendRequestButtonProps from './types';
 
 function SendFriendRequestButton({
@@ -20,6 +22,12 @@ function SendFriendRequestButton({
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const {translate} = useLocalize();
   const styles = useThemeStyles();
+  const userData = useCurrentUserData();
+  // Discovery filter (#759): if the signed-in user has blocked this user, never
+  // offer the send/accept-request action. The server rejects the write either
+  // way; this keeps the UI from offering it. Blocked users are normally filtered
+  // out of the lists upstream, so this is a defensive fallback.
+  const isUserBlocked = isBlocked(userData?.blocked, userTo);
 
   const handleSendRequestPress = () => {
     (async (): Promise<void> => {
@@ -72,6 +80,9 @@ function SendFriendRequestButton({
   const renderContents = () => {
     if (userFrom === userTo) {
       return renderText('searchResult.self');
+    }
+    if (isUserBlocked) {
+      return renderText('searchResult.blocked');
     }
     if (alreadyAFriend) {
       return renderText('searchResult.friend');

--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -108,7 +108,14 @@ function useDrinkingSessionsFetch(
       setIsFetchingOlderMonths(false);
     };
 
-    DrinkingSession.openFriendDrinkingSessions(userID, from).finally(finalize);
+    // A block-gated / privacy-denied read rejects with a non-2xx (it bypasses
+    // SaveResponseInOnyx, so failureData never runs). Swallow it: the calendar
+    // should resolve to a clean empty state (the server evicts the cached key on
+    // deny — #786), never throw an unhandled rejection. `finalize` still clears
+    // the loading flags either way.
+    DrinkingSession.openFriendDrinkingSessions(userID, from)
+      .catch(() => undefined)
+      .finally(finalize);
   }, [userID, sessionsMonthsBack, monthsLoadedMeta.status]);
 
   // Re-issue the windowed read when connectivity resumes.
@@ -127,7 +134,10 @@ function useDrinkingSessionsFetch(
       const from = startOfMonth(
         subMonths(new Date(), sessionsMonthsBack),
       ).getTime();
-      DrinkingSession.openFriendDrinkingSessions(userID, from);
+      // Swallow a block-gated / privacy-denied rejection here too (see above).
+      DrinkingSession.openFriendDrinkingSessions(userID, from).catch(
+        () => undefined,
+      );
     },
   });
 

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -467,6 +467,7 @@ export default {
     sent: 'Awaiting a response',
     accept: 'Accept friend request',
     add: 'Send a request',
+    blocked: 'Blocked',
   },
   socialScreen: {
     title: 'Friends',

--- a/src/libs/BlockUtils.ts
+++ b/src/libs/BlockUtils.ts
@@ -1,0 +1,50 @@
+import type {UserArray, UserID, UserList} from '@src/types/onyx/OnyxCommon';
+
+/**
+ * Block-filtering helpers for the one-way block feature.
+ *
+ * The client only ever holds the signed-in user's OWN OUTBOUND block list
+ * (`USER_DATA_LIST[myUid].blocked` = the uids *I* have blocked). A user can NOT
+ * see who has blocked *them* — that list is owner-private server-side. So these
+ * helpers answer only "did I block this user?". The inbound case (they blocked
+ * me) needs no client filtering: the server gate already makes their data
+ * unreadable (the read is denied / the cached entry is evicted), and the UI's
+ * job there is just to degrade gracefully into an empty state.
+ *
+ * The server is the source of truth (it severs the friendship both ways and
+ * denies block-gated reads). These helpers are the defense-in-depth UX layer so
+ * the client never surfaces, counts, or offers actions on a user the signed-in
+ * user has blocked, even for cached or edge-case data the server has not yet
+ * evicted. Mirrors the friend-list helpers in [[FriendUtils]].
+ */
+
+/**
+ * Whether `uid` is in the signed-in user's outbound block list.
+ *
+ * @param blockedList - the signed-in user's `blocked` map, i.e.
+ *   `USER_DATA_LIST[myUid].blocked`. Undefined when the user has blocked nobody.
+ * @param uid - the user to test.
+ */
+function isBlocked(blockedList: UserList | undefined, uid: UserID): boolean {
+  return !!blockedList?.[uid];
+}
+
+/**
+ * Remove every uid the signed-in user has blocked from `userIds`, preserving
+ * order. Returns the input array unchanged when there is no block list, so the
+ * common "nobody blocked" path allocates nothing.
+ *
+ * @param userIds - the candidate user ids (e.g. search results, a friend list).
+ * @param blockedList - the signed-in user's `blocked` map.
+ */
+function filterBlockedUsers(
+  userIds: UserArray,
+  blockedList: UserList | undefined,
+): UserArray {
+  if (!blockedList) {
+    return userIds;
+  }
+  return userIds.filter(uid => !isBlocked(blockedList, uid));
+}
+
+export {isBlocked, filterBlockedUsers};

--- a/src/libs/FriendUtils.ts
+++ b/src/libs/FriendUtils.ts
@@ -1,17 +1,23 @@
 import type {FriendRequestList, FriendRequestStatus} from '@src/types/onyx';
-import type {UserArray} from '@src/types/onyx/OnyxCommon';
+import type {UserArray, UserList} from '@src/types/onyx/OnyxCommon';
 import CONST from '@src/CONST';
 import {isEmptyArray} from '@src/types/utils/EmptyObject';
+import {filterBlockedUsers} from '@libs/BlockUtils';
 
 /**
  * Returns an array of common friends between two users.
  * @param user1Friends - The friends data of user 1.
  * @param user2Friends - The friends data of user 2.
+ * @param blockedList - The signed-in user's outbound block list. When provided,
+ *   any user the signed-in user has blocked is excluded from the result, so a
+ *   blocked user is never surfaced even if a cached friend list still references
+ *   them (defense-in-depth; the server already severs blocked friendships).
  * @returns An array of common friends.
  */
 function getCommonFriends(
   user1FriendIds: UserArray,
   user2FriendIds: UserArray,
+  blockedList?: UserList,
 ): UserArray {
   let commonFriends: UserArray = [];
   if (isEmptyArray(user1FriendIds) && isEmptyArray(user2FriendIds)) {
@@ -20,20 +26,23 @@ function getCommonFriends(
   commonFriends = user2FriendIds.filter(friendId =>
     user1FriendIds.includes(friendId),
   );
-  return commonFriends;
+  return filterBlockedUsers(commonFriends, blockedList);
 }
 
 /**
  * Calculates the number of common friends between two users.
  * @param user1Friends - The friends of user 1.
  * @param user2Friends - The friends of user 2.
+ * @param blockedList - The signed-in user's outbound block list; blocked users
+ *   are excluded from the count (see {@link getCommonFriends}).
  * @returns The number of common friends.
  */
 function getCommonFriendsCount(
   user1FriendIds: UserArray,
   user2FriendIds: UserArray,
+  blockedList?: UserList,
 ): number {
-  return getCommonFriends(user1FriendIds, user2FriendIds).length;
+  return getCommonFriends(user1FriendIds, user2FriendIds, blockedList).length;
 }
 
 /**

--- a/src/screens/Profile/FriendsFriendsScreen.tsx
+++ b/src/screens/Profile/FriendsFriendsScreen.tsx
@@ -14,6 +14,7 @@ import SearchResult from '@components/Search/SearchResult';
 import SearchWindow from '@components/Social/SearchWindow';
 import GrayHeader from '@components/Header/GrayHeader';
 import {getCommonFriends, getCommonFriendsCount} from '@libs/FriendUtils';
+import {filterBlockedUsers} from '@libs/BlockUtils';
 import type {
   UserIDToNicknameMapping,
   UserSearchResults,
@@ -55,6 +56,16 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
   // The target user's friends, read via the kiroku-api into
   // `userDataList[userID].friends` (replacing the direct Firebase read).
   const friends = userDataList?.[userID]?.friends;
+  // Consumption filter (#760): exclude anyone the signed-in user has blocked
+  // from the viewed user's friend list, so a user I blocked never appears in
+  // their "common"/"other" friends (counts or rows). `blocked` is my own
+  // outbound block list; `friends` here is someone else's list, which the server
+  // does not filter against my blocks. The effects below recompute this from the
+  // stable `friends`/`blocked` Onyx refs to keep their dependency arrays
+  // referentially stable; this render-scoped copy serves the synchronous render
+  // paths (search handlers + the empty-state check).
+  const blocked = userData?.blocked;
+  const visibleFriendIds = filterBlockedUsers(objKeys(friends), blocked);
   const [searching, setSearching] = useState<boolean>(false);
   const [displayedFriends, setDisplayedFriends] = useState<UserSearchResults>(
     [],
@@ -75,7 +86,7 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
         'display_name',
       );
       const relevantResults = searchArrayByText(
-        objKeys(friends),
+        visibleFriendIds,
         searchText,
         searchMapping,
       );
@@ -180,30 +191,32 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
   useEffect(() => {
     const initialSearch = async (): Promise<void> => {
       setSearching(true);
-      const friendIds = objKeys(friends);
+      const friendIds = filterBlockedUsers(objKeys(friends), blocked);
       await updateHooksBasedOnSearchResults(friendIds);
       setDisplayedFriends(friendIds);
       setSearching(false);
     };
     initialSearch();
-  }, [friends, updateHooksBasedOnSearchResults]);
+  }, [friends, blocked, updateHooksBasedOnSearchResults]);
 
   // Monitor friend groups
   useEffect(() => {
     let newCommonFriends: string[] = [];
     let newOtherFriends: string[] = [];
     if (friends) {
+      const friendIds = filterBlockedUsers(objKeys(friends), blocked);
       newCommonFriends = getCommonFriends(
-        objKeys(friends),
+        friendIds,
         objKeys(userData?.friends),
+        blocked,
       );
-      newOtherFriends = objKeys(friends).filter(
+      newOtherFriends = friendIds.filter(
         friend => !newCommonFriends.includes(friend),
       );
     }
     setCommonFriends(newCommonFriends);
     setOtherFriends(newOtherFriends);
-  }, [userData?.friends, friends]);
+  }, [userData?.friends, friends, blocked]);
 
   useEffect(() => {
     let newNoUsersFound = true;
@@ -215,8 +228,7 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
 
   const resetSearch = (): void => {
     // Reset all values displayed on screen
-    const friendIds = objKeys(friends);
-    setDisplayedFriends(friendIds);
+    setDisplayedFriends(visibleFriendIds);
     setSearching(false);
     setNoUsersFound(false);
   };
@@ -259,7 +271,7 @@ function FriendsFriendsScreen({route}: FriendsFriendsScreenProps) {
               ) : (
                 noUsersFound && (
                   <Text style={styles.noResultsText}>
-                    {objKeys(friends).length > 0
+                    {visibleFriendIds.length > 0
                       ? `${translate('friendsFriendsScreen.noFriendsFound')}\n\n${translate(
                           'friendsFriendsScreen.trySearching',
                         )}`

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -14,6 +14,7 @@ import {dateToDateData, dateStringToDate, objKeys} from '@libs/DataHandling';
 import SessionsCalendar from '@components/SessionsCalendar';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import {getCommonFriendsCount} from '@libs/FriendUtils';
+import {isBlocked} from '@libs/BlockUtils';
 import * as FeatureFlags from '@libs/FeatureFlags';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import type {StackScreenProps} from '@react-navigation/stack';
@@ -111,6 +112,12 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // viewer's own friends back from Onyx (hydrated below via `openFriendList`).
   const selfFriends =
     user && user.uid !== userID ? userDataList?.[user.uid]?.friends : friends;
+  // The signed-in user's own outbound block list. Used to (a) exclude blocked
+  // users from the common-friends count and (b) hard-gate the profile of a user
+  // we've blocked into the empty state even if a stale cache still holds their
+  // data (the server denies block-gated reads, but a cached entry may linger).
+  const myBlocked = user ? userDataList?.[user.uid]?.blocked : undefined;
+  const isViewingBlockedUser = !isSelf && isBlocked(myBlocked, userID);
 
   const friendCountLabel = useMemo((): string => {
     return `${translate('profileScreen.commonFriendsLabel', {
@@ -149,10 +156,11 @@ function ProfileScreen({route}: ProfileScreenProps) {
     const newCommonFriendCount = getCommonFriendsCount(
       objKeys(selfFriends),
       objKeys(friends),
+      myBlocked,
     );
     setFriendCount(newFriendCount);
     setCommonFriendCount(newCommonFriendCount);
-  }, [friends, selfFriends]);
+  }, [friends, selfFriends, myBlocked]);
 
   const header = (
     <HeaderWithBackButton
@@ -170,7 +178,11 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // (ScreenWrapper renders its own OfflineIndicator) and show a graceful
   // loading/empty state rather than the blank dark screen an early `return`
   // produced.
-  if (isLoading) {
+  //
+  // Consumption filter (#760): when the signed-in user has blocked this user,
+  // skip the loading state entirely and fall straight through to the empty
+  // state below, so a stale cache can never flash their sessions/profile.
+  if (isLoading && !isViewingBlockedUser) {
     return (
       <ScreenWrapper
         testID={ProfileScreen.displayName}
@@ -187,7 +199,10 @@ function ProfileScreen({route}: ProfileScreenProps) {
       </ScreenWrapper>
     );
   }
-  if (!profileData || !preferences || !userData) {
+  // A blocked/blocking user resolves with no profile (we blocked them, or they
+  // blocked us and the server denied/evicted the read), so this is a clean empty
+  // state with no sessions and no common-friends count — never a surfaced error.
+  if (!profileData || !preferences || !userData || isViewingBlockedUser) {
     return (
       <ScreenWrapper
         testID={ProfileScreen.displayName}

--- a/src/screens/Social/FriendListScreen.tsx
+++ b/src/screens/Social/FriendListScreen.tsx
@@ -5,6 +5,7 @@ import type {UserIDToNicknameMapping} from '@src/types/various/Search';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {objKeys} from '@libs/DataHandling';
 import {getNicknameMapping, searchArrayByText} from '@libs/Search';
+import {filterBlockedUsers} from '@libs/BlockUtils';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import type {UserArray} from '@src/types/onyx/OnyxCommon';
 import Text from '@components/Text';
@@ -96,7 +97,13 @@ function FriendListScreen() {
   ]);
 
   useEffect(() => {
-    const friendsArray = objKeys(userData?.friends);
+    // Consumption filter (#760): a block severs the friendship server-side, so
+    // a blocked user normally won't be in `friends` at all. Filter on the
+    // signed-in user's own block list anyway to cover any cached/edge case.
+    const friendsArray = filterBlockedUsers(
+      objKeys(userData?.friends),
+      userData?.blocked,
+    );
     setFriends(friendsArray);
     setFriendsToDisplay(friendsArray);
     setUserHasFriends(friendsArray.length > 0);

--- a/src/screens/Social/FriendSearchScreen.tsx
+++ b/src/screens/Social/FriendSearchScreen.tsx
@@ -25,6 +25,7 @@ import useNetwork from '@hooks/useNetwork';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import FlatList from '@components/FlatList';
+import {filterBlockedUsers} from '@libs/BlockUtils';
 import ERRORS from '@src/ERRORS';
 
 function FriendSearchScreen() {
@@ -185,16 +186,24 @@ function FriendSearchScreen() {
     if (searching) {
       return <FlexibleLoadingIndicator style={styles.pt4} />;
     }
+    // Discovery filter (#759): never surface a user the signed-in user has
+    // blocked. The server already excludes blocked users from search, so this is
+    // defense-in-depth for any cached/edge-case result. When a search returns
+    // only blocked users the list is empty, so fall through to "no users found".
+    const visibleSearchResults = filterBlockedUsers(
+      searchResultData,
+      userData?.blocked,
+    );
     return (
       <FlatList
         style={[styles.w100, styles.flex1]}
         contentContainerStyle={[styles.pt1]}
         keyboardShouldPersistTaps="always"
-        data={searchResultData}
+        data={visibleSearchResults}
         renderItem={renderItem}
         keyExtractor={userID => `${userID}-container`}
         ListEmptyComponent={
-          noUsersFound ? (
+          noUsersFound || !isEmptyArray(searchResultData) ? (
             <Text style={styles.noResultsText}>
               {translate('friendSearchScreen.noUsersFound')}
             </Text>

--- a/src/types/onyx/UserData.ts
+++ b/src/types/onyx/UserData.ts
@@ -111,6 +111,18 @@ type UserData = {
   /** A list of friends of this user */
   friends?: UserList;
 
+  /**
+   * The signed-in user's OWN outbound block list: a map of uids this user has
+   * blocked (`{[uid]: true}`). Server-authoritative — written by the kiroku-api
+   * BlockUser/UnblockUser handlers and hydrated into Onyx the same way `friends`
+   * is: via the whole `users/{uid}` node on `app/open` plus Pusher + `/v1/updates`.
+   * Only ever populated for the signed-in user's own `USER_DATA_LIST` entry; a
+   * user can NOT see who has blocked *them* (that list stays owner-private
+   * server-side). The UI uses it to filter blocked users out of discovery and
+   * consumption surfaces, as defense-in-depth on top of the server's block gate.
+   */
+  blocked?: UserList;
+
   /** User's private data */
   private_data?: UserPrivateData;
 


### PR DESCRIPTION
## What & why

Client-side **"filter blocked users from the UI"** for the one-way block feature — the UX / defense-in-depth layer on top of the already-merged server gate (kiroku-api `BlockUser`/`UnblockUser` + block-gated reads). Closes #759 (discovery filtering) and #760 (consumption filtering).

The server is the authority: blocking A→B severs the friendship both ways, clears requests, and denies friend-gated reads across the block. This PR makes sure the **UI never surfaces, counts, or offers actions on a blocked relationship**, and degrades gracefully when a read is denied.

## Block semantics (outbound vs inbound)

The client only ever holds the signed-in user's **own outbound** block list (`USER_DATA_LIST[myUid].blocked` = uids *I* blocked). A user can **not** see who has blocked *them* — that list is owner-private server-side. So:

- **Outbound (I blocked them)** → filtered client-side using my `blocked` list. This is the work here.
- **Inbound (they blocked me)** → no client filtering possible or needed. The server gate makes their data unreadable (the read is denied / the cached entry is evicted); the client's only job is to **not crash and show a clean empty state**.

## Server hydration of `blocked` — confirmed ✅

Before building the filter I verified the server actually delivers the list (otherwise this would be a no-op). On **kiroku-api `origin/master`** (commit `d4d4ca3 feat(block): server-side BlockUser/UnblockUser + block-gated reads`):

- The block is stored at `users/{uid}/blocked/{otherUserId} = true` (`DBPATHS.USERS_USER_ID_BLOCKED`).
- `GET /v1/app/open` reads the **entire** `users/{uid}` node and does `merge(USER_DATA_LIST, {[uid]: userNode})` — so `blocked` hydrates into `USER_DATA_LIST[myUid].blocked` on bootstrap.
- The `BlockUser` handler returns/publishes `userDataPatch(uid, { blocked: { [otherUserId]: true }, friends: {…: null}, friend_requests: {…: null} })` **inline as `onyxData`** and via `publisher.publish` (Pusher + `/v1/updates` replay). `UnblockUser` publishes `{ blocked: { [otherUserId]: null } }`.

Shape is `Record<UserID, boolean>` = `UserList`, hydrated exactly like `friends`. No kiroku-api work needed.

## Changes

**Expose the list on the client**
- `types/onyx/UserData.ts`: add `blocked?: UserList` (documented like `friends`).
- `libs/BlockUtils.ts` (new): `isBlocked(blockedList, uid)` + `filterBlockedUsers(userIds, blockedList)`, mirroring the `FriendUtils` helpers.

**Discovery (#759)**
- `FriendSearchScreen`: drop blocked users from search results (empty-after-filter falls through to "no users found").
- `SendFriendRequestButton`: never offer send/accept for a user I've blocked (renders `searchResult.blocked`).

**Consumption (#760)**
- `FriendListScreen`: filter blocked users from the friend list.
- `ProfileScreen`: hard-gate a blocked user into the existing empty state (skips the loading flash even with stale cache) and exclude blocked users from the common-friends count.
- `FriendsFriendsScreen` + `FriendUtils.getCommonFriends`/`getCommonFriendsCount`: exclude blocked users from the common/other friend lists and counts.
- `useDrinkingSessionsFetch`: swallow a block-gated / privacy-denied rejection (`.catch`) so a denied read resolves to an empty calendar instead of throwing an unhandled rejection.

**Copy**
- `en.ts`: add `searchResult.blocked` (English only). Other locales are the `translate` follow-up (#762).

## Out of scope (handled elsewhere)
- Friends-list latest-session / `user_status` leak → #1001 (not touched).
- "Blocked users" management screen → #761. Full translate run → #762.

## Tests / gates
- New `__tests__/unit/BlockUtils.test.ts` (14 cases) covering `isBlocked`, `filterBlockedUsers`, and the `FriendUtils` blocked-exclusion wiring — all green.
- `prettier`, `lint` (changed files, frozen seatbelt), `typecheck-tsgo`, and `react-compiler-compliance-check check-changed` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
