### PR TITLE
feat(report): client-side report user flow (#765)

### DIFF
--- a/__tests__/actions/Report.test.ts
+++ b/__tests__/actions/Report.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-in-views -- this is a test that asserts on the mocked API.write, not a view */
+
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import * as Report from '@userActions/Report';
+import CONST from '@src/CONST';
+
+jest.mock('@libs/API', () => ({write: jest.fn()}));
+
+const OTHER = 'friend-2';
+
+const mockedWrite = jest.mocked(API.write);
+
+function lastWrite() {
+  const call = mockedWrite.mock.calls.at(-1);
+  return {command: call?.[0], params: call?.[1], onyxData: call?.[2]};
+}
+
+describe('Report actions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reportUser: forwards the reason + description with no optimistic Onyx data', () => {
+    Report.reportUser(
+      OTHER,
+      CONST.REPORT.REASON.HARASSMENT,
+      'They keep messaging me.',
+    );
+    const {command, params, onyxData} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.REPORT_USER);
+    // Reporter is derived server-side from auth — only the target, reason, and
+    // optional description are sent.
+    expect(params).toEqual({
+      otherUserId: OTHER,
+      reason: CONST.REPORT.REASON.HARASSMENT,
+      description: 'They keep messaging me.',
+    });
+    // Reports are server-only/admin-reviewed: fire-and-forget, no optimistic data.
+    expect(onyxData).toBeUndefined();
+  });
+
+  it('reportUser: omits the description when none is provided', () => {
+    Report.reportUser(OTHER, CONST.REPORT.REASON.INAPPROPRIATE_NAME);
+    const {command, params} = lastWrite();
+
+    expect(command).toBe(WRITE_COMMANDS.REPORT_USER);
+    expect(params).toEqual({
+      otherUserId: OTHER,
+      reason: CONST.REPORT.REASON.INAPPROPRIATE_NAME,
+      description: undefined,
+    });
+  });
+});

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -805,6 +805,17 @@ const CONST = {
   } as const,
 
   MICROSECONDS_PER_MS: 1000,
