### PR TITLE
Fix friend calendar freezing at the 12-month window edge (#1197)

### DIFF
--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -9,6 +9,8 @@ import type {
   Preferences,
 } from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
+import type * as OnyxModule from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 jest.mock('@hooks/useResolvedPalette', () => ({
   __esModule: true,
@@ -26,7 +28,37 @@ jest.mock('@userActions/Calendar', () => ({
   setSessionsCalendarMonthsLoadedForUser: jest.fn(),
 }));
 
+// Drive `USER_DATA_LIST` per test so we can exercise both the self path (a
+// canonical `earliest_session_at` floor) and the friend path (no such floor).
+// Everything else keeps the real Onyx behaviour the existing tests rely on
+// (the per-user months key resolves to `undefined`/`loaded`, and `loadUpTo`
+// updates the hook's local `loadedMonths` state). Mock-prefixed so the
+// `jest.mock` factory may reference it (jest hoists the factory above imports).
+let mockUserDataList:
+  | Record<string, {earliest_session_at?: number}>
+  | undefined;
+const mockUserDataKey = ONYXKEYS.USER_DATA_LIST;
+jest.mock('react-native-onyx', () => {
+  const actual = jest.requireActual<typeof OnyxModule>('react-native-onyx');
+  return {
+    ...actual,
+    __esModule: true,
+    default: actual.default,
+    useOnyx: (key: string) => {
+      if (key === mockUserDataKey) {
+        return [mockUserDataList, {status: 'loaded'}];
+      }
+      return [undefined, {status: 'loaded'}];
+    },
+  };
+});
+
 const TEST_UID = 'user-123';
+
+beforeEach(() => {
+  // Default: friend profile (no canonical floor). Self-path tests opt in.
+  mockUserDataList = undefined;
+});
 
 function makePreferences(): Preferences {
   return {
@@ -108,9 +140,11 @@ describe('useLazyMarkedDates.loadUpTo', () => {
 });
 
 describe('useLazyMarkedDates earliest-month cap', () => {
-  test('clamps the loaded window to the earliest tracked month, ignoring an inflated depth', () => {
-    // One session ~10 months ago is the user's entire history.
+  test('clamps the loaded window to the canonical earliest tracked month, ignoring an inflated depth', () => {
+    // Self profile: a canonical `earliest_session_at` floor ~10 months back is
+    // what gates the cap (the windowed session list no longer does).
     const earliest = subMonths(new Date(), 10);
+    mockUserDataList = {[TEST_UID]: {earliest_session_at: earliest.getTime()}};
     const sessions = {
       s1: {start_time: earliest.getTime(), timezone: 'UTC', drinks: {}},
     } as unknown as DrinkingSessionList;
@@ -131,6 +165,95 @@ describe('useLazyMarkedDates earliest-month cap', () => {
     const depth = differenceInMonths(new Date(), getLoadedFrom(result));
     expect(depth).toBeGreaterThanOrEqual(9);
     expect(depth).toBeLessThanOrEqual(11);
+  });
+});
+
+describe('useLazyMarkedDates friend window (no canonical floor) — Kiroku #1197', () => {
+  // A friend's `sessions` is the server-windowed slice and `earliest_session_at`
+  // is never present, so the floor must NOT be derived from the loaded slice or
+  // scroll-back freezes at the 12-month prefetch edge. These assert the
+  // window-exhaustion signal that replaces the windowed hard floor.
+
+  test('hasPersistedFloor is false and the window is NOT exhausted while the slice still hugs its lower edge', () => {
+    // Friend history predates the loaded window: the earliest LOADED session
+    // sits right at the fetch floor month (12 months back), so older months may
+    // still exist — widening must stay allowed.
+    const windowEdge = subMonths(new Date(), 12);
+    const sessions = {
+      s1: {start_time: windowEdge.getTime(), timezone: 'UTC', drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    act(() => {
+      // The fullscreen prefetch lands the window at 12 months back.
+      result.current.loadUpTo(subMonths(new Date(), 12));
+    });
+
+    expect(result.current.hasPersistedFloor).toBe(false);
+    // The earliest loaded session is IN the fetch floor month, so the slice may
+    // be clipping older sessions — not exhausted. This is the off-by-one that
+    // used to freeze the friend calendar at the month-start boundary: the
+    // earliest-loaded month must compare equal to the fetch floor month, not a
+    // month later (which `startOfMonth(loadedFromDate)` — a `startOfMonth − 1
+    // day` — would have produced).
+    expect(result.current.isWindowExhausted).toBe(false);
+  });
+
+  test('window IS exhausted once the earliest loaded session sits above the fetch floor', () => {
+    // Friend whose entire history is recent (one session ~2 months back). Even
+    // at the default 12-month window the server returned everything, and the
+    // earliest session sits well above the floor → nothing older to fetch.
+    const recent = subMonths(new Date(), 2);
+    const sessions = {
+      s1: {start_time: recent.getTime(), timezone: 'UTC', drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    act(() => {
+      result.current.loadUpTo(subMonths(new Date(), 12));
+    });
+
+    expect(result.current.hasPersistedFloor).toBe(false);
+    expect(result.current.isWindowExhausted).toBe(true);
+  });
+
+  test('empty / privacy-denied friend read is exhausted (no infinite widen loop)', () => {
+    // An empty slice (denied / evicted #786 read) has nothing to widen into.
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, {}, makePreferences()),
+    );
+
+    expect(result.current.hasPersistedFloor).toBe(false);
+    expect(result.current.isWindowExhausted).toBe(true);
+  });
+
+  test('widening deepens the build floor for a friend (no windowed-floor cap)', () => {
+    // Friend history older than the window. With the windowed-floor cap removed,
+    // a deeper `loadUpTo` must actually deepen the build floor (the old cap
+    // clamped it to the earliest loaded session and froze scroll-back).
+    const windowEdge = subMonths(new Date(), 12);
+    const sessions = {
+      s1: {start_time: windowEdge.getTime(), timezone: 'UTC', drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    act(() => {
+      result.current.loadUpTo(subMonths(new Date(), 24));
+    });
+
+    // The build floor follows the requested depth (~24 months), not the
+    // earliest loaded session's month (~12).
+    const depth = differenceInMonths(new Date(), getLoadedFrom(result));
+    expect(depth).toBeGreaterThanOrEqual(23);
   });
 });
 

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -96,6 +96,8 @@ function SessionsCalendar({
     loadedFromDate,
     loadMoreMonths,
     loadUpTo,
+    hasPersistedFloor,
+    isWindowExhausted,
     isLoading,
   } = useLazyMarkedDates(
     userID,
@@ -158,17 +160,29 @@ function SessionsCalendar({
   // empty months — and for the day-list (which renders no empty months) that
   // means the list never grows, so an unguarded `loadUpTo` would loop until
   // React's update-depth limit. Clamp to this and short-circuit once reached.
+  //
+  // Only authoritative when `hasPersistedFloor` (self): then `minDate` is the
+  // canonical `earliest_session_at`. For a friend `minDate` is derived from the
+  // windowed session slice, so it collapses onto the current loaded edge — using
+  // it as a hard floor froze scroll-back at the 12-month prefetch window
+  // (Kiroku #1197). The friend path uses `isWindowExhausted` instead (below).
   const minDateFloor = useMemo(
     () => startOfMonth(parseISO(minDate)),
     [minDate],
   );
 
   // Whether there is older data still to load — drives the day-list's load
-  // trigger and its "loading older" header. Once the loaded floor reaches the
-  // earliest tracked month there is nothing more to fetch.
-  const canLoadOlder =
-    loadedFromDate !== null &&
-    loadedFromDate.getTime() > minDateFloor.getTime();
+  // trigger and its "loading older" header.
+  //  - Self (canonical floor): stop once the loaded window reaches the earliest
+  //    tracked month. Compared at month granularity (`startOfMonth`) so the
+  //    harmless boundary day baked into `loadedFromDate` (a `startOfMonth − 1
+  //    day`, see `useLazyMarkedDates`) can't trip the guard a day early.
+  //  - Friend (no canonical floor): keep loading until the window is exhausted —
+  //    the server returns nothing earlier than what we already have.
+  const canLoadOlder = hasPersistedFloor
+    ? loadedFromDate !== null &&
+      startOfMonth(loadedFromDate).getTime() > minDateFloor.getTime()
+    : !isWindowExhausted;
 
   // Regular function — `loadedFrom` is a ref whose `.current` mutates
   // without re-rendering. A `useCallback` keyed on it would either be stale
@@ -176,8 +190,16 @@ function SessionsCalendar({
   // events, so referential stability isn't required.
   const handleRequestOlder = (earliestVisible: Date) => {
     const floor = loadedFrom?.current ?? new Date();
-    if (floor.getTime() <= minDateFloor.getTime()) {
-      // Already loaded back to the earliest tracked month — nothing more.
+    // Self (canonical floor): stop once loaded back to the earliest tracked
+    // month. Friend (no canonical floor): stop only once the window is exhausted
+    // — `minDateFloor` is the windowed edge for friends, so never clamp to it.
+    if (hasPersistedFloor) {
+      if (startOfMonth(floor).getTime() <= minDateFloor.getTime()) {
+        // Already loaded back to the earliest tracked month — nothing more.
+        return;
+      }
+    } else if (isWindowExhausted) {
+      // Friend whose history is fully loaded (or empty/denied) — nothing more.
       return;
     }
     let target = computeLoadTarget(
@@ -189,7 +211,11 @@ function SessionsCalendar({
     if (!target) {
       return;
     }
-    if (target.getTime() < minDateFloor.getTime()) {
+    // Clamp to the canonical floor only when we actually know it (self). For a
+    // friend the floor is the windowed edge, so clamping there would re-freeze
+    // scroll-back at the current window; let the target ride down past it and
+    // rely on `isWindowExhausted` to stop once the history runs out.
+    if (hasPersistedFloor && target.getTime() < minDateFloor.getTime()) {
       target = minDateFloor;
     }
     deepestRequestedRef.current = target;

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -208,24 +208,27 @@ function useLazyMarkedDates(
   // monthsLoaded)))`), NOT `loadedFromDate`: the latter is `startOfMonth − 1 day`,
   // which lands in the previous month and would report exhaustion a month early.
   // For self this is unused — the persisted floor drives the guards directly.
-  const isWindowExhausted = useMemo(() => {
-    if (hasPersistedFloor) {
-      // Self: the canonical floor governs; this signal isn't consulted.
-      return false;
-    }
+  // Plain derivation: React Compiler memoizes it from the captured reads
+  // (`hasPersistedFloor`, `sessions`, `loadedMonths`), so no manual `useMemo`.
+  let isWindowExhausted = false;
+  if (!hasPersistedFloor) {
+    // Self: the canonical floor governs; this signal isn't consulted, so it
+    // stays false above.
     const earliestLoaded = DSUtils.getUserTrackingStartDate(sessions);
     if (!earliestLoaded) {
-      return true;
+      isWindowExhausted = true;
+    } else {
+      const fetchFloorMonths = Math.max(
+        CONST.SESSIONS_INITIAL_FETCH_MONTHS,
+        loadedMonths,
+      );
+      const fetchFloorMonth = startOfMonth(
+        subMonths(new Date(), fetchFloorMonths),
+      );
+      isWindowExhausted =
+        startOfMonth(earliestLoaded).getTime() > fetchFloorMonth.getTime();
     }
-    const fetchFloorMonths = Math.max(
-      CONST.SESSIONS_INITIAL_FETCH_MONTHS,
-      loadedMonths,
-    );
-    const fetchFloorMonth = startOfMonth(
-      subMonths(new Date(), fetchFloorMonths),
-    );
-    return startOfMonth(earliestLoaded).getTime() > fetchFloorMonth.getTime();
-  }, [hasPersistedFloor, sessions, loadedMonths]);
+  }
 
   // Resolve which palette to render with. When the viewer has enabled
   // `use_own_palette_for_others`, this swaps the viewed user's palette for the

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -96,22 +96,37 @@ function useLazyMarkedDates(
 
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
 
-  // Cap the effective scroll depth at the user's earliest tracked month. The
+  // Whether the viewed user has a *canonical* earliest-tracked floor. It is
+  // only ever written for the signed-in user (the `earliest_session_at` backfill
+  // / session-write path keys it on the authoring uid); no friend read carries
+  // it. So this is `true` for self and `false` for friends — the distinction the
+  // capping below and the orchestrator's load-older guards both turn on.
+  const persistedEarliest = userDataList?.[userID]?.earliest_session_at;
+  const hasPersistedFloor = persistedEarliest !== undefined;
+
+  // Cap the effective scroll depth at the user's earliest tracked month — but
+  // ONLY when we know the canonical floor (self). The
   // `SESSIONS_CALENDAR_MONTHS_BY_USER_ID` lever is shared with the Statistics
   // fetch-window widener (`StatsContextProvider`), which a comparison/All
   // range can push a full span *before* the first session — inflating the
   // persisted depth well past the user's data. There are no sessions (and no
   // tracking) before `earliest_session_at`, so building day-keys / week-rows
   // there is pure waste and would paint "sober day" dots on untracked days.
-  // Prefer the canonical backfilled floor, falling back to the earliest loaded
-  // session for friend profiles and pre-backfill accounts.
+  //
+  // For a FRIEND there is no canonical floor: `sessions` is the server-windowed
+  // slice, so its earliest entry is the edge of what we've fetched, NOT the
+  // friend's real first session. Capping to it would clamp the build to the
+  // current window and freeze scroll-back at the window edge (Kiroku #1197).
+  // So when the floor is unknown we don't cap — `loadUpTo` only ever deepens as
+  // far as the user actually scrolls, and the fetch hook stops returning earlier
+  // sessions once the friend's history is exhausted, so the build can't run away
+  // into empty pre-tracking months.
   const earliestTracked = useMemo<Date | null>(() => {
-    const persistedEarliest = userDataList?.[userID]?.earliest_session_at;
-    if (persistedEarliest !== undefined) {
+    if (hasPersistedFloor) {
       return new Date(persistedEarliest);
     }
-    return DSUtils.getUserTrackingStartDate(sessions);
-  }, [userDataList, userID, sessions]);
+    return null;
+  }, [hasPersistedFloor, persistedEarliest]);
 
   const cappedMonths = useMemo(() => {
     if (!earliestTracked) {
@@ -172,6 +187,45 @@ function useLazyMarkedDates(
         loadedFromDate: start,
       };
     }, [sessions, cappedMonths, defaultTimezone]);
+
+  // Whether scrolling back can still reveal older data. Only meaningful when the
+  // viewed user has NO canonical floor (a friend): `sessions` is the windowed
+  // slice, so we can't derive the true first session from it. Instead we ask
+  // "did the current window actually reach the bottom of the friend's history?"
+  //
+  //  - No sessions at all (empty / privacy-denied / evicted #786 read): there is
+  //    nothing to widen into. Exhausted — so the orchestrator stops, no infinite
+  //    widen loop and a clean empty calendar.
+  //  - Earliest loaded session's month is STRICTLY LATER than the fetch floor
+  //    month: the server returned every session with `start_time >= fetch floor`
+  //    and the earliest one still sits above that floor, so there is provably
+  //    nothing older. Exhausted — the earliest loaded session IS the real first.
+  //  - Earliest loaded session sits IN the fetch floor month: the window may be
+  //    clipping older sessions at the edge, so keep widening (not exhausted).
+  //
+  // The comparison is against the FETCH floor (`useDrinkingSessionsFetch` reads
+  // `start_time >= startOfMonth(subMonths(now, max(SESSIONS_INITIAL_FETCH_MONTHS,
+  // monthsLoaded)))`), NOT `loadedFromDate`: the latter is `startOfMonth − 1 day`,
+  // which lands in the previous month and would report exhaustion a month early.
+  // For self this is unused — the persisted floor drives the guards directly.
+  const isWindowExhausted = useMemo(() => {
+    if (hasPersistedFloor) {
+      // Self: the canonical floor governs; this signal isn't consulted.
+      return false;
+    }
+    const earliestLoaded = DSUtils.getUserTrackingStartDate(sessions);
+    if (!earliestLoaded) {
+      return true;
+    }
+    const fetchFloorMonths = Math.max(
+      CONST.SESSIONS_INITIAL_FETCH_MONTHS,
+      loadedMonths,
+    );
+    const fetchFloorMonth = startOfMonth(
+      subMonths(new Date(), fetchFloorMonths),
+    );
+    return startOfMonth(earliestLoaded).getTime() > fetchFloorMonth.getTime();
+  }, [hasPersistedFloor, sessions, loadedMonths]);
 
   // Resolve which palette to render with. When the viewer has enabled
   // `use_own_palette_for_others`, this swaps the viewed user's palette for the
@@ -369,6 +423,14 @@ function useLazyMarkedDates(
     loadedFromDate,
     loadMoreMonths,
     loadUpTo,
+    // `true` only for the viewed user with a canonical `earliest_session_at`
+    // (self). The orchestrator uses this to pick which load-older guard applies:
+    // a hard month floor for self, or the window-exhaustion signal for friends.
+    hasPersistedFloor,
+    // For friends (no canonical floor): `true` once scrolling back can reveal
+    // nothing older — an empty/denied read, or the earliest loaded session
+    // already sits above the loaded window edge. Always `false` for self.
+    isWindowExhausted,
     isLoading: false,
   };
 }


### PR DESCRIPTION
Closes #1197

## Symptom

When viewing **another user's** (friend's) fullscreen/infinite calendar, scrolling back never went past the lower edge of the one-time 12-month prefetch (the last day of `today − 12 months`, e.g. May 31 2025 in June 2026). Older months never loaded. The signed-in user's **own** calendar was unaffected.

## Root cause

The friend calendar's "earliest tracked day" floor was derived from the already-loaded, **server-windowed** session slice instead of the user's true tracking-start date:

1. Friend sessions load windowed: `useDrinkingSessionsFetch` reads `start_time >= startOfMonth(subMonths(now, monthsBack))`, so the friend's session data is never the full history.
2. `minDate`/`minDateFloor` fall back to `getUserTrackingStartDate(windowedSlice)` because `earliest_session_at` is **only ever written for the authenticated user** — no friend read carries it. So the floor collapses onto the current loaded edge.
3. The one-time 12-month prefetch is the only widen not gated by the floor, so the window lands at `subMonths(now, 12)`.
4. An off-by-one (`loadedFromDate = startOfMonth − 1 day` vs `minDateFloor = startOfMonth`) then trips both `canLoadOlder` and `handleRequestOlder` a day early. The result is a self-referential floor: the floor is computed from data that is only fetched down to the floor.

Self is unaffected because its session data is the complete live history **and** `earliest_session_at` is populated, so the floor sits far below the loaded edge.

## Fix path chosen — fully client-side

I first checked whether the kiroku-api friend reads already return the friend's `earliest_session_at`. They do not: `OPEN_FRIEND_DRINKING_SESSIONS` returns only the windowed session map; the profile / `GET_USERS_BATCH` reads merge `profile` + `is_supporter` (+ optional `user_status`), never `earliest_session_at`. Since this change is scoped to the client repo and cannot modify kiroku-api, the "preferred" wiring path isn't available — so this implements the issue's **fully client-side** path.

The fix distinguishes the **canonical floor** (self / backfilled) from the **windowed slice** (friends):

- **Self (`hasPersistedFloor` true):** keep the hard month floor, and compare at month granularity (`startOfMonth(loadedFromDate)` vs `minDateFloor`) so the `startOfMonth − 1 day` off-by-one can't trip the guard a day early. Behavior is otherwise unchanged.
- **Friend (`hasPersistedFloor` false):** stop using the windowed earliest as a hard floor. Keep `canLoadOlder` true and keep widening until the window is **exhausted** — the server returned every session down to the fetch floor and the earliest loaded session still sits **above** it (so there's provably nothing older), or the read is empty/denied. Exhaustion is measured against the actual **fetch floor month** (`startOfMonth(subMonths(now, max(SESSIONS_INITIAL_FETCH_MONTHS, monthsLoaded)))`), not `loadedFromDate`, so it can't report a month early. The windowed-floor cap on the build depth is also no longer applied for friends (it was clamping the build to the loaded slice and re-freezing scroll-back).

The empty/denied friend read (Kiroku #786 eviction) resolves to `isWindowExhausted = true`, so the orchestrator stops immediately — a clean empty calendar, no infinite widen loop, no unhandled rejection.

### Files

- `src/hooks/useLazyMarkedDates.ts` — `hasPersistedFloor` split; cap is now self-only; new `isWindowExhausted` signal; both exposed from the hook.
- `src/components/SessionsCalendar/index.tsx` — `canLoadOlder` / `handleRequestOlder` branch on `hasPersistedFloor`, use `isWindowExhausted` for friends, and compare at month granularity for self.
- `__tests__/unit/useLazyMarkedDates.test.ts` — friend-path regression tests + updated the earliest-month-cap test to the self path (the cap is now canonical-floor-gated).

## Acceptance criteria

- [x] Friend whose history predates the 12-month window keeps widening on scroll and reaches their actual first session.
- [x] No "last day of (today − 12 months)" dead-stop, independent of the current date (exhaustion is measured against the fetch floor month, not a date-dependent boundary).
- [x] The signed-in user's own calendar behavior is unchanged.
- [x] Empty/denied friend reads resolve to a clean empty calendar — no infinite widen loop, no unhandled rejection.
- [x] Regression test added: a friend with sessions older than the loaded window keeps `canLoadOlder` true / `isWindowExhausted` false (asserting the month-start off-by-one no longer freezes it); a fully-loaded friend reports exhausted; an empty read is exhausted; a deeper `loadUpTo` deepens the build floor.

## Checklist results

- `npx prettier --write` on all changed files — done (all formatted).
- `npm run lint-changed` — pass, no errors.
- `npm run typecheck-tsgo` — pass, no errors.
- `npm run react-compiler-compliance-check check-changed` — pass (3 changed React files compiled).
- `npm run test` (touched area: `useLazyMarkedDates` + `SessionsCalendarUtils`) — pass: 11/11 in `useLazyMarkedDates.test.ts` (incl. 4 new friend-path tests), 6/6 in `SessionsCalendarUtils.test.ts`.

https://claude.ai/code/session_01BTxKA4PBqfbnH67nxEEYNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTxKA4PBqfbnH67nxEEYNk)_