### PR TITLE
fix(home): disable glass background on FAB popover menu

### DIFF
--- a/src/components/StartSessionButtonAndPopover.tsx
+++ b/src/components/StartSessionButtonAndPopover.tsx
@@ -332,7 +332,6 @@ function StartSessionButtonAndPopover(
           ...staticSessionTypeMenuItems,
         ]}
         withoutOverlay
-        shouldUseGlassBackground
         anchorRef={fabRef}
       />
       <FloatingActionButton


### PR DESCRIPTION
## Summary
- Removes `shouldUseGlassBackground` from the FAB `PopoverMenu` in `StartSessionButtonAndPopover`
- The home screen FAB action sheet now uses the standard opaque background instead of the iOS 26 liquid-glass material

## Test plan
- [ ] Open the app on iOS 26 and tap the FAB on the home screen — popover should appear with a solid background, no glass effect
- [ ] Verify the popover still opens/closes correctly and all menu items work

🤖 Generated with [Claude Code](https://claude.com/claude-code)