### PR TITLE
feat(settings): add in-app Help & support entry (App Store Guideline 1.2)

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -84,6 +84,7 @@ const CONST = {
   DISCORD_INVITE_URL: 'https://discord.gg/PjvUFkuwMv',
   TERMS_URL: `${KIROKU_URL}/terms`,
   PRIVACY_URL: `${KIROKU_URL}/privacy`,
+  SUPPORT_URL: `${KIROKU_URL}/support`,
   SUBSCRIPTION_TERMS_URL: `${KIROKU_URL}/subscription-terms`,
   CURRENT_TERMS_VERSION: 1,
   GITHUB_RELEASE_URL:

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -119,6 +119,7 @@ const ROUTES = {
   SETTINGS_COLOR_PALETTE: 'settings/preferences/color-palette',
 
   SETTINGS_SUPPORT: 'settings/support',
+  SETTINGS_HELP: 'settings/help',
   SETTINGS_MANAGE_SUBSCRIPTION: 'settings/manage-subscription',
   SETTINGS_TERMS_OF_SERVICE: 'settings/terms-of-service',
   SETTINGS_PRIVACY_POLICY: 'settings/privacy-policy',

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -88,6 +88,7 @@ const SCREENS = {
 
     ABOUT: 'Settings_About',
     SUPPORT: 'Settings_Support',
+    HELP: 'Settings_Help',
     MANAGE_SUBSCRIPTION: 'Settings_ManageSubscription',
     TERMS_OF_SERVICE: 'Settings_TermsOfService',
     PRIVACY_POLICY: 'Settings_PrivacyPolicy',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -747,6 +747,7 @@ export default {
     general: 'Obecné',
     reportBug: 'Nahlásit chybu',
     giveFeedback: 'Poslat zpětnou vazbu',
+    help: 'Nápověda a podpora',
     signOut: 'Odhlásit se',
     shareTheApp: 'Sdílet aplikaci',
     adminTools: 'Nástroje pro administrátory',
@@ -775,6 +776,9 @@ export default {
     },
     subscriptionTermsScreen: {
       loading: 'Načítám Podmínky předplatného…',
+    },
+    helpScreen: {
+      loading: 'Načítám podporu…',
     },
     error: {},
   },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -743,6 +743,7 @@ export default {
     general: 'General',
     reportBug: 'Report a bug',
     giveFeedback: 'Give us feedback',
+    help: 'Help & support',
     signOut: 'Sign out',
     shareTheApp: 'Share the app',
     adminTools: 'Admin tools',
@@ -772,6 +773,9 @@ export default {
     },
     subscriptionTermsScreen: {
       loading: 'Loading Subscription Terms...',
+    },
+    helpScreen: {
+      loading: 'Loading support...',
     },
     error: {},
   },

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -188,6 +188,8 @@ const SettingsModalStackNavigator =
     [SCREENS.SETTINGS.SUPPORT]: () =>
       require<ReactComponentModule>('@screens/Settings/SupportKirokuScreen')
         .default,
+    [SCREENS.SETTINGS.HELP]: () =>
+      require<ReactComponentModule>('@screens/Settings/HelpScreen').default,
     [SCREENS.SETTINGS.MANAGE_SUBSCRIPTION]: () =>
       require<ReactComponentModule>('@screens/Settings/ManageSubscriptionScreen')
         .default,

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -174,6 +174,7 @@ const config: LinkingOptions<RootStackParamList>['config'] = {
             },
             [SCREENS.SETTINGS.APP_SHARE]: ROUTES.SETTINGS_APP_SHARE,
             [SCREENS.SETTINGS.SUPPORT]: ROUTES.SETTINGS_SUPPORT,
+            [SCREENS.SETTINGS.HELP]: ROUTES.SETTINGS_HELP,
             [SCREENS.SETTINGS.MANAGE_SUBSCRIPTION]: {
               path: ROUTES.SETTINGS_MANAGE_SUBSCRIPTION,
               exact: true,

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -129,6 +129,7 @@ type SettingsNavigatorParamList = {
   [SCREENS.SETTINGS.ADMIN.BUGS]: undefined;
   [SCREENS.SETTINGS.APP_SHARE]: undefined;
   [SCREENS.SETTINGS.SUPPORT]: undefined;
+  [SCREENS.SETTINGS.HELP]: undefined;
   [SCREENS.SETTINGS.MANAGE_SUBSCRIPTION]: undefined;
   [SCREENS.SETTINGS.TERMS_OF_SERVICE]: undefined;
   [SCREENS.SETTINGS.PRIVACY_POLICY]: undefined;

--- a/src/screens/Settings/HelpScreen.tsx
+++ b/src/screens/Settings/HelpScreen.tsx
@@ -1,0 +1,61 @@
+import {Linking, View} from 'react-native';
+import {WebView} from 'react-native-webview';
+import Navigation from '@libs/Navigation/Navigation';
+import ScreenWrapper from '@components/ScreenWrapper';
+import CONST from '@src/CONST';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import {useState} from 'react';
+import useThemeStyles from '@hooks/useThemeStyles';
+import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import {useUserConnection} from '@context/global/UserConnectionContext';
+import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
+import useLocalize from '@hooks/useLocalize';
+import type WebViewRequest from '@libs/WebView/types';
+
+function HelpScreen() {
+  const styles = useThemeStyles();
+  const {isOnline} = useUserConnection();
+  const {translate} = useLocalize();
+  const loadingText = translate('settingsScreen.helpScreen.loading');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleStartLoadWithRequest = (request: WebViewRequest) => {
+    // Check if the URL has "mailto:" scheme
+    if (request.url.startsWith('mailto:')) {
+      // Use Linking to open the default email client
+      Linking.openURL(request.url);
+      return false; // Returning false prevents WebView from trying to handle the URL
+    }
+    return true;
+  };
+
+  return (
+    <ScreenWrapper testID={HelpScreen.displayName}>
+      <HeaderWithBackButton
+        title={translate('settingsScreen.help')}
+        onBackButtonPress={Navigation.goBack}
+      />
+      {isLoading ? (
+        <FullScreenLoadingIndicator loadingText={loadingText} />
+      ) : (
+        <View style={[styles.flex1, styles.appContent]}>
+          {!isOnline ? (
+            <FlexibleLoadingIndicator text={loadingText} />
+          ) : (
+            <WebView
+              originWhitelist={['*']}
+              source={{uri: CONST.SUPPORT_URL}}
+              onShouldStartLoadWithRequest={handleStartLoadWithRequest}
+              style={styles.flex1}
+              onLoadEnd={() => setIsLoading(false)}
+              javaScriptEnabled
+            />
+          )}
+        </View>
+      )}
+    </ScreenWrapper>
+  );
+}
+
+HelpScreen.displayName = 'Help Screen';
+export default HelpScreen;

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -173,6 +173,11 @@ function SettingsScreen() {
           routeName: ROUTES.SETTINGS_FEEDBACK,
         },
         {
+          translationKey: 'settingsScreen.help',
+          icon: KirokuIcons.Mail,
+          routeName: ROUTES.SETTINGS_HELP,
+        },
+        {
           translationKey: 'settingsScreen.shareTheApp',
           icon: KirokuIcons.Share,
           routeName: ROUTES.SETTINGS_APP_SHARE,


### PR DESCRIPTION
### Details

App Store **Guideline 1.2** (epic #757, issue #766) requires a published, user-reachable contact for objectionable-content complaints that is discoverable **from within the app**. The contact is already published on the website (https://kiroku.cz/support and `kiroku.alcohol.tracker@gmail.com`), but the app surfaced no path to it.

This PR adds a **Help & support** entry to the Settings → General section. It opens `kiroku.cz/support` in an in-app `WebView`, mirroring the existing legal-link screens (`TermsOfServiceScreen` / `PrivacyPolicyScreen`): same WebView setup, `mailto:` handoff to the system mail client, and an offline fallback. The published page surfaces both the support email and the contact form, satisfying the discoverable-contact requirement.

**Changes**
- `src/CONST.ts` — new `SUPPORT_URL` (`${KIROKU_URL}/support`)
- `src/screens/Settings/HelpScreen.tsx` — new WebView screen (clone of `TermsOfServiceScreen`)
- `src/screens/Settings/SettingsScreen.tsx` — menu entry (`KirokuIcons.Mail`) next to "Give us feedback"
- Route / screen / nav wiring: `ROUTES.ts`, `SCREENS.ts`, `Navigation/types.ts`, `linkingConfig/config.ts`, `ModalStackNavigators/index.tsx`
- `src/languages/en.ts` + `src/languages/cs_cz.ts` — `settingsScreen.help` and `settingsScreen.helpScreen.loading` (Czech filled via the `translate` skill)

No new code patterns; this reuses the established legal-link WebView pattern.

### Tests

1. Open the app, go to **Settings**.
2. In the **General** section, verify a **Help & support** row appears (mail icon) below "Give us feedback".
3. Tap it. Verify the in-app browser opens and loads `kiroku.cz/support`, showing the support contact (email + contact form).
4. Tap the support email link on that page. Verify it opens the system mail client (`mailto:` handoff) rather than navigating inside the WebView.
5. Tap back. Verify you return to Settings.
6. Switch the app language to Czech. Verify the row reads **Nápověda a podpora** and the loading text reads **Načítám podporu…**.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, open **Settings → Help & support**. Verify the offline loading indicator is shown instead of a broken/blank WebView (same behavior as Terms / Privacy).
2. Reconnect, reopen the screen, verify the page loads.

### QA Steps

1. On staging, navigate **Settings → Help & support**.
2. Verify `kiroku.cz/support` loads and the published support email / contact form is reachable.
3. Verify the email link opens the mail composer.
4. Repeat in Czech locale and confirm localized labels.

- [ ] Verify that no errors appear in the JS console

### Automated checks

- `Translate.test.ts` passes (key parity en ↔ cs_cz)
- `typecheck-tsgo` clean
- React Compiler compliance check passes
- Prettier formatted
