### PR TITLE
fix(nav): always show bottom-tab labels on Android

### DIFF
--- a/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
@@ -54,6 +54,12 @@ function BottomTabNavigator() {
         // selected tab in the dark theme. Both are no-ops on iOS.
         activeIndicatorColor={theme.activeComponentBG}
         rippleColor={theme.hoverComponentBG}
+        // Always show every tab's text label, not just the selected one. The
+        // Android Material bar defaults to label-on-selected-only (the library
+        // passes `labeled: undefined` on Android), which hid the inactive
+        // labels and left bare icons. iOS already defaults to labels-always-on,
+        // so this only changes Android and brings it in line.
+        labeled
         // On iOS 26, let the system render its native Liquid Glass tab bar: it
         // gives the items the roomier, vertically-centered spacing of modern iOS
         // (the legacy opaque appearance looked vertically squashed). On older iOS


### PR DESCRIPTION
## Problem

On **Android**, the native Material bottom bar shows a tab's text label only when that tab is selected, leaving the other tabs as bare icons. iOS always shows every label. The labels (Home / Friends / Statistics / Settings) should always be visible on both platforms.

## Root cause

The bar is `react-native-bottom-tabs` (v1.2.0) via `@bottom-tabs/react-navigation`. The library gates always-on labels on its `labeled` prop, which defaults differently per platform:

```js
// node_modules/react-native-bottom-tabs/lib/module/TabView.js
labeled = Platform.OS !== 'android' ? true : undefined,
```

So Android gets `undefined` (label-on-selected-only) while iOS gets `true`.

## Fix

Pass `labeled` explicitly on `<Tab.Navigator>` in [`BottomTabNavigator.tsx`](src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx). The prop flows through cleanly: `NativeBottomTabNavigationConfig` is `Partial<Omit<ComponentProps<typeof TabView>, ...>>` (it does **not** omit `labeled`), and the navigator spreads it via `...rest` → `NativeBottomTabView` → `TabView` → the native component.

This is a **no-op on iOS** (already defaults to `true`) and only changes Android.

## Scope / safety

- Native bar only. The custom web bar (`BottomTabNavigator.web.tsx`) is untouched.
- **Overflow check:** longest label is "Statistics" (10 chars) at `fontSizeSmall` (11px base). The Material 3 bar truncates within each tab slot rather than overflowing off-screen, and iOS already renders these same labels always-on, so the existing `tabLabelStyle` needs no change.

## Checks

- ✅ `prettier --write` (unchanged)
- ✅ `lint` (scripts/lint.sh on the file, clean)
- ✅ `typecheck-tsgo`
- ✅ `react-compiler-compliance-check check-changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)