### PR TITLE
ci(testBuild): cancel superseded test builds so they stop posting false "FAILED" comments

### DIFF
--- a/.github/workflows/testBuild.yml
+++ b/.github/workflows/testBuild.yml
@@ -10,6 +10,19 @@ on:
   pull_request:
     types: [labeled]
 
+# Supersede an in-flight test build for the same PR + trigger label. A rebase or
+# a re-applied "Ready To Build" label starts a fresh run; without this, the older
+# run keeps compiling, and when it is cancelled its platform jobs end as
+# `cancelled` while the `postGithubComment` job (`if: always()`) still runs and
+# renders that result as "❌ FAILED ❌" — a false failure on a build that was only
+# superseded. Cancelling the stale run as a whole unit stops the misleading
+# comment and frees the expensive macOS/Android runners. The label name is part
+# of the key so the single-platform "- iOS" / "- Android" builds stay independent
+# of each other (and of the combined "Ready To Build").
+concurrency:
+  group: testBuild-${{ github.event.pull_request.number || github.event.inputs.PULL_REQUEST_NUMBER }}-${{ github.event.label.name || 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   pull-requests: write


### PR DESCRIPTION
## Context

The test build for #1243 was reported as **❌ FAILED ❌** on both Android and iOS, but neither build actually broke.

## Root cause — a *superseded* run, not a failed one

[Run `27360274182`](https://github.com/PetrCala/Kiroku/actions/runs/27360274182) was still **compiling** when it was cancelled:

- Android was at `Run Fastlane - Build Android`, still building Gradle's *own plugins* (it never reached app compilation or JS bundling).
- iOS was still on `Install cocoapods`.

While it ran, #1243 was rebased and the **"Ready To Build"** label was re-applied, which started a newer run ([`27360504497`](https://github.com/PetrCala/Kiroku/actions/runs/27360504497)) on the latest commit. The stale run's platform jobs ended as `cancelled`, and because the `postGithubComment` job is `if: ${{ always() }}`, it still ran and rendered the cancelled result as `❌ FAILED ❌` — the comment action (`postTestBuildComment.ts`) treats every non-`success`, non-`skipped` result as a failure.

Two gaps combined:

1. **`testBuild.yml` had no `concurrency` group**, so a superseded run was neither cancelled cleanly as a unit nor stopped from posting the misleading comment, and redundant builds piled up on the expensive `macos-26` / Android runners.
2. The download-link comment can't tell `cancelled` apart from `failure`.

The PR's own code was never the problem: typecheck, lint, tests, web build and React-Compiler all passed, and the re-run on the latest commit built both apps cleanly.

## Fix

Add a `concurrency` group to `testBuild.yml`, keyed by **PR number + trigger label**, with `cancel-in-progress: true`. A new run for the same PR/label now cancels the stale run **as a whole unit** (including its `postGithubComment` job), so:

- no false `FAILED` comment is posted for a build that was only superseded, and
- the runners are freed instead of finishing a build whose result will be discarded.

Keying on the label name keeps the single-platform `Ready To Build - iOS` / `Ready To Build - Android` builds independent of each other and of the combined `Ready To Build`.

### Follow-up (not in this PR)

`postTestBuildComment.ts` could additionally render `cancelled` distinctly from `failure` for defense-in-depth, but that requires rebuilding the action's compiled `index.js` bundle (ncc), which isn't possible in this environment. The `concurrency` guard already removes the only path that produced the misleading comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aa4waMcXoJKZCuznkfVp1T)_