### PR TITLE
feat(splash): gate logo fly-in behind LOGO_FLY_IN flag, disabled

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -116,6 +116,10 @@ const CONST = {
   FEATURES: {
     BADGES: false,
     FULLSCREEN_CALENDAR: true,
+    // Boot-splash logo fly-in / splash→logo handoff (#1196). Off so the in-app
+    // logo plays its full assembly + liquid-fill entrance instead of being
+    // masked by the flying splash logo.
+    LOGO_FLY_IN: false,
   },
   APP_UPDATE: {
     // How long the dismiss update button should hide the window for

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -13,6 +13,7 @@ import ImageSVG from '@components/ImageSVG';
 import SplashScreenStateContext from '@context/global/SplashScreenStateContext';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BootSplash from '@libs/BootSplash';
+import * as FeatureFlags from '@libs/FeatureFlags';
 import Log from '@libs/Log';
 import colors from '@src/styles/theme/colors';
 import type {
@@ -117,9 +118,12 @@ function SplashScreenHider({
       const reduceMotionEnabled =
         await AccessibilityInfo.isReduceMotionEnabled().catch(() => false);
 
-      // Handoff only when the signed-out tree reported a usable logo slot and
-      // motion isn't reduced. Otherwise keep today's hide.
+      // Handoff only when the fly-in feature is enabled, the signed-out tree
+      // reported a usable logo slot, and motion isn't reduced. Otherwise keep
+      // today's hide. With LOGO_FLY_IN off, every path shrinks out and the
+      // in-app logo plays its full assembly + liquid-fill entrance.
       if (
+        !FeatureFlags.isEnabled('LOGO_FLY_IN') ||
         !target ||
         target.width <= 0 ||
         target.height <= 0 ||


### PR DESCRIPTION
## Context

On signed-out cold boot, the native boot-splash logo **flies in** from screen center into the InitialScreen logo slot, then crossfades onto the in-app logo (the splash→logo handoff, #1196). While that fly-in runs, the in-app logo is forced to render fully **settled** underneath the overlay, so its **assembly ("appear in")** and **liquid-fill** animations never play (the handoff jumps `progress` straight to `1` with `duration: 0`).

This PR stops hiding those phases by gating the fly-in behind a single static feature flag, defaulted **off**. With the flag off, the splash falls back to the existing **shrink-out** path and the in-app logo plays its full assembly + liquid-fill + shimmer entrance.

## Changes

- **`src/CONST.ts`** — add `LOGO_FLY_IN: false` to `CONST.FEATURES`.
- **`src/components/SplashScreenHider/index.native.tsx`** — read the flag via `FeatureFlags.isEnabled('LOGO_FLY_IN')` and add it as the first short-circuit in the existing fallback guard, so a disabled flag always takes `shrinkOut()`.

All fly-in code (the flight transform, `setIsLogoHandoffActive`, the reveal fade, and the in-app logo's `isHandoff` branch) stays in place, dormant, and re-enables by flipping the flag back on. Native-only; the web `SplashScreenHider` has no fly-in.

## Why one gate point is enough

The in-app logo only skips its entrance when `isLogoHandoffActive` is `true`, and that flag is set solely inside the fly-in branch. Never entering that branch keeps it `false`, so the in-app logo plays its normal entrance automatically — no other files need behavioral changes. The shrink-out fallback doesn't depend on the logo-slot target, so forcing it can't strand the splash.

## Verification

- `npm run typecheck-tsgo` passes (confirms `'LOGO_FLY_IN'` is a valid `FeatureFlag`).
- `npm run lint-changed` clean.
- Manual (flag OFF, shipped state): signed-out iOS cold boot shows the splash shrink out, then the InitialScreen logo plays its appear-in + fill.
- Regression (flag ON): temporarily set `LOGO_FLY_IN: true` and confirm the original fly-in handoff still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)