### PR TITLE
fix(date-picker): correct capitalization of accented month/day names

### DIFF
--- a/__tests__/unit/StrRecapitalize.test.ts
+++ b/__tests__/unit/StrRecapitalize.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+import Str from '@libs/common/str';
+
+describe('Str.recapitalize', () => {
+  describe('accented (non-ASCII) words', () => {
+    // Regression: the old ASCII-only regex treated accented letters as word
+    // boundaries and uppercased the letter that followed them. In the Czech
+    // locale this broke month/day names shown in the statistics date picker
+    // (e.g. "červen" -> "ČErven", "úte" -> "ÚTe", "pát" -> "PáT").
+    it.each([
+      ['červen', 'Červen'],
+      ['úte', 'Úte'],
+      ['pát', 'Pát'],
+      ['únor', 'Únor'],
+      ['září', 'Září'],
+      ['čtvrtek', 'Čtvrtek'],
+      ['neděle', 'Neděle'],
+    ])('capitalizes only the first letter of %s', (input, expected) => {
+      expect(Str.recapitalize(input)).toBe(expected);
+    });
+  });
+
+  describe('ASCII multi-word behavior is preserved', () => {
+    it.each([
+      ['new york', 'New York'],
+      ['jean-pierre', 'Jean-Pierre'],
+      ['HELLO WORLD', 'Hello World'],
+      ['hello', 'Hello'],
+    ])('capitalizes the first letter of each word in %s', (input, expected) => {
+      expect(Str.recapitalize(input)).toBe(expected);
+    });
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(Str.recapitalize('')).toBe('');
+  });
+});

--- a/src/libs/common/str.ts
+++ b/src/libs/common/str.ts
@@ -132,11 +132,13 @@ const Str = {
     function recapCallaback(t: unknown, a: string, b: string) {
       return a + b.toUpperCase();
     }
-    return str.replace(
-      // **NOTE: Match to _libfop.php
-      /([^A-Za-z'.0-9])([a-z])/g,
-      recapCallaback,
-    );
+    // Uppercase the first letter following any separator (space, hyphen, etc.).
+    // The character classes are Unicode-aware (`\p{L}` letter, `\p{Ll}`
+    // lowercase letter, `u` flag) so accented letters are treated as letters,
+    // not word boundaries. An ASCII-only class like `[^A-Za-z...]` would treat
+    // e.g. Czech "č"/"á"/"ú" as separators and wrongly capitalize the next
+    // letter ("červen" -> "ČErven", "pát" -> "PáT").
+    return str.replace(/([^\p{L}'.0-9])(\p{Ll})/gu, recapCallaback);
   },
 
   /**


### PR DESCRIPTION
## Problem

In the Czech locale, month and day names in the statistics date picker render with broken capitalization. For example:

- `červen` → **ČErven** (should be Červen)
- `úte` → **ÚTe** (should be Úte)
- `pát` → **PáT** (should be Pát)

The diacritics themselves are fine; it's the casing of the letters *after* an accented character that is wrong.

## Root cause

`Calendar.tsx` (and `DowHourHeatmap.tsx`) run localized month/day names through `Str.recapitalize` (`src/libs/common/str.ts`). That helper, ported long ago from `expensify-common`, capitalizes the first letter of each "word" using an **ASCII-only** word-boundary regex:

```js
/([^A-Za-z'.0-9])([a-z])/g
```

Any character that isn't an ASCII letter/digit/`'`/`.` is treated as a word boundary, including accented letters such as `Č`, `á`, `ú`. So after the first letter is uppercased (`červen` → `Červen`), the regex sees `Č` as a "separator" and uppercases the following `e` → `ČErven`. The same happens for `Pát` → `PáT` (after `á`) and `Úte` → `ÚTe` (after `Ú`).

This affects any locale with accented letters in month/day names, not just Czech.

## Fix

Make the word-boundary character classes Unicode-aware using property escapes with the `u` flag, so accented letters count as letters rather than separators:

```js
/([^\p{L}'.0-9])(\p{Ll})/gu
```

ASCII multi-word behavior is unchanged (`new york` → `New York`, `jean-pierre` → `Jean-Pierre`), and accented single words now keep correct casing. Hermes (RN 0.81) and the web/Node runtimes all support Unicode property escapes.

## Testing

- Added `__tests__/unit/StrRecapitalize.test.ts` covering Czech month/day names and the preserved ASCII multi-word behavior.
- `npm run typecheck-tsgo` ✅
- ESLint (changed files) ✅
- Prettier ✅

https://claude.ai/code/session_01Rmnek6X6PiURLTjBe4aRnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmnek6X6PiURLTjBe4aRnZ)_