### PR TITLE
fix(calendar): stop FlashList v2 rendering blank until scroll on Android

### DIFF
--- a/src/components/DateSelectorModal/Calendar.tsx
+++ b/src/components/DateSelectorModal/Calendar.tsx
@@ -11,7 +11,8 @@ import {
   subMonths,
 } from 'date-fns';
 import {FlashList} from '@shopify/flash-list';
-import React, {useState} from 'react';
+import type {FlashListRef} from '@shopify/flash-list';
+import React, {useCallback, useRef, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import ArrowIcon from '@components/DatePicker/CalendarPicker/ArrowIcon';
 import generateMonthMatrix from '@components/DatePicker/CalendarPicker/generateMonthMatrix';
@@ -214,6 +215,19 @@ function Calendar(props: CalendarProps) {
   );
   const initialScrollIndex = Math.max(0, monthView.getFullYear() - minYear);
 
+  // FlashList v2 only knows the real year-block height after its first layout
+  // (`onLoad`); `initialScrollIndex` alone is resolved against the default
+  // estimate, so on Android the overview can open parked a few years off (and
+  // not repaint until a scroll). Re-apply the scroll once measured so the
+  // current year lands where it should.
+  const yearListRef = useRef<FlashListRef<number>>(null);
+  const handleYearListLoad = useCallback(() => {
+    yearListRef.current?.scrollToIndex({
+      index: initialScrollIndex,
+      animated: false,
+    });
+  }, [initialScrollIndex]);
+
   const renderYearBlock = ({item: year}: {item: number}) => (
     <View style={localStyles.yearBlock}>
       <View style={localStyles.yearLabel}>
@@ -304,11 +318,13 @@ function Calendar(props: CalendarProps) {
       {view === 'overview' ? (
         <View style={localStyles.overview}>
           <FlashList
+            ref={yearListRef}
             data={years}
             extraData={`${monthView.getFullYear()}-${monthView.getMonth()}`}
             keyExtractor={year => String(year)}
             renderItem={renderYearBlock}
             initialScrollIndex={initialScrollIndex}
+            onLoad={handleYearListLoad}
             showsVerticalScrollIndicator={false}
           />
         </View>

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -192,6 +192,14 @@ function DayOverviewListView({
 
   const listRef = useRef<FlashListRef<ListItem>>(null);
   const hasAppliedInitialScrollRef = useRef(false);
+  // FlashList v2 renders nothing on its first cycle: it measures itself and its
+  // rows, then fires `onLoad`. Only after that are the real row heights known.
+  // The initial centering scroll must wait for it — applied earlier (e.g. in a
+  // mount effect, as this used to do) it runs against v2's 200px-per-row
+  // default estimate, lands at the wrong offset, and on Android leaves the list
+  // blank until a manual scroll re-engages the renderer (the reported bug).
+  // This flips true in `onLoad`.
+  const hasLoadedRef = useRef(false);
   // Whether the user has actually dragged the list. Until they do, the only
   // scroll is our programmatic centering, so there's no new position to sync —
   // gating the write on a real drag keeps an open-and-close-without-moving a
@@ -201,44 +209,83 @@ function DayOverviewListView({
     hasUserScrolledRef.current = true;
   }, []);
 
-  useEffect(() => {
+  // Apply the one-time initial scroll, then reveal the list (via
+  // `onInitialScrollReady`). Runs only once `onLoad` has fired, so the scroll
+  // is computed against measured rows: `scrollToIndex` steps toward the target,
+  // measuring rows along the way (so it lands precisely) and re-engaging the
+  // renderer (so Android actually paints). Revealing only after the returned
+  // promise settles avoids a visible jump. Idempotent — safe to call from both
+  // `onLoad` and the data-widening effect below.
+  const maybeApplyInitialScroll = useCallback(() => {
     if (hasAppliedInitialScrollRef.current) {
       return;
     }
-    if (!initialDay) {
+    // Empty list: nothing to scroll or measure — and FlashList v2 doesn't fire
+    // `onLoad` for empty data — so reveal immediately (the ListEmptyComponent
+    // is what shows). Waiting on a layout signal that never arrives would hang
+    // the screen on its skeleton.
+    if (items.length === 0) {
       hasAppliedInitialScrollRef.current = true;
       onInitialScrollReady?.();
       return;
     }
+    // Everything below scrolls, so it needs measured rows: wait for the first
+    // layout (`onLoad`). Applied earlier it would scroll against v2's default
+    // row estimate and leave the list blank on Android until a manual scroll.
+    if (!hasLoadedRef.current) {
+      return;
+    }
+    // Scroll, then reveal once the scroll settles (avoids a visible jump). Falls
+    // back to an immediate reveal if the ref somehow isn't attached, so the
+    // screen never hangs on its skeleton waiting for a scroll that can't run.
+    const reveal = () => onInitialScrollReady?.();
+    const list = listRef.current;
+    const scrollThenReveal = (index: number, viewPosition?: number) => {
+      hasAppliedInitialScrollRef.current = true;
+      if (list) {
+        list
+          .scrollToIndex({index, animated: false, viewPosition})
+          .then(reveal, reveal);
+      } else {
+        reveal();
+      }
+    };
     if (targetIndex !== undefined) {
       // Center the focused day in the viewport (context above and below). The
       // list's bottom padding (`contentContainerStyle`) gives the newest day
       // room to settle at center rather than clamping to the bottom edge. The
       // oldest day (no top padding) and short lists still land toward the top.
-      listRef.current?.scrollToIndex({
-        index: targetIndex,
-        animated: false,
-        viewPosition: 0.5,
-      });
-      hasAppliedInitialScrollRef.current = true;
-      onInitialScrollReady?.();
+      scrollThenReveal(targetIndex, 0.5);
       return;
     }
-    // No matching day yet. If we can't load any older data (window already
-    // covers the user's earliest session) or there's nothing to show, stop
-    // waiting and reveal the list. Otherwise wait for the orchestrator to
-    // widen the window; this effect re-fires on `items`.
-    if (canLoadOlder === false || items.length === 0) {
-      hasAppliedInitialScrollRef.current = true;
-      onInitialScrollReady?.();
+    // No resolved target: either no focused day was requested, or the requested
+    // day is outside the loaded window and can't be loaded (window already
+    // covers the user's earliest session). Land on the newest sessions
+    // (bottom), matching `initialScrollIndex`'s fallback, and reveal.
+    if (!initialDay || canLoadOlder === false) {
+      scrollThenReveal(items.length - 1);
     }
+    // Otherwise the focused day isn't loaded yet — wait for the orchestrator to
+    // widen the window; the effect below re-fires as `items` grows.
   }, [
-    initialDay,
     targetIndex,
-    items.length,
+    initialDay,
     canLoadOlder,
+    items.length,
     onInitialScrollReady,
   ]);
+
+  const handleListLoad = useCallback(() => {
+    hasLoadedRef.current = true;
+    maybeApplyInitialScroll();
+  }, [maybeApplyInitialScroll]);
+
+  // Re-attempt the initial scroll when the loaded window widens (older months
+  // arriving can make a previously-out-of-range focused day resolvable). No-op
+  // until `onLoad` has set `hasLoadedRef`.
+  useEffect(() => {
+    maybeApplyInitialScroll();
+  }, [maybeApplyInitialScroll]);
 
   // Record the day the user is looking at so the home/profile calendar can
   // sync to it on back-navigation, and report it to the screen (for the
@@ -350,6 +397,13 @@ function DayOverviewListView({
 
   const keyExtractor = useCallback((item: ListItem) => item.key, []);
 
+  // Distinct recycling pools (and per-type size estimates) for the two row
+  // shapes — day headers are far shorter than session tiles, so a shared pool
+  // would recycle a header view into a session row (and vice versa), thrashing
+  // layout. v2 keys its running height estimate by type, so this also sharpens
+  // the offset math that `initialScrollIndex`/`scrollToIndex` rely on.
+  const getItemType = useCallback((item: ListItem) => item.kind, []);
+
   // Sits above the oldest loaded day (the top of the list) — only while an
   // older-data fetch is in flight, signaling "more on the way".
   const listHeader = useMemo(() => {
@@ -401,11 +455,13 @@ function DayOverviewListView({
         data={items}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
+        getItemType={getItemType}
         initialScrollIndex={initialScrollIndex}
         contentContainerStyle={contentContainerStyle}
         showsVerticalScrollIndicator
         ListHeaderComponent={listHeader}
         ListEmptyComponent={listEmpty}
+        onLoad={handleListLoad}
         onScrollBeginDrag={onScrollBeginDrag}
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={VIEWABILITY_CONFIG}

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -217,6 +217,14 @@ function SessionsCalendarWeekListView({
 
   const listRef = useRef<FlashListRef<ListItem>>(null);
   const hasAppliedInitialScrollRef = useRef(false);
+  // FlashList v2 renders nothing on its first cycle: it measures itself and its
+  // rows, then fires `onLoad`. Only after that are the real row heights known.
+  // The initial centering scroll must wait for it — applied earlier (e.g. in a
+  // mount effect, as this used to do) it runs against v2's 200px-per-row
+  // default estimate, lands at the wrong offset, and on Android leaves the list
+  // blank until a manual scroll re-engages the renderer (the reported bug).
+  // This flips true in `onLoad`.
+  const hasLoadedRef = useRef(false);
   // Whether the user has actually dragged the list. Until they do, the only
   // scroll is our programmatic centering, so there's no new position to sync —
   // syncing then would write whatever the centering math reports (a neighbour
@@ -238,32 +246,60 @@ function SessionsCalendarWeekListView({
 
   const wantsInitialScroll = !!initialMonthYear;
 
-  useEffect(() => {
-    if (hasAppliedInitialScrollRef.current) {
+  // Apply the one-time initial scroll, then reveal the calendar (via
+  // `onInitialScrollReady`). Runs only once `onLoad` has fired, so the scroll
+  // is computed against measured rows: `scrollToIndex` steps toward the target,
+  // measuring rows along the way (so it lands precisely) and re-engaging the
+  // renderer (so Android actually paints). Revealing only after the returned
+  // promise settles avoids a visible jump. Idempotent — safe to call from both
+  // `onLoad` and the data-widening effect below.
+  const maybeApplyInitialScroll = useCallback(() => {
+    if (hasAppliedInitialScrollRef.current || !hasLoadedRef.current) {
+      return;
+    }
+    // Scroll, then reveal once the scroll settles (avoids a visible jump). Falls
+    // back to an immediate reveal if the ref somehow isn't attached, so the
+    // screen never hangs on its skeleton waiting for a scroll that can't run.
+    const reveal = () => onInitialScrollReady?.();
+    const list = listRef.current;
+    const scrollThenReveal = (index: number, viewPosition?: number) => {
+      hasAppliedInitialScrollRef.current = true;
+      if (list) {
+        list
+          .scrollToIndex({index, animated: false, viewPosition})
+          .then(reveal, reveal);
+      } else {
+        reveal();
+      }
+    };
+    if (targetIndex !== undefined) {
+      // Center the target month's first week-row, mirroring the day-overview's
+      // centered open. The bottom spacer (`contentContainerStyle`) gives a
+      // near-latest target room to reach center rather than clamping to the
+      // bottom edge.
+      scrollThenReveal(targetIndex, 0.5);
       return;
     }
     if (!wantsInitialScroll) {
-      hasAppliedInitialScrollRef.current = true;
-      onInitialScrollReady?.();
-      return;
+      // No target month requested — land on the latest weeks (bottom),
+      // matching `initialScrollIndex`'s fallback, and reveal.
+      scrollThenReveal(Math.max(0, items.length - 1));
     }
-    if (targetIndex === undefined) {
-      // Waiting for the data fetcher to widen the loaded range so the
-      // target month enters `items`. The effect will re-fire on `items`.
-      return;
-    }
-    // Center the target month's first week-row, mirroring the day-overview's
-    // centered open. The bottom spacer (`contentContainerStyle`) gives a
-    // near-latest target room to reach center rather than clamping to the
-    // bottom edge.
-    listRef.current?.scrollToIndex({
-      index: targetIndex,
-      animated: false,
-      viewPosition: 0.5,
-    });
-    hasAppliedInitialScrollRef.current = true;
-    onInitialScrollReady?.();
-  }, [items, targetIndex, wantsInitialScroll, onInitialScrollReady]);
+    // Otherwise the target month isn't in the loaded range yet — wait for the
+    // data fetcher to widen it; the effect below re-fires as `items` grows.
+  }, [items.length, targetIndex, wantsInitialScroll, onInitialScrollReady]);
+
+  const handleListLoad = useCallback(() => {
+    hasLoadedRef.current = true;
+    maybeApplyInitialScroll();
+  }, [maybeApplyInitialScroll]);
+
+  // Re-attempt the initial scroll when the loaded range widens (the target
+  // month entering `items`) or when `onLoad` arrives. No-op until `onLoad` has
+  // set `hasLoadedRef`.
+  useEffect(() => {
+    maybeApplyInitialScroll();
+  }, [maybeApplyInitialScroll]);
 
   // Room below the newest week so `scrollToIndex({viewPosition: 0.5})` can pull
   // a near-latest target toward center instead of clamping it to the bottom.
@@ -388,6 +424,12 @@ function SessionsCalendarWeekListView({
 
   const keyExtractor = useCallback((item: ListItem) => item.key, []);
 
+  // Distinct recycling pools (and per-type size estimates) for the two row
+  // shapes — a one-line month label vs. a full week grid-row. v2 keys its
+  // running height estimate by type, so this also sharpens the offset math that
+  // `initialScrollIndex`/`scrollToIndex` rely on.
+  const getItemType = useCallback((item: ListItem) => item.kind, []);
+
   // FlashList renders this above the first item in the list — i.e. above
   // the oldest loaded week. It only shows while a data fetch is in flight,
   // signaling "more months are on the way" when the user has scrolled past
@@ -440,11 +482,13 @@ function SessionsCalendarWeekListView({
           data={items}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
+          getItemType={getItemType}
           stickyHeaderIndices={stickyHeaderIndices}
           initialScrollIndex={initialScrollIndex}
           contentContainerStyle={contentContainerStyle}
           showsVerticalScrollIndicator
           ListHeaderComponent={listHeader}
+          onLoad={handleListLoad}
           onScrollBeginDrag={onScrollBeginDrag}
           onViewableItemsChanged={onViewableItemsChanged}
           viewabilityConfig={VIEWABILITY_CONFIG}


### PR DESCRIPTION
## Problem

On **Android only**, opening the drinking-sessions history (the day-overview scroll and the fullscreen week-list calendar) sometimes showed a **blank list**, with the sessions only appearing after a manual scroll. iOS was fine.

## Root cause

The lists are FlashList **v2** (`@shopify/flash-list@2.0.3`) and use `initialScrollIndex`. v2 renders nothing on its first cycle, measures itself + its rows, then fires `onLoad`. Until rows are measured, the layout manager estimates **every** row at its hardcoded **200px-per-type default** (v2 removed `estimatedItemSize`, with no public knob to seed it).

Our rows are much shorter than 200px (~30–90px day/session rows, ~45px week-grid rows), so the `initialScrollIndex` offset **overshoots far past the real content**. Worse, both lists applied their centering `scrollToIndex` from a **mount `useEffect`** — i.e. *before* that first measurement — and then revealed the (opacity-gated) list immediately. On Android the renderer doesn't repaint after a mis-estimated scroll until a real touch re-engages it → blank until scroll.

This matches the open upstream report [Shopify/flash-list#1887](https://github.com/Shopify/flash-list/issues/1887) (same RN + flash-list 2.0.3), which has no official fix yet.

## Fix

Drive the corrective scroll **and** the reveal off FlashList's **`onLoad`** (post first-layout) instead of a pre-measurement effect:

- By `onLoad`, the rows around the target are measured, so v2's `scrollToIndex` steps toward the target **measuring rows along the way** (lands precisely) while **re-engaging the renderer** (so Android paints).
- The reveal (`onInitialScrollReady`) now waits for the `scrollToIndex` promise to settle, so the existing skeleton stays up until the list is genuinely drawn rather than flashing a blank area. No new skeletons added (the screens already gate with one).
- A data-widening effect still re-attempts the scroll once a previously out-of-range focused day/month loads.
- Empty day-overview lists reveal immediately (v2 never fires `onLoad` for empty data), preserving prior behavior and avoiding a stuck skeleton.
- Added `getItemType` to the two-row-shape lists (day header vs. session tile; month label vs. week row) so they recycle in separate pools and v2 keeps a per-type height estimate — which also sharpens the offset math.
- The year-overview date picker re-applies its initial scroll on `onLoad` for the same precision.

iOS behavior is unchanged (it already painted correctly; the `onLoad`-driven scroll lands at the same place).

## Scope

Only the three FlashLists that use `initialScrollIndex`:
- `src/components/SessionsCalendar/DayOverviewListView.tsx`
- `src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx`
- `src/components/DateSelectorModal/Calendar.tsx`

## Checks

`npx prettier --write`, `lint` (scoped), `npm run typecheck-tsgo`, and `npm run react-compiler-compliance-check check-changed` all pass.

## Testing notes

Needs a device/emulator check on **Android**: open a day from the calendar (day-overview scroll) and tap a month header (fullscreen week calendar) — the list should appear already scrolled to the focused day/month with no blank frame or scroll-to-reveal. Confirm **iOS** still opens centered with no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)