### PR TITLE
fix(nav): reset last visited path on sign-out so re-login always lands on Home

### DIFF
--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -682,6 +682,9 @@ function cleanupSession() {
   // Drop the cached drinking sessions snapshot so the next account on this
   // device can't briefly render the previous user's data on cold launch.
   Onyx.set(ONYXKEYS.CACHED_DRINKING_SESSIONS, null);
+  // Reset the last visited path so re-login always starts at Home, not wherever
+  // the user happened to be when they signed out.
+  Onyx.set(ONYXKEYS.LAST_VISITED_PATH, null);
   clearCache().then(() => {
     Log.info('Cleared all cache data', true, {}, true);
   });


### PR DESCRIPTION
## Summary

- `LAST_VISITED_PATH` was never cleared during `cleanupSession()`, so `NavigationRoot` would restore the user to whatever tab was active at sign-out (e.g. Settings) instead of the default Home tab.
- Added `Onyx.set(ONYXKEYS.LAST_VISITED_PATH, null)` to `cleanupSession()` alongside the other per-session Onyx clears, so re-login always starts fresh at Home.

## Root cause

`NavigationRoot` computes `initialState` once (memoized on `user`). If `lastVisitedPath` is set and there's no deep-link `initialUrl`, it calls `getAdaptedStateFromPath(lastVisitedPath)` and reconstructs the full navigator state — including the active tab — from the stored path. Because sign-out never cleared that key, the Settings path survived into the next session.

## Test plan

- [ ] Sign in, navigate to Settings, sign out, sign back in → should land on Home
- [ ] Sign in, navigate to a non-Home tab, sign out, sign back in → should land on Home
- [ ] Deep-link into the app after sign-in still works (unaffected path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)