### PR TITLE
fix(home): align start-session FAB position with the Social screen FAB

### DIFF
--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -108,7 +108,6 @@ function FloatingActionButton(
           buttonRef.current = el ?? null;
         }
       }}
-      style={[styles.bottomTabBarItem, {transform: [{translateY: -4}]}]}
       accessibilityLabel={accessibilityLabel}
       onPress={toggleFabAction}
       onLongPress={() => {}}

--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -319,7 +319,7 @@ function StartSessionButtonAndPopover(
   ]);
 
   return (
-    <View style={[styles.flexShrink1, styles.ph2]}>
+    <View>
       <PopoverMenu
         onClose={hideCreateMenu}
         isVisible={isCreateMenuActive && (!shouldUseNarrowLayout || isFocused)}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -21,7 +21,6 @@ import MonthlyOverviewCard, {
 import ScreenWrapper from '@components/ScreenWrapper';
 import HomeBanner, {HomeBannerSkeleton} from '@components/Info/HomeBanner';
 import useThemeStyles from '@hooks/useThemeStyles';
-import getPlatform from '@libs/getPlatform';
 import * as FeatureFlags from '@libs/FeatureFlags';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
@@ -266,7 +265,7 @@ function HomeScreen({route}: HomeScreenProps) {
       <ScreenWrapper
         testID={HomeScreen.displayName}
         shouldShowOfflineIndicator={false}
-        includeSafeAreaPaddingBottom={getPlatform() !== CONST.PLATFORM.IOS}>
+        includeSafeAreaPaddingBottom={false}>
         {/* // TODO rewrite this into the HeaderWithBackButton component */}
         {isUserDataReady ? (
           <View style={[styles.headerBar, styles.borderBottom, styles.ph2]}>


### PR DESCRIPTION
## Summary

The Home start-session FAB sat in a different spot than the Social screen's search FAB, even though both use the same floating container (`floatingActionButtonContainer` + `bottom: bottomTabBarHeight + 16`). Two independent causes:

**1. Android-only vertical drift (safe-area double count)**
- `HomeScreen` passed `includeSafeAreaPaddingBottom={getPlatform() !== CONST.PLATFORM.IOS}` to `ScreenWrapper`, adding `paddingBottom = safeAreaInset` on Android
- That shrinks the inner `KeyboardAvoidingView` (`height: '100%'` resolves against the padded content box), raising the floor the absolute-positioned FAB measures `bottom` from
- `bottomTabBarHeight` already includes the bottom safe-area, so this double-counted it; `SocialScreen` correctly passes `false`. Now Home does too.

**2. All-platform 8px-left / 4px-up offset (tab-bar leftovers)**
- The FAB kept styles from when it rendered inside the bottom tab bar: `ph2` (8px horizontal padding) on its wrapper in `StartSessionButtonAndPopover`, and `bottomTabBarItem` + `translateY(-4)` on the pressable in `FloatingActionButton`
- In the floating container these shifted the circle 8px left and 4px up; the Social FAB renders flush. Removed them.

## Test plan

- [ ] iOS: Home FAB and Social → Friend Requests search FAB sit at the same right offset and the same height above the tab bar
- [ ] Android (gesture nav, non-zero bottom inset): same check
- [ ] Home FAB still opens the start-session popover anchored correctly, icon rotation animation intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)