### PR TITLE
feat(web): center the app as a phone frame on wide desktop (#1219)

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -16,8 +16,74 @@
  * barrel) keeps `Skia.web.ts` out of the main bundle so it isn't evaluated
  * early. Native links CanvasKit into the binary and uses `index.js` directly.
  */
+import {Dimensions} from 'react-native';
 // eslint-disable-next-line import/extensions
 import {LoadSkiaWeb} from '@shopify/react-native-skia/lib/module/web/LoadSkiaWeb';
+
+/*
+ * Desktop "phone frame" (issue #1219).
+ *
+ * Kiroku is mobile-first (native bottom tabs, no central pane), so on a wide
+ * desktop window the layout inherited from Expensify pins the tab content to a
+ * 375px column and leaves ~70% of the window an empty central pane. Instead we
+ * render the app at a phone width, centered on a backdrop (CSS in
+ * web/index.html), and make the app *believe* the viewport is that width so it
+ * uses its existing, already-clean mobile layout and every overlay (modals,
+ * RHP, FAB, popovers) positions against the frame rather than the real window.
+ *
+ * react-native-web's `useWindowDimensions` resolves entirely through
+ * `Dimensions.get('window')` + its `'change'` event, so clamping `Dimensions`
+ * here is the single source of truth for both the ~28 `useWindowDimensions`
+ * consumers AND the few helpers that read `Dimensions.get('window')` directly
+ * (e.g. `getIsSmallScreenWidth` -> the navigation router, `commonStyles`). Only
+ * the width of `'window'` is clamped, and only above the breakpoint, so real
+ * mobile / narrow desktop windows are untouched. Keep FRAME_WIDTH / BREAKPOINT
+ * in sync with web/index.html and variables.mobileResponsiveWidthBreakpoint.
+ */
+const FRAME_WIDTH = 480;
+const BREAKPOINT = 800;
+const clampWindow = window => {
+  if (
+    !window ||
+    typeof window.width !== 'number' ||
+    window.width <= BREAKPOINT
+  ) {
+    return window;
+  }
+  return {...window, width: FRAME_WIDTH};
+};
+const originalGet = Dimensions.get.bind(Dimensions);
+Dimensions.get = dimension =>
+  dimension === 'window'
+    ? clampWindow(originalGet('window'))
+    : originalGet(dimension);
+// Wrap 'change' so live resizes stay clamped. Preserve handler identity via a
+// WeakMap so react-native-web's `removeEventListener('change', handler)` (which
+// matches by reference) still finds and removes the wrapped listener.
+const wrappedChangeHandlers = new WeakMap();
+const originalAddEventListener = Dimensions.addEventListener.bind(Dimensions);
+Dimensions.addEventListener = (type, handler) => {
+  if (type !== 'change' || typeof handler !== 'function') {
+    return originalAddEventListener(type, handler);
+  }
+  const wrapped = ({window, screen}) =>
+    handler({window: clampWindow(window), screen});
+  wrappedChangeHandlers.set(handler, wrapped);
+  return originalAddEventListener('change', wrapped);
+};
+if (typeof Dimensions.removeEventListener === 'function') {
+  const originalRemoveEventListener =
+    Dimensions.removeEventListener.bind(Dimensions);
+  Dimensions.removeEventListener = (type, handler) => {
+    if (type !== 'change' || typeof handler !== 'function') {
+      return originalRemoveEventListener(type, handler);
+    }
+    return originalRemoveEventListener(
+      'change',
+      wrappedChangeHandlers.get(handler) ?? handler,
+    );
+  };
+}
 
 // The CanvasKit WASM is emitted at the web root by the webpack CopyPlugin.
 LoadSkiaWeb({locateFile: () => '/canvaskit.wasm'})

--- a/web/index.html
+++ b/web/index.html
@@ -81,6 +81,31 @@
         transition-property: opacity;
         z-index: 10000;
       }
