### PR TITLE
fix(calendar): open on current month after a fresh launch

### DIFF
--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -543,9 +543,9 @@ function setLastViewedCalendarDate(date: DateString) {
 }
 
 /** Clear the consumed last-viewed date so subsequent focuses don't re-apply
- *  it. The cold-launch reset lives in `setup` via `Onyx.merge(key, null)` (the
- *  `initialKeyStates` null is a no-op — Onyx drops null defaults); this is for
- *  in-app clears, e.g. manual month navigation. */
+ *  it. The cold-launch reset lives in the `Calendar.resetCalendarStateForColdLaunch`
+ *  action (the `initialKeyStates` null is a no-op — Onyx drops null defaults);
+ *  this is for in-app clears, e.g. manual month navigation. */
 function clearLastViewedCalendarDate() {
   Onyx.set(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
 }

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -543,8 +543,9 @@ function setLastViewedCalendarDate(date: DateString) {
 }
 
 /** Clear the consumed last-viewed date so subsequent focuses don't re-apply
- *  it. The launch reset lives in `Onyx.init`'s `initialKeyStates` (race-free
- *  with hydration); this is for in-app clears, e.g. manual month navigation. */
+ *  it. The cold-launch reset lives in `setup` via `Onyx.merge(key, null)` (the
+ *  `initialKeyStates` null is a no-op — Onyx drops null defaults); this is for
+ *  in-app clears, e.g. manual month navigation. */
 function clearLastViewedCalendarDate() {
   Onyx.set(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
 }

--- a/src/libs/actions/Calendar.ts
+++ b/src/libs/actions/Calendar.ts
@@ -17,7 +17,26 @@ function setSessionsCalendarMonthsLoadedForUser(
   );
 }
 
+/**
+ * Reset the calendar's cross-screen sync state on a cold launch so the home and
+ * profile calendars always open on the current month, regardless of where the
+ * user was when they last closed the app.
+ *
+ * Why `Onyx.merge(key, null)` and not `Onyx.init`'s `initialKeyStates` or
+ * `Onyx.set`: Onyx drops null defaults during hydration
+ * (`shouldRemoveNestedNulls`), so a value persisted from a previous session
+ * survives `initialKeyStates: null`. `Onyx.set(key, null)` also no-ops here, it
+ * early-returns on the empty pre-hydration cache. `Onyx.merge` reads the stored
+ * value first, then removes it (delete + broadcast). Called from `setup` before
+ * the React tree mounts, so the value is cleared before any screen subscribes
+ * (no month "flip").
+ */
+function resetCalendarStateForColdLaunch(): void {
+  Onyx.merge(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
+  Onyx.merge(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED, null);
+}
+
 export {
-  // eslint-disable-next-line import/prefer-default-export
   setSessionsCalendarMonthsLoadedForUser,
+  resetCalendarStateForColdLaunch,
 };

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -43,12 +43,6 @@ export default function () {
       [ONYXKEYS.NETWORK]: CONST.DEFAULT_NETWORK_DATA,
       [ONYXKEYS.IS_SIDEBAR_LOADED]: false,
       [ONYXKEYS.HAS_CHECKED_AUTO_LOGIN]: false,
-      [ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED]: null, // Reset calendar
-      // Reset to today on launch. This is a transient cross-screen sync value;
-      // resetting it here (rather than via a module-load side effect) is
-      // race-free with Onyx hydration, so a cold start never lands the home
-      // calendar on a month persisted from a previous session.
-      [ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE]: null,
       [ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT]: true,
       [ONYXKEYS.MODAL]: {
         isVisible: false,
@@ -58,6 +52,16 @@ export default function () {
       [ONYXKEYS.LAST_VISITED_PATH]: initializeLastVisitedPath(),
     },
   });
+
+  // Reset the calendar's cross-screen sync state on every cold launch so the home
+  // calendar always opens on the current month. These can't go in `initialKeyStates`
+  // above: Onyx drops `null` defaults (shouldRemoveNestedNulls), so a value persisted
+  // from a previous session would survive hydration. `Onyx.merge(key, null)` reads the
+  // stored value first, then removes it (delete + broadcast); `Onyx.set(key, null)`
+  // can't here, it no-ops on the empty pre-hydration cache. Running before the React
+  // tree mounts clears the value before any screen subscribes, so there's no flip.
+  Onyx.merge(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
+  Onyx.merge(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED, null);
 
   Device.setDeviceID();
 

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,5 +1,6 @@
 import {I18nManager} from 'react-native';
 import Onyx from 'react-native-onyx';
+import * as Calendar from '@userActions/Calendar';
 import * as Device from '@userActions/Device';
 import * as Subscriptions from '@userActions/Subscriptions';
 import CONST from '@src/CONST';
@@ -54,14 +55,12 @@ export default function () {
   });
 
   // Reset the calendar's cross-screen sync state on every cold launch so the home
-  // calendar always opens on the current month. These can't go in `initialKeyStates`
+  // calendar always opens on the current month. Can't go in `initialKeyStates`
   // above: Onyx drops `null` defaults (shouldRemoveNestedNulls), so a value persisted
-  // from a previous session would survive hydration. `Onyx.merge(key, null)` reads the
-  // stored value first, then removes it (delete + broadcast); `Onyx.set(key, null)`
-  // can't here, it no-ops on the empty pre-hydration cache. Running before the React
-  // tree mounts clears the value before any screen subscribes, so there's no flip.
-  Onyx.merge(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
-  Onyx.merge(ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED, null);
+  // from a previous session would survive hydration. The action uses `Onyx.merge`,
+  // which clears the persisted value; running here (before the React tree mounts)
+  // clears it before any screen subscribes, so there's no month flip.
+  Calendar.resetCalendarStateForColdLaunch();
 
   Device.setDeviceID();
 


### PR DESCRIPTION
### Details

On a cold launch the Home (and Profile) calendar must always show the **current month**, regardless of where the user was when they last closed the app. In practice it sometimes opened on a *past* month.

**Root cause** (verified against `react-native-onyx@3.0.15` source): the compact calendar's remembered month is the persisted Onyx key `NVP_LAST_VIEWED_CALENDAR_DATE` (written, debounced, while scrolling the enlarged calendar / day overview). The intended cold-boot reset lived in `Onyx.init()`'s `initialKeyStates` as `[KEY]: null` — but that is a **silent no-op**. `initializeWithDefaultKeyStates()` merges defaults via `fastMerge(storageData, defaults, {shouldRemoveNestedNulls: true})`, and that flag makes the merge **drop** any null-valued default. So the `null` neither overwrites nor deletes the stored value; the persisted date survives hydration and is delivered to `useOnyx`, forcing the past month.

**Fix**: replace the ineffective `initialKeyStates` entries with an explicit `Onyx.merge(KEY, null)` right after `Onyx.init()` in `src/setup/index.ts`. Unlike `Onyx.set(KEY, null)` (which no-ops on the empty pre-hydration cache), `merge` calls `get(key)` first (loads storage → cache) then `remove(key)` (delete + broadcast `undefined`) because the final change is `null`. Running at module load — before the React tree mounts — clears the value before any screen subscribes, so there is no visible month "flip".

The sibling key `SESSIONS_CALENDAR_MONTHS_LOADED` had the identical latent no-op (it only sizes the data-load window, not the visible month) and is cleared the same way for consistency.

No screen-level changes: `HomeScreen` / `ProfileScreen` derive `visibleDate = lastViewedCalendarDate ? <that month> : today`, which is correct once the persisted value is actually cleared.

Files:
- `src/setup/index.ts` — drop the two no-op `null` `initialKeyStates` entries; add `Onyx.merge(..., null)` resets after `Onyx.init`.
- `src/libs/actions/App.ts` — correct the stale doc comment on `clearLastViewedCalendarDate` that referenced the (ineffective) `initialKeyStates` reset.

### Tests

1. From Home, open the enlarged/fullscreen calendar and scroll back to a past month (or open a day-overview for a past day) so `NVP_LAST_VIEWED_CALENDAR_DATE` is persisted.
2. Back out to Home and verify the compact calendar syncs to that month (in-session behavior must still work).
3. Force-quit and cold-launch the app.
4. Verify Home opens on the **current month** (before this PR it opened on the past month).
5. Repeat the in-session scroll-sync after relaunch to confirm it still works — only the cross-launch leak is removed.

Dev shortcut to seed the bug without scrolling: set `NVP_LAST_VIEWED_CALENDAR_DATE` to a past date (e.g. `'2026-03-15'`) in Onyx, reload, and verify Home still shows the current month.

- [ ] Verify that no errors appear in the JS console

### Offline tests

The reset is a local Onyx operation with no network dependency. Cold-launch the app while offline and verify the calendar still opens on the current month and in-session scroll-sync still works.

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Browse a past month via the enlarged calendar so the app remembers it.
2. Fully close the app (swipe away), then reopen it.
3. Verify the Home calendar shows the current month, not the previously browsed one.
4. Repeat on both Android and iOS.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what"
- [x] I verified all code is DRY
- [ ] I ran the tests on **all platforms** & verified they passed on Android / iOS (pending on-device verification)

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- pending on-device capture -->

</details>

<details>
<summary>iOS</summary>

<!-- pending on-device capture -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)