### PR TITLE
Add client-side profanity filter for display name and username

### DIFF
--- a/__tests__/unit/ProfanityFilter.test.ts
+++ b/__tests__/unit/ProfanityFilter.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+import ProfanityFilter from '@src/libs/ProfanityFilter';
+
+describe('ProfanityFilter', () => {
+  describe('containsProfanity', () => {
+    test('Should return false for a clean name', () => {
+      expect(ProfanityFilter.containsProfanity('Petr Cala')).toBe(false);
+    });
+
+    test('Should return false for an empty string', () => {
+      expect(ProfanityFilter.containsProfanity('')).toBe(false);
+    });
+
+    test('Should catch an obvious slur', () => {
+      expect(ProfanityFilter.containsProfanity('you are a fucker')).toBe(true);
+    });
+
+    test('Should catch a leetspeak/obfuscated variant', () => {
+      expect(ProfanityFilter.containsProfanity('fvck')).toBe(true);
+      expect(ProfanityFilter.containsProfanity('sh1t')).toBe(true);
+    });
+
+    test('Should not flag clean words that embed a profane substring', () => {
+      // The recommended whitelist transformers guard against false positives
+      // like "Scunthorpe" or "assassin".
+      expect(ProfanityFilter.containsProfanity('Scunthorpe')).toBe(false);
+      expect(ProfanityFilter.containsProfanity('assassin')).toBe(false);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "idb-keyval": "^6.2.5",
         "jquery": "^3.7.1",
         "lodash": "^4.17.21",
+        "obscenity": "^0.4.6",
         "pusher-js": "8.3.0",
         "react": "19.1.0",
         "react-content-loader": "^7.0.0",
@@ -23813,6 +23814,15 @@
       "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true
+    },
+    "node_modules/obscenity": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/obscenity/-/obscenity-0.4.6.tgz",
+      "integrity": "sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/obuf": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "idb-keyval": "^6.2.5",
     "jquery": "^3.7.1",
     "lodash": "^4.17.21",
+    "obscenity": "^0.4.6",
     "pusher-js": "8.3.0",
     "react": "19.1.0",
     "react-content-loader": "^7.0.0",

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -452,6 +452,8 @@ export default {
     error: {
       hasInvalidCharacter: 'Invalid character',
       containsReservedWord: 'This name contains a reserved word.',
+      containsProfanity:
+        'This name contains inappropriate language. Please choose another.',
       characterLimitExceedCounter: ({length, limit}) =>
         `Character limit exceeded (${length}/${limit})`,
       characterLimit: ({limit}: CharacterLimitParams) =>

--- a/src/libs/ProfanityFilter.ts
+++ b/src/libs/ProfanityFilter.ts
@@ -1,0 +1,38 @@
+import {
+  RegExpMatcher,
+  englishDataset,
+  englishRecommendedTransformers,
+} from 'obscenity';
+
+/**
+ * A single, shared matcher built once at module scope from the English dataset
+ * plus the recommended transformers (which add transliteration/leetspeak
+ * normalization, so obfuscated variants like "fvck" or "sh1t" are caught).
+ *
+ * Building the matcher is relatively expensive, so it is constructed a single
+ * time and reused for every check rather than re-instantiated per call.
+ */
+const matcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+});
+
+/**
+ * Soft, client-side check for objectionable language in a user-controlled text
+ * field (display name, username). This is a UX-only guard meant to give users
+ * immediate inline feedback so most never submit an objectionable name. It is
+ * intentionally bypassable. The authoritative gate lives on the server.
+ *
+ * @param text - The text to inspect.
+ * @returns `true` if the text appears to contain profanity, `false` otherwise.
+ */
+function containsProfanity(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+  return matcher.hasMatch(text);
+}
+
+export default {
+  containsProfanity,
+};

--- a/src/libs/ValidationUtils.ts
+++ b/src/libs/ValidationUtils.ts
@@ -27,6 +27,7 @@ import type {TranslationPaths} from '@src/languages/types';
 import DateUtils from './DateUtils';
 import type {MaybePhraseKey} from './Localize';
 import * as Localize from './Localize';
+import ProfanityFilter from './ProfanityFilter';
 import StringUtils from './StringUtils';
 import {URL_REGEX_WITH_REQUIRED_PROTOCOL} from './common/Url';
 
@@ -220,10 +221,16 @@ function getAgeRequirementError(
 }
 
 /**
- * Checks that the provided name doesn't contain any commas or semicolons
+ * Checks that the provided name doesn't contain any commas or semicolons, and
+ * doesn't contain objectionable language. The profanity check is a soft,
+ * client-side guard for immediate inline feedback; the server is authoritative.
  */
 function isValidDisplayName(name: string): boolean {
-  return !name.includes(',') && !name.includes(';');
+  return (
+    !name.includes(',') &&
+    !name.includes(';') &&
+    !ProfanityFilter.containsProfanity(name)
+  );
 }
 
 /**
@@ -295,6 +302,12 @@ function validateUsername(
 ): TranslationPaths | null {
   if (username.length === 0) {
     return 'username.error.usernameRequired';
+  }
+  // Check profanity before the generic character check so the dedicated
+  // message wins over the broader "invalid character" one (isValidDisplayName
+  // also rejects profanity, but only as a boolean without a tailored message).
+  if (ProfanityFilter.containsProfanity(username)) {
+    return 'personalDetails.error.containsProfanity';
   }
   if (!isValidDisplayName(username)) {
     return 'personalDetails.error.hasInvalidCharacter';


### PR DESCRIPTION
Closes #763. Part of the UGC content-moderation epic #757.

## What & why
Adds a soft, client-side profanity/objectionable-content guard on the two user-controlled text fields other users can see: **display name** and **username**. It gives immediate inline feedback so most users never even submit an objectionable name.

This is a UX-only, intentionally bypassable layer. The authoritative gate is server-side (#764, a separate parallel task) and is **not** touched here. The report flow (#765), the block feature, and the server filter are out of scope.

## Changes
- Add the [`obscenity`](https://github.com/jo3-l/obscenity) dependency (handles leetspeak/obfuscation with low false positives).
- New `src/libs/ProfanityFilter.ts` wrapper that builds a **single shared** `RegExpMatcher` (English dataset + recommended transformers for transliteration/leetspeak) once at module scope and exposes `containsProfanity(text): boolean`. The matcher is never re-instantiated per call.
- Wire `containsProfanity` into both existing validators in `src/libs/ValidationUtils.ts`, matching their existing return shapes:
  - `isValidDisplayName` (boolean) now also rejects profanity, surfacing the field's existing inline error on the username form (first/last name).
  - `validateUsername` (returns a translation key) returns a dedicated profanity message, checked before the generic character check so the tailored message wins. This covers the display-name screen (settings) and the onboarding display-name screen.
- Add the English key `personalDetails.error.containsProfanity` (the grouping both fields already use). Per CLAUDE.md, only English is added here; other locales are backfilled later via the `translate` skill.
- Add `__tests__/unit/ProfanityFilter.test.ts`: a clean name passes, an obvious slur is caught, a leetspeak/obfuscated variant (`fvck`, `sh1t`) is caught, and benign names that embed a profane substring (`Scunthorpe`, `assassin`) are not flagged.

> Note: I placed the error under the current `personalDetails.error` grouping (where `hasInvalidCharacter` / `containsReservedWord` already live and which both validators reference), rather than the `username.error.profanity` / `displayName.error.profanity` keys suggested in the now-stale issue body.

## Verification
- `npx prettier --write` on all changed files (already formatted).
- `npm run lint-changed` — clean.
- `npm run typecheck-tsgo` — clean.
- `npm run test` for `ProfanityFilter`, `Translate`, and `ValidationUtils` suites — all pass (en.ts key parity intact).
- No React components/hooks were added or changed, so the React Compiler check does not apply.

https://claude.ai/code/session_01YHZqP9ed81WB755NEVNVcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHZqP9ed81WB755NEVNVcs)_