### PR TITLE
fix(profile): don't fetch own sessions through the friend endpoint

### DIFF
--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -24,6 +24,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 import useFriendProfile from '@hooks/useFriendProfile';
 import useFriendPreferences from '@hooks/useFriendPreferences';
+import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useDrinkingSessionsFetch from '@hooks/useDrinkingSessionsFetch';
 import useUserMonthlyStats from '@hooks/useUserMonthlyStats';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -57,11 +58,22 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const StyleUtils = useStyleUtils();
   const {userData, isLoading: isProfileFetchLoading} = useFriendProfile(userID);
   const {preferences, isLoading: isPrefsLoading} = useFriendPreferences(userID);
+  // Own sessions come straight off the app/open snapshot in Onyx; the windowed
+  // friend fetch runs only for other users' profiles (an empty userID is a
+  // no-op, matching SessionsCalendarScreen / DayOverviewScreen).
+  const currentUserSessions = useCurrentUserDrinkingSessions();
   const {
-    data: drinkingSessionData,
-    isLoading: isSessionsLoading,
-    isFetchingOlderMonths,
-  } = useDrinkingSessionsFetch(userID);
+    data: friendSessionData,
+    isLoading: isFriendSessionsLoading,
+    isFetchingOlderMonths: isFetchingFriendOlderMonths,
+  } = useDrinkingSessionsFetch(isSelf ? '' : userID);
+  const drinkingSessionData = isSelf ? currentUserSessions : friendSessionData;
+  const isSessionsLoading = isSelf
+    ? currentUserSessions === undefined
+    : isFriendSessionsLoading;
+  // Self widening needs no fetch — the full own-session snapshot is already
+  // cached, so older months are indexed locally.
+  const isFetchingOlderMonths = isSelf ? false : isFetchingFriendOlderMonths;
   const isLoading =
     isProfileFetchLoading || isPrefsLoading || isSessionsLoading;
   // Defer the (heavy) calendar mount until after the navigation slide. The


### PR DESCRIPTION
## Problem

`ProfileScreen` was the only screen calling `useDrinkingSessionsFetch(userID)` without the `isSelf ? '' : userID` guard that `SessionsCalendarScreen` and `DayOverviewScreen` use. Visiting your own profile therefore re-fetched your own sessions through the friend endpoint (`GET /v1/users/:uid/sessions`) and rendered the calendar from that windowed snapshot, instead of the authoritative `app/open` snapshot already in Onyx.

Found while investigating the "active session shows as the only calendar entry" bug — this isn't its root cause, but it's the one screen that diverged from the self/friend split pattern.

## Fix

Mirror the sibling screens: source sessions from `useCurrentUserDrinkingSessions()` when viewing yourself, and run the windowed friend fetch only for other users' profiles (an empty `userID` is a no-op for the hook). `isSessionsLoading` derives from snapshot presence for self, and `isFetchingOlderMonths` is `false` for self since the full own-session snapshot is already cached.

## Testing

- `npm run typecheck-tsgo` ✅
- `npm run lint-changed` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)