### PR TITLE
feat(signup): ambient shimmer idle loop on the InitialScreen logo

### DIFF
--- a/__tests__/unit/components/KirokuLogo.test.tsx
+++ b/__tests__/unit/components/KirokuLogo.test.tsx
@@ -2,10 +2,20 @@
 import {render} from '@testing-library/react-native';
 import React from 'react';
 import AnimatedKirokuLogoSvg from '@components/KirokuLogo/AnimatedKirokuLogoSvg';
+import {SHIMMER_SWEEP_FRACTION} from '@components/KirokuLogo/animationTimings';
 import KirokuLogoSvg from '@components/KirokuLogo/KirokuLogoSvg';
 import buildWavePathD from '@components/KirokuLogo/liquidWave';
 import {LOGO_SHAPES} from '@components/KirokuLogo/logoShapes';
+import getShimmerBandX, {
+  SHIMMER_TRAVEL_END,
+  SHIMMER_TRAVEL_START,
+} from '@components/KirokuLogo/shimmerBand';
 import CONST from '@src/CONST';
+
+// Handle to the mutable reduced-motion flag inside the Reanimated mock factory.
+// Annotated (not asserted) so jest.requireMock infers the type without a cast.
+const reanimatedMock: {setReduceMotion: (value: boolean) => void} =
+  jest.requireMock('react-native-reanimated');
 
 // A self-contained Reanimated mock: just enough surface for the animated logo
 // (+ animationTimings' Easing composition). We deliberately do NOT
