### PR TITLE
feat(signup): splash → InitialScreen logo handoff

### DIFF
--- a/__tests__/unit/components/KirokuLogo.test.tsx
+++ b/__tests__/unit/components/KirokuLogo.test.tsx
@@ -270,4 +270,20 @@ describe('AnimatedKirokuLogoSvg', () => {
       reanimatedMock.setReduceMotion(false);
     }
   });
+
+  it('renders the full mark when handed off (entrance skipped)', () => {
+    // On the splash → logo handoff the entrance is suppressed and the settled
+    // mark renders underneath the flying splash logo.
+    const {toJSON} = render(
+      <AnimatedKirokuLogoSvg
+        fill="#000000"
+        liquidColor="#F5C400"
+        environment={CONST.ENVIRONMENT.PROD}
+        shouldStart={false}
+        isHandoff
+      />,
+    );
+    const ds = collectProp(toJSON() as RenderedNode, 'd');
+    EXPECTED_SHAPES.forEach(d => expect(ds).toContain(d));
+  });
 });

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -66,9 +66,12 @@ function Kiroku() {
   const appStateChangeListener = useRef<NativeEventSubscription | null>(null);
   const [isNavigationReady, setIsNavigationReady] = useState(false);
   const [isOnyxMigrated, setIsOnyxMigrated] = useState(false);
-  const {splashScreenState, setSplashScreenState, isAuthDataReady} = useContext(
-    SplashScreenStateContext,
-  );
+  const {
+    splashScreenState,
+    setSplashScreenState,
+    isAuthDataReady,
+    setIsLogoHandoffActive,
+  } = useContext(SplashScreenStateContext);
   const [lastVisitedPath] = useOnyx(ONYXKEYS.LAST_VISITED_PATH);
   const [lastRoute] = useOnyx(ONYXKEYS.LAST_ROUTE);
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
@@ -196,7 +199,12 @@ function Kiroku() {
   // condition can't pin the splash forever.
   const onSplashHide = useCallback(() => {
     setSplashScreenState(CONST.BOOT_SPLASH_STATE.HIDDEN);
-  }, [setSplashScreenState]);
+    // The logo handoff (if any) is finished once the splash is hidden. Clear
+    // the flag so a later logout remount of InitialScreen plays its assembly
+    // entrance again — the InitialScreen logo that just received the handoff is
+    // already latched-settled, so it ignores the change.
+    setIsLogoHandoffActive(false);
+  }, [setSplashScreenState, setIsLogoHandoffActive]);
 
   useLayoutEffect(() => {
     // Initialize this client as being an active client

--- a/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
+++ b/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
@@ -40,6 +40,15 @@ type AnimatedKirokuLogoSvgProps = {
    * false never restarts.
    */
   shouldStart: boolean;
+
+  /**
+   * True only while the boot splash is handing its logo off into this slot. The
+   * mark renders already-settled (progress 1) instead of playing the assembly
+   * entrance — the splash flight stands in for it. Latched per mount: once a
+   * handoff settles this mount it never plays the entrance, even after the flag
+   * clears. Defaults to false, so every non-handoff appearance plays normally.
+   */
+  isHandoff?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -62,6 +71,7 @@ function AnimatedKirokuLogoSvg({
   liquidColor,
   environment,
   shouldStart,
+  isHandoff = false,
 }: AnimatedKirokuLogoSvgProps) {
   const reduceMotion = useReducedMotion();
   const isFocused = useIsFocused();
@@ -79,29 +89,43 @@ function AnimatedKirokuLogoSvg({
   // never plays over the entrance. Set from the timing's completion callback.
   const [hasSettled, setHasSettled] = useState(false);
 
+  // One latched timeline so `progress` keeps a single mutation site (two would
+  // regress react-compiler). It settles one of two ways, then never re-arms:
+  //   • Handoff (isHandoff): jump straight to the settled mark — zero duration,
+  //     no wave — underneath the flying splash logo, so the entrance never
+  //     plays. When the splash later releases `shouldStart` the latch is
+  //     already set and this stays put.
+  //   • Entrance (shouldStart, no reduced motion): run the full assembly.
   useEffect(() => {
-    if (shouldStart && !reduceMotion && !hasStarted.current) {
+    const shouldHandoff = isHandoff;
+    const shouldPlayEntrance = shouldStart && !reduceMotion;
+    if (!hasStarted.current && (shouldHandoff || shouldPlayEntrance)) {
       hasStarted.current = true;
       // eslint-disable-next-line react-compiler/react-compiler
       progress.value = withTiming(
         1,
-        {duration: TOTAL_DURATION_MS, easing: Easing.linear},
+        {
+          duration: shouldHandoff ? 0 : TOTAL_DURATION_MS,
+          easing: Easing.linear,
+        },
         () => {
           cancelAnimation(wavePhase);
           runOnJS(setHasSettled)(true);
         },
       );
-      // eslint-disable-next-line react-compiler/react-compiler
-      wavePhase.value = withRepeat(
-        withTiming(1, {duration: WAVE_PERIOD_MS, easing: Easing.linear}),
-        -1,
-      );
+      if (!shouldHandoff) {
+        // eslint-disable-next-line react-compiler/react-compiler
+        wavePhase.value = withRepeat(
+          withTiming(1, {duration: WAVE_PERIOD_MS, easing: Easing.linear}),
+          -1,
+        );
+      }
     }
     return () => {
       cancelAnimation(progress);
       cancelAnimation(wavePhase);
     };
-  }, [shouldStart, reduceMotion, progress, wavePhase]);
+  }, [shouldStart, reduceMotion, isHandoff, progress, wavePhase]);
 
   // Ambient shimmer loop. Runs only after the entrance settles and only while
   // the screen is focused: navigating InitialScreen → AuthScreen pushes over

--- a/src/components/KirokuLogo/index.tsx
+++ b/src/components/KirokuLogo/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useCallback, useContext, useEffect, useRef} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
+import SplashScreenStateContext from '@context/global/SplashScreenStateContext';
 import useEnvironment from '@hooks/useEnvironment';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -29,11 +30,45 @@ function KirokuLogo({style, shouldPlayAnimation}: KirokuLogoProps) {
   const theme = useTheme();
   const StyleUtils = useStyleUtils();
   const {environment} = useEnvironment();
+  const {reportLogoHandoffTarget, isLogoHandoffActive} = useContext(
+    SplashScreenStateContext,
+  );
 
   const {shouldUseNarrowLayout} = useResponsiveLayout();
 
+  // Only the animated variant (the InitialScreen logo) takes part in the
+  // splash → logo handoff: it reports its on-screen slot so the native splash
+  // hider can fly its logo there, and renders settled while that flight runs.
+  const isHandoffSlot = shouldPlayAnimation !== undefined;
+  const wrapperRef = useRef<View>(null);
+
+  const reportSlot = useCallback(() => {
+    if (!isHandoffSlot) {
+      return;
+    }
+    wrapperRef.current?.measureInWindow((x, y, width, height) => {
+      if (width > 0 && height > 0) {
+        reportLogoHandoffTarget({x, y, width, height});
+      }
+    });
+  }, [isHandoffSlot, reportLogoHandoffTarget]);
+
+  useEffect(() => {
+    if (!isHandoffSlot) {
+      return undefined;
+    }
+    return () => {
+      // Clear on unmount so a slot that no longer exists (e.g. authenticated
+      // cold boot briefly mounting the public stack) can't make the splash
+      // hider fly its logo to a dead position — it falls back to shrink-out.
+      reportLogoHandoffTarget(null);
+    };
+  }, [isHandoffSlot, reportLogoHandoffTarget]);
+
   return (
     <View
+      ref={wrapperRef}
+      onLayout={isHandoffSlot ? reportSlot : undefined}
       style={[
         StyleUtils.getSignUpLogoWidthStyle(shouldUseNarrowLayout, environment),
         StyleUtils.getHeight(
@@ -56,6 +91,7 @@ function KirokuLogo({style, shouldPlayAnimation}: KirokuLogoProps) {
           liquidColor={theme.success}
           environment={environment}
           shouldStart={shouldPlayAnimation}
+          isHandoff={isLogoHandoffActive}
         />
       )}
     </View>

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,7 +1,16 @@
-import {useCallback, useEffect, useMemo, useRef} from 'react';
-import {Animated, Easing, Image, Platform, StyleSheet} from 'react-native';
+import {useCallback, useContext, useEffect, useMemo, useRef} from 'react';
+import {
+  AccessibilityInfo,
+  Animated,
+  Dimensions,
+  Easing,
+  Image,
+  Platform,
+  StyleSheet,
+} from 'react-native';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import ImageSVG from '@components/ImageSVG';
+import SplashScreenStateContext from '@context/global/SplashScreenStateContext';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
 import Log from '@libs/Log';
@@ -20,11 +29,28 @@ const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 // renders the logo at the same size so the native → JS handoff is seamless.
 const LOGO_SIZE = 108;
 
+// Shrink-out (every path except the signed-out cold-boot handoff): the centered
+// logo shrinks while the overlay fades, revealing whatever is underneath.
+const SHRINK_SCALE_MS = 200;
+const SHRINK_FADE_MS = 250;
+
+// Handoff (signed-out cold boot): the splash logo flies from screen center into
+// the InitialScreen logo slot, then the whole overlay fades — crossfading the
+// splash logo onto the settled in-app logo already rendered at the same spot,
+// so launch → initial screen reads as one continuous scene.
+const HANDOFF_FLIGHT_MS = 450;
+const HANDOFF_REVEAL_MS = 220;
+// Decelerating curve so the logo eases into the slot rather than stopping dead.
+const HANDOFF_FLIGHT_EASING = Easing.bezier(0.22, 1, 0.36, 1);
+
 function SplashScreenHider({
   onHide = () => {},
   shouldHideSplash,
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const styles = useThemeStyles();
+  const {logoHandoffTargetRef, setIsLogoHandoffActive} = useContext(
+    SplashScreenStateContext,
+  );
 
   // Use React Native's Animated API (not Reanimated). Reanimated 4 on Fabric
   // binds animated styles via a worklet that may not execute on the first
@@ -37,6 +63,11 @@ function SplashScreenHider({
   // the react-hooks/refs lint rule (ref access during render).
   const opacity = useMemo(() => new Animated.Value(1), []);
   const scale = useMemo(() => new Animated.Value(1), []);
+  // Translation from screen center toward the logo slot, used only on the
+  // handoff path; stays 0 for the shrink-out so its transform matches the old
+  // scale-only behavior exactly.
+  const translateX = useMemo(() => new Animated.Value(0), []);
+  const translateY = useMemo(() => new Animated.Value(0), []);
 
   const hideHasBeenCalled = useRef(false);
 
@@ -47,27 +78,20 @@ function SplashScreenHider({
 
     hideHasBeenCalled.current = true;
 
-    // BootSplash.hide() runs a 250ms cross-dissolve on the native side
-    // (fade=1 in RCTBootSplash.mm). The dissolve forces iOS to render
-    // the React tree underneath the storyboard view to prepare its
-    // AFTER state — which masks Fabric's incremental mounting cascade
-    // (proxy → GestureHandlerRootView → SplashScreenHider). By the
-    // time the dissolve resolves, the React tree is fully composited.
-    //
-    // After the native dissolve resolves, run a JS-side fade so the
-    // logo gracefully shrinks + fades to reveal the home screen
-    // beneath, instead of cutting instantly.
-    BootSplash.hide().then(() => {
+    // The unchanged shrink-out: logo scales to nothing while the overlay fades.
+    // Every non-handoff path lands here, and it never depends on the logo slot,
+    // so it can't be stranded waiting for a target that never arrives.
+    const shrinkOut = () => {
       Animated.parallel([
         Animated.timing(scale, {
           toValue: 0,
-          duration: 200,
+          duration: SHRINK_SCALE_MS,
           easing: Easing.out(Easing.ease),
           useNativeDriver: true,
         }),
         Animated.timing(opacity, {
           toValue: 0,
-          duration: 250,
+          duration: SHRINK_FADE_MS,
           easing: Easing.out(Easing.ease),
           useNativeDriver: true,
         }),
@@ -76,8 +100,102 @@ function SplashScreenHider({
           onHide();
         }
       });
+    };
+
+    // BootSplash.hide() runs a 250ms cross-dissolve on the native side
+    // (fade=1 in RCTBootSplash.mm). The dissolve forces iOS to render
+    // the React tree underneath the storyboard view to prepare its
+    // AFTER state — which masks Fabric's incremental mounting cascade
+    // (proxy → GestureHandlerRootView → SplashScreenHider). By the
+    // time the dissolve resolves, the React tree is fully composited.
+    //
+    // After the native dissolve resolves, either fly the logo into the
+    // InitialScreen slot (signed-out cold boot) or fall back to the
+    // shrink-out (authenticated boot, reduced motion, or no slot reported).
+    BootSplash.hide().then(async () => {
+      const target = logoHandoffTargetRef.current;
+      const reduceMotionEnabled =
+        await AccessibilityInfo.isReduceMotionEnabled().catch(() => false);
+
+      // Handoff only when the signed-out tree reported a usable logo slot and
+      // motion isn't reduced. Otherwise keep today's hide.
+      if (
+        !target ||
+        target.width <= 0 ||
+        target.height <= 0 ||
+        reduceMotionEnabled
+      ) {
+        shrinkOut();
+        return;
+      }
+
+      // The overlay is full-window and centers the logo, so its center is the
+      // window center. (iOS SafeArea only insets left/right, and cold boot is
+      // portrait, so there's no vertical offset to account for.)
+      const {width: windowWidth, height: windowHeight} =
+        Dimensions.get('window');
+      const slotCenterX = target.x + target.width / 2;
+      const slotCenterY = target.y + target.height / 2;
+      const dx = slotCenterX - windowWidth / 2;
+      const dy = slotCenterY - windowHeight / 2;
+      // KirokuLogoSvg preserves aspect ratio (meet), so the visible mark is
+      // bounded by the slot's smaller side. The splash logo and the in-app logo
+      // derive from the same master art, so scaling the 108pt splash frame to
+      // that size lands the two marks on top of each other.
+      const targetScale = Math.min(target.width, target.height) / LOGO_SIZE;
+
+      // Tell the in-app logo to render settled underneath; the opaque overlay
+      // still masks it until the reveal fade below.
+      setIsLogoHandoffActive(true);
+
+      Animated.parallel([
+        Animated.timing(translateX, {
+          toValue: dx,
+          duration: HANDOFF_FLIGHT_MS,
+          easing: HANDOFF_FLIGHT_EASING,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: dy,
+          duration: HANDOFF_FLIGHT_MS,
+          easing: HANDOFF_FLIGHT_EASING,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: targetScale,
+          duration: HANDOFF_FLIGHT_MS,
+          easing: HANDOFF_FLIGHT_EASING,
+          useNativeDriver: true,
+        }),
+      ]).start(({finished}) => {
+        if (!finished) {
+          return;
+        }
+        // Reveal: fade the whole overlay (yellow bg + splash logo) out. Because
+        // the settled in-app logo sits at the same spot and size, the splash
+        // logo crossfades onto it with no positional pop and no hard cut to
+        // expose the storyboard-PNG vs SVG rasterization difference.
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: HANDOFF_REVEAL_MS,
+          easing: Easing.out(Easing.ease),
+          useNativeDriver: true,
+        }).start(({finished: revealFinished}) => {
+          if (revealFinished) {
+            onHide();
+          }
+        });
+      });
     });
-  }, [onHide, opacity, scale]);
+  }, [
+    onHide,
+    opacity,
+    scale,
+    translateX,
+    translateY,
+    logoHandoffTargetRef,
+    setIsLogoHandoffActive,
+  ]);
 
   useEffect(() => {
     if (!shouldHideSplash) {
@@ -105,7 +223,7 @@ function SplashScreenHider({
   return (
     <Animated.View
       style={[StyleSheet.absoluteFill, styles.splashScreenHider, {opacity}]}>
-      <Animated.View style={{transform: [{scale}]}}>
+      <Animated.View style={{transform: [{translateX}, {translateY}, {scale}]}}>
         {Platform.OS === 'ios' ? (
           // iOS: load BootSplashLogo from the asset catalog via
           // [UIImage imageNamed:]. The string-uri form falls through to

--- a/src/context/global/SplashScreenStateContext.tsx
+++ b/src/context/global/SplashScreenStateContext.tsx
@@ -1,7 +1,20 @@
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
 import type {ValueOf} from 'type-fest';
 import CONST from '@src/CONST';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
+
+/**
+ * On-screen rectangle (window coordinates) of the InitialScreen logo slot.
+ * Reported by the animated KirokuLogo so the native boot-splash hider can fly
+ * its logo into that exact spot on a signed-out cold boot. See
+ * SplashScreenHider/index.native.tsx and KirokuLogo/index.tsx.
+ */
+type LogoHandoffTargetRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
 
 type SplashScreenStateContextType = {
   splashScreenState: ValueOf<typeof CONST.BOOT_SPLASH_STATE>;
@@ -17,6 +30,29 @@ type SplashScreenStateContextType = {
    */
   isAuthDataReady: boolean;
   setIsAuthDataReady: React.Dispatch<React.SetStateAction<boolean>>;
+  /**
+   * Read side of the splash → InitialScreen logo handoff channel. The native
+   * splash hider reads `.current` once, at hide time, to decide whether to fly
+   * the splash logo into the slot. A ref (not state) so the frequent layout
+   * writes that feed it never re-render the boot tree. Write via
+   * `reportLogoHandoffTarget`.
+   */
+  logoHandoffTargetRef: React.MutableRefObject<LogoHandoffTargetRect | null>;
+  /**
+   * Write side of that channel. The animated logo reports its measured window
+   * rect on layout (and null on unmount). A stable callback that mutates the
+   * provider-owned ref, so consumers never touch the ref directly.
+   */
+  reportLogoHandoffTarget: (rect: LogoHandoffTargetRect | null) => void;
+  /**
+   * True only while the splash hider is performing the handoff. The animated
+   * logo reads this to render already-settled underneath the flying splash
+   * logo (skipping its assembly entrance, which the splash stands in for).
+   * Stays false on every non-handoff path (authenticated boot, logout remount,
+   * reduced motion) so the entrance plays as usual.
+   */
+  isLogoHandoffActive: boolean;
+  setIsLogoHandoffActive: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const SplashScreenStateContext =
@@ -25,6 +61,10 @@ const SplashScreenStateContext =
     setSplashScreenState: () => {},
     isAuthDataReady: false,
     setIsAuthDataReady: () => {},
+    logoHandoffTargetRef: {current: null},
+    reportLogoHandoffTarget: () => {},
+    isLogoHandoffActive: false,
+    setIsLogoHandoffActive: () => {},
   });
 
 function SplashScreenStateContextProvider({children}: ChildrenProps) {
@@ -32,14 +72,31 @@ function SplashScreenStateContextProvider({children}: ChildrenProps) {
     ValueOf<typeof CONST.BOOT_SPLASH_STATE>
   >(CONST.BOOT_SPLASH_STATE.VISIBLE);
   const [isAuthDataReady, setIsAuthDataReady] = useState(false);
+  const [isLogoHandoffActive, setIsLogoHandoffActive] = useState(false);
+  const logoHandoffTargetRef = useRef<LogoHandoffTargetRect | null>(null);
+  const reportLogoHandoffTarget = useCallback(
+    (rect: LogoHandoffTargetRect | null) => {
+      logoHandoffTargetRef.current = rect;
+    },
+    [],
+  );
   const splashScreenStateContext = useMemo(
     () => ({
       splashScreenState,
       setSplashScreenState,
       isAuthDataReady,
       setIsAuthDataReady,
+      logoHandoffTargetRef,
+      reportLogoHandoffTarget,
+      isLogoHandoffActive,
+      setIsLogoHandoffActive,
     }),
-    [splashScreenState, isAuthDataReady],
+    [
+      splashScreenState,
+      isAuthDataReady,
+      isLogoHandoffActive,
+      reportLogoHandoffTarget,
+    ],
   );
 
   return (
@@ -54,4 +111,5 @@ function useSplashScreenStateContext() {
 }
 
 export default SplashScreenStateContext;
+export type {LogoHandoffTargetRect};
 export {SplashScreenStateContextProvider, useSplashScreenStateContext};


### PR DESCRIPTION
Closes #1177. Phase 3 of the InitialScreen logo animation, following #1174 (assembly entrance) and #1175 (liquid fill).

## What changes
On a **signed-out cold boot**, instead of the boot-splash logo shrinking to nothing as the splash hides, it now **translates + scales from screen center into the InitialScreen logo slot**, then the overlay fades onto the settled in-app logo rendered at the same spot. Launch → initial screen reads as one continuous scene. On that path the InitialScreen assembly entrance is **skipped** (the logo is already on screen — the splash flight stands in for it).

Every **other path keeps today's behavior unchanged**:
- **Authenticated cold boot** — no InitialScreen, no slot reported → falls back to the shrink-out.
- **Logout remount** — splash isn't shown; the entrance plays as before.
- **Reduced motion** — the handoff is skipped and the current hide is kept.

## How it works
A one-way handoff channel on `SplashScreenStateContext`:
- The animated `KirokuLogo` (InitialScreen only) reports its measured **window rect** via `reportLogoHandoffTarget` on layout, and clears it on unmount. It's backed by a **ref** (`logoHandoffTargetRef`), so the frequent layout writes never re-render the boot tree.
- `SplashScreenHider` reads the slot once, at hide time (after the native cross-dissolve). With a usable slot **and** motion enabled it flies the logo (`translate + scale`, native driver) while keeping the yellow background opaque, then fades the whole overlay — crossfading the splash logo onto the identical settled in-app logo. Otherwise it runs the unchanged shrink-out, which never waits on the slot and so **can't hang the splash**.
- The hider flips `isLogoHandoffActive`; `AnimatedKirokuLogoSvg` reads it to settle instantly and **latch** (single `progress` mutation site, react-compiler clean), suppressing the entrance for the handed-off mount only.
- `Kiroku` clears `isLogoHandoffActive` when the splash hides, so a later logout remount replays the entrance.

## Anti-blink invariants preserved
- iOS overlay still loads the **same `BootSplashLogo` UIImage** the storyboard rendered, and the hider still uses **RN Animated (not Reanimated)** — no opacity-0 first frame, no cross-dissolve blink.
- The reveal is a **soft crossfade** between the storyboard PNG and the SVG logo (same position/size/shape), so the rasterization and color differences (white-on-yellow → themed-on-app-bg) never appear as a hard cut.
- The 108pt splash frame and the in-app logo derive from the **same master art**, so scaling the frame to the slot's smaller side (`min(slotW,slotH)/108`) lands the marks on top of each other.

## Tests / checks
- Added an `AnimatedKirokuLogoSvg` unit test for the handoff (entrance suppressed, full mark rendered). Existing logo tests still green (8/8).
- prettier, `lint-changed` (scoped), `typecheck-tsgo`, and `react-compiler-compliance-check check-changed` all pass.

## Verification note
Logic verified via static checks + RNTL. This is a native-feel transition best confirmed on device — adding **`Ready To Build - iOS`** for a device build to eyeball: continuous handoff on signed-out cold boot, unchanged shrink-out on authenticated boot, no logo blink at the native→JS boundary, and reduced-motion still instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)