### PR TITLE
fix(nav): disable native iOS page animations on tab switch

### DIFF
--- a/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
@@ -64,6 +64,7 @@ function BottomTabNavigator() {
         tabBarStyle={{backgroundColor: theme.appBG}}
         translucent={SUPPORTS_LIQUID_GLASS}
         scrollEdgeAppearance={SUPPORTS_LIQUID_GLASS ? 'default' : 'opaque'}
+        disablePageAnimations
         // Match the rest of the app's typography on the native labels.
         tabLabelStyle={{
           fontFamily: FontUtils.fontFamily.platform.EXP_NEUE.fontFamily,


### PR DESCRIPTION
## Summary
- The `react-native-bottom-tabs` `TabView` defaults `disablePageAnimations` to `false`, enabling native iOS slide animations between tabs
- This caused root tab content to visually "fly off" on iOS when switching between Home / Friends / Statistics / Settings
- Fix: pass `disablePageAnimations` to `Tab.Navigator` — one prop, one line

## Test plan
- [ ] Switch between all four root tabs on iOS and confirm content swaps instantly with no slide animation
- [ ] Confirm Android tab switching is unaffected (`disablePageAnimations` is iOS-only per the library docs)
- [ ] Confirm web tab switching is unaffected (uses `@react-navigation/bottom-tabs`, separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)