### PR TITLE
fix(nav): remove Android black strip above the bottom tab bar on tab roots

### DIFF
--- a/src/hooks/useBottomTabBarHeight/index.android.ts
+++ b/src/hooks/useBottomTabBarHeight/index.android.ts
@@ -1,0 +1,24 @@
+/**
+ * Android: the native Material tab bar is NOT an overlay. In
+ * `react-native-bottom-tabs`' `ReactBottomNavigationView` the scene area and
+ * the bar are stacked siblings in a vertical LinearLayout (scene with
+ * `weight=1`, bar below it), so the scene already ends at the top of the bar
+ * and content needs NO extra clearance to stay visible.
+ *
+ * Returning the measured bar height here (as iOS does) double-insets every
+ * consumer — scroll padding, the offline indicator's margin, the Home FAB
+ * offset — stacking a bar-sized (or worse) dead band above the bar. Worse,
+ * the library's Android measurement can report an inflated height at launch
+ * and never re-report (its layout listener gates re-reports on the OUTER
+ * view's size while reporting the INNER bar/scene sizes, so a bad first
+ * capture sticks; see callstack/react-native-bottom-tabs#228), which blew the
+ * dead band up to ~half the screen on Home/Social/Statistics.
+ *
+ * iOS keeps the measured height (`index.native.ts`): there the bar genuinely
+ * overlays the scene. Web has its own static fallback (`index.ts`).
+ */
+function useBottomTabBarHeight(): number {
+  return 0;
+}
+
+export default useBottomTabBarHeight;

