### PR TITLE
Rename Czech 'heavy' session intensity from Těžká to Náročná

### DIFF
--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -73,7 +73,7 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 | streak (alcohol-free)       | **série** (dnů bez alkoholu)                      |                |
 | session intensity: light    | **mírná** (relace)                                | lehká          |
 | session intensity: moderate | **střední** (relace)                              |                |
-| session intensity: heavy    | **těžká** (relace)                                | silná, náročná |
+| session intensity: heavy    | **náročná** (relace)                              | silná, těžká   |
 
 ## Do-not-translate (keep verbatim)
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -639,7 +639,7 @@ export default {
   unitsToColorsScreen: {
     title: 'Jednotky na barvy',
     description:
-      'Nastavte maximální počet jednotek pro mírnou a střední relaci. Cokoli nad tím už je těžká relace.',
+      'Nastavte maximální počet jednotek pro mírnou a střední relaci. Cokoli nad tím už je náročná relace.',
   },
   colorPaletteScreen: {
     title: 'Barvy relací',
@@ -1102,7 +1102,7 @@ export default {
             af: 'Bez alk.',
             light: 'Mírná',
             moderate: 'Střední',
-            heavy: 'Těžká',
+            heavy: 'Náročná',
           },
         },
         empty: {


### PR DESCRIPTION
## Summary

Renames the Czech locale's "heavy" session-intensity label from **Těžká** to **Náročná**, including the glossary rule that governs the term.

## Changes

- **`src/languages/cs_cz.ts`**
  - `statistics.texture.distribution.heavy`: `Těžká` → `Náročná` (chart label under "Dny podle intenzity")
  - `unitsToColorsScreen.description`: "...už je **těžká** relace." → "...už je **náročná** relace."
- **`src/languages/context/cs_cz.md`** (translator glossary)
  - Canonical term for `session intensity: heavy` is now **náročná** (relace)
  - Moved **těžká** into the "Do NOT use" column (alongside *silná*) so future translations stay consistent

## Notes

- All occurrences use the feminine nominative **náročná** to agree with the feminine noun *relace*, matching the other intensity labels (*mírná*, *střední*).
- A repo-wide search confirms no remaining usages of the *těžk-* stem for this concept.
- Prettier and `lint-changed` pass.

https://claude.ai/code/session_01PxwfdrFiw29oxSrWLuozii

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxwfdrFiw29oxSrWLuozii)_