+
+      /*
+        Desktop "phone frame" (issue #1219). Kiroku is mobile-first (native
+        bottom tabs, no central pane), so above the responsive breakpoint we
+        center the app at a phone width on a backdrop rather than show the
+        inherited wide layout with a large empty central pane. index.web.js
+        clamps the reported viewport width to match, so the app renders its
+        normal mobile layout inside this column. Keep the 480px width and the
+        801px breakpoint in sync with index.web.js (FRAME_WIDTH / BREAKPOINT).
+      */
+      @media (min-width: 801px) {
+        body {
+          background: radial-gradient(
+            circle at 50% 30%,
+            #2a2a2e 0%,
+            #0d0d0f 75%
+          );
+        }
+        #root {
+          width: 480px;
+          max-width: 100%;
+          margin: 0 auto;
+          box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
+        }
+      }
     </style>
     <meta
       name="viewport"


### PR DESCRIPTION
## What & why

Resolves **#1219** (follow-up from the #934 web QA sweep, part of epic #925). On a wide desktop browser, every bottom-tab root (Home, Friends, Statistics, Settings) rendered inside a fixed 375px column with the remaining **~70% of the window an empty central pane** — the layout Kiroku inherited from Expensify, whose central pane Kiroku (mobile-first, native bottom tabs, no LHN) never fills.

Rather than build out a desktop two-pane experience, we render the app **at a phone width, centered on a backdrop** — the chosen direction from #1219. This also makes the **already-clean mobile layout the only layout to maintain** on web.

## How it works (two coordinated pieces)

1. **`web/index.html`** — a `@media (min-width: 801px)` block centers `#root` at **480px** on a dark radial-gradient backdrop (with a subtle shadow). Below the breakpoint it's untouched → real mobile stays full-bleed.

2. **`index.web.js`** — CSS alone isn't enough: the whole layout branches on `useWindowDimensions().windowWidth` vs the 800px breakpoint, so if the box shrinks but the app still reads 1440 it renders the *wide* layout squished into the frame. So we **clamp the reported viewport width to 480 above the breakpoint** at the single source everything funnels through. `react-native-web`'s `useWindowDimensions` resolves entirely through `Dimensions.get('window')` + its `'change'` event, so wrapping `Dimensions` here is one seam that covers **all ~28 `useWindowDimensions` consumers AND the direct readers** (`getIsSmallScreenWidth` → the navigation router/`CustomRouter`, `commonStyles`). `'change'` is wrapped too (live resizes stay clamped), preserving handler identity via a `WeakMap` so RNW's `removeEventListener('change', handler)` still unhooks the wrapper (no listener leak). Only `'window'` width, only above the breakpoint.

### Why not an iframe (like `web/simulator.html`)
`simulator.html` frames by iframing the app, but **Google OAuth misbehaves in iframes** (works only on the un-framed `/`) and it would break deep-linking/URLs. This keeps the same `/`, same router, same auth — no iframe.

## Verified on web
- **Desktop 1440×900:** app is a centered 480px column on the backdrop; Home renders the clean mobile layout (no empty pane); Settings → Profile Details opens **full-screen within the frame** (correct narrow RHP behavior, proving the clamp drives the router too); **no console errors**.
- **Mobile 393×852:** `#root` is 393px full-bleed, no frame, clamp is a no-op — primary surface unchanged.
- `simulator.html` still works (it iframes at <800px, so the clamp no-ops).

## Gates
`prettier --check` ✅ · `typecheck-tsgo` ✅ · `react-compiler-compliance-check check-changed` ✅ (no React files changed) · `lint-changed` ✅.

## Build labels
Web-only change (HTML shell + web entry); native (`index.js`) untouched. Should get **Ready To Build - Web** (preview channel) to eyeball the framed desktop layout; native build is unaffected but **Ready To Build** can confirm.

Closes #1219. Refs #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)