### PR TITLE
fix(web): Phase 1 QA sweep — complete the logged-in screen walk + guard native BackHandler (#934)

### DIFF
--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -8,6 +8,7 @@ import type {DrinkingSession} from '@src/types/onyx';
 import DrinkTypesView from '@components/DrinkTypesView';
 import SessionDetailsWindow from '@components/SessionDetailsWindow';
 import FillerView from '@components/FillerView';
+import getPlatform from '@libs/getPlatform';
 import CONST from '@src/CONST';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
@@ -169,8 +170,13 @@ function DrinkingSessionWindow({
     setSessionColor(newSessionColor);
   }, [session?.drinks, preferences, totalUnits]);
 
-  // Make the system back press toggle the go back handler
+  // Make the system back press toggle the go back handler. BackHandler is a
+  // native-only API; on web it warns and no-ops, so skip it (web uses the
+  // browser back button / Escape instead).
   useEffect(() => {
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       handleBackPress();
       return true; // Prevent the event from bubbling up and being handled by the default handler

--- a/src/components/OnboardingScreenLayout/index.tsx
+++ b/src/components/OnboardingScreenLayout/index.tsx
@@ -13,6 +13,8 @@ import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
+import getPlatform from '@libs/getPlatform';
+import CONST from '@src/CONST';
 import * as Session from '@userActions/Session';
 
 type OnboardingScreenLayoutProps = {
@@ -51,6 +53,10 @@ function OnboardingScreenLayout({
   const [isSigningOut, setIsSigningOut] = useState(false);
 
   useEffect(() => {
+    // BackHandler is native-only; on web it warns and no-ops, so skip it.
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       if (isFirstScreen) {
         return true;

--- a/src/screens/Settings/Admin/AdminScreen.tsx
+++ b/src/screens/Settings/Admin/AdminScreen.tsx
@@ -4,6 +4,8 @@ import type {StackScreenProps} from '@react-navigation/stack';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import Navigation from '@libs/Navigation/Navigation';
+import getPlatform from '@libs/getPlatform';
+import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type {TranslationPaths} from '@src/languages/types';
 import type {Route} from '@src/ROUTES';
@@ -111,8 +113,13 @@ function AdminScreen({route}: AdminScreenProps) {
     [generalMenuItemsData, getMenuItemsSection],
   );
 
-  // Make the system back press toggle the go back handler
+  // Make the system back press toggle the go back handler. BackHandler is a
+  // native-only API; on web it warns and no-ops, so skip it (web uses the
+  // browser back button / Escape instead).
   useEffect(() => {
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       Navigation.goBack();
       return true; // Prevent the event from bubbling up and being handled by the default handler

--- a/src/screens/Settings/Preferences/PreferencesScreen.tsx
+++ b/src/screens/Settings/Preferences/PreferencesScreen.tsx
@@ -19,6 +19,7 @@ import MenuItemGroup from '@components/MenuItemGroup';
 import LocaleUtils from '@libs/LocaleUtils';
 import Section from '@components/Section';
 import MenuItem from '@components/MenuItem';
+import getPlatform from '@libs/getPlatform';
 import CONST from '@src/CONST';
 import type {PaletteId} from '@libs/SessionColorPalettes';
 import {
@@ -180,8 +181,13 @@ function PreferencesScreen({route}: PreferencesScreenProps) {
     [drinksAndUnitsMenuItemsData, getMenuItemsSection],
   );
 
-  // Make the system back press toggle the go back handler
+  // Make the system back press toggle the go back handler. BackHandler is a
+  // native-only API; on web it warns and no-ops, so skip it (web uses the
+  // browser back button / Escape instead).
   useEffect(() => {
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       Navigation.goBack();
       return true; // Prevent the event from bubbling up and being handled by the default handler

--- a/src/screens/Settings/Privacy/BlockedUsersScreen.tsx
+++ b/src/screens/Settings/Privacy/BlockedUsersScreen.tsx
@@ -12,6 +12,8 @@ import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
+import getPlatform from '@libs/getPlatform';
+import CONST from '@src/CONST';
 import {unblockUser} from '@userActions/Block';
 import ONYXKEYS from '@src/ONYXKEYS';
 
@@ -54,6 +56,10 @@ function BlockedUsersScreen() {
   // Match PrivacyScreen: route the Android hardware back press through the
   // app's navigation stack rather than the OS default.
   useEffect(() => {
+    // BackHandler is native-only; on web it warns and no-ops, so skip it.
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       Navigation.goBack();
       return true;

--- a/src/screens/Settings/Privacy/PrivacyScreen.tsx
+++ b/src/screens/Settings/Privacy/PrivacyScreen.tsx
@@ -4,6 +4,8 @@ import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserDataVisibility from '@hooks/useCurrentUserDataVisibility';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
+import getPlatform from '@libs/getPlatform';
+import CONST from '@src/CONST';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
@@ -160,6 +162,10 @@ function PrivacyScreen() {
   // Match PreferencesScreen: the system back press goes back through the
   // app's navigation stack rather than the OS default.
   useEffect(() => {
+    // BackHandler is native-only; on web it warns and no-ops, so skip it.
+    if (getPlatform() === CONST.PLATFORM.WEB) {
+      return;
+    }
     const backAction = () => {
       Navigation.goBack();
       return true;


### PR DESCRIPTION
## What & why

Completes **Phase 1 issue #934** (part of the web epic #925) — the screen-by-screen logged-in **visual** QA walk that the previous chip left unfinished. Building on the merged crash/console fixes (#1154) and the desktop RHP layout fix (#1188), this PR drives **every logged-in screen at both widths** (393×852 mobile + 1440×900 desktop), signed in against the dev backend, and lands the one contained, low-risk, clearly-web-only fix the sweep surfaced.

The deep **Drinking Session / Day Overview** flows (never previously driven end-to-end) were exercised fully: start live session → log drinks → notes → save → summary → confirm → calendar → day overview → session detail → edit. All clean.

## Fix landed here

**Guard native-only `BackHandler` so it no-ops on web** (6 files). Six screens registered an Android `hardwareBackPress` listener via `BackHandler.addEventListener` inside a `useEffect`; on web `react-native-web`'s `BackHandler` logs `"BackHandler is not supported on web and should not be used"` and no-ops, producing console-error noise on every affected screen (live/edit session, Preferences, Privacy, Blocked users, Admin, onboarding). Added the same `getPlatform() === CONST.PLATFORM.WEB` early-return guard that `ReanimatedModal` already uses (and that upstream Expensify uses via `.android` splits). **Native behaviour is unchanged**; web users navigate via the browser back button / Escape. Verified in-browser: the warning is gone after mounting a previously-affected screen.

- `src/components/DrinkingSessionWindow/index.tsx`
- `src/components/OnboardingScreenLayout/index.tsx`
- `src/screens/Settings/Preferences/PreferencesScreen.tsx`
- `src/screens/Settings/Privacy/PrivacyScreen.tsx`
- `src/screens/Settings/Privacy/BlockedUsersScreen.tsx`
- `src/screens/Settings/Admin/AdminScreen.tsx`

## Sweep results — categorized

### ✅ Verified clean (no web-only visual defects)
Walked at **both** widths unless noted. Full per-screen verdict is posted on #934.

| Cluster | Verdict |
|---|---|
| Initial / Login (email + Google), Verify-email gate, T&C gate | ✅ |
| Home (cards, calendar, alcohol-free markers, FAB, bottom tabs) | ✅ |
| Calendar + month pager (prev/next, reset-to-today) | ✅ |
| **Drinking Session** — live create, drink steppers, units total, Blackout, Note screen (text input), Save | ✅ |
| Session Summary + Confirm; Session **edit** screen (Delete/Save) | ✅ |
| Day Overview ("Drinking sessions" list, date separators, session tiles) | ✅ |
| Statistics — Overview / Trends / Patterns / Breakdown; Skia charts paint (axes, donut, polar, heatmap, gradient trend mini-charts plot data); no chart console errors | ✅ |
| Profile — own public profile + Settings → Profile Details | ✅ |
| Settings list + **every** detail RHP (Profile, Preferences, Privacy) — RHP pinned to fixed-width right panel on desktop (#1188 holds) | ✅ |
| Social/Friends — Friend List, Friend Requests (SwipeablePager), Friend Overview, Manage-Friend popover (Hide/Unfriend/Block) | ✅ |
| Modals — FAB menu (bottom-docked), verify-email, T&C, Manage-Friend | ✅ |

### ⚠️ Follow-up (filed, linked to #925)
- **Wide desktop layout leaves the central pane empty** — tab roots render in a 375px left column with ~70% dead space on the right. It's the inherited Expensify sidebar+central-pane architecture with no central content; a design decision + shared-nav surgery, deliberately **not** refactored here. → #1219

### 🚫 Won't-fix here (benign / not web-perceivable)
- `Accessing element.ref was removed in React 19` console warning — emitted from a dependency accessing `.ref` as a prop; benign, no functional impact, would require patching a dep. Noted for a possible later dependency bump.
- One friend's avatar (a sent-request) showed a persistent loading spinner — all other avatars load fine, so it's that user's image URL, not a systematic web issue.
- Minor native-vs-web spacing/shadow differences — out of scope per the sweep's parity rule.

## Gates
`prettier --write` ✅ · `npm run typecheck-tsgo` ✅ · `npm run react-compiler-compliance-check check-changed` ✅ (6 files) · `npm run lint-changed` ✅. CI `typecheck` (tsc) + `lint` remain the merge gates.

## Build labels
Touches shared cross-platform screen code (behaviour-preserving on native). Should get **Ready To Build** (confirm iOS/Android still build) and **Ready To Build - Web** (preview channel).

Closes #934. Refs #925, #1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)