### PR TITLE
feat(moderation): suspend signed-in user when banned (Kiroku#1238)

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -33,8 +33,10 @@ import UnderMaintenanceModal from './components/Modals/UnderMaintenanceModal';
 import UpdateAppModal from './components/UpdateAppModal';
 import ForceUpdateModal from './components/Modals/ForceUpdateModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
+import AccountSuspendedModal from './components/Modals/AccountSuspendedModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
 import useNativeAppearanceSync from './hooks/useNativeAppearanceSync';
+import useCurrentUserData from './hooks/useCurrentUserData';
 import colors from './styles/theme/colors';
 import CONST from './CONST';
 
@@ -88,6 +90,12 @@ function Kiroku() {
 
   const {config} = useConfig();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  // An admin ban pushes `banned: true` onto the signed-in user's own record
+  // (Kiroku #1238); lock the app out immediately rather than waiting for the
+  // Firebase token to expire.
+  const currentUserData = useCurrentUserData();
+  const isAccountSuspended =
+    isAuthenticated && currentUserData?.banned === true;
   const [authenticationChecked, setAuthenticationChecked] = useState(false);
   const [isUnderMaintenance, setIsUnderMaintenance] = useState<boolean>(false);
   const [updateAvailable, setUpdateAvailable] = useState<boolean>(false);
@@ -325,13 +333,18 @@ function Kiroku() {
             isUnderMaintenance && <UnderMaintenanceModal config={config} />
           )}
 
-          {shouldInit && (
-            <>
-              {shouldShowVerifyEmailModal && <VerifyEmailModal />}
-              {shouldShowUpdateModal && <UpdateAppModal />}
-              {/* // TODO show shared session invites here */}
-            </>
-          )}
+          {shouldInit &&
+            (isAccountSuspended ? (
+              // A suspended account supersedes every other gate — the only
+              // affordance is sign-out.
+              <AccountSuspendedModal />
+            ) : (
+              <>
+                {shouldShowVerifyEmailModal && <VerifyEmailModal />}
+                {shouldShowUpdateModal && <UpdateAppModal />}
+                {/* // TODO show shared session invites here */}
+              </>
+            ))}
 
           <NavigationRoot
             onReady={setNavigationReady}

--- a/src/components/Modals/AccountSuspendedModal.tsx
+++ b/src/components/Modals/AccountSuspendedModal.tsx
@@ -1,0 +1,104 @@
+import {View} from 'react-native';
+import {useFirebase} from '@context/global/FirebaseContext';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import * as Session from '@libs/actions/Session';
+import * as Link from '@libs/actions/Link';
+import CONST from '@src/CONST';
+import Button from '@components/Button';
+import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import Modal from '@components/Modal';
+import {PressableWithFeedback} from '@components/Pressable';
+import SafeAreaConsumer from '@components/SafeAreaConsumer';
+import Text from '@components/Text';
+
+/**
+ * Mandatory "your account has been suspended" lockout. Shown when the signed-in
+ * user's own record carries `banned === true` (an admin ban — kiroku-api also
+ * disables the Firebase Auth account, but that only bites on the next token
+ * refresh; the pushed `banned` flag locks the client out immediately, Kiroku
+ * #1238). Like VerifyEmailModal it is an unswipeable, undismissable gate — the
+ * only affordance is "Sign out". A "Contact support" link points at the
+ * published moderation contact (kiroku.cz/support) for appeals.
+ */
+function AccountSuspendedModal() {
+  const {auth} = useFirebase();
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+
+  const onSignOutPress = () => {
+    Session.signOut(auth).catch(() => {
+      // Best-effort: even if the network sign-out call fails, the modal stays
+      // up (the user remains locked out) — nothing else to surface here.
+    });
+  };
+
+  const onContactSupportPress = () => {
+    Link.openExternalLink(CONST.SUPPORT_URL);
+  };
+
+  return (
+    <SafeAreaConsumer>
+      {({safeAreaPaddingBottomStyle}) => (
+        <Modal
+          isVisible
+          type={CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
+          onClose={() => {}}
+          innerContainerStyle={{flex: 1, boxShadow: 'none'}}>
+          <View
+            style={[
+              styles.flex1,
+              styles.mh4,
+              styles.alignItemsCenter,
+              safeAreaPaddingBottomStyle.paddingBottom
+                ? safeAreaPaddingBottomStyle
+                : styles.pb5,
+            ]}>
+            <View
+              style={[
+                styles.flexGrow1,
+                styles.justifyContentCenter,
+                styles.alignItemsCenter,
+              ]}>
+              <Icon src={KirokuIcons.Lock} fill={theme.danger} large />
+              <Text
+                textAlign="center"
+                style={[styles.textHeadlineH2, styles.mt3]}>
+                {translate('accountSuspendedScreen.title')}
+              </Text>
+              <Text textAlign="center" style={styles.mt3}>
+                {translate('accountSuspendedScreen.body')}
+              </Text>
+            </View>
+            <View style={styles.pb1}>
+              <Button
+                success
+                large
+                style={styles.mt1}
+                text={translate('settingsScreen.signOut')}
+                onPress={onSignOutPress}
+              />
+              <PressableWithFeedback
+                style={[styles.mt4, styles.alignItemsCenter]}
+                onPress={onContactSupportPress}
+                role={CONST.ROLE.BUTTON}
+                accessibilityLabel={translate(
+                  'accountSuspendedScreen.contactSupport',
+                )}>
+                <Text style={styles.link}>
+                  {translate('accountSuspendedScreen.contactSupport')}
+                </Text>
+              </PressableWithFeedback>
+            </View>
+          </View>
+        </Modal>
+      )}
+    </SafeAreaConsumer>
+  );
+}
+
+AccountSuspendedModal.displayName = 'AccountSuspendedModal';
+export default AccountSuspendedModal;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -994,6 +994,11 @@ export default {
     sending: 'Odesílám zpětnou vazbu…',
     error: 'Došlo k chybě při odesílání zpětné vazby. Zkuste to prosím znovu.',
   },
+  accountSuspendedScreen: {
+    title: 'Účet pozastaven',
+    body: 'Váš účet byl pozastaven kvůli porušení našich pravidel komunity. Pokud si myslíte, že jde o omyl, kontaktujte podporu.',
+    contactSupport: 'Kontaktovat podporu',
+  },
   manageAccountScreen: {
     title: 'Správa účtu',
     dangerZone: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -990,6 +990,11 @@ export default {
     sending: 'Sending feedback...',
     error: 'There was an error sending your feedback. Please try again.',
   },
+  accountSuspendedScreen: {
+    title: 'Account suspended',
+    body: 'Your account has been suspended for violating our community guidelines. If you think this is a mistake, contact support.',
+    contactSupport: 'Contact support',
+  },
   reportUserScreen: {
     title: 'Report',
     prompt:

--- a/src/types/onyx/UserData.ts
+++ b/src/types/onyx/UserData.ts
@@ -124,6 +124,17 @@ type UserData = {
    */
   blocked?: UserList;
 
+  /**
+   * Whether an admin has banned/suspended this account (`users/{uid}/banned`,
+   * Kiroku #766/#1238). Server-authoritative — written by the kiroku-api admin
+   * ban/unban handlers (which also disable the Firebase Auth account) and pushed
+   * to the signed-in user's own `USER_DATA_LIST` entry via Pusher / `/v1/updates`
+   * / `app/open`. The app reads it on the OWN record to force an immediate
+   * "account suspended" lockout + sign-out, instead of waiting for the Firebase
+   * token to expire. Not meaningful on other users' records.
+   */
+  banned?: boolean;
+
   /** User's private data */
   private_data?: UserPrivateData;
 


### PR DESCRIPTION
The Kiroku-app half of **PetrCala/Kiroku#1238** (honor the admin ban flag) — part of the UGC-moderation epic **#757**. Companion to the kiroku-api PR (PetrCala/kiroku-api#103).

An admin "ban" (#766) disables the Firebase Auth account and sets `users/{uid}/banned = true`, but the Auth `disabled` flag only bites on the next ID-token refresh (~1h). This locks a banned user out of the app immediately.

## What's here
- **`UserData.banned?: boolean`** — hydrates onto the signed-in user's own `USER_DATA_LIST` record the same way `blocked` does (app/open + Pusher + `/v1/updates`). kiroku-api pushes it instantly on ban.
- **`AccountSuspendedModal`** — a mandatory, unswipeable gate (mirrors `VerifyEmailModal`: `CENTERED_UNSWIPEABLE`, no dismiss). Only affordance is **Sign out** (`Session.signOut`), plus a **Contact support** link to `kiroku.cz/support` for appeals.
- **`Kiroku.tsx`** — renders it (gated on `useCurrentUserData().banned`) ahead of the verify/update modals; a suspended account supersedes every other gate.
- en/cs copy.

Backstop: `Reauthentication.ts` already breaks the reauth loop on a revoked/disabled account, so even without the instant push the user lands on sign-in within the token TTL.

## Testing
`npm run typecheck` ✅; ESLint on the changed files ✅ (0 errors). Manual: with the kiroku-api PR deployed to dev, banning the signed-in test user surfaces the suspended modal within seconds; unban clears it on next session.

## Not doing
Client-side filtering of *other* banned users — the client has no `banned` flag for others; the api PR hides them server-side (visibility eviction + search).

Refs: PetrCala/Kiroku#1238, PetrCala/Kiroku#766, PetrCala/Kiroku#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