+  REPORT: {
+    // Why the user is reporting another user. These values are the wire contract
+    // shared with kiroku-api (the server stores them verbatim for admin review),
+    // so they must not be renamed without a coordinated backend change.
+    REASON: {
+      INAPPROPRIATE_NAME: 'inappropriate_name',
+      INAPPROPRIATE_PHOTO: 'inappropriate_photo',
+      HARASSMENT: 'harassment',
+      OTHER: 'other',
+    },
+  },
   RED_BRICK_ROAD_PENDING_ACTION: {
     ADD: 'add',
     DELETE: 'delete',

--- a/src/ERRORS.ts
+++ b/src/ERRORS.ts
@@ -65,6 +65,7 @@ const ERRORS = {
   USER: {
     BUG_SUBMISSION_FAILED: 'user/bug-submission-failed',
     COULD_NOT_BLOCK_USER: 'user/could-not-block-user',
+    COULD_NOT_REPORT_USER: 'user/could-not-report-user',
     COULD_NOT_UNFRIEND: 'user/could-not-unfriend',
     DATA_FETCH_FAILED: 'user/data-fetch-failed',
     FEEDBACK_REMOVAL_FAILED: 'user/feedback-removal-failed',

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -139,6 +139,10 @@ const ROUTES = {
     route: 'profile/:userID/friends',
     getRoute: (userID: UserID) => `profile/${userID}/friends` as const,
   },
+  PROFILE_REPORT_USER: {
+    route: 'profile/:userID/report',
+    getRoute: (userID: UserID) => `profile/${userID}/report` as const,
+  },
 
   SESSIONS_CALENDAR_FULLSCREEN: {
     route: 'sessions-calendar/:userID',

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -101,6 +101,7 @@ const SCREENS = {
   PROFILE: {
     ROOT: 'Profile_Root',
     FRIENDS_FRIENDS: 'Profile_FriendsFriends',
+    REPORT_USER: 'Profile_ReportUser',
   },
 
   SESSIONS_CALENDAR: {

--- a/src/components/ManageFriendPopover.tsx
+++ b/src/components/ManageFriendPopover.tsx
@@ -11,6 +11,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import ERRORS from '@src/ERRORS';
+import ROUTES from '@src/ROUTES';
 import * as KirokuIcons from './Icon/KirokuIcons';
 import type {PopoverMenuItem} from './PopoverMenu';
 import PopoverMenu from './PopoverMenu';
@@ -71,6 +72,17 @@ function ManageFriendPopover({
       icon: KirokuIcons.Lock,
       onSelected: () => {
         setBlockModalVisible(true);
+      },
+    },
+    // Report sits beside Block so the two moderation actions share one surface.
+    // Every reachable profile is currently a friend's (see #765; public
+    // profiles tracked in #1217), so the friend-management popover covers all
+    // reportable users today.
+    {
+      text: translate('profileScreen.report'),
+      icon: KirokuIcons.Info,
+      onSelected: () => {
+        Navigation.navigate(ROUTES.PROFILE_REPORT_USER.getRoute(friendId));
       },
     },
   ];

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -976,6 +976,23 @@ export default {
     sending: 'Sending feedback...',
     error: 'There was an error sending your feedback. Please try again.',
   },
+  reportUserScreen: {
+    title: 'Report',
+    prompt:
+      'Why are you reporting this user? Your report is private and goes to our moderation team.',
+    reasons: {
+      inappropriateName: 'Inappropriate name',
+      inappropriatePhoto: 'Inappropriate profile photo',
+      harassment: 'Harassment or bullying',
+      other: 'Something else',
+    },
+    descriptionLabel: 'Add details (optional)',
+    alsoBlock: 'Also block this user',
+    submit: 'Submit report',
+    successTitle: 'Report received',
+    successMessage:
+      'Thanks for letting us know. Our moderation team will review this user.',
+  },
   manageAccountScreen: {
     title: 'Manage account',
     dangerZone: {
@@ -1013,6 +1030,7 @@ export default {
     unitsConsumed: ({unitCount}: UnitCountParams) =>
       `${Str.pluralize('Unit', 'Units', unitCount)} Consumed`,
     manageFriend: 'Manage Friend',
+    report: 'Report',
     unfriendPrompt: 'Do you really want to unfriend this user?',
     unfriend: 'Unfriend',
     blockUser: 'Block user',
@@ -1824,6 +1842,11 @@ export default {
         title: 'Could Not Block User',
         message:
           'There was an issue trying to block this user. Please try again.',
+      },
+      couldNotReportUser: {
+        title: 'Could Not Report User',
+        message:
+          'There was an issue trying to report this user. Please try again.',
       },
       couldNotUnfriend: {
         title: 'Could Not Unfriend',

--- a/src/libs/API/parameters/ReportUserParams.ts
+++ b/src/libs/API/parameters/ReportUserParams.ts
@@ -1,0 +1,7 @@
+type ReportUserParams = {
+  otherUserId: string;
+  reason: string;
+  description?: string;
+};
+
+export default ReportUserParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -5,6 +5,7 @@ export type {default as AcceptFriendRequestParams} from './AcceptFriendRequestPa
 export type {default as DeleteFriendRequestParams} from './DeleteFriendRequestParams';
 export type {default as UnfriendParams} from './UnfriendParams';
 export type {default as BlockUserParams} from './BlockUserParams';
+export type {default as ReportUserParams} from './ReportUserParams';
 export type {default as UnblockUserParams} from './UnblockUserParams';
 export type {default as UpdateSessionParams} from './UpdateSessionParams';
 export type {default as DeleteSessionParams} from './DeleteSessionParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -37,6 +37,7 @@ const WRITE_COMMANDS = {
   UNFRIEND: 'Unfriend',
   BLOCK_USER: 'BlockUser',
   UNBLOCK_USER: 'UnblockUser',
+  REPORT_USER: 'ReportUser',
   UPDATE_SESSION: 'UpdateSession',
   DELETE_SESSION: 'DeleteSession',
   UPDATE_PREFERENCES: 'UpdatePreferences',
@@ -90,6 +91,7 @@ type WriteCommandParameters = {
   [WRITE_COMMANDS.UNFRIEND]: Parameters.UnfriendParams;
   [WRITE_COMMANDS.BLOCK_USER]: Parameters.BlockUserParams;
   [WRITE_COMMANDS.UNBLOCK_USER]: Parameters.UnblockUserParams;
+  [WRITE_COMMANDS.REPORT_USER]: Parameters.ReportUserParams;
   [WRITE_COMMANDS.UPDATE_SESSION]: Parameters.UpdateSessionParams;
   [WRITE_COMMANDS.DELETE_SESSION]: Parameters.DeleteSessionParams;
   [WRITE_COMMANDS.UPDATE_PREFERENCES]: Parameters.UpdatePreferencesParams;

--- a/src/libs/Errors/ERROR_MAPPING.ts
+++ b/src/libs/Errors/ERROR_MAPPING.ts
@@ -49,6 +49,7 @@ const ERROR_MAPPING: ErrorMapping = {
   [ERRORS.SESSION.START_FAILED]: 'errors.session.startFailed',
   [ERRORS.USER.BUG_SUBMISSION_FAILED]: 'errors.user.bugSubmissionFailed',
   [ERRORS.USER.COULD_NOT_BLOCK_USER]: 'errors.user.couldNotBlockUser',
+  [ERRORS.USER.COULD_NOT_REPORT_USER]: 'errors.user.couldNotReportUser',
   [ERRORS.USER.COULD_NOT_UNFRIEND]: 'errors.user.couldNotUnfriend',
   [ERRORS.USER.DATA_FETCH_FAILED]: 'errors.user.dataFetchFailed',
   [ERRORS.USER.FEEDBACK_REMOVAL_FAILED]: 'errors.user.feedbackRemovalFailed',

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -223,6 +223,9 @@ const ProfileModalStackNavigator =
     [SCREENS.PROFILE.FRIENDS_FRIENDS]: () =>
       require<ReactComponentModule>('@screens/Profile/FriendsFriendsScreen')
         .default,
+    [SCREENS.PROFILE.REPORT_USER]: () =>
+      require<ReactComponentModule>('@screens/Profile/ReportUserScreen')
+        .default,
   });
 
 const SessionsCalendarModalStackNavigator =

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -204,6 +204,9 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
             [SCREENS.PROFILE.FRIENDS_FRIENDS]: {
               path: ROUTES.PROFILE_FRIENDS_FRIENDS.route,
             },
+            [SCREENS.PROFILE.REPORT_USER]: {
+              path: ROUTES.PROFILE_REPORT_USER.route,
+            },
           },
         },
         [SCREENS.RIGHT_MODAL.SOCIAL]: {

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -147,6 +147,9 @@ type ProfileNavigatorParamList = {
   [SCREENS.PROFILE.FRIENDS_FRIENDS]: {
     userID: string;
   };
+  [SCREENS.PROFILE.REPORT_USER]: {
+    userID: string;
+  };
 };
 
 type SessionsCalendarNavigatorParamList = {

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1,0 +1,35 @@
+import type {ValueOf} from 'type-fest';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import type CONST from '@src/CONST';
+
+/**
+ * Reporting a user is feedback-shaped, not block-shaped: it is additive,
+ * server-only, admin-reviewed content (reviewed later via kiroku-cli, #766). The
+ * server owns the generated id, `submit_time`, and the reporter id (derived from
+ * the caller's Firebase ID token), so the client passes only the reported user,
+ * a reason, and an optional free-text description. Like `submitFeedback` /
+ * `reportABug` in `Feedback.ts`, this is a fire-and-forget write with no
+ * `onyxData` — there is no client-side report collection to optimistically
+ * mutate, and the reporter never sees their own submitted reports. The caller
+ * surfaces a success confirmation; a dismissible error is raised at the call
+ * site (mirroring the block flow) if the write throws synchronously.
+ *
+ * Reporting is intentionally NOT gated behind the friend-management flow: any
+ * viewable profile (friend, friend-of-friend, search result) can be reported, so
+ * unlike block this carries no unfriend side effect. Part of the moderation epic
+ * (#757) required for App Store Guideline 1.2.
+ */
+
+type ReportReason = ValueOf<typeof CONST.REPORT.REASON>;
+
+function reportUser(
+  otherUserId: string,
+  reason: ReportReason,
+  description?: string,
+) {
+  API.write(WRITE_COMMANDS.REPORT_USER, {otherUserId, reason, description});
+}
+
+export {reportUser};
+export type {ReportReason};

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -15,10 +15,11 @@ import type CONST from '@src/CONST';
  * surfaces a success confirmation; a dismissible error is raised at the call
  * site (mirroring the block flow) if the write throws synchronously.
  *
- * Reporting is intentionally NOT gated behind the friend-management flow: any
- * viewable profile (friend, friend-of-friend, search result) can be reported, so
- * unlike block this carries no unfriend side effect. Part of the moderation epic
- * (#757) required for App Store Guideline 1.2.
+ * Unlike block, reporting carries no unfriend side effect, and the action is
+ * profile-agnostic: it works for any user id, even though every profile the app
+ * can currently navigate to belongs to a friend (so the entry point lives in the
+ * friend-management popover beside Block). Part of the moderation epic (#757)
+ * required for App Store Guideline 1.2.
  */
 
 type ReportReason = ValueOf<typeof CONST.REPORT.REASON>;

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -34,7 +34,6 @@ import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Button from '@components/Button';
 import ManageFriendPopover from '@components/ManageFriendPopover';
-import type {PopoverMenuItem} from '@components/PopoverMenu';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -163,21 +162,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
     setCommonFriendCount(newCommonFriendCount);
   }, [friends, selfFriends, myBlocked]);
 
-  // Reporting is reachable from ANY viewable profile (friend, friend-of-friend,
-  // search result), so it lives in the profile header overflow rather than the
-  // friend-only Manage popover. Hidden on your own profile and on a user you've
-  // already blocked (their profile resolves to the empty state). See #765.
-  const reportMenuItems: PopoverMenuItem[] = [
-    {
-      text: translate('profileScreen.report'),
-      icon: KirokuIcons.Info,
-      onSelected: () =>
-        Navigation.navigate(ROUTES.PROFILE_REPORT_USER.getRoute(userID)),
-    },
-  ];
-
-  const canReportUser = !isSelf && !isViewingBlockedUser;
-
   const header = (
     <HeaderWithBackButton
       title={
@@ -186,8 +170,6 @@ function ProfileScreen({route}: ProfileScreenProps) {
           : translate('profileScreen.titleNotSelf')
       }
       onBackButtonPress={Navigation.goBack}
-      shouldShowThreeDotsButton={canReportUser}
-      threeDotsMenuItems={reportMenuItems}
     />
   );
 

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -34,6 +34,7 @@ import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Button from '@components/Button';
 import ManageFriendPopover from '@components/ManageFriendPopover';
+import type {PopoverMenuItem} from '@components/PopoverMenu';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -162,6 +163,21 @@ function ProfileScreen({route}: ProfileScreenProps) {
     setCommonFriendCount(newCommonFriendCount);
   }, [friends, selfFriends, myBlocked]);
 
+  // Reporting is reachable from ANY viewable profile (friend, friend-of-friend,
+  // search result), so it lives in the profile header overflow rather than the
+  // friend-only Manage popover. Hidden on your own profile and on a user you've
+  // already blocked (their profile resolves to the empty state). See #765.
+  const reportMenuItems: PopoverMenuItem[] = [
+    {
+      text: translate('profileScreen.report'),
+      icon: KirokuIcons.Info,
+      onSelected: () =>
+        Navigation.navigate(ROUTES.PROFILE_REPORT_USER.getRoute(userID)),
+    },
+  ];
+
+  const canReportUser = !isSelf && !isViewingBlockedUser;
+
   const header = (
     <HeaderWithBackButton
       title={
@@ -170,6 +186,8 @@ function ProfileScreen({route}: ProfileScreenProps) {
           : translate('profileScreen.titleNotSelf')
       }
       onBackButtonPress={Navigation.goBack}
+      shouldShowThreeDotsButton={canReportUser}
+      threeDotsMenuItems={reportMenuItems}
     />
   );
 

--- a/src/screens/Profile/ReportUserScreen.tsx
+++ b/src/screens/Profile/ReportUserScreen.tsx
@@ -1,9 +1,9 @@
 import React, {useState} from 'react';
 import type {StackScreenProps} from '@react-navigation/stack';
+import {View} from 'react-native';
 import Button from '@components/Button';
 import CheckboxWithLabel from '@components/CheckboxWithLabel';
 import ConfirmModal from '@components/ConfirmModal';
-import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItem from '@components/MenuItem';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -11,6 +11,7 @@ import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
 import useLocalize from '@hooks/useLocalize';
+import useStyledSafeAreaInsets from '@hooks/useStyledSafeAreaInsets';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
@@ -57,6 +58,14 @@ function ReportUserScreen({route}: ReportUserScreenProps) {
   const {userID} = route.params;
   const styles = useThemeStyles();
   const {translate} = useLocalize();
+  // Mimic FormWrapper (the FeedbackScreen/ReportBugScreen footer): the screen
+  // disables ScreenWrapper's own bottom inset and pads the area below the
+  // submit button itself, with the device's bottom inset or pb5 when there is
+  // none (e.g. Android, devices without a home indicator).
+  const {safeAreaPaddingBottomStyle} = useStyledSafeAreaInsets();
+  const footerPaddingStyle = safeAreaPaddingBottomStyle.paddingBottom
+    ? safeAreaPaddingBottomStyle
+    : styles.pb5;
   const [selectedReason, setSelectedReason] = useState<ReportReason | null>(
     null,
   );
@@ -95,6 +104,7 @@ function ReportUserScreen({route}: ReportUserScreenProps) {
   return (
     <ScreenWrapper
       includeSafeAreaPaddingBottom={false}
+      shouldShowOfflineIndicator={false}
       testID={ReportUserScreen.displayName}>
       <HeaderWithBackButton
         title={translate('reportUserScreen.title')}
@@ -102,47 +112,54 @@ function ReportUserScreen({route}: ReportUserScreenProps) {
       />
       <ScrollView
         style={[styles.flex1]}
-        contentContainerStyle={[styles.ph5, styles.pb5]}>
-        <Text style={[styles.mb3]}>{translate('reportUserScreen.prompt')}</Text>
-        {REASONS.map(({reason, translationKey}) => (
-          <MenuItem
-            key={reason}
-            title={translate(translationKey)}
-            shouldShowSelectedState
-            isSelected={selectedReason === reason}
-            onPress={() => setSelectedReason(reason)}
-            wrapperStyle={[styles.ph0]}
+        contentContainerStyle={[
+          styles.flexGrow1,
+          styles.ph5,
+          footerPaddingStyle,
+        ]}>
+        <View style={styles.flexGrow1}>
+          <Text style={[styles.mb3]}>
+            {translate('reportUserScreen.prompt')}
+          </Text>
+          {REASONS.map(({reason, translationKey}) => (
+            <MenuItem
+              key={reason}
+              title={translate(translationKey)}
+              shouldShowSelectedState
+              isSelected={selectedReason === reason}
+              onPress={() => setSelectedReason(reason)}
+              wrapperStyle={[styles.ph0]}
+            />
+          ))}
+          <TextInput
+            accessibilityLabel={translate('reportUserScreen.descriptionLabel')}
+            label={translate('reportUserScreen.descriptionLabel')}
+            role={CONST.ROLE.PRESENTATION}
+            value={description}
+            onChangeText={setDescription}
+            autoGrowHeight
+            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+            maxLength={CONST.DESCRIPTION_LIMIT}
+            spellCheck={false}
+            containerStyles={[styles.mt5]}
           />
-        ))}
-        <TextInput
-          accessibilityLabel={translate('reportUserScreen.descriptionLabel')}
-          label={translate('reportUserScreen.descriptionLabel')}
-          role={CONST.ROLE.PRESENTATION}
-          value={description}
-          onChangeText={setDescription}
-          autoGrowHeight
-          maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-          maxLength={CONST.DESCRIPTION_LIMIT}
-          spellCheck={false}
-          containerStyles={[styles.mt5]}
-        />
-        <CheckboxWithLabel
-          label={translate('reportUserScreen.alsoBlock')}
-          accessibilityLabel={translate('reportUserScreen.alsoBlock')}
-          isChecked={alsoBlock}
-          onInputChange={value => setAlsoBlock(value ?? false)}
-          style={[styles.mt5]}
-        />
-      </ScrollView>
-      <FixedFooter>
+          <CheckboxWithLabel
+            label={translate('reportUserScreen.alsoBlock')}
+            accessibilityLabel={translate('reportUserScreen.alsoBlock')}
+            isChecked={alsoBlock}
+            onInputChange={value => setAlsoBlock(value ?? false)}
+            style={[styles.mt5]}
+          />
+        </View>
         <Button
           success
           large
+          style={styles.mt5}
           text={translate('reportUserScreen.submit')}
           onPress={onSubmit}
           isDisabled={!selectedReason}
         />
-      </FixedFooter>
+      </ScrollView>
       <ConfirmModal
         isVisible={isSuccessVisible}
         title={translate('reportUserScreen.successTitle')}

--- a/src/screens/Profile/ReportUserScreen.tsx
+++ b/src/screens/Profile/ReportUserScreen.tsx
@@ -1,0 +1,162 @@
+import React, {useState} from 'react';
+import type {StackScreenProps} from '@react-navigation/stack';
+import Button from '@components/Button';
+import CheckboxWithLabel from '@components/CheckboxWithLabel';
+import ConfirmModal from '@components/ConfirmModal';
+import FixedFooter from '@components/FixedFooter';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import MenuItem from '@components/MenuItem';
+import ScreenWrapper from '@components/ScreenWrapper';
+import ScrollView from '@components/ScrollView';
+import Text from '@components/Text';
+import TextInput from '@components/TextInput';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import * as ErrorUtils from '@libs/ErrorUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
+import * as Block from '@userActions/Block';
+import * as Report from '@userActions/Report';
+import type {ReportReason} from '@userActions/Report';
+import CONST from '@src/CONST';
+import ERRORS from '@src/ERRORS';
+import type {TranslationPaths} from '@src/languages/types';
+import type SCREENS from '@src/SCREENS';
+import variables from '@src/styles/variables';
+
+type ReportUserScreenProps = StackScreenProps<
+  ProfileNavigatorParamList,
+  typeof SCREENS.PROFILE.REPORT_USER
+>;
+
+// Pair each wire-contract reason (CONST.REPORT.REASON, shared with kiroku-api)
+// with its English label key. The order here is the order shown to the user.
+const REASONS = [
+  {
+    reason: CONST.REPORT.REASON.INAPPROPRIATE_NAME,
+    translationKey: 'reportUserScreen.reasons.inappropriateName',
+  },
+  {
+    reason: CONST.REPORT.REASON.INAPPROPRIATE_PHOTO,
+    translationKey: 'reportUserScreen.reasons.inappropriatePhoto',
+  },
+  {
+    reason: CONST.REPORT.REASON.HARASSMENT,
+    translationKey: 'reportUserScreen.reasons.harassment',
+  },
+  {
+    reason: CONST.REPORT.REASON.OTHER,
+    translationKey: 'reportUserScreen.reasons.other',
+  },
+] as const satisfies ReadonlyArray<{
+  reason: ReportReason;
+  translationKey: TranslationPaths;
+}>;
+
+function ReportUserScreen({route}: ReportUserScreenProps) {
+  const {userID} = route.params;
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+  const [selectedReason, setSelectedReason] = useState<ReportReason | null>(
+    null,
+  );
+  const [description, setDescription] = useState('');
+  const [alsoBlock, setAlsoBlock] = useState(false);
+  const [isSuccessVisible, setIsSuccessVisible] = useState(false);
+
+  const onSubmit = () => {
+    if (!selectedReason) {
+      return;
+    }
+    // Compute the optional description outside the try/catch: the React Compiler
+    // rejects value expressions (logical/ternary) inside a try block.
+    const trimmedDescription = description.trim();
+    const reportDescription =
+      trimmedDescription.length > 0 ? trimmedDescription : undefined;
+    try {
+      // Fire-and-forget like feedback: the report is server-only/admin-reviewed,
+      // so there is no optimistic Onyx state and no confirmation to wait on.
+      Report.reportUser(userID, selectedReason, reportDescription);
+      // Opt-in graft: block only after the report when the user asked for it.
+      if (alsoBlock) {
+        Block.blockUser(userID);
+      }
+      setIsSuccessVisible(true);
+    } catch (error) {
+      ErrorUtils.raiseAppError(ERRORS.USER.COULD_NOT_REPORT_USER, error);
+    }
+  };
+
+  const onSuccessConfirm = () => {
+    setIsSuccessVisible(false);
+    Navigation.goBack();
+  };
+
+  return (
+    <ScreenWrapper
+      includeSafeAreaPaddingBottom={false}
+      testID={ReportUserScreen.displayName}>
+      <HeaderWithBackButton
+        title={translate('reportUserScreen.title')}
+        onBackButtonPress={Navigation.goBack}
+      />
+      <ScrollView
+        style={[styles.flex1]}
+        contentContainerStyle={[styles.ph5, styles.pb5]}>
+        <Text style={[styles.mb3]}>{translate('reportUserScreen.prompt')}</Text>
+        {REASONS.map(({reason, translationKey}) => (
+          <MenuItem
+            key={reason}
+            title={translate(translationKey)}
+            shouldShowSelectedState
+            isSelected={selectedReason === reason}
+            onPress={() => setSelectedReason(reason)}
+            wrapperStyle={[styles.ph0]}
+          />
+        ))}
+        <TextInput
+          accessibilityLabel={translate('reportUserScreen.descriptionLabel')}
+          label={translate('reportUserScreen.descriptionLabel')}
+          role={CONST.ROLE.PRESENTATION}
+          value={description}
+          onChangeText={setDescription}
+          autoGrowHeight
+          maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+          maxLength={CONST.DESCRIPTION_LIMIT}
+          spellCheck={false}
+          containerStyles={[styles.mt5]}
+        />
+        <CheckboxWithLabel
+          label={translate('reportUserScreen.alsoBlock')}
+          accessibilityLabel={translate('reportUserScreen.alsoBlock')}
+          isChecked={alsoBlock}
+          onInputChange={value => setAlsoBlock(value ?? false)}
+          style={[styles.mt5]}
+        />
+      </ScrollView>
+      <FixedFooter>
+        <Button
+          success
+          large
+          text={translate('reportUserScreen.submit')}
+          onPress={onSubmit}
+          isDisabled={!selectedReason}
+        />
+      </FixedFooter>
+      <ConfirmModal
+        isVisible={isSuccessVisible}
+        title={translate('reportUserScreen.successTitle')}
+        prompt={translate('reportUserScreen.successMessage')}
+        confirmText={translate('common.ok')}
+        onConfirm={onSuccessConfirm}
+        onCancel={onSuccessConfirm}
+        shouldShowCancelButton={false}
+        success
+      />
+    </ScreenWrapper>
+  );
+}
+
+ReportUserScreen.displayName = 'ReportUserScreen';
+
+export default ReportUserScreen;


### PR DESCRIPTION
## What & why

Implements the **client side of the "Report user" flow** (closes #765), part of the launch-blocking UGC content-moderation epic #757 (App Store Guideline 1.2). The matching `kiroku-api` `ReportUser` endpoint is being built in parallel — this PR pins the cross-repo contract below.

A report is **feedback-shaped, not block-shaped**: additive, server-only, admin-reviewed content (reviewed later via kiroku-cli, #766). So it mirrors `src/libs/actions/Feedback.ts` (`submitFeedback` → `API.write`), **not** `Block.ts`: a fire-and-forget `API.write` with **no optimistic Onyx** and a success confirmation. The only differences from feedback are a target user and a reason.

> Note: issue #765 references `src/database/friends.ts` and `src/storage/storageUpload.ts`, both **deleted** in the Firebase-direct → kiroku-api HTTP migration. This PR uses the current `API.write(WRITE_COMMANDS.X, params, {optimisticData})` HTTP path instead.

## Pinned cross-repo contract (for the kiroku-api side + #766 review queue)

- **Command:** `WRITE_COMMANDS.REPORT_USER = 'ReportUser'`
- **Params:** `{otherUserId: string, reason: string, description?: string}` — reporter is derived server-side from auth; the client never sends a reporter id.
- **`reason` wire values** (exact): `'inappropriate_name' | 'inappropriate_photo' | 'harassment' | 'other'` (defined as `CONST.REPORT.REASON.*`).
- No client Onyx collection for reports (server-only/admin-read).

## UX / architectural decisions

- **Entry point: the profile "Manage" popover, beside Block.** An earlier revision used a profile header overflow ("⋮") menu on the theory that non-friend profiles needed coverage — but a code audit showed **every reachable profile today belongs to a friend** (search-result and friend-request rows have no profile tap-through; the friends-of-friends "See profile" button renders only for common friends). The Manage popover therefore covers all reportable users, and keeps both moderation actions (Block, Report) on one surface. Public profiles for non-friends are tracked separately in #1217; the report route/screen are profile-agnostic and survive that change unchanged.
- **RHP screen, not a bottom sheet.** A new `ReportUserScreen` (registered in the `PROFILE` modal stack, matching `Profile_FriendsFriends`) hosts a radio reason list + optional free-text description + an opt-in **"Also block this user"** checkbox + submit. This matches the existing RHP form screens (`FeedbackScreen`, `ReportBugScreen`).
- **Bottom spacing mimics FormWrapper** (the FeedbackScreen idiom): ScreenWrapper's bottom inset + offline indicator disabled, submit button pinned via `flexGrow` inside the scroll content, footer padded with the device bottom inset (or `pb5` fallback).
- **"Report and block" graft** is opt-in (unchecked by default); when enabled, `Block.blockUser(otherUserId)` is chained after the report submits.
- **Success confirmation:** there is no toast utility in the app, so submission shows a `ConfirmModal` success dialog, then navigates back.
- **Icon:** KirokuIcons has no flag/report glyph. Per the icon-sourcing policy (Expensify-MIT/owned only, no new art), I reused the existing `KirokuIcons.Info` for the menu item rather than adding art.
- **Failure surfacing:** mirrors the block popover — the submit handler wraps the call in try/catch and raises `ERRORS.USER.COULD_NOT_REPORT_USER` via `ErrorUtils.raiseAppError`.
- **i18n:** English-only (`en.ts`). Other locales (cs_cz) fall back; the Czech backfill is a separate `translate`-skill pass per `CLAUDE.md`. UI copy avoids em-dashes.

## Files changed

**Action / command / types**
- `src/libs/actions/Report.ts` (new) — `reportUser(otherUserId, reason, description?)`, exports `ReportReason`
- `src/libs/API/parameters/ReportUserParams.ts` (new) + `parameters/index.ts` export
- `src/libs/API/types.ts` — `REPORT_USER` in `WRITE_COMMANDS` + param map
- `src/CONST.ts` — `REPORT.REASON.*` wire vocabulary

**Errors / i18n**
- `src/ERRORS.ts` + `src/libs/Errors/ERROR_MAPPING.ts` — `COULD_NOT_REPORT_USER`
- `src/languages/en.ts` — `reportUserScreen.*` group, `profileScreen.report`, `errors.user.couldNotReportUser`

**UI / navigation**
- `src/screens/Profile/ReportUserScreen.tsx` (new)
- `src/components/ManageFriendPopover.tsx` — "Report" menu item beside Block
- `src/SCREENS.ts`, `src/ROUTES.ts`, `src/libs/Navigation/types.ts`, `.../ModalStackNavigators/index.tsx`, `.../linkingConfig/config.ts` — `PROFILE.REPORT_USER` registration

**Test**
- `__tests__/actions/Report.test.ts` (new) — mirrors `Block.test.ts`

## Verification

- `npx prettier --write <changed>` — clean
- `npm run lint-changed` — pass
- `npm run typecheck-tsgo` — pass
- `npm run react-compiler-compliance-check check-changed` — pass
- `npx jest __tests__/actions/Report.test.ts` — 2/2 pass
- `npx jest __tests__/unit/Translate.test.ts` — 6/6 pass (EN-only additions stay parity-clean via fallback)

Refs #757. Closes #765. Follow-up: #1217 (public profiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
