### PR TITLE
feat(privacy): email marketing consent toggle

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -576,6 +576,14 @@ export default {
       description:
         'Odesílejte hlášení o pádech, abychom mohli rychleji opravovat chyby.',
     },
+    communicationsSection: {
+      title: 'Komunikace',
+    },
+    emailMarketing: {
+      label: 'Novinky o aplikaci e-mailem',
+      description:
+        'Občas vám e-mailem pošleme novinky a tipy k aplikaci Kiroku. Kdykoli to můžete vypnout.',
+    },
     locationSection: {
       title: 'Poloha',
     },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -574,6 +574,14 @@ export default {
       label: 'Send crash reports',
       description: 'Send crash reports so we can fix bugs faster.',
     },
+    communicationsSection: {
+      title: 'Communications',
+    },
+    emailMarketing: {
+      label: 'Product news by email',
+      description:
+        'Get occasional news and tips about Kiroku by email. You can turn this off at any time.',
+    },
     locationSection: {
       title: 'Location',
     },

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -40,6 +40,15 @@ function PrivacyScreen() {
   const displayCrashReporting =
     pendingCrashReporting ?? persistedCrashReporting;
 
+  // Absent ⇒ off (strict opt-in consent default).
+  const persistedEmailMarketing = preferences?.email_marketing_consent === true;
+  const [pendingEmailMarketing, setPendingEmailMarketing] = useState<
+    boolean | null
+  >(null);
+  const [savingEmailMarketing, setSavingEmailMarketing] = useState(false);
+  const displayEmailMarketing =
+    pendingEmailMarketing ?? persistedEmailMarketing;
+
   const persistedTrackLocation =
     preferences?.track_location_during_sessions === true;
   const [pendingTrackLocation, setPendingTrackLocation] = useState<
@@ -84,6 +93,23 @@ function PrivacyScreen() {
         Alert.alert(translate('privacyScreen.error.save'), errorMessage);
       })
       .finally(() => setSavingCrashReporting(false));
+  };
+
+  const onToggleEmailMarketing = (next: boolean) => {
+    if (savingEmailMarketing || next === displayEmailMarketing) {
+      return;
+    }
+    setPendingEmailMarketing(next);
+    setSavingEmailMarketing(true);
+    Preferences.updatePreferences({
+      email_marketing_consent: next,
+    })
+      .catch(error => {
+        setPendingEmailMarketing(null);
+        const errorMessage = error instanceof Error ? error.message : '';
+        Alert.alert(translate('privacyScreen.error.save'), errorMessage);
+      })
+      .finally(() => setSavingEmailMarketing(false));
   };
 
   const onToggleTrackLocation = (next: boolean) => {
@@ -283,6 +309,37 @@ function PrivacyScreen() {
                 text={translate('privacyScreen.clearLocationHistory.button')}
                 isDisabled={isPurging}
                 onPress={() => setShowPurgeConfirmModal(true)}
+              />
+            </View>
+          </View>
+        </Section>
+        <Section
+          title={translate('privacyScreen.communicationsSection.title')}
+          titleStyles={styles.generalSectionTitle}
+          isCentralPane
+          childrenStyles={styles.pt3}>
+          <View style={styles.sectionMenuItemTopDescription}>
+            <View
+              style={[
+                styles.flexRow,
+                styles.alignItemsCenter,
+                styles.justifyContentBetween,
+                styles.mb4,
+              ]}>
+              <View style={[styles.flexColumn, styles.flex1, styles.mr3]}>
+                <Text style={[styles.textNormal, styles.textStrong]}>
+                  {translate('privacyScreen.emailMarketing.label')}
+                </Text>
+                <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                  {translate('privacyScreen.emailMarketing.description')}
+                </Text>
+              </View>
+              <Switch
+                accessibilityLabel={translate(
+                  'privacyScreen.emailMarketing.label',
+                )}
+                isOn={displayEmailMarketing}
+                onToggle={onToggleEmailMarketing}
               />
             </View>
           </View>

--- a/src/types/onyx/Preferences.ts
+++ b/src/types/onyx/Preferences.ts
@@ -77,6 +77,12 @@ type Preferences = {
    *  shown at live-session start. Gates that prompt so it appears at most once
    *  per account; undefined means it has not been shown yet. */
   location_prompt_seen?: boolean;
+
+  /** Whether the user has opted in to marketing emails (product news and
+   *  tips). Strictly opt-in (GDPR consent basis): undefined/false means no
+   *  consent and no marketing email may be sent. The server timestamps
+   *  consent changes for accountability. */
+  email_marketing_consent?: boolean;
 };
 
 /** A collection of preferences of multiple users */

--- a/src/types/onyx/User.ts
+++ b/src/types/onyx/User.ts
@@ -1,8 +1,5 @@
 /** Model of user data */
 type User = {
-  /** Whether or not the user is subscribed to news updates */
-  isSubscribedToNewsletter: boolean;
-
   /** Whether we should use the staging version of the secure API server */
   shouldUseStagingServer?: boolean;
 


### PR DESCRIPTION
Client leg of #1180 (email platform epic #1187). Pairs with PetrCala/kiroku-api#91 (server validation + admin-only consent audit record).

### Changes
- **`email_marketing_consent?: boolean`** added to the `Preferences` Onyx type. Strict opt-in consent semantics: absent/false = no consent, no marketing email may be sent (GDPR Art. 6(1)(a) basis, per the Privacy Policy update in PetrCala/kiroku-web#29).
- **Privacy screen**: new Communications section with a "Product news by email" switch, mirroring the crash-reporting toggle exactly (pending/saving local state, `Preferences.updatePreferences` round-trip, rollback + alert on failure). Default **off**.
- **Dead code removal**: `isSubscribedToNewsletter` deleted from the Onyx `User` type (unused Expensify inheritance, zero readers) so it can't be confused with the new flag.
- **Czech translations** filled via the `translate` skill against the cs_cz glossary (vykání, sentence case, no em-dashes).

### Verification
- `Translate.test.ts` 6/6 green (key parity).
- `npm run typecheck-tsgo` clean.
- `npm run react-compiler-compliance-check check-changed` passed (5 files).
- Prettier applied.

### Notes for review
- The server PR stores a consent **audit record** (`email_consent/$uid`: consent + server timestamp + terms version) outside `user_preferences`, since `app/open` echoes that node to the client and friends can read it.
- The toggle is safe to ship before any marketing email exists; it only records consent. The broadcast command (kiroku-cli#28, merged) already filters on this flag.

Closes #1180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)