@@ -22,8 +32,15 @@ jest.mock('react-native-reanimated', () => {
     Record<string, unknown>
   >((props, ref) => ReactLocal.createElement(View, {...props, ref}));
 
+  // Mutable so a test can flip into the reduced-motion (settled) branch; lives
+  // inside the factory closure to dodge jest.mock hoisting / TDZ.
+  const motionState = {reduceMotion: false};
+
   return {
     __esModule: true,
+    setReduceMotion: (value: boolean) => {
+      motionState.reduceMotion = value;
+    },
     default: {
       View: PassthroughView,
       createAnimatedComponent: (c: unknown) => c,
@@ -39,7 +56,8 @@ jest.mock('react-native-reanimated', () => {
     withTiming: (toValue: unknown) => toValue,
     withRepeat: (toValue: unknown) => toValue,
     cancelAnimation: () => {},
-    useReducedMotion: () => false,
+    runOnJS: (fn: unknown) => fn,
+    useReducedMotion: () => motionState.reduceMotion,
     interpolate: (
       value: number,
       [inMin, inMax]: number[],
@@ -60,6 +78,13 @@ jest.mock('react-native-reanimated', () => {
     },
   };
 });
+
+// AnimatedKirokuLogoSvg reads useIsFocused to pause the shimmer behind other
+// screens; standalone renders have no navigation container, so stub it focused.
+jest.mock('@react-navigation/native', () => ({
+  __esModule: true,
+  useIsFocused: () => true,
+}));
 
 // The mark's six shapes. The stem and baseline entries are the axis-aligned
 // path conversions of the rotated <rect>s in the master art — this literal
@@ -124,6 +149,38 @@ describe('buildWavePathD', () => {
   });
 });
 
+describe('getShimmerBandX', () => {
+  // The visible sweep sits at the END of the loop, so the first shimmer lands a
+  // full interval after the entrance settles (not on top of the fill).
+  const sweepStartPhase = 1 - SHIMMER_SWEEP_FRACTION;
+
+  it('parks the band off the left edge at the start of the loop', () => {
+    expect(getShimmerBandX(0)).toBe(SHIMMER_TRAVEL_START);
+  });
+
+  it('keeps the band parked off the left edge through the whole dwell', () => {
+    // Everything before the sweep window is dwell: no visible motion.
+    expect(getShimmerBandX(0.25)).toBe(SHIMMER_TRAVEL_START);
+    expect(getShimmerBandX(sweepStartPhase / 2)).toBe(SHIMMER_TRAVEL_START);
+    expect(getShimmerBandX(sweepStartPhase)).toBe(SHIMMER_TRAVEL_START);
+  });
+
+  it('reaches the right edge exactly at the end of the loop', () => {
+    expect(getShimmerBandX(1)).toBe(SHIMMER_TRAVEL_END);
+  });
+
+  it('advances monotonically across the visible sweep window', () => {
+    const samples = [0, 0.25, 0.5, 0.75, 1].map(t =>
+      getShimmerBandX(sweepStartPhase + t * SHIMMER_SWEEP_FRACTION),
+    );
+    expect(samples[0]).toBe(SHIMMER_TRAVEL_START);
+    expect(samples[samples.length - 1]).toBe(SHIMMER_TRAVEL_END);
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThan(samples[i - 1]);
+    }
+  });
+});
+
 describe('KirokuLogoSvg', () => {
   it('renders exactly the six logo shapes on production (no badge)', () => {
     const {toJSON} = render(
@@ -170,5 +227,47 @@ describe('AnimatedKirokuLogoSvg', () => {
       />,
     );
     expect(toJSON()).toBeTruthy();
+  });
+
+  it('mounts the ambient shimmer layer when motion is allowed', () => {
+    const {toJSON} = render(
+      <AnimatedKirokuLogoSvg
+        fill="#000000"
+        liquidColor="#F5C400"
+        environment={CONST.ENVIRONMENT.PROD}
+        shouldStart
+      />,
+    );
+    // react-native-svg surfaces an element's `id` as a `name` prop, so the
+    // shimmer's gradient/clip defs are detectable by their unique id prefix.
+    const names = collectProp(toJSON() as RenderedNode, 'name').filter(
+      (value): value is string => typeof value === 'string',
+    );
+    expect(names.some(n => n.includes('kirokuLogoShimmer'))).toBe(true);
+  });
+
+  it('renders the settled logo with no shimmer under reduced motion', () => {
+    reanimatedMock.setReduceMotion(true);
+    try {
+      const {toJSON} = render(
+        <AnimatedKirokuLogoSvg
+          fill="#000000"
+          liquidColor="#F5C400"
+          environment={CONST.ENVIRONMENT.PROD}
+          shouldStart
+        />,
+      );
+      const tree = toJSON() as RenderedNode;
+      // The settled mark still draws all six shapes...
+      const ds = collectProp(tree, 'd');
+      EXPECTED_SHAPES.forEach(d => expect(ds).toContain(d));
+      // ...but the shimmer layer is absent entirely.
+      const names = collectProp(tree, 'name').filter(
+        (value): value is string => typeof value === 'string',
+      );
+      expect(names.some(n => n.includes('kirokuLogoShimmer'))).toBe(false);
+    } finally {
+      reanimatedMock.setReduceMotion(false);
+    }
   });
 });

--- a/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
+++ b/src/components/KirokuLogo/AnimatedKirokuLogoSvg.tsx
@@ -1,8 +1,10 @@
-import React, {useEffect, useRef} from 'react';
+import {useIsFocused} from '@react-navigation/native';
+import React, {useEffect, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {
   cancelAnimation,
   Easing,
+  runOnJS,
   useReducedMotion,
   useSharedValue,
   withRepeat,
@@ -11,10 +13,15 @@ import {
 import Svg from 'react-native-svg';
 import type Environment from '@libs/Environment/getEnvironment/types';
 import AnimatedLogoShape from './AnimatedLogoShape';
-import {TOTAL_DURATION_MS, WAVE_PERIOD_MS} from './animationTimings';
+import {
+  SHIMMER_PERIOD_MS,
+  TOTAL_DURATION_MS,
+  WAVE_PERIOD_MS,
+} from './animationTimings';
 import LiquidFill from './LiquidFill';
 import LogoBadge from './LogoBadge';
 import {LOGO_CANVAS, LOGO_SHAPES} from './logoShapes';
+import ShimmerSweep from './ShimmerSweep';
 
 type AnimatedKirokuLogoSvgProps = {
   /** Fill color of the mark (theme.appLogo) */
@@ -45,8 +52,10 @@ const styles = StyleSheet.create({
 /**
  * Animated variant of the logo: the six shapes stagger in as a faint ghost,
  * a liquid with a waving surface fills the silhouette, and a final crossfade
- * solidifies the mark. Settles to the exact render output of the static
- * KirokuLogoSvg (full opacity, fill = theme.appLogo, no liquid).
+ * solidifies the mark. Once settled, a subtle brand-yellow shimmer sweeps
+ * across the resting mark on a long loop. Settles to the exact render output of
+ * the static KirokuLogoSvg (full opacity, fill = theme.appLogo, no liquid) and,
+ * between shimmer sweeps, is pixel-identical to it.
  */
 function AnimatedKirokuLogoSvg({
   fill,
@@ -55,13 +64,20 @@ function AnimatedKirokuLogoSvg({
   shouldStart,
 }: AnimatedKirokuLogoSvgProps) {
   const reduceMotion = useReducedMotion();
+  const isFocused = useIsFocused();
   // With reduced motion the timeline starts (and stays) settled.
   const progress = useSharedValue(reduceMotion ? 1 : 0);
   // Repeating 0–1 phase for the wave surface; only oscillates while the
   // master timeline runs, then is cancelled so the settled logo costs nothing
   // per frame.
   const wavePhase = useSharedValue(0);
+  // Repeating 0–1 phase for the ambient shimmer; only runs once the entrance
+  // has settled and the screen is focused (see the effect below).
+  const shimmerPhase = useSharedValue(0);
   const hasStarted = useRef(false);
+  // Flipped true when the master timeline finishes, gating the shimmer so it
+  // never plays over the entrance. Set from the timing's completion callback.
+  const [hasSettled, setHasSettled] = useState(false);
 
   useEffect(() => {
     if (shouldStart && !reduceMotion && !hasStarted.current) {
@@ -72,8 +88,10 @@ function AnimatedKirokuLogoSvg({
         {duration: TOTAL_DURATION_MS, easing: Easing.linear},
         () => {
           cancelAnimation(wavePhase);
+          runOnJS(setHasSettled)(true);
         },
       );
+      // eslint-disable-next-line react-compiler/react-compiler
       wavePhase.value = withRepeat(
         withTiming(1, {duration: WAVE_PERIOD_MS, easing: Easing.linear}),
         -1,
@@ -84,6 +102,27 @@ function AnimatedKirokuLogoSvg({
       cancelAnimation(wavePhase);
     };
   }, [shouldStart, reduceMotion, progress, wavePhase]);
+
+  // Ambient shimmer loop. Runs only after the entrance settles and only while
+  // the screen is focused: navigating InitialScreen → AuthScreen pushes over
+  // this screen without unmounting it, so an always-on loop would keep burning
+  // frames behind AuthScreen. Cancelled on blur and on unmount, mirroring the
+  // wavePhase lifecycle. Restarts from a clean sweep when focus returns.
+  useEffect(() => {
+    if (reduceMotion || !hasSettled || !isFocused) {
+      return undefined;
+    }
+    // eslint-disable-next-line react-compiler/react-compiler
+    shimmerPhase.value = 0;
+    // eslint-disable-next-line react-compiler/react-compiler
+    shimmerPhase.value = withRepeat(
+      withTiming(1, {duration: SHIMMER_PERIOD_MS, easing: Easing.linear}),
+      -1,
+    );
+    return () => {
+      cancelAnimation(shimmerPhase);
+    };
+  }, [reduceMotion, hasSettled, isFocused, shimmerPhase]);
 
   return (
     <View style={styles.container}>
@@ -101,6 +140,9 @@ function AnimatedKirokuLogoSvg({
         progress={progress}
         wavePhase={wavePhase}
       />
+      {!reduceMotion && (
+        <ShimmerSweep color={liquidColor} shimmerPhase={shimmerPhase} />
+      )}
       <Svg
         width="100%"
         height="100%"

--- a/src/components/KirokuLogo/ShimmerSweep.tsx
+++ b/src/components/KirokuLogo/ShimmerSweep.tsx
@@ -1,0 +1,91 @@
+import React, {useId} from 'react';
+import {StyleSheet} from 'react-native';
+import type {SharedValue} from 'react-native-reanimated';
+import Animated, {useAnimatedProps} from 'react-native-reanimated';
+import Svg, {
+  ClipPath,
+  Defs,
+  LinearGradient,
+  Path,
+  Rect,
+  Stop,
+} from 'react-native-svg';
+import {SHIMMER_BAND_WIDTH, SHIMMER_PEAK_OPACITY} from './animationTimings';
+import {LOGO_CANVAS, LOGO_SHAPES} from './logoShapes';
+import getShimmerBandX, {
+  SHIMMER_BAND_HEIGHT,
+  SHIMMER_BAND_Y,
+} from './shimmerBand';
+
+const AnimatedRect = Animated.createAnimatedComponent(Rect);
+
+type ShimmerSweepProps = {
+  /** Highlight color (theme.success brand yellow) */
+  color: string;
+
+  /** Repeating 0–1 loop phase driving the sweep */
+  shimmerPhase: SharedValue<number>;
+};
+
+/**
+ * Ambient idle shimmer: a soft brand-yellow gradient band, clipped to the logo
+ * silhouette, that sweeps diagonally across the resting mark each loop. The
+ * gradient lives in the band's own bounding box (the default objectBoundingBox
+ * units) so it travels with the Rect, and the diagonal 0,0→1,1 axis paints the
+ * highlight as a tilted stripe (transparent edges, brand yellow at the center).
+ *
+ * Only the Rect's `x` animates — a direct native prop that is Fabric-safe,
+ * unlike an SVG transform, which exposes no translate to Fabric (see
+ * AnimatedLogoShape / LiquidFill). When the band parks off-screen during the
+ * dwell, nothing renders, so the settled frame stays pixel-identical to the
+ * static logo.
+ */
+function ShimmerSweep({color, shimmerPhase}: ShimmerSweepProps) {
+  // Unique per mount so a second logo on screen (or web's document-global DOM
+  // ids) can't collide; sanitized like LiquidFill's clip id.
+  const idSuffix = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const clipPathId = `kirokuLogoShimmerClip-${idSuffix}`;
+  const gradientId = `kirokuLogoShimmerGradient-${idSuffix}`;
+
+  const animatedProps = useAnimatedProps(() => ({
+    x: getShimmerBandX(shimmerPhase.value),
+  }));
+
+  return (
+    <Svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${LOGO_CANVAS} ${LOGO_CANVAS}`}
+      style={StyleSheet.absoluteFill}
+      pointerEvents="none">
+      <Defs>
+        <ClipPath id={clipPathId}>
+          {LOGO_SHAPES.map(d => (
+            <Path key={d} d={d} />
+          ))}
+        </ClipPath>
+        <LinearGradient id={gradientId} x1={0} y1={0} x2={1} y2={1}>
+          <Stop offset={0} stopColor={color} stopOpacity={0} />
+          <Stop
+            offset={0.5}
+            stopColor={color}
+            stopOpacity={SHIMMER_PEAK_OPACITY}
+          />
+          <Stop offset={1} stopColor={color} stopOpacity={0} />
+        </LinearGradient>
+      </Defs>
+      <AnimatedRect
+        animatedProps={animatedProps}
+        y={SHIMMER_BAND_Y}
+        width={SHIMMER_BAND_WIDTH}
+        height={SHIMMER_BAND_HEIGHT}
+        fill={`url(#${gradientId})`}
+        clipPath={`url(#${clipPathId})`}
+      />
+    </Svg>
+  );
+}
+
+ShimmerSweep.displayName = 'ShimmerSweep';
+
+export default ShimmerSweep;

--- a/src/components/KirokuLogo/animationTimings.ts
+++ b/src/components/KirokuLogo/animationTimings.ts
@@ -39,6 +39,28 @@ const CROSSFADE_START_FRACTION = 2200 / TOTAL_DURATION_MS;
 /** Period of one full wave oscillation (drives the independent phase value) */
 const WAVE_PERIOD_MS = 1600;
 
+// Ambient idle shimmer: after the entrance settles, a soft brand-yellow band
+// sweeps diagonally across the resting mark on its own repeating phase value.
+// One loop = a long dwell with the band parked off-screen followed by a short
+// visible sweep, so it reads as a gentle premium accent, not a loader. The sweep
+// sits at the END of the loop, so the first shimmer lands a full interval after
+// the entrance settles rather than right on top of the liquid fill.
+/** Period of one full shimmer loop (dwell + visible sweep) */
+const SHIMMER_PERIOD_MS = 7000;
+/** Length of the visible sweep within a loop; the rest of the period is dwell */
+const SHIMMER_SWEEP_DURATION_MS = 1100;
+/**
+ * Fraction of the loop spent sweeping (at the loop's end). The dwell is baked
+ * into the band's interpolation (it parks off-screen for everything before the
+ * sweep) rather than a literal delay, so the shared value can repeat on a single
+ * uninterrupted timing.
+ */
+const SHIMMER_SWEEP_FRACTION = SHIMMER_SWEEP_DURATION_MS / SHIMMER_PERIOD_MS;
+/** Width of the gradient highlight band (viewBox units) */
+const SHIMMER_BAND_WIDTH = 460;
+/** Peak alpha of the brand-yellow highlight at the band's center */
+const SHIMMER_PEAK_OPACITY = 0.32;
+
 // Composed at module scope so the worklets below capture ready-made easing
 // functions instead of rebuilding them per frame.
 const SHAPE_OPACITY_EASING = Easing.out(Easing.quad);
@@ -68,6 +90,11 @@ export {
   LIQUID_SURFACE_END_Y,
   CROSSFADE_START_FRACTION,
   WAVE_PERIOD_MS,
+  SHIMMER_PERIOD_MS,
+  SHIMMER_SWEEP_DURATION_MS,
+  SHIMMER_SWEEP_FRACTION,
+  SHIMMER_BAND_WIDTH,
+  SHIMMER_PEAK_OPACITY,
   SHAPE_OPACITY_EASING,
   SHAPE_TRANSLATE_EASING,
   LIQUID_LEVEL_EASING,

--- a/src/components/KirokuLogo/shimmerBand.ts
+++ b/src/components/KirokuLogo/shimmerBand.ts
@@ -1,0 +1,43 @@
+import {SHIMMER_BAND_WIDTH, SHIMMER_SWEEP_FRACTION} from './animationTimings';
+import {LOGO_CANVAS} from './logoShapes';
+
+/** Top edge of the sweep band (viewBox units); sits just above the silhouette */
+const SHIMMER_BAND_Y = 110;
+/** Band height; spans the full silhouette (y 134–808) with margin top and bottom */
+const SHIMMER_BAND_HEIGHT = 800;
+/** The band parks fully off the left edge and sweeps off the right */
+const SHIMMER_TRAVEL_START = -SHIMMER_BAND_WIDTH;
+const SHIMMER_TRAVEL_END = LOGO_CANVAS;
+/** Loop phase at which the visible sweep begins (dwell occupies everything before) */
+const SHIMMER_SWEEP_START_PHASE = 1 - SHIMMER_SWEEP_FRACTION;
+
+/**
+ * Horizontal offset of the sweep band for a given loop phase (0–1). The band
+ * dwells parked off the left edge for the first (1 - SHIMMER_SWEEP_FRACTION) of
+ * the loop, then sweeps across to off the right edge during the final
+ * SHIMMER_SWEEP_FRACTION with a smoothstep ease. Putting the sweep at the *end*
+ * of the loop means the first shimmer lands a full interval after the entrance
+ * settles, rather than immediately on top of the liquid fill. The dwell is baked
+ * into this interpolation rather than implemented as a literal delay. Runs on the
+ * UI thread once per frame via useAnimatedProps, so it sticks to plain arithmetic
+ * (like buildWavePathD).
+ */
+function getShimmerBandX(phase: number): number {
+  'worklet';
+
+  const raw = (phase - SHIMMER_SWEEP_START_PHASE) / SHIMMER_SWEEP_FRACTION;
+  const sweep = Math.min(1, Math.max(0, raw));
+  // smoothstep: gentle ease-in-out so the band glides rather than starts hard.
+  const eased = sweep * sweep * (3 - 2 * sweep);
+  return (
+    SHIMMER_TRAVEL_START + (SHIMMER_TRAVEL_END - SHIMMER_TRAVEL_START) * eased
+  );
+}
+
+export default getShimmerBandX;
+export {
+  SHIMMER_BAND_HEIGHT,
+  SHIMMER_BAND_Y,
+  SHIMMER_TRAVEL_END,
+  SHIMMER_TRAVEL_START,
+};


### PR DESCRIPTION
## Summary

Phase 2 of the InitialScreen logo animation (follow-up to #1174 and #1175). Resolves #1176.

After the entrance + liquid fill sequence settles, the resting mark now gets a subtle, looping ambient shimmer: a soft brand-yellow (`theme.success`) gradient band sweeps diagonally across the logo on a long ~7s loop, then parks off-screen for the dwell. It reads as a gentle premium accent, not a loader.

- **`ShimmerSweep`** (new layer, next to `LiquidFill`): a gradient-filled `Rect` clipped to the logo silhouette. Reuses `LiquidFill`'s per-mount unique-`useId` clip pattern and the shared `logoShapes` geometry. The gradient lives in the band's own bounding box (objectBoundingBox units) so it travels with the `Rect` — only the `Rect`'s `x` animates, a direct native prop that is Fabric-safe, unlike an SVG transform (which exposes no translate to Fabric; see #1174). The diagonal `0,0→1,1` gradient axis paints the highlight as a tilted stripe with transparent edges.
- **Driver**: a new repeating `shimmerPhase` shared value in `AnimatedKirokuLogoSvg`, kicked off only *after* the master timeline completes (via the existing `withTiming` completion callback → `runOnJS`). The long dwell between sweeps is baked into the interpolation (`getShimmerBandX` parks the band off-screen past the sweep window) rather than a literal delay, so the value repeats on a single uninterrupted timing.
- **Pauses when not focused**: navigating InitialScreen → AuthScreen pushes over InitialScreen without unmounting it, so the loop would otherwise keep burning frames behind the login screen. `useIsFocused` cancels the loop on blur and restarts a clean sweep on focus. Cancelled on unmount too, mirroring the `wavePhase` lifecycle.
- **Reduced motion**: renders the settled mark with no shimmer at all. Between sweeps (and in the reduced-motion / static paths) the frame is pixel-identical to the static logo.
- New timing constants (period, sweep duration, gradient alpha, band width) live in `animationTimings.ts`.
- The geometry helper is named **`shimmerBand.ts`** (not `shimmerSweep.ts`) deliberately: a camelCase `shimmerSweep.ts` would collide with `ShimmerSweep.tsx` on case-insensitive filesystems (macOS), and `import ShimmerSweep from './ShimmerSweep'` would silently resolve to the helper. This mirrors the existing `LiquidFill.tsx` / `liquidWave.ts` split (distinct words).

## Testing

- `__tests__/unit/components/KirokuLogo.test.tsx` (extended): `getShimmerBandX` sweep math (off-left start, reaches the right edge at the end of the visible sweep, parks for the whole dwell, monotonic across the sweep); the shimmer layer mounts when motion is allowed; the reduced-motion branch renders the settled logo with no shimmer. The self-contained Reanimated mock gained `runOnJS` and a controllable `useReducedMotion`; `@react-navigation/native`'s `useIsFocused` is stubbed focused.
- `typecheck-tsgo`, `lint-changed`, `prettier`, `react-compiler-compliance-check check-changed`, and `jest` (13/13) all green.
- Web (dev server): the entrance plays and settles to the solid mark (pixel-identical to the static logo); the shimmer layer mounts with the expected gradient/clip and the loop starts once settled (`shimmerPhase` ticks past 0 → the band's `x` advances from `-460`). Navigating to the login screen renders the static logo (no second animated logo); navigating back restores InitialScreen and resets the sweep. No console errors.
  - Note: the headless preview throttles `requestAnimationFrame` when the tab isn't actively painting, so the literal mid-sweep highlight frame couldn't be filmed there; the sweep geometry and start/pause logic are covered by the unit tests. Worth an eyeball on the iOS simulator (Fabric) for the live sweep, same as the #1175 liquid note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)