### PR TITLE
fix(statistics): keep top-tab labels on one line on narrow screens

### DIFF
--- a/src/components/TopTabBar.tsx
+++ b/src/components/TopTabBar.tsx
@@ -49,7 +49,19 @@ function renderTopTabLabel({
   route: TopTabRoute;
   color: string;
 }): React.ReactNode {
-  return <Text style={[styles.tabBarLabel, {color}]}>{route.title}</Text>;
+  // Tabs are fixed equal-width (`scrollEnabled={false}`), so a long label like
+  // "Breakdown" can overflow a narrow tab. Keep it on one line and let it shrink
+  // to fit rather than wrap or truncate, so every label stays readable at any
+  // screen width.
+  return (
+    <Text
+      style={[styles.tabBarLabel, {color}]}
+      numberOfLines={1}
+      adjustsFontSizeToFit
+      minimumFontScale={0.8}>
+      {route.title}
+    </Text>
+  );
 }
 
 /** Shared `commonOptions` for a top-tab `TabView` — themes the labels. */


### PR DESCRIPTION
## Problem

In the **Statistics** tab bar, the longest label — **"Breakdown"** — wrapped onto two lines (`Breakdow` / `n`) on narrow Android widths, which looked broken. The top tabs are fixed equal-width (`scrollEnabled={false}` on the underlying `react-native-tab-view` `TabBar`), so on a small screen a long label can exceed its tab's share of the width and wrap.

## Fix

Render the label in the shared [`TopTabBar`](src/components/TopTabBar.tsx) with:

```tsx
<Text
  style={[styles.tabBarLabel, {color}]}
  numberOfLines={1}
  adjustsFontSizeToFit
  minimumFontScale={0.8}>
  {route.title}
</Text>
```

- `numberOfLines={1}` — the label can never wrap to a second line.
- `adjustsFontSizeToFit` — if a label is too wide for its tab, the font shrinks just enough to fit on that single line instead of truncating with an ellipsis.
- `minimumFontScale={0.8}` — a floor so a label never shrinks below 80% (14 → 11.2px), keeping it readable in the worst case.

On every normal-width device the label stays at full size; only a too-tight tab shrinks, and only as far as it needs to.

## Why this approach (options weighed)

| Option | Verdict |
| --- | --- |
| `numberOfLines={1}` alone | Stops the wrap but truncates to `Breakdo…` on the narrowest devices — still ugly. |
| **`numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale`** | ✅ **Chosen.** Never wraps, never truncates; degrades gracefully at any width and for every label. |
| Reduce per-tab padding / `fontSize` globally | Penalizes every device to fix the narrowest one. |
| Make the bar scrollable / `width: 'auto'` | Abandons the intended fixed equal-width tabs — a larger UX change. |
| Shorten the English copy | Would force a translations pass across every locale; avoided deliberately. |

This keeps the change **styling-only** — no copy/translation edits.

## Scope

The fix lives in the shared `TopTabBar`, so it covers **all** top-tab labels in one place:

- **Statistics** (4 equal tabs): Overview, Trends, Patterns, **Breakdown** ← the reported case
- **Social** (2 equal tabs): Friend List, Friend Requests

`adjustsFontSizeToFit` is a native iOS/Android prop (react-native-web ignores it), but the wrap bug is Android-specific so it's covered where it matters; on web the equal-width tabs are wide enough to fit at full size and `numberOfLines={1}` prevents any wrap regardless.

## Checklist

- [x] Prettier (`npx prettier --write`)
- [x] `npm run lint-changed`
- [x] `npm run typecheck-tsgo`
- [x] `npm run react-compiler-compliance-check check-changed`
- [x] No English copy changed → no translation pass needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)