### PR TITLE
fix(web): pin RHP to a fixed-width right panel on wide screens

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -716,7 +716,7 @@ export default {
     improvementThoughts: 'Co byste chtěli zlepšit?',
     general: 'Obecné',
     reportBug: 'Nahlásit chybu',
-    giveFeedback: 'Zpětná vazba',
+    giveFeedback: 'Poslat zpětnou vazbu',
     signOut: 'Odhlásit se',
     shareTheApp: 'Sdílet aplikaci',
     adminTools: 'Nástroje pro administrátory',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -732,7 +732,7 @@ export default {
     improvementThoughts: 'What would you like us to improve?',
     general: 'General',
     reportBug: 'Report a bug',
-    giveFeedback: 'Give use a feedback',
+    giveFeedback: 'Give us feedback',
     signOut: 'Sign out',
     shareTheApp: 'Share the app',
     adminTools: 'Admin tools',

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -1,6 +1,7 @@
 import type {StackScreenProps} from '@react-navigation/stack';
 import {createStackNavigator} from '@react-navigation/stack';
 import React, {useMemo, useRef} from 'react';
+import {View} from 'react-native';
 // import NoDropZone from '@components/DragAndDrop/NoDropZone';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -41,8 +42,6 @@ function RightModalNavigator({navigation}: RightModalNavigatorProps) {
   // }, [isSmallScreenWidth, styleUtils, styles]);
 
   return (
-    // <NoDropZone>
-    // <View style={styles.RHPNavigatorContainer(isSmallScreenWidth)}>
     <>
       {!shouldUseNarrowLayout && (
         <Overlay
@@ -55,28 +54,30 @@ function RightModalNavigator({navigation}: RightModalNavigatorProps) {
           }}
         />
       )}
-      <Stack.Navigator screenOptions={screenOptions}>
-        <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.BADGES}
-          component={ModalStackNavigators.BadgesModalStackNavigator}
-        />
-        <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.DRINKING_SESSION}
-          component={ModalStackNavigators.DrinkingSessionModalStackNavigator}
-        />
-        <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.PROFILE}
-          component={ModalStackNavigators.ProfileModalStackNavigator}
-        />
-        <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.SETTINGS}
-          component={ModalStackNavigators.SettingsModalStackNavigator}
-        />
-        <Stack.Screen
-          name={SCREENS.RIGHT_MODAL.SOCIAL}
-          component={ModalStackNavigators.SocialModalStackNavigator}
-        />
-      </Stack.Navigator>
+      <View style={styles.RHPNavigatorContainer(shouldUseNarrowLayout)}>
+        <Stack.Navigator screenOptions={screenOptions}>
+          <Stack.Screen
+            name={SCREENS.RIGHT_MODAL.BADGES}
+            component={ModalStackNavigators.BadgesModalStackNavigator}
+          />
+          <Stack.Screen
+            name={SCREENS.RIGHT_MODAL.DRINKING_SESSION}
+            component={ModalStackNavigators.DrinkingSessionModalStackNavigator}
+          />
+          <Stack.Screen
+            name={SCREENS.RIGHT_MODAL.PROFILE}
+            component={ModalStackNavigators.ProfileModalStackNavigator}
+          />
+          <Stack.Screen
+            name={SCREENS.RIGHT_MODAL.SETTINGS}
+            component={ModalStackNavigators.SettingsModalStackNavigator}
+          />
+          <Stack.Screen
+            name={SCREENS.RIGHT_MODAL.SOCIAL}
+            component={ModalStackNavigators.SocialModalStackNavigator}
+          />
+        </Stack.Navigator>
+      </View>
     </>
   );
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1547,12 +1547,13 @@ const styles = (theme: ThemeColors) =>
         flex: 1,
       }) satisfies ViewStyle,
 
-    RHPNavigatorContainerNavigatorContainerStyles: (
-      isSmallScreenWidth: boolean,
-    ) =>
+    RHPNavigatorContainer: (shouldUseNarrowLayout: boolean) =>
       ({
-        marginLeft: isSmallScreenWidth ? 0 : variables.sideBarWidth,
-        flex: 1,
+        position: 'absolute',
+        right: 0,
+        height: '100%',
+        width: shouldUseNarrowLayout ? '100%' : variables.sideBarWidth,
+        overflow: 'hidden',
       }) satisfies ViewStyle,
 
     onboardingNavigatorOuterView: {


### PR DESCRIPTION
## What & why

On desktop web, opening any Right-Hand-Panel (RHP) screen — e.g. **Settings → Profile Details** — rendered the panel at ~200% of the window width (~1810px on a ~905px window) and shifted it off-screen to the left, so content was clipped/unreachable. Tracked under #934 (web visual QA).

### Root cause
The root `RIGHT_MODAL_NAVIGATOR` card is intentionally `width: '200%'`, `right: 0` (`getRootNavigatorScreenOptions.tsx`) so the dimmed overlay can cover the translated sidebar. The inner `Stack.Navigator` is supposed to be wrapped in a fixed-width, right-pinned container so the actual screens occupy only a `sideBarWidth` panel — but that wrapper was commented out in `RightModalNavigator.tsx`. The inner screens therefore filled the full 200% card. Mobile uses the `100%` branch, so it was unaffected.

The referenced style had also been mangled to `RHPNavigatorContainerNavigatorContainerStyles` with the wrong body (`marginLeft`/`flex`) and zero references (dead).

## Changes
1. `src/styles/index.ts` — replace the dead `RHPNavigatorContainerNavigatorContainerStyles` with a working `RHPNavigatorContainer(shouldUseNarrowLayout)` returning `position:absolute; right:0; height:100%; width: narrow ? '100%' : sideBarWidth; overflow:hidden` — matching upstream Expensify's `pAbsolute/r0/h100/overflowHidden + sideBarWidth` pattern.
2. `RightModalNavigator.tsx` — import `View`; wrap only the `Stack.Navigator` in `<View style={styles.RHPNavigatorContainer(shouldUseNarrowLayout)}>`, keeping `Overlay` as a full-backdrop sibling so the dimmed area stays clickable.

## Verification
- `npx prettier --write` ✅
- `lint` (seatbelt-aware wrapper) ✅
- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- Browser verification (1440×900 desktop + 393×852 mobile) in progress as part of the #934 sweep.

Refs #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)