--- a/src/hooks/useBottomTabBarHeight/index.native.ts
+++ b/src/hooks/useBottomTabBarHeight/index.native.ts
@@ -3,10 +3,13 @@ import {BottomTabBarHeightContext} from 'react-native-bottom-tabs';
 import variables from '@src/styles/variables';
 
 /**
- * The height of the native bottom tab bar (bar + bottom safe-area inset),
- * read from `react-native-bottom-tabs`' context. Tab-root screens use this to
- * inset scroll content (and lift the Home FAB) so nothing is hidden behind the
- * bar, which overlays the scene rather than insetting it.
+ * iOS (Android resolves to `index.android.ts` instead, which returns 0 —
+ * there the bar is a sibling laid out below the scene, not an overlay, so
+ * content needs no clearance): the height of the native bottom tab bar (bar +
+ * bottom safe-area inset), read from `react-native-bottom-tabs`' context.
+ * Tab-root screens use this to inset scroll content (and lift the Home FAB)
+ * so nothing is hidden behind the bar, which on iOS overlays the scene rather
+ * than insetting it.
  *
  * Reads the context directly (rather than the library's `useBottomTabBarHeight`,
  * which throws without a provider) so it degrades gracefully to the static bar

--- a/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/BottomTabNavigator.tsx
@@ -3,9 +3,10 @@ import type {NativeBottomTabNavigationOptions} from '@bottom-tabs/react-navigati
 import {useNavigationState} from '@react-navigation/native';
 import {isLiquidGlassAvailable} from 'expo-glass-effect';
 import React from 'react';
-import {Platform} from 'react-native';
+import {Platform, View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
 import FontUtils from '@styles/utils/FontUtils';
 import variables from '@styles/variables';
 import getTopmostCentralPaneRoute from '@navigation/getTopmostCentralPaneRoute';
@@ -36,6 +37,7 @@ const SUPPORTS_LIQUID_GLASS = isLiquidGlassAvailable();
 
 function BottomTabNavigator() {
   const theme = useTheme();
+  const styles = useThemeStyles();
   const {translate} = useLocalize();
   const activeRoute = useNavigationState<
     RootStackParamList,
@@ -44,60 +46,73 @@ function BottomTabNavigator() {
 
   return (
     <ActiveCentralPaneRouteContext.Provider value={activeRoute}>
-      <Tab.Navigator
-        initialRouteName={SCREENS.HOME}
-        tabBarActiveTintColor={theme.appColor}
-        tabBarInactiveTintColor={theme.icon}
-        // Android Material tab bar only: theme the active-indicator "pill" and
-        // touch ripple. Otherwise they fall back to Material's default light
-        // `colorSecondaryContainer`, which shows as a bright hue behind the
-        // selected tab in the dark theme. Both are no-ops on iOS.
-        activeIndicatorColor={theme.activeComponentBG}
-        rippleColor={theme.hoverComponentBG}
-        // Always show every tab's text label, not just the selected one. The
-        // Android Material bar defaults to label-on-selected-only (the library
-        // passes `labeled: undefined` on Android), which hid the inactive
-        // labels and left bare icons. iOS already defaults to labels-always-on,
-        // so this only changes Android and brings it in line.
-        labeled
-        // On iOS 26, let the system render its native Liquid Glass tab bar: it
-        // gives the items the roomier, vertically-centered spacing of modern iOS
-        // (the legacy opaque appearance looked vertically squashed). On older iOS
-        // we keep the opaque dark bar that matches the app theme and avoided the
-        // bright translucent default that flashed white on tab change.
-        // `backgroundColor` themes the Android bar and is a no-op on iOS 26,
-        // where the glass bar adapts to the content behind it.
-        tabBarStyle={{backgroundColor: theme.appBG}}
-        translucent={SUPPORTS_LIQUID_GLASS}
-        scrollEdgeAppearance={SUPPORTS_LIQUID_GLASS ? 'default' : 'opaque'}
-        disablePageAnimations
-        // Match the rest of the app's typography on the native labels.
-        tabLabelStyle={{
-          fontFamily: FontUtils.fontFamily.platform.EXP_NEUE.fontFamily,
-          fontSize: variables.fontSizeSmall,
-        }}>
-        {BOTTOM_TAB_CONFIG.map(tab => {
-          const options: NativeBottomTabNavigationOptions = {
-            tabBarLabel: translate(tab.labelKey),
-            tabBarIcon: () =>
-              Platform.OS === 'ios'
-                ? {sfSymbol: tab.sfSymbol}
-                : tab.androidIcon,
-            freezeOnBlur: true,
-            // Opaque scene background so the previous tab never shows through
-            // during a switch — the swap reads as instant.
-            sceneStyle: {backgroundColor: theme.appBG},
-          };
-          return (
-            <Tab.Screen
-              key={tab.name}
-              name={tab.name}
-              getComponent={tab.getComponent}
-              options={options}
-            />
-          );
-        })}
-      </Tab.Navigator>
+      {/* `theme.appBG` backdrop behind the native tab view. On Android the bar
+          is a sibling laid out *below* the scene (a vertical LinearLayout:
+          scene area with weight 1, then the tab bar) rather than an overlay, so
+          where a root screen's content doesn't fill to the bottom, the scene's
+          own background doesn't cover the gap and the dark Android window
+          background shows through as a black strip just above the tab buttons.
+          (Settings' scrolling menu fills the viewport, which is why it never
+          showed it.) The backdrop guarantees any uncovered region paints
+          `appBG`, keeping all four tab roots consistent. It's a no-op on iOS
+          (the glass/opaque bar still blurs/covers the appBG scene) and unused
+          on web, which renders a separate navigator. */}
+      <View style={[styles.flex1, styles.appBG]}>
+        <Tab.Navigator
+          initialRouteName={SCREENS.HOME}
+          tabBarActiveTintColor={theme.appColor}
+          tabBarInactiveTintColor={theme.icon}
+          // Android Material tab bar only: theme the active-indicator "pill" and
+          // touch ripple. Otherwise they fall back to Material's default light
+          // `colorSecondaryContainer`, which shows as a bright hue behind the
+          // selected tab in the dark theme. Both are no-ops on iOS.
+          activeIndicatorColor={theme.activeComponentBG}
+          rippleColor={theme.hoverComponentBG}
+          // Always show every tab's text label, not just the selected one. The
+          // Android Material bar defaults to label-on-selected-only (the library
+          // passes `labeled: undefined` on Android), which hid the inactive
+          // labels and left bare icons. iOS already defaults to labels-always-on,
+          // so this only changes Android and brings it in line.
+          labeled
+          // On iOS 26, let the system render its native Liquid Glass tab bar: it
+          // gives the items the roomier, vertically-centered spacing of modern iOS
+          // (the legacy opaque appearance looked vertically squashed). On older iOS
+          // we keep the opaque dark bar that matches the app theme and avoided the
+          // bright translucent default that flashed white on tab change.
+          // `backgroundColor` themes the Android bar and is a no-op on iOS 26,
+          // where the glass bar adapts to the content behind it.
+          tabBarStyle={{backgroundColor: theme.appBG}}
+          translucent={SUPPORTS_LIQUID_GLASS}
+          scrollEdgeAppearance={SUPPORTS_LIQUID_GLASS ? 'default' : 'opaque'}
+          disablePageAnimations
+          // Match the rest of the app's typography on the native labels.
+          tabLabelStyle={{
+            fontFamily: FontUtils.fontFamily.platform.EXP_NEUE.fontFamily,
+            fontSize: variables.fontSizeSmall,
+          }}>
+          {BOTTOM_TAB_CONFIG.map(tab => {
+            const options: NativeBottomTabNavigationOptions = {
+              tabBarLabel: translate(tab.labelKey),
+              tabBarIcon: () =>
+                Platform.OS === 'ios'
+                  ? {sfSymbol: tab.sfSymbol}
+                  : tab.androidIcon,
+              freezeOnBlur: true,
+              // Opaque scene background so the previous tab never shows through
+              // during a switch — the swap reads as instant.
+              sceneStyle: {backgroundColor: theme.appBG},
+            };
+            return (
+              <Tab.Screen
+                key={tab.name}
+                name={tab.name}
+                getComponent={tab.getComponent}
+                options={options}
+              />
+            );
+          })}
+        </Tab.Navigator>
+      </View>
     </ActiveCentralPaneRouteContext.Provider>
   );
 }


