### PR TITLE
ci(ios): retry iOS Fastlane deploy step on transient ASC failures

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -222,7 +222,16 @@ jobs:
         run: bash scripts/generateReleaseNotes.sh
 
       - name: Run Fastlane
-        run: bundle exec fastlane ios ${{ inputs.SHOULD_DEPLOY_PRODUCTION && 'production' || 'beta' }}
+        uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
+        with:
+          # The iOS archive+upload took ~27 min in a single attempt, so 60 min
+          # comfortably exceeds one full `fastlane ios` lane re-run. Retry guards
+          # against transient App Store Connect failures (e.g. altool HTTP 500
+          # during the upload-complete step), mirroring the Android step above.
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: bundle exec fastlane ios ${{ inputs.SHOULD_DEPLOY_PRODUCTION && 'production' || 'beta' }}
         env:
           APPLE_CONTACT_EMAIL: ${{ secrets.APPLE_CONTACT_EMAIL }}
           APPLE_CONTACT_PHONE: ${{ secrets.APPLE_CONTACT_PHONE }}


### PR DESCRIPTION
## Why

The "Build and deploy android and iOS clients" workflow failed on release **0.3.15-12** ([run 27148595341](https://github.com/PetrCala/Kiroku/actions/runs/27148595341), 2026-06-08). The iOS build, signing, archive, and export **all succeeded** — the failure was purely in the App Store Connect upload via Apple's `altool`:

```
ERROR: [ContentDelivery.Uploader] CHANGE UPLOAD STATE TO COMPLETE (ASSET_UPLOAD): received status code 500; internal server error. (500)
[!] Error uploading ipa file: ... received status code 500
fastlane finished with errors
```

This is a **transient Apple-side HTTP 500**, not a code/cert/config problem. In the same run, the Android job hit a transient timeout but **self-healed** because its "Run Fastlane" step is wrapped in `nick-fields/retry`. The iOS "Run Fastlane" step was a bare `run:` with no retry, so a single transient Apple 500 killed the entire iOS deploy job.

## What changed

`.github/workflows/platformDeploy.yml` — the iOS **Run Fastlane** step now uses `nick-fields/retry` (pinned to the same SHA already used elsewhere in this file, `3f757583fb1b1f940bc8ef4bf4734c8dc02a5847`), mirroring the existing Android step:

- `max_attempts: 3` — same as Android.
- `timeout_minutes: 60` — the iOS archive+upload took ~27 min in run 12, and a retry re-runs the full `fastlane ios` lane, so 60 min comfortably exceeds one full attempt.
- `retry_wait_seconds: 30` — brief pause between attempts (also used by the iOS platform-SDK step in this file).

The entire `env:` block (including `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT`/`RETRIES`) is preserved unchanged — `env:` is valid on a `uses:` step.

## Notes

- CI-only YAML change; nothing in the app to typecheck/lint. YAML validated as well-formed and the job/step structure (indentation, `if:` conditions, ordering) is unchanged.
- Behavior now matches the Android job, which already survives transient deploy failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_015xJdV13kBWprFcWs26ew1c)_