### PR TITLE
feat(signup): liquid fill sequence in the InitialScreen logo entrance

### DIFF
--- a/__tests__/unit/components/KirokuLogo.test.tsx
+++ b/__tests__/unit/components/KirokuLogo.test.tsx
@@ -3,6 +3,7 @@ import {render} from '@testing-library/react-native';
 import React from 'react';
 import AnimatedKirokuLogoSvg from '@components/KirokuLogo/AnimatedKirokuLogoSvg';
 import KirokuLogoSvg from '@components/KirokuLogo/KirokuLogoSvg';
+import buildWavePathD from '@components/KirokuLogo/liquidWave';
 import {LOGO_SHAPES} from '@components/KirokuLogo/logoShapes';
 import CONST from '@src/CONST';
 
@@ -28,11 +29,15 @@ jest.mock('react-native-reanimated', () => {
       createAnimatedComponent: (c: unknown) => c,
     },
     View: PassthroughView,
-    // useAnimatedStyle invokes its worklet immediately and returns the style.
+    // useAnimatedStyle/useAnimatedProps invoke their worklet immediately and
+    // return the result.
     useAnimatedStyle: (factory: () => unknown) => factory(),
+    useAnimatedProps: (factory: () => unknown) => factory(),
     useSharedValue: (initial: unknown) => ({value: initial}),
-    // withTiming resolves to the target value, mirroring the official mock.
+    // withTiming/withRepeat resolve to the target value, mirroring the
+    // official mock.
     withTiming: (toValue: unknown) => toValue,
+    withRepeat: (toValue: unknown) => toValue,
     cancelAnimation: () => {},
     useReducedMotion: () => false,
     interpolate: (
@@ -47,8 +52,11 @@ jest.mock('react-native-reanimated', () => {
     Easing: {
       linear: (t: number) => t,
       quad: (t: number) => t * t,
+      cubic: (t: number) => t * t * t,
+      ease: (t: number) => t,
       back: () => (t: number) => t,
       out: (fn: (t: number) => number) => (t: number) => 1 - fn(1 - t),
+      inOut: (fn: (t: number) => number) => (t: number) => fn(t),
     },
   };
 });
@@ -88,6 +96,34 @@ describe('logoShapes', () => {
   });
 });
 