### PR DESCRIPTION
## Problem

On **Android only**, the Home, Social (Friends), and Statistics bottom-tab **root** screens showed a large black region above the tab buttons — on a real device it covered roughly the bottom half of the screen, reaching up to where the offline indicator sits. The Settings tab looked fine. iOS and web were unaffected.

## Root cause (two compounding issues)

`react-native-bottom-tabs` lays out its bar differently per platform:

- **iOS** — the bar (Liquid Glass / opaque) **overlays** the scene, so the scene fills the full height behind it.
- **Android** — the bar is a **sibling laid out _below_ the scene**: in the native `ReactBottomNavigationView` (a vertical `LinearLayout`), the scene area (`layoutHolder`) gets `weight=1` and the bar sits beneath it as `WRAP_CONTENT`.

**1. Redundant inset.** Every consumer of `useBottomTabBarHeight` (scroll padding, offline-indicator margin, Home FAB offset, inner TabView scene padding — 12 sites across the 5 tab-root files) uses it as *in-scene clearance so content clears the bar*. That is pure iOS-overlay compensation. On Android the scene already ends at the top of the bar, so all of it stacks a dead band above the bar.

**2. Unreliable Android measurement.** The library's layout listener (`RCTTabView.kt`) gates re-reports on the **outer** view's size while reporting the **inner** bar/scene sizes — and the outer size essentially never changes after first layout, so a bad first capture sticks until the app is backgrounded. An inflated launch-time bar measurement (a known condition: callstack/react-native-bottom-tabs#228) multiplies the already-redundant inset into a band covering ~half the screen.

**Why Settings looked fine:** its only artifact is `paddingBottom` at the *end of a long scrollable list* — invisible unless scrolled fully to the bottom. The other three expose the inset directly (offline-indicator margin, FAB offset, TabView scene padding, short content).

## Fix

1. **`src/hooks/useBottomTabBarHeight/index.android.ts` (new)** — returns `0`. On Android the bar isn't an overlay, so content needs no clearance; this removes both the redundant inset and any dependence on the buggy Android measurement. iOS keeps the measured height (`index.native.ts`); web keeps its static fallback (`index.ts`).
2. **`BottomTabNavigator.tsx`** — `theme.appBG` backdrop behind the native tab view, so any region the scene ever leaves uncovered paints the app background instead of the window background (defense-in-depth; no-op on iOS, unused on web).

## Verification

- `npx prettier` ✅ · `npm run lint-changed` ✅ · `npm run typecheck-tsgo` ✅ · `npm run react-compiler-compliance-check check-changed` ✅
- Rebased on master (0.3.15-81), including the `labeled` prop from the bottom-tab-labels fix.

⚠️ No Android emulator was available in this environment; the diagnosis comes from reading the JS + native (`RCTTabView.kt`) layout end-to-end. **Please verify on the Android test build**: Home/Social/Statistics should show content (or themed background) all the way down to the tab bar, the offline indicator should sit just above the bar, and the Home FAB just above that. iOS should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)