### PR TITLE
fix(calendar): allow tapping pre-tracking days to add past sessions

### DIFF
--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -10,13 +10,21 @@ function DayComponent({
   units,
   marking,
   theme, // eslint-disable-line @typescript-eslint/no-unused-vars
+  trackingStartDate,
   onPress,
   onLongPress,
 }: DayComponentProps) {
   const StyleUtils = useStyleUtils();
+  // `isDisabled` gates clickability — set only for out-of-range days (future
+  // days, via the calendar's maxDate). `isBeforeTracking` is a styling-only
+  // signal for days before the user started tracking: those stay clickable so
+  // the user can add a past session, but render dimmed like future days.
   const isDisabled = state === 'disabled';
+  const isBeforeTracking =
+    !!trackingStartDate && !!date && date.dateString < trackingStartDate;
+  const isDimmed = isDisabled || isBeforeTracking;
   const unitsText =
-    !isDisabled && units !== undefined && units > 0
+    !isDimmed && units !== undefined && units > 0
       ? (Number.isInteger(units) ? units : units.toFixed(1)).toString()
       : '';
 
@@ -28,14 +36,11 @@ function DayComponent({
         onPress={() => onPress && date && onPress(date)}
         onLongPress={onLongPress ? () => date && onLongPress(date) : undefined}>
         <View
-          style={StyleUtils.getSessionsCalendarDayCellStyle(
-            marking,
-            isDisabled,
-          )}>
+          style={StyleUtils.getSessionsCalendarDayCellStyle(marking, isDimmed)}>
           <Text
             style={StyleUtils.getSessionsCalendarDayLabelStyle(
               marking,
-              isDisabled,
+              isDimmed,
             )}>
             {date?.day}
           </Text>

--- a/src/components/SessionsCalendar/DayComponent/types.ts
+++ b/src/components/SessionsCalendar/DayComponent/types.ts
@@ -11,6 +11,10 @@ type DayComponentProps = {
   units?: number;
   marking?: MarkingProps;
   theme?: Theme;
+  /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed (like
+   *  future days) but stay clickable, so the user can still add a past session.
+   *  Styling-only — never gates the press. */
+  trackingStartDate?: string;
   onPress?: (day: DateData) => void;
   onLongPress?: (day: DateData) => void;
 };

--- a/src/components/SessionsCalendar/SessionsCalendarView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarView.tsx
@@ -49,6 +49,11 @@ type SessionsCalendarViewProps = {
   /** Latest selectable date (defaults to today) */
   maxDate?: string;
 
+  /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed (like
+   *  future days) but stay clickable. Styling-only — distinct from `minDate`,
+   *  which gates clickability/navigation. */
+  trackingStartDate?: string;
+
   /** Tapped-day handler; omit to make the calendar non-interactive */
   onDayPress?: (day: DateData) => void;
 
@@ -95,6 +100,7 @@ function SessionsCalendarView({
   visibleDate,
   minDate,
   maxDate,
+  trackingStartDate,
   onDayPress,
   onDayLongPress,
   onLeftArrowPress,
@@ -125,11 +131,12 @@ function SessionsCalendarView({
         units={date ? unitsMap.get(date.dateString as DateString) : 0}
         marking={marking}
         theme={dayTheme}
+        trackingStartDate={trackingStartDate}
         onPress={onDayPress}
         onLongPress={onDayLongPress}
       />
     ),
-    [unitsMap, onDayPress, onDayLongPress],
+    [unitsMap, trackingStartDate, onDayPress, onDayLongPress],
   );
 
   // Custom header: matches the default month-text styling but reserves space

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -49,6 +49,9 @@ type SessionsCalendarWeekListViewProps = {
   monthlyTotalsMap: Map<string, number>;
   /** Earliest day currently loaded (drives the bottom of the list). */
   loadedFromDate: Date | null;
+  /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed but stay
+   *  clickable. Styling-only; the parent decides how far the list renders. */
+  trackingStartDate?: string;
   /** Latest day to render (defaults to today). */
   endDate?: Date;
   /** True while the data fetcher is widening the loaded window. The view
@@ -108,6 +111,7 @@ function SessionsCalendarWeekListView({
   unitsMap,
   monthlyTotalsMap,
   loadedFromDate,
+  trackingStartDate,
   endDate,
   isFetchingOlderMonths,
   onDayPress,
@@ -361,6 +365,7 @@ function SessionsCalendarWeekListView({
           row={args.item.row}
           markedDates={markedDates}
           unitsMap={unitsMap}
+          trackingStartDate={trackingStartDate}
           onDayPress={onDayPress}
           onDayLongPress={onDayLongPress}
         />
@@ -370,6 +375,7 @@ function SessionsCalendarWeekListView({
       markedDates,
       unitsMap,
       monthlyTotalsMap,
+      trackingStartDate,
       onDayPress,
       onDayLongPress,
       translate,

--- a/src/components/SessionsCalendar/WeekRow.tsx
+++ b/src/components/SessionsCalendar/WeekRow.tsx
@@ -13,6 +13,9 @@ type WeekRowProps = {
   row: MonthWeek;
   markedDates: MarkedDates;
   unitsMap: Map<DateString, number>;
+  /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed but stay
+   *  clickable. Styling-only. */
+  trackingStartDate?: string;
   onDayPress?: (day: DateData) => void;
   onDayLongPress?: (day: DateData) => void;
 };
@@ -43,6 +46,7 @@ function WeekRow({
   row,
   markedDates,
   unitsMap,
+  trackingStartDate,
   onDayPress,
   onDayLongPress,
 }: WeekRowProps) {
@@ -67,6 +71,7 @@ function WeekRow({
               date={dayKeyToDateData(dayKey)}
               units={unitsMap.get(dayKey)}
               marking={marking}
+              trackingStartDate={trackingStartDate}
               onPress={onDayPress}
               onLongPress={onDayLongPress}
             />

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -254,7 +254,6 @@ function SessionsCalendar({
   useEffect(() => {
     if (mode === 'compact') {
       hasPrefetchedRef.current = false;
-      setRenderFromDate(null);
       return;
     }
     if (hasPrefetchedRef.current) {

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -52,6 +52,12 @@ const LOAD_AHEAD_BUFFER_MONTHS = 6;
 // is idempotent — a no-op if the persisted depth is already deeper.
 const INITIAL_PREFETCH_MONTHS = 12;
 
+// Once the fullscreen list has scrolled past the earliest-tracked floor there
+// is no more data to fetch (those months are empty), but the user may still
+// want to scroll into them to add a past session. Extend the *rendered* range
+// by this many months at a time as they approach the top — no fetch involved.
+const RENDER_AHEAD_MONTHS = 12;
+
 function SessionsCalendar({
   userID,
   visibleDate,
@@ -163,6 +169,31 @@ function SessionsCalendar({
     [minDate],
   );
 
+  // Absolute floor for navigation/rendering — the product's 20-year horizon.
+  // Bounds how far the compact calendar can page and the fullscreen list can
+  // scroll into empty pre-tracking months, so neither can run away to year 1.
+  const absoluteFloor = useMemo(
+    () => startOfMonth(CONST.CALENDAR_PICKER.MIN_DATE),
+    [],
+  );
+
+  // Fullscreen-only render floor, decoupled from the data floor. The data
+  // floor (`loadedFromDate`, capped at the earliest tracked month) governs
+  // what's *fetched*; this governs what's *rendered*. It extends past the data
+  // floor as the user scrolls toward the top, letting them reach pre-tracking
+  // days (which render blank/dimmed — no fetch) down to `absoluteFloor`.
+  const [renderFromDate, setRenderFromDate] = useState<Date | null>(null);
+  const fullscreenRenderFrom = useMemo(() => {
+    if (!loadedFromDate) {
+      return loadedFromDate;
+    }
+    const candidate =
+      renderFromDate && renderFromDate < loadedFromDate
+        ? renderFromDate
+        : loadedFromDate;
+    return candidate < absoluteFloor ? absoluteFloor : candidate;
+  }, [loadedFromDate, renderFromDate, absoluteFloor]);
+
   // Whether there is older data still to load — drives the day-list's load
   // trigger and its "loading older" header. Once the loaded floor reaches the
   // earliest tracked month there is nothing more to fetch.
@@ -177,7 +208,26 @@ function SessionsCalendar({
   const handleRequestOlder = (earliestVisible: Date) => {
     const floor = loadedFrom?.current ?? new Date();
     if (floor.getTime() <= minDateFloor.getTime()) {
-      // Already loaded back to the earliest tracked month — nothing more.
+      // Already loaded back to the earliest tracked month — there is no more
+      // data to fetch. In fullscreen, keep widening the *rendered* range so the
+      // user can scroll into the empty pre-tracking months (to add a past
+      // session); those render blank/dimmed for free. Walls at `absoluteFloor`.
+      if (mode === 'fullscreen') {
+        setRenderFromDate(prev => {
+          const current = prev ?? loadedFromDate ?? new Date();
+          if (current.getTime() <= absoluteFloor.getTime()) {
+            return prev;
+          }
+          let next = startOfMonth(
+            subMonths(earliestVisible, RENDER_AHEAD_MONTHS),
+          );
+          if (next < absoluteFloor) {
+            next = absoluteFloor;
+          }
+          // Monotonic — only ever grow older.
+          return !prev || next < prev ? next : prev;
+        });
+      }
       return;
     }
     let target = computeLoadTarget(
@@ -204,6 +254,7 @@ function SessionsCalendar({
   useEffect(() => {
     if (mode === 'compact') {
       hasPrefetchedRef.current = false;
+      setRenderFromDate(null);
       return;
     }
     if (hasPrefetchedRef.current) {
@@ -330,7 +381,8 @@ function SessionsCalendar({
           markedDates={markedDates}
           unitsMap={unitsMap}
           monthlyTotalsMap={monthlyTotalsMap}
-          loadedFromDate={loadedFromDate}
+          loadedFromDate={fullscreenRenderFrom}
+          trackingStartDate={minDate}
           isFetchingOlderMonths={isFetchingOlderMonths}
           onDayPress={onDayPress}
           onDayLongPress={dayLongPressHandler}
@@ -351,7 +403,8 @@ function SessionsCalendar({
         markedDates={markedDates}
         unitsMap={unitsMap}
         visibleDate={visibleDate}
-        minDate={minDate}
+        minDate={format(absoluteFloor, CONST.DATE.CALENDAR_FORMAT)}
+        trackingStartDate={minDate}
         onDayPress={onDayPress}
         onDayLongPress={dayLongPressHandler}
         onLeftArrowPress={handleLeftArrowPress}

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1386,7 +1386,7 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
    */
   getSessionsCalendarDayCellStyle: (
     marking: MarkingProps | undefined,
-    isDisabled: boolean,
+    isDimmed: boolean,
   ): ViewStyle => {
     const markingColor = marking?.color;
     // Every marked tile gets a 1px border derived from its own swatch, shifted
@@ -1406,7 +1406,7 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: markingColor ?? 'transparent',
-      opacity: isDisabled ? 0.35 : 1,
+      opacity: isDimmed ? 0.35 : 1,
     };
   },
 
@@ -1420,14 +1420,14 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
    */
   getSessionsCalendarDayLabelStyle: (
     marking: MarkingProps | undefined,
-    isDisabled: boolean,
+    isDimmed: boolean,
   ): TextStyle => {
     const markingColor = marking?.color;
     const isLightColor = !!markingColor && isLightHex(markingColor);
     let textColor: Color;
     if (!markingColor) {
       textColor = theme.textSupporting;
-    } else if (isDisabled) {
+    } else if (isDimmed) {
       textColor = theme.textMutedReversed;
     } else if (isLightColor) {
       textColor = theme.textDark;


### PR DESCRIPTION
## What

Pre-tracking calendar day tiles (days before the user's earliest recorded session) were non-clickable, identical to future days. Future days *should* stay disabled, but past empty days are valid targets for adding a session and should be selectable.

This separates the two concerns that were previously conflated into one signal:

- **Clickability** is now governed *only* by the "after today" check (`maxDate`).
- **Dimming** is governed by a new styling-only `trackingStartDate` prop, so pre-tracking days look identical to future days (dimmed, no units number) but stay tappable.

## Why

The orchestrator fed a session-derived `minDate` into `react-native-calendars`, which marks everything outside `[minDate, today]` as `state==='disabled'` — gating both the press *and* the dimming. A user with only one recorded day couldn't tap any earlier day to log a past session.

## Changes

- **`DayComponent`** — `disabled` keyed on `isDisabled` (future) alone; new `isBeforeTracking` feeds `isDimmed = isDisabled || isBeforeTracking` for visuals only.
- **Style utils** — renamed the `isDisabled` param to `isDimmed` in the two calendar day-style helpers (they only ever drove opacity/label color, never touch).
- **Compact mode** — `minDate` is now a fixed 20-year `absoluteFloor` (`CONST.CALENDAR_PICKER.MIN_DATE`), which also lifts the swipe/arrow navigation wall at the tracking start. `trackingStartDate` is passed for dimming.
- **Fullscreen mode** — a `renderFromDate` state decouples the *render floor* from the *data floor*. Past the earliest tracked month, `handleRequestOlder` stops fetching (those months are empty) but keeps widening the rendered range 12 months at a time as the user scrolls, walled at the 20-year floor. `trackingStartDate` threads through `WeekListView → WeekRow → DayComponent`.

## Out of scope / reviewer notes

- **`useLazyMarkedDates.ts` is intentionally untouched.** Its cap at the tracking start is what keeps untracked days free of green "alcohol-free" dots; widening only the *render* range never adds marking entries, so pre-tracking days render blank for free.
- **`dayList` mode is unaffected** — it renders session tiles, not empty cells; the render-extension branch is gated to `fullscreen`.
- **Follow-up:** when a user saves a session on a now-tappable pre-tracking day, `earliest_session_at` should move earlier (shrinking the dimmed band). That recompute lives in the session write path and is a separate change to verify after this lands.

## Verification

- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed (7 files)
- Prettier applied
- Manual: compact (Home/Profile) page-back past earliest month → dimmed-but-tappable; fullscreen scroll past earliest month → blank/dimmed, no spinner, no green dots, stops near 20y; dayList unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)