+describe('buildWavePathD', () => {
+  it('builds a closed path whose surface stays within one amplitude of the level', () => {
+    const surfaceY = 500;
+    const d = buildWavePathD(surfaceY, 0.3);
+    expect(d.startsWith('M')).toBe(true);
+    expect(d.endsWith('Z')).toBe(true);
+    const ys = Array.from(
+      d.matchAll(/[ML]-?\d+(?:\.\d+)? (-?\d+(?:\.\d+)?)/g),
+      m => Number(m[1]),
+    );
+    // Surface samples hug the level; the two closing points sit below the
+    // 1024-unit canvas.
+    const surface = ys.filter(y => y < 1024);
+    const closing = ys.filter(y => y >= 1024);
+    expect(surface.length).toBeGreaterThan(15);
+    expect(closing).toHaveLength(2);
+    surface.forEach(y => {
+      expect(Math.abs(y - surfaceY)).toBeLessThanOrEqual(14);
+    });
+  });
+
+  it('shifts the surface as the phase advances', () => {
+    expect(buildWavePathD(500, 0)).not.toEqual(buildWavePathD(500, 0.25));
+    // Phase is periodic: a full cycle reproduces the same surface.
+    expect(buildWavePathD(500, 0)).toEqual(buildWavePathD(500, 1));
+  });
+});
+
 describe('KirokuLogoSvg', () => {
   it('renders exactly the six logo shapes on production (no badge)', () => {
     const {toJSON} = render(
@@ -113,17 +149,22 @@ describe('AnimatedKirokuLogoSvg', () => {
     const {toJSON} = render(
       <AnimatedKirokuLogoSvg
         fill="#000000"
+        liquidColor="#F5C400"
         environment={CONST.ENVIRONMENT.PROD}
         shouldStart
       />,
     );
-    expect(collectProp(toJSON() as RenderedNode, 'd')).toEqual(EXPECTED_SHAPES);
+    // The liquid's clip path repeats the silhouette, so the tree holds the
+    // six shapes at least once each rather than exactly once.
+    const ds = collectProp(toJSON() as RenderedNode, 'd');
+    EXPECTED_SHAPES.forEach(d => expect(ds).toContain(d));
   });
 
   it('renders while armed (shouldStart false) without throwing', () => {
     const {toJSON} = render(
       <AnimatedKirokuLogoSvg
         fill="#000000"
+        liquidColor="#F5C400"
         environment={CONST.ENVIRONMENT.DEV}
         shouldStart={false}
       />,

--- a/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
+++ b/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
@@ -5,18 +5,23 @@ import {
   Easing,
   useReducedMotion,
   useSharedValue,
+  withRepeat,
   withTiming,
 } from 'react-native-reanimated';
 import Svg from 'react-native-svg';
 import type Environment from '@libs/Environment/getEnvironment/types';
 import AnimatedLogoShape from './AnimatedLogoShape';
-import {TOTAL_DURATION_MS} from './animationTimings';
+import {TOTAL_DURATION_MS, WAVE_PERIOD_MS} from './animationTimings';
+import LiquidFill from './LiquidFill';
 import LogoBadge from './LogoBadge';
 import {LOGO_CANVAS, LOGO_SHAPES} from './logoShapes';
 
 type AnimatedKirokuLogoSvgProps = {
   /** Fill color of the mark (theme.appLogo) */
   fill: string;
+
+  /** Color of the rising liquid (theme.success) */
+  liquidColor: string;
 
   /** Current app environment for the badge overlay (static, non-prod only) */
   environment: Environment;
@@ -38,31 +43,47 @@ const styles = StyleSheet.create({
 });
 
 /**
- * Animated variant of the logo: the six shapes stagger into place on a single
- * master timeline. Settles to the exact render output of the static
- * KirokuLogoSvg (full opacity, fill = theme.appLogo).
+ * Animated variant of the logo: the six shapes stagger in as a faint ghost,
+ * a liquid with a waving surface fills the silhouette, and a final crossfade
+ * solidifies the mark. Settles to the exact render output of the static
+ * KirokuLogoSvg (full opacity, fill = theme.appLogo, no liquid).
  */
 function AnimatedKirokuLogoSvg({
   fill,
+  liquidColor,
   environment,
   shouldStart,
 }: AnimatedKirokuLogoSvgProps) {
   const reduceMotion = useReducedMotion();
   // With reduced motion the timeline starts (and stays) settled.
   const progress = useSharedValue(reduceMotion ? 1 : 0);
+  // Repeating 0–1 phase for the wave surface; only oscillates while the
+  // master timeline runs, then is cancelled so the settled logo costs nothing
+  // per frame.
+  const wavePhase = useSharedValue(0);
   const hasStarted = useRef(false);
 
   useEffect(() => {
     if (shouldStart && !reduceMotion && !hasStarted.current) {
       hasStarted.current = true;
       // eslint-disable-next-line react-compiler/react-compiler
-      progress.value = withTiming(1, {
-        duration: TOTAL_DURATION_MS,
-        easing: Easing.linear,
-      });
+      progress.value = withTiming(
+        1,
+        {duration: TOTAL_DURATION_MS, easing: Easing.linear},
+        () => {
+          cancelAnimation(wavePhase);
+        },
+      );
+      wavePhase.value = withRepeat(
+        withTiming(1, {duration: WAVE_PERIOD_MS, easing: Easing.linear}),
+        -1,
+      );
     }
-    return () => cancelAnimation(progress);
-  }, [shouldStart, reduceMotion, progress]);
+    return () => {
+      cancelAnimation(progress);
+      cancelAnimation(wavePhase);
+    };
+  }, [shouldStart, reduceMotion, progress, wavePhase]);
 
   return (
     <View style={styles.container}>
@@ -75,6 +96,11 @@ function AnimatedKirokuLogoSvg({
           progress={progress}
         />
       ))}
+      <LiquidFill
+        color={liquidColor}
+        progress={progress}
+        wavePhase={wavePhase}
+      />
       <Svg
         width="100%"
         height="100%"

--- a/src/components/KirokuLogo/AnimatedLogoShape.tsx
+++ b/src/components/KirokuLogo/AnimatedLogoShape.tsx
@@ -8,9 +8,11 @@ import Animated, {
 } from 'react-native-reanimated';
 import Svg, {Path} from 'react-native-svg';
 import {
+  CROSSFADE_EASING,
+  CROSSFADE_START_FRACTION,
   getShapeWindow,
+  GHOST_OPACITY,
   SHAPE_OPACITY_EASING,
-  SHAPE_TARGET_OPACITY,
   SHAPE_TRANSLATE_DISTANCE,
   SHAPE_TRANSLATE_EASING,
 } from './animationTimings';
@@ -41,18 +43,29 @@ function AnimatedLogoShape({d, index, fill, progress}: AnimatedLogoShapeProps) {
   const [windowStart, windowEnd] = getShapeWindow(index);
 
   const animatedStyle = useAnimatedStyle(() => {
-    const local = interpolate(
+    const entrance = interpolate(
       progress.value,
       [windowStart, windowEnd],
       [0, 1],
       Extrapolation.CLAMP,
     );
+    // Entrance fades the shape in to its faint ghost state; the crossfade at
+    // the end of the timeline solidifies it to full opacity as the liquid
+    // drains away.
+    const crossfade = interpolate(
+      progress.value,
+      [CROSSFADE_START_FRACTION, 1],
+      [0, 1],
+      Extrapolation.CLAMP,
+    );
     return {
-      opacity: SHAPE_OPACITY_EASING(local) * SHAPE_TARGET_OPACITY,
+      opacity:
+        SHAPE_OPACITY_EASING(entrance) * GHOST_OPACITY +
+        (1 - GHOST_OPACITY) * CROSSFADE_EASING(crossfade),
       transform: [
         {
           translateY:
-            (1 - SHAPE_TRANSLATE_EASING(local)) * SHAPE_TRANSLATE_DISTANCE,
+            (1 - SHAPE_TRANSLATE_EASING(entrance)) * SHAPE_TRANSLATE_DISTANCE,
         },
       ],
     };

--- a/src/components/KirokuLogo/LiquidFill.tsx
+++ b/src/components/KirokuLogo/LiquidFill.tsx
@@ -1,0 +1,97 @@
+import React, {useId} from 'react';
+import {StyleSheet} from 'react-native';
+import type {SharedValue} from 'react-native-reanimated';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedProps,
+} from 'react-native-reanimated';
+import Svg, {ClipPath, Defs, Path} from 'react-native-svg';
+import {
+  CROSSFADE_EASING,
+  CROSSFADE_START_FRACTION,
+  LIQUID_END_FRACTION,
+  LIQUID_LEVEL_EASING,
+  LIQUID_START_FRACTION,
+  LIQUID_SURFACE_END_Y,
+  LIQUID_SURFACE_START_Y,
+} from './animationTimings';
+import buildWavePathD from './liquidWave';
+import {LOGO_CANVAS, LOGO_SHAPES} from './logoShapes';
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+
+type LiquidFillProps = {
+  /** Liquid color (theme.success brand yellow) */
+  color: string;
+
+  /** Master timeline progress (0–1) owned by AnimatedKirokuLogoSvg */
+  progress: SharedValue<number>;
+
+  /** Repeating 0–1 phase driving the wave oscillation */
+  wavePhase: SharedValue<number>;
+};
+
+/**
+ * The rising liquid: a wave-topped body clipped to the logo silhouette.
+ * Surface level and crossfade opacity derive from the master timeline; the
+ * wave shape oscillates on its own repeating phase value. `d` and `opacity`
+ * are the only animated props — both are direct native props of Path, which
+ * is what makes this safe on Fabric (transforms would not be).
+ */
+function LiquidFill({color, progress, wavePhase}: LiquidFillProps) {
+  // Unique per mount so a second logo instance on screen (e.g. AuthScreen's
+  // static one, or web where DOM ids are document-global) can't collide.
+  // Sanitized because React's id tokens contain ':', which is awkward
+  // inside an `url(#...)` reference.
+  const clipPathId = `kirokuLogoLiquidClip-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`;
+
+  const animatedProps = useAnimatedProps(() => {
+    const level = interpolate(
+      progress.value,
+      [LIQUID_START_FRACTION, LIQUID_END_FRACTION],
+      [0, 1],
+      Extrapolation.CLAMP,
+    );
+    const surfaceY =
+      LIQUID_SURFACE_START_Y +
+      (LIQUID_SURFACE_END_Y - LIQUID_SURFACE_START_Y) *
+        LIQUID_LEVEL_EASING(level);
+    const crossfade = interpolate(
+      progress.value,
+      [CROSSFADE_START_FRACTION, 1],
+      [0, 1],
+      Extrapolation.CLAMP,
+    );
+    return {
+      d: buildWavePathD(surfaceY, wavePhase.value),
+      opacity: 1 - CROSSFADE_EASING(crossfade),
+    };
+  });
+
+  return (
+    <Svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${LOGO_CANVAS} ${LOGO_CANVAS}`}
+      style={StyleSheet.absoluteFill}
+      pointerEvents="none">
+      <Defs>
+        <ClipPath id={clipPathId}>
+          {LOGO_SHAPES.map(d => (
+            <Path key={d} d={d} />
+          ))}
+        </ClipPath>
+      </Defs>
+      <AnimatedPath
+        animatedProps={animatedProps}
+        fill={color}
+        clipPath={`url(#${clipPathId})`}
+      />
+    </Svg>
+  );
+}
+
+LiquidFill.displayName = 'LiquidFill';
+
+export default LiquidFill;

--- a/src/components/KirokuLogo/animationTimings.ts
+++ b/src/components/KirokuLogo/animationTimings.ts
@@ -3,23 +3,48 @@ import {Easing} from 'react-native-reanimated';
 // Master timeline for the InitialScreen logo sequence: a single `progress`
 // shared value runs 0→1 linearly over TOTAL_DURATION_MS (driven by
 // AnimatedKirokuLogoSvg); every animated element derives its own window as a
-// 0–1 fraction of that timeline and applies its easing locally. The liquid
-// fill increment extends this table without touching the driver.
-const TOTAL_DURATION_MS = 700;
+// 0–1 fraction of that timeline and applies its easing locally.
+//
+// | element            | window (ms) | property                  |
+// |--------------------|-------------|---------------------------|
+// | shape i (0–5)      | 70i–70i+280 | opacity 0→GHOST, settle Y |
+// | liquid level       | 800–2200    | surface 830→110 (viewBox) |
+// | crossfade          | 2200–2600   | shapes GHOST→1, liquid →0 |
+const TOTAL_DURATION_MS = 2600;
 
 /** Delay between consecutive shape entrances */
 const SHAPE_STAGGER_MS = 70;
 /** Duration of a single shape's entrance */
 const SHAPE_DURATION_MS = 280;
-/** Opacity each shape reaches at the end of its entrance window */
-const SHAPE_TARGET_OPACITY = 1;
+/** Faint "ghost" opacity the shapes hold while the liquid fills them */
+const GHOST_OPACITY = 0.13;
 /** Downward offset (layout px) each shape starts from */
 const SHAPE_TRANSLATE_DISTANCE = 8;
+
+/** Window in which the liquid surface rises through the mark */
+const LIQUID_START_FRACTION = 800 / TOTAL_DURATION_MS;
+const LIQUID_END_FRACTION = 2200 / TOTAL_DURATION_MS;
+/**
+ * Liquid surface levels in viewBox coordinates. The silhouette spans
+ * y 134–808; starting below 808 + wave amplitude keeps the liquid fully
+ * clipped out before the window, and ending above 134 - amplitude reads as
+ * 100% full.
+ */
+const LIQUID_SURFACE_START_Y = 830;
+const LIQUID_SURFACE_END_Y = 110;
+
+/** Window in which the ghost shapes solidify and the liquid fades away */
+const CROSSFADE_START_FRACTION = 2200 / TOTAL_DURATION_MS;
+
+/** Period of one full wave oscillation (drives the independent phase value) */
+const WAVE_PERIOD_MS = 1600;
 
 // Composed at module scope so the worklets below capture ready-made easing
 // functions instead of rebuilding them per frame.
 const SHAPE_OPACITY_EASING = Easing.out(Easing.quad);
 const SHAPE_TRANSLATE_EASING = Easing.out(Easing.back(1.5));
+const LIQUID_LEVEL_EASING = Easing.inOut(Easing.cubic);
+const CROSSFADE_EASING = Easing.inOut(Easing.ease);
 
 /**
  * Window of the master timeline (as 0–1 fractions) in which the shape at
@@ -35,9 +60,17 @@ function getShapeWindow(index: number): [start: number, end: number] {
 
 export {
   TOTAL_DURATION_MS,
-  SHAPE_TARGET_OPACITY,
+  GHOST_OPACITY,
   SHAPE_TRANSLATE_DISTANCE,
+  LIQUID_START_FRACTION,
+  LIQUID_END_FRACTION,
+  LIQUID_SURFACE_START_Y,
+  LIQUID_SURFACE_END_Y,
+  CROSSFADE_START_FRACTION,
+  WAVE_PERIOD_MS,
   SHAPE_OPACITY_EASING,
   SHAPE_TRANSLATE_EASING,
+  LIQUID_LEVEL_EASING,
+  CROSSFADE_EASING,
   getShapeWindow,
 };

--- a/src/components/KirokuLogo/index.tsx
+++ b/src/components/KirokuLogo/index.tsx
@@ -53,6 +53,7 @@ function KirokuLogo({style, shouldPlayAnimation}: KirokuLogoProps) {
       ) : (
         <AnimatedKirokuLogoSvg
           fill={theme.appLogo}
+          liquidColor={theme.success}
           environment={environment}
           shouldStart={shouldPlayAnimation}
         />

--- a/src/components/KirokuLogo/liquidWave.ts
+++ b/src/components/KirokuLogo/liquidWave.ts
@@ -1,0 +1,39 @@
+import {LOGO_CANVAS} from './logoShapes';
+
+/** Vertical amplitude of the wave crest (viewBox units) */
+const WAVE_AMPLITUDE = 14;
+/** Horizontal length of one full wave (viewBox units) */
+const WAVE_LENGTH = 256;
+/** Horizontal sampling step; ~20 segments across the canvas */
+const WAVE_STEP = 55;
+/** Overshoot past the canvas edges so the wave never exposes a seam */
+const WAVE_OVERSCAN = 60;
+/** Bottom edge of the liquid body, safely below the canvas */
+const WAVE_BOTTOM_Y = LOGO_CANVAS + 76;
+
+/**
+ * Builds the liquid body path: a sine-wave surface at `surfaceY` (phase 0–1
+ * shifts it by one full wavelength) closed into a rectangle that extends past
+ * the canvas bottom. Runs on the UI thread once per frame while the fill
+ * animates, so it sticks to simple string concatenation.
+ */
+function buildWavePathD(surfaceY: number, phase: number): string {
+  'worklet';
+
+  let d = '';
+  for (
+    let x = -WAVE_OVERSCAN;
+    x <= LOGO_CANVAS + WAVE_OVERSCAN;
+    x += WAVE_STEP
+  ) {
+    const y =
+      surfaceY +
+      WAVE_AMPLITUDE *
+        Math.sin((2 * Math.PI * x) / WAVE_LENGTH + 2 * Math.PI * phase);
+    d += `${d ? ' L' : 'M'}${x} ${y.toFixed(1)}`;
+  }
+  d += ` L${LOGO_CANVAS + WAVE_OVERSCAN} ${WAVE_BOTTOM_Y} L${-WAVE_OVERSCAN} ${WAVE_BOTTOM_Y} Z`;
+  return d;
+}
+
+export default buildWavePathD;


### PR DESCRIPTION
## Summary

Second of the two stacked logo-animation PRs (stacked on #1174 — merge that first; this PR's base is its branch).

- The assembly entrance now lands the six shapes at a faint ghost opacity (13%), then a brand-yellow (`theme.success`) liquid with a waving surface rises through the logo silhouette (800–2200 ms) and crossfades into the solid mark (2200–2600 ms). Total sequence 2.6 s, played once per mount of InitialScreen.
- One master timeline still drives every window (the PR is mostly a constants change in `animationTimings.ts` plus the new liquid layer). The wave oscillates on an independent repeating phase value, cancelled in the master timeline's completion callback and on unmount, so the settled logo does zero per-frame work.
- The liquid animates only `d` and `opacity` via `useAnimatedProps` — both direct native Path props, which is what keeps it Fabric-safe (transforms would silently no-op; see #1174). The wave path is built in a worklet (~20 segments per frame).
- Clipping uses a per-mount unique `ClipPath` id (sanitized `useId`) built from the shared `logoShapes` module, so a second logo instance on screen can't collide on web where DOM ids are document-global.

## Testing

- Unit: wave-path builder bounds/periodicity, plus the existing shape-geometry and render tests extended for the liquid layer (7 tests).
- typecheck-tsgo, lint-changed, prettier, react-compiler-compliance-check, jest all green.
- Web (dev server): verified the full sequence runs and settles — the liquid path's final DOM state shows the wave surface at the full level (~110 viewBox units, from 830) with opacity 0 and the solid mark at full opacity, pixel-identical to the static logo; clip id unique per mount; no console errors.
- Outstanding: eyeball the wave smoothness on the iOS simulator (Fabric). If `d` animation misbehaves there, the agreed fallback seam is a flat-top Rect via a platform file for LiquidFill — not pre-built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)