### PR TITLE
fix(api): wire BlockUser/UnblockUser/ReportUser to kiroku-api routes

### DIFF
--- a/src/libs/API/kirokuRoutes.ts
+++ b/src/libs/API/kirokuRoutes.ts
@@ -146,6 +146,18 @@ const KIROKU_ROUTES: Record<string, KirokuRoute> = {
     method: 'post',
     path: '/v1/friends/remove',
   },
+  [WRITE_COMMANDS.BLOCK_USER]: {
+    method: 'post',
+    path: '/v1/friends/block',
+  },
+  [WRITE_COMMANDS.UNBLOCK_USER]: {
+    method: 'post',
+    path: '/v1/friends/unblock',
+  },
+  [WRITE_COMMANDS.REPORT_USER]: {
+    method: 'post',
+    path: '/v1/reports',
+  },
   [WRITE_COMMANDS.UPDATE_SESSION]: {
     method: 'post',
     path: '/v1/sessions/update',


### PR DESCRIPTION
## Summary

`BlockUser`, `UnblockUser`, and `ReportUser` were never registered in `KIROKU_ROUTES` (`src/libs/API/kirokuRoutes.ts`). Their action modules, params, and `WRITE_COMMANDS` constants all shipped, but with no route entry `HttpUtils.xhr` falls through `getKirokuRoute() → undefined` to the **legacy** `getCommandURL` path (`<root>api/BlockUser?`, `<root>api/ReportUser?`, …) which kiroku-api does not serve. So all three writes silently never reached the server.

Discovered while investigating why a user report on dev never landed: the dev RTDB `/reports` node was `null` and there were **no** `/reports` requests in the dev Cloud Run logs.

`git log -S` confirms these entries were **never** present in `kirokuRoutes.ts` in any commit — not a regression of a removed line.

## Why it slipped through

- **Block (#756)** was authored for the original **Firebase-direct** design (`src/database/block.ts`, atomic RTDB multi-path `update()`), which needs no `kirokuRoutes` entry. The later pivot to the `API.write` pattern dropped the wiring.
- **Report (#765)** closed without verifying its *"report is persisted with reporter, target, reason"* acceptance criterion end-to-end.

The canonical recipe both missed is spelled out in migration epic #778: *add WRITE/READ command + params + **`kirokuRoutes` entry** → action with `API.write(...)`*.

## Change

Three entries mapping each command to its existing kiroku-api endpoint:

| Command | Endpoint |
| --- | --- |
| `BlockUser` | `POST /v1/friends/block` |
| `UnblockUser` | `POST /v1/friends/unblock` |
| `ReportUser` | `POST /v1/reports` |

The server endpoints already exist (`kiroku-api` `routes/friends` `/block` + `/unblock`, `routes/reports`).

## Testing

- `npx prettier --write` — clean
- `npm run typecheck-tsgo` — clean
- `scripts/lint.sh` on the file — clean
- [ ] **End-to-end pending:** file a real report on dev, confirm it persists to `/reports`, and confirm block/unblock hit `/v1/friends/*`.

Refs #756, #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)