### PR TITLE
fix(session): pad and balance the session window action bar buttons

### DIFF
--- a/src/components/BottomActionBar.tsx
+++ b/src/components/BottomActionBar.tsx
@@ -19,6 +19,10 @@ type BottomActionBarProps = {
  * the disabled button. OfflineIndicator self-hides while online, so this adds no
  * visual gap when connected.
  *
+ * The bar applies a default horizontal padding (`ph5`) so its button(s) never
+ * touch the screen edges on any device. Pass `containerStyle` to add more (e.g.
+ * `gap`/vertical padding) or to override the horizontal padding when needed.
+ *
  * Screens using this should pass `shouldShowOfflineIndicator={false}` to their
  * `ScreenWrapper` to avoid a duplicate indicator rendering below the button.
  */
@@ -28,7 +32,7 @@ function BottomActionBar({children, containerStyle}: BottomActionBarProps) {
   return (
     <View style={styles.flexShrink0}>
       <OfflineIndicator />
-      <View style={[styles.bottomTabBarContainer, containerStyle]}>
+      <View style={[styles.bottomTabBarContainer, styles.ph5, containerStyle]}>
         {children}
       </View>
     </View>

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -241,7 +241,7 @@ function DrinkingSessionWindow({
           text={translate('liveSessionScreen.discardSession', {
             discardWord: deleteSessionWording,
           })}
-          style={styles.buttonLarge}
+          style={[styles.buttonLarge, styles.flex1]}
           onPress={handleDiscardSession}
         />
         <Button
@@ -249,7 +249,7 @@ function DrinkingSessionWindow({
           large
           isDisabled={isSaveDisabled}
           text={translate('liveSessionScreen.saveSession')}
-          style={styles.buttonLargeSuccess}
+          style={[styles.buttonLargeSuccess, styles.flex1]}
           onPress={() => saveSession(user)}
         />
       </BottomActionBar>

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -236,22 +236,29 @@ function DrinkingSessionWindow({
         <FillerView />
       </ScrollView>
       <BottomActionBar containerStyle={styles.gap2}>
-        <Button
-          large
-          text={translate('liveSessionScreen.discardSession', {
-            discardWord: deleteSessionWording,
-          })}
-          style={[styles.buttonLarge, styles.flex1]}
-          onPress={handleDiscardSession}
-        />
-        <Button
-          success
-          large
-          isDisabled={isSaveDisabled}
-          text={translate('liveSessionScreen.saveSession')}
-          style={[styles.buttonLargeSuccess, styles.flex1]}
-          onPress={() => saveSession(user)}
-        />
+        {/* Each button is wrapped in a flex:1 view so the pair splits the row
+            evenly; the wrapper (not the button) carries the flex, so the
+            buttons keep their natural height instead of stretching vertically. */}
+        <View style={styles.flex1}>
+          <Button
+            large
+            text={translate('liveSessionScreen.discardSession', {
+              discardWord: deleteSessionWording,
+            })}
+            style={styles.buttonLarge}
+            onPress={handleDiscardSession}
+          />
+        </View>
+        <View style={styles.flex1}>
+          <Button
+            success
+            large
+            isDisabled={isSaveDisabled}
+            text={translate('liveSessionScreen.saveSession')}
+            style={styles.buttonLargeSuccess}
+            onPress={() => saveSession(user)}
+          />
+        </View>
       </BottomActionBar>
       <ConfirmModal
         danger

--- a/src/screens/DrinkingSession/SessionDateScreen.tsx
+++ b/src/screens/DrinkingSession/SessionDateScreen.tsx
@@ -116,7 +116,7 @@ function SesssionDateScreen({route}: SessionDateScreenProps) {
           onChangeSingle={setSelectedDate}
         />
       </View>
-      <BottomActionBar containerStyle={styles.ph5}>
+      <BottomActionBar>
         <Button
           large
           success

--- a/src/screens/DrinkingSession/SessionSummaryScreen.tsx
+++ b/src/screens/DrinkingSession/SessionSummaryScreen.tsx
@@ -343,7 +343,7 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
           {otherMenuItems}
         </MenuItemGroup>
       </ScrollView>
-      <BottomActionBar containerStyle={styles.ph5}>
+      <BottomActionBar>
         <Button
           large
           text={translate('common.confirm')}


### PR DESCRIPTION
## Problem

On the drinking-session window (edit/live session), the **Discard/Delete session** and **Save session** buttons stretched the full width and touched the left/right screen edges with no padding. It looked especially rough on Android.

Root cause: that `BottomActionBar` was the only one in the app passing just `styles.gap2` (8px gap, **no horizontal padding**), while every other action bar passes `ph5`/`p5`. The two buttons also had no flex, so their balance across screen sizes was undefined.

## Fix (general, not a one-off)

1. **`BottomActionBar` now defaults to `ph5` (20px) horizontal padding** — `[bottomTabBarContainer, ph5, containerStyle]`. No action bar can touch the screen edges on any device, and `containerStyle` still overrides it when a caller needs different padding.
2. **The two session-window buttons get `flex1`** (`[buttonLarge, flex1]` / `[buttonLargeSuccess, flex1]`) so they split the padded row 50/50 and stay balanced on both small phones and wide/web screens. The bar keeps `gap2` for the 8px between them.
3. **Dropped the now-redundant explicit `ph5`** from the two callers that only passed it, so the default is the single source of truth. Visually identical.

## BottomActionBar usages audited (grep)

| File | Before | After |
|---|---|---|
| `DrinkingSessionWindow/index.tsx` | `gap2` (no h-pad) — **the bug** | `gap2` + default `ph5`; buttons `flex1` |
| `SessionDateScreen.tsx` | `ph5` | none (inherits default `ph5`) |
| `SessionSummaryScreen.tsx` | `ph5` | none (inherits default `ph5`) |
| `DrinksToUnitsScreen.tsx` | `p5` | `p5` (unchanged — also supplies vertical padding; `paddingHorizontal` still resolves to 20) |
| `UnitsToColorsScreen.tsx` | `p5` | `p5` (unchanged — same reason) |

No usage intentionally had zero padding, so the default regresses nothing.

## Not affected: the navigation bottom tab bar

The on-screen footer `BottomActionBar` is a **different component** from the navigation tab bar at `src/libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar.tsx`, which composes `bottomTabBarContainer` directly (`[bottomTabBarContainer, ph1]`). This PR only changes the `BottomActionBar` component, not the shared `bottomTabBarContainer` style, so the navigation bar is untouched.

## Checklist

- ✅ `prettier --write` on changed files
- ✅ `npm run lint-changed`
- ✅ `npm run typecheck-tsgo`
- ✅ `npm run react-compiler-compliance-check check-changed` (4 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)