### PR TITLE
fix(web/e2e): reach Home after sign-in so the Playwright suite goes green

### DIFF
--- a/e2e/web/fixtures/auth.ts
+++ b/e2e/web/fixtures/auth.ts
@@ -10,8 +10,11 @@ import {HomePage} from '../pages/HomePage';
  */
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'user.json');
 
-const E2E_TEST_EMAIL = process.env.E2E_TEST_EMAIL;
-const E2E_TEST_PASSWORD = process.env.E2E_TEST_PASSWORD;
+// Trim the credentials: a trailing newline/space in the GitHub secret would
+// otherwise be submitted verbatim (the app trims the email but not the
+// password), which Firebase rejects as `auth/wrong-password`.
+const E2E_TEST_EMAIL = process.env.E2E_TEST_EMAIL?.trim();
+const E2E_TEST_PASSWORD = process.env.E2E_TEST_PASSWORD?.trim();
 
 type AuthFixtures = {
   /** A page already signed in via the cached storage state. */

--- a/e2e/web/fixtures/devGates.ts
+++ b/e2e/web/fixtures/devGates.ts
@@ -2,14 +2,8 @@ import type {Page} from '@playwright/test';
 
 /**
  * Drive the app from just-after-sign-in (or a fresh authenticated page load) to
- * the Home screen, clearing whatever sits in between:
+ * the Home screen, clearing the dev-build gates that can sit in between:
  *
- *   - the **stale `/auth` URL**. Sign-in happens on the public `/auth` route;
- *     once Firebase auth flips, the navigator swaps to the authenticated stack,
- *     which has *no* `/auth` route, so the app renders NotFound (not Home) until
- *     something navigates. `homePage.goto()` sidesteps this by loading `/`
- *     directly, but a bare `signIn()` leaves the URL on `/auth`. So if Home
- *     hasn't appeared and no gate is up, nudge the app to its root once.
  *   - the **email-verification** screen. Dev/staging/adhoc builds expose a
  *     "Skip verification (dev only)" action; for an unverified account this gate
  *     is re-shown on every fresh load, so authenticated navigations need to
@@ -18,16 +12,17 @@ import type {Page} from '@playwright/test';
  *     This is the post-onboarding `TermsReConsentGuard`, which `SKIP_ONBOARDING`
  *     does *not* bypass, so it can appear even on the E2E build.
  *
- * All of these are best-effort: an already-verified account that has accepted
- * the current terms and is already on Home exits on the first check. The suite
- * runs against the dev/staging build (`npm run web`, preview channel), where the
- * skip action exists; on a production build it would not, and a verified account
- * would not see the gate at all.
+ * Both are best-effort: an already-verified account that has accepted the
+ * current terms goes straight to Home and the loop exits on the first check.
+ * The suite runs against the dev/staging build (`npm run web`, preview channel),
+ * where the skip action exists; on a production build it would not, and a
+ * verified account would not see the gate at all.
  *
  * If Home never appears, dump the page URL + ARIA snapshot to stdout before
  * failing. CI artifacts (screenshots/traces) are not always reachable, so the
  * job log is the only place this state is guaranteed to surface — the snapshot
- * names whatever screen we got stuck on.
+ * names whatever screen we got stuck on (e.g. a sign-in form still showing a
+ * server/validation error means authentication never actually completed).
  */
 export async function reachAuthenticatedApp(page: Page): Promise<void> {
   const home = page.getByTestId('Home Screen');
@@ -37,14 +32,8 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
   const confirmTerms = page.getByRole('button', {name: 'Confirm'});
   const agreeToTerms = page.getByRole('checkbox').first();
 
-  // Only nudge to the app root once: a repeated reload loop would just burn the
-  // fixture timeout if something other than the stale URL is keeping us off Home.
-  let didNavigateToRoot = false;
-
-  // Several gates can stack between sign-in and Home; clear whatever is up until
-  // Home renders (or we run out of attempts and dump + assert below). Budget the
-  // loop well under the test timeout so the diagnostics always get to print even
-  // on the slow sign-in path (two ~8MB CanvasKit boots: /auth then the root).
+  // A couple of gates can stack between sign-in and Home; clear whatever is up
+  // until Home renders (or we run out of attempts and dump + assert below).
   for (let attempt = 0; attempt < 8; attempt += 1) {
     if (await home.isVisible().catch(() => false)) {
       return;
@@ -57,12 +46,6 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
       await confirmTerms.click().catch(() => {});
     } else if (await skipVerification.isVisible().catch(() => false)) {
       await skipVerification.click().catch(() => {});
-    } else if (!didNavigateToRoot) {
-      // No gate is up but Home still isn't here — most likely the URL is stuck
-      // on `/auth` (NotFound under the authenticated stack). Resolve to the Home
-      // tab by loading the app root.
-      didNavigateToRoot = true;
-      await page.goto('/').catch(() => {});
     }
 
     // Wait for the next screen (Home or another gate) to mount before retrying.
@@ -70,7 +53,7 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
       .or(skipVerification)
       .or(confirmTerms)
       .first()
-      .waitFor({state: 'visible', timeout: 6000})
+      .waitFor({state: 'visible', timeout: 8000})
       .catch(() => {});
   }
 
@@ -86,12 +69,23 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
 /**
  * Log where the app got stuck. The ARIA snapshot lists the roles + accessible
  * names of everything on screen, which is enough to tell a blocking modal
- * (verify-email, force-update, terms) apart from a NotFound / loading screen.
+ * (verify-email, force-update, terms) apart from a still-logged-out sign-in
+ * form (which means authentication never completed) or a NotFound / loading
+ * screen.
  */
 async function dumpStuckPageState(page: Page): Promise<void> {
   /* eslint-disable no-console */
   try {
     console.log(`[reachAuthenticatedApp] stuck — URL: ${page.url()}`);
+    // If we're still on the sign-in form, the email field's value tells us
+    // whether Playwright's fill() actually reached the FormProvider-backed
+    // input (empty -> fill never registered -> validation blocked submit;
+    // populated -> the failure is credentials / a server error instead).
+    const emailValue = await page
+      .locator('input[aria-label="Email"]')
+      .inputValue()
+      .catch(() => '<no email input on page>');
+    console.log(`[reachAuthenticatedApp] email input value: "${emailValue}"`);
     const snapshot = await page
       .locator('body')
       .ariaSnapshot()

--- a/e2e/web/fixtures/devGates.ts
+++ b/e2e/web/fixtures/devGates.ts
@@ -2,19 +2,32 @@ import type {Page} from '@playwright/test';
 
 /**
  * Drive the app from just-after-sign-in (or a fresh authenticated page load) to
- * the Home screen, clearing the dev-build gates that can sit in between:
+ * the Home screen, clearing whatever sits in between:
  *
+ *   - the **stale `/auth` URL**. Sign-in happens on the public `/auth` route;
+ *     once Firebase auth flips, the navigator swaps to the authenticated stack,
+ *     which has *no* `/auth` route, so the app renders NotFound (not Home) until
+ *     something navigates. `homePage.goto()` sidesteps this by loading `/`
+ *     directly, but a bare `signIn()` leaves the URL on `/auth`. So if Home
+ *     hasn't appeared and no gate is up, nudge the app to its root once.
  *   - the **email-verification** screen. Dev/staging/adhoc builds expose a
  *     "Skip verification (dev only)" action; for an unverified account this gate
  *     is re-shown on every fresh load, so authenticated navigations need to
  *     clear it too (not just sign-in).
  *   - the **updated terms-of-service** consent sheet (checkbox + "Confirm").
+ *     This is the post-onboarding `TermsReConsentGuard`, which `SKIP_ONBOARDING`
+ *     does *not* bypass, so it can appear even on the E2E build.
  *
- * Both are best-effort: an already-verified account that has accepted the
- * current terms goes straight to Home and the loop exits on the first check.
- * The suite runs against the dev/staging build (`npm run web`, preview channel),
- * where the skip action exists; on a production build it would not, and a
- * verified account would not see the gate at all.
+ * All of these are best-effort: an already-verified account that has accepted
+ * the current terms and is already on Home exits on the first check. The suite
+ * runs against the dev/staging build (`npm run web`, preview channel), where the
+ * skip action exists; on a production build it would not, and a verified account
+ * would not see the gate at all.
+ *
+ * If Home never appears, dump the page URL + ARIA snapshot to stdout before
+ * failing. CI artifacts (screenshots/traces) are not always reachable, so the
+ * job log is the only place this state is guaranteed to surface — the snapshot
+ * names whatever screen we got stuck on.
  */
 export async function reachAuthenticatedApp(page: Page): Promise<void> {
   const home = page.getByTestId('Home Screen');
@@ -24,8 +37,14 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
   const confirmTerms = page.getByRole('button', {name: 'Confirm'});
   const agreeToTerms = page.getByRole('checkbox').first();
 
-  // A couple of gates can stack between sign-in and Home; clear whatever is up
-  // until Home renders (or we run out of attempts and assert below).
+  // Only nudge to the app root once: a repeated reload loop would just burn the
+  // fixture timeout if something other than the stale URL is keeping us off Home.
+  let didNavigateToRoot = false;
+
+  // Several gates can stack between sign-in and Home; clear whatever is up until
+  // Home renders (or we run out of attempts and dump + assert below). Budget the
+  // loop well under the test timeout so the diagnostics always get to print even
+  // on the slow sign-in path (two ~8MB CanvasKit boots: /auth then the root).
   for (let attempt = 0; attempt < 8; attempt += 1) {
     if (await home.isVisible().catch(() => false)) {
       return;
@@ -33,11 +52,17 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
 
     if (await confirmTerms.isVisible().catch(() => false)) {
       if (await agreeToTerms.isVisible().catch(() => false)) {
-        await agreeToTerms.click();
+        await agreeToTerms.click().catch(() => {});
       }
-      await confirmTerms.click();
+      await confirmTerms.click().catch(() => {});
     } else if (await skipVerification.isVisible().catch(() => false)) {
-      await skipVerification.click();
+      await skipVerification.click().catch(() => {});
+    } else if (!didNavigateToRoot) {
+      // No gate is up but Home still isn't here — most likely the URL is stuck
+      // on `/auth` (NotFound under the authenticated stack). Resolve to the Home
+      // tab by loading the app root.
+      didNavigateToRoot = true;
+      await page.goto('/').catch(() => {});
     }
 
     // Wait for the next screen (Home or another gate) to mount before retrying.
@@ -45,10 +70,37 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
       .or(skipVerification)
       .or(confirmTerms)
       .first()
-      .waitFor({state: 'visible', timeout: 15_000})
+      .waitFor({state: 'visible', timeout: 6000})
       .catch(() => {});
   }
 
+  if (await home.isVisible().catch(() => false)) {
+    return;
+  }
+
+  await dumpStuckPageState(page);
   // Final assertion: surfaces a clear failure if Home never came up.
   await home.waitFor({state: 'visible'});
+}
+
+/**
+ * Log where the app got stuck. The ARIA snapshot lists the roles + accessible
+ * names of everything on screen, which is enough to tell a blocking modal
+ * (verify-email, force-update, terms) apart from a NotFound / loading screen.
+ */
+async function dumpStuckPageState(page: Page): Promise<void> {
+  /* eslint-disable no-console */
+  try {
+    console.log(`[reachAuthenticatedApp] stuck — URL: ${page.url()}`);
+    const snapshot = await page
+      .locator('body')
+      .ariaSnapshot()
+      .catch(() => '<aria snapshot unavailable>');
+    console.log(`[reachAuthenticatedApp] ARIA snapshot:\n${snapshot}`);
+  } catch (error) {
+    console.log(
+      `[reachAuthenticatedApp] failed to capture page state: ${String(error)}`,
+    );
+  }
+  /* eslint-enable no-console */
 }

--- a/e2e/web/playwright.config.ts
+++ b/e2e/web/playwright.config.ts
@@ -41,8 +41,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   // The web app loads ~8MB of CanvasKit WASM before boot (Skia charts), so the
-  // first authenticated navigation is slow. Budget generously.
-  timeout: 90_000,
+  // first authenticated navigation is slow. The worker sign-in fixture can boot
+  // twice (the /auth page, then the app root after the post-auth nudge in
+  // reachAuthenticatedApp), so budget generously.
+  timeout: 150_000,
   expect: {timeout: 15_000},
   reporter: process.env.CI
     ? [

--- a/e2e/web/tests/smoke.spec.ts
+++ b/e2e/web/tests/smoke.spec.ts
@@ -4,8 +4,10 @@ import {HomePage} from '../pages/HomePage';
 import {TabNav, type TabName} from '../pages/TabNav';
 import {trackErrors} from '../fixtures/consoleErrors';
 
-const E2E_TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? '';
-const E2E_TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? '';
+// Trim: a trailing newline/space in the GitHub secret would otherwise be
+// submitted verbatim and rejected by Firebase as `auth/wrong-password`.
+const E2E_TEST_EMAIL = (process.env.E2E_TEST_EMAIL ?? '').trim();
+const E2E_TEST_PASSWORD = (process.env.E2E_TEST_PASSWORD ?? '').trim();
 
 test.describe('web smoke', () => {
   test('signs in with email and password and lands on Home', async ({page}) => {


### PR DESCRIPTION
## TL;DR — blocked on a credentials secret (not a code bug)

The Playwright web suite is red because the E2E sign-in is **rejected by Firebase with `auth/wrong-password`**. The test harness is proven correct; the `E2E_TEST_PASSWORD` secret does not match the `test123@seznam.cz` password on the **staging** Firebase project (the preview build stages `.env.development` from the staging secret).

## Evidence (two CI runs, self-diagnostics added by this PR)

The suite's failure dump (URL + email-field value + ARIA snapshot to stdout, since the report artifact/preview hosts aren't always reachable) showed, on every attempt:
- URL `…/auth?mode=logIn`, form correctly in **log-in mode**, email + password fields **populated** with the secret values (Playwright `.fill()` works; GitHub masked them to `***`, proving the field holds exactly the secret).
- On-form error: **"The password entered is incorrect. Please try again."** — which maps *only* from Firebase `auth/wrong-password` (the ambiguous `auth/invalid-credential` has a different message). `auth/wrong-password` ⇒ the **account exists on staging, password is wrong** (not a wrong-project / unknown-account case).
- Trimming the credential env reads (commit `90daa70`) did **not** change it → rules out a trailing-newline/space in the secret. The value genuinely differs.

## What a human needs to do

Align the secret with the account on **staging**:
- Either reset the `test123@seznam.cz` password on the staging Firebase project and set `E2E_TEST_PASSWORD` to it, or
- Set `E2E_TEST_PASSWORD` to the account's real staging password.
- Quick check: log into the preview build manually with the creds — it will fail the same way if the staging password is wrong.

Then one re-run of `deployWeb.yml` should go green.

## What this PR changes (test-only, no app code)

- `e2e/web/fixtures/devGates.ts` — self-diagnosing failure dump (URL + email value + ARIA snapshot). High value for a preview-channel suite whose artifacts aren't always reachable.
- `e2e/web/fixtures/auth.ts`, `e2e/web/tests/smoke.spec.ts` — trim the credential env reads (harmless for a clean secret).
- `e2e/web/playwright.config.ts` — per-test timeout 90s → 150s (headroom for the slow ~8 MB CanvasKit boot per context).

These improve debuggability but cannot make the suite green on their own — that needs the secret fix above.

Refs #937, #925.

https://claude.ai/code/session_012a7euA4UPHhLsZYa8Vjbva