### PR TITLE
i18n(block): backfill Czech translations for the block feature (#762)

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -469,6 +469,7 @@ export default {
     sent: 'Žádost odeslána',
     accept: 'Přijmout',
     add: 'Poslat žádost',
+    blocked: 'Zablokováno',
   },
   socialScreen: {
     title: 'Přátelé',
@@ -524,6 +525,8 @@ export default {
         'Nepodařilo se odstranit žádost o přátelství. Zkuste to prosím znovu.',
       couldNotUnfriend:
         'Nepodařilo se odebrat tohoto přítele. Zkuste to prosím znovu.',
+      couldNotBlockUser:
+        'Nepodařilo se zablokovat tohoto uživatele. Zkuste to prosím znovu.',
     },
   },
   notFoundScreen: {
@@ -595,6 +598,13 @@ export default {
       success: 'Vaše historie polohy byla vymazána.',
       error: 'Nepodařilo se vymazat historii polohy. Zkuste to prosím znovu.',
     },
+    blockingSection: {
+      title: 'Blokování',
+    },
+    blockedUsers: {
+      label: 'Zablokovaní uživatelé',
+      description: 'Zobrazte a spravujte lidi, které jste zablokovali.',
+    },
     accountSection: {
       title: 'Účet',
     },
@@ -604,6 +614,18 @@ export default {
     },
     error: {
       save: 'Nepodařilo se uložit nastavení soukromí. Zkuste to prosím znovu.',
+    },
+  },
+  blockedUsersScreen: {
+    title: 'Zablokovaní uživatelé',
+    unblockNote:
+      'Odblokování nepřidá daného člověka zpět mezi přátele. Abyste byli znovu přáteli, musí jeden z vás poslat novou žádost o přátelství.',
+    unblock: 'Odblokovat',
+    unknownUser: 'Zablokovaný uživatel',
+    emptyList: {
+      title: 'Zatím jste nikoho nezablokovali',
+      subtitle:
+        'Když někoho zablokujete, objeví se zde, abyste ho mohli později odblokovat.',
     },
   },
   unitsToColorsScreen: {
@@ -999,6 +1021,10 @@ export default {
     manageFriend: 'Spravovat přítele',
     unfriendPrompt: 'Opravdu chcete tohoto uživatele odebrat z přátel?',
     unfriend: 'Odebrat z přátel',
+    blockUser: 'Zablokovat uživatele',
+    blockUserTitle: 'Zablokovat tohoto uživatele?',
+    blockUserPrompt:
+      'Zablokování zruší vaše přátelství a skryje vás navzájem. Daný uživatel vás nenajde ani vám nepošle žádost o přátelství. Později ho můžete odblokovat.',
     hideDataFromFriend: 'Skrýt má data před tímto přítelem',
     showDataToFriend: 'Zobrazit má data tomuto příteli',
     commonFriendsLabel: ({hasCommonFriends}: CommonFriendsLabelParams) =>
@@ -1794,6 +1820,11 @@ export default {
         title: 'Nepodařilo se odeslat hlášení chyby',
         message:
           'Při odesílání chyby došlo k problému. Zkuste to prosím znovu.',
+      },
+      couldNotBlockUser: {
+        title: 'Nepodařilo se zablokovat uživatele',
+        message:
+          'Při blokování tohoto uživatele došlo k problému. Zkuste to prosím znovu.',
       },
       couldNotUnfriend: {
         title: 'Nepodařilo se odebrat z přátel',


### PR DESCRIPTION
## What

Fills the **cs_cz** (Czech) locale for the block-user feature keys that shipped English-only in #1162 / #1169 / #1170. This is issue #762, the final remaining task of the block epic (#755–#762) and the block leg of the UGC-moderation epic (#757).

## Keys backfilled

| Key | Czech |
| --- | --- |
| `searchResult.blocked` | Zablokováno |
| `friendAction.error.couldNotBlockUser` | Nepodařilo se zablokovat tohoto uživatele. Zkuste to prosím znovu. |
| `privacyScreen.blockingSection.title` | Blokování |
| `privacyScreen.blockedUsers.label` | Zablokovaní uživatelé |
| `privacyScreen.blockedUsers.description` | Zobrazte a spravujte lidi, které jste zablokovali. |
| `blockedUsersScreen.title` | Zablokovaní uživatelé |
| `blockedUsersScreen.unblockNote` | Odblokování nepřidá daného člověka zpět mezi přátele. … |
| `blockedUsersScreen.unblock` | Odblokovat |
| `blockedUsersScreen.unknownUser` | Zablokovaný uživatel |
| `blockedUsersScreen.emptyList.title` | Zatím jste nikoho nezablokovali |
| `blockedUsersScreen.emptyList.subtitle` | Když někoho zablokujete, objeví se zde, … |
| `profileScreen.blockUser` | Zablokovat uživatele |
| `profileScreen.blockUserTitle` | Zablokovat tohoto uživatele? |
| `profileScreen.blockUserPrompt` | Zablokování zruší vaše přátelství a skryje vás navzájem. … |
| `errors.user.couldNotBlockUser.{title,message}` | Nepodařilo se zablokovat uživatele / Při blokování tohoto uživatele došlo k problému. … |

## How

Generated via the `translate` skill against `src/languages/context/cs_cz.md`:
- **vykání** (formal plural) register, matching the file's established convention for "you did X" prose (`jste zamítli`, `abyste mohli`)
- sentence case (not English Title Case)
- canonical glossary terms (`žádost o přátelství` for "friend request")
- no em-dashes

## Verification

- `npm run test -- __tests__/unit/Translate.test.ts` ✅ 6/6
- `npm run test -- __tests__/unit/TranslationContext.test.ts` ✅ 2/2
- `npm run typecheck-tsgo` ✅ clean
- `npx prettier --write` ✅ (no changes — already formatted)

Closes #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)