### PR TITLE
Make alcohol-free days trend continuous across year boundaries

### DIFF
--- a/__tests__/unit/Statistics/trends/afCumulative.test.ts
+++ b/__tests__/unit/Statistics/trends/afCumulative.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import buildAfYtdSeries from '@libs/Statistics/trends/afYtd';
+import buildAfCumulativeSeries from '@libs/Statistics/trends/afCumulative';
 import type {DrinkEvent} from '@libs/Statistics';
 
 function event(localDay: string): DrinkEvent {
@@ -23,9 +23,9 @@ function event(localDay: string): DrinkEvent {
   };
 }
 
-describe('buildAfYtdSeries', () => {
+describe('buildAfCumulativeSeries', () => {
   test('returns empty array when end is before start', () => {
-    const out = buildAfYtdSeries(
+    const out = buildAfCumulativeSeries(
       [],
       new Date('2026-05-02'),
       new Date('2026-05-01'),
@@ -34,7 +34,7 @@ describe('buildAfYtdSeries', () => {
   });
 
   test('counts up by one for each day with no events', () => {
-    const out = buildAfYtdSeries(
+    const out = buildAfCumulativeSeries(
       [],
       new Date('2026-05-01T00:00:00.000Z'),
       new Date('2026-05-04T00:00:00.000Z'),
@@ -49,7 +49,7 @@ describe('buildAfYtdSeries', () => {
   });
 
   test('day with events does not increment the counter', () => {
-    const out = buildAfYtdSeries(
+    const out = buildAfCumulativeSeries(
       [event('2026-05-02')],
       new Date('2026-05-01T00:00:00.000Z'),
       new Date('2026-05-04T00:00:00.000Z'),
@@ -57,14 +57,20 @@ describe('buildAfYtdSeries', () => {
     expect(out.map(p => p.count)).toEqual([1, 1, 2, 3]);
   });
 
-  test('resets to zero on Jan 1', () => {
-    const out = buildAfYtdSeries(
+  test('does not reset across a year boundary', () => {
+    const out = buildAfCumulativeSeries(
       [],
       new Date('2025-12-30T00:00:00.000Z'),
       new Date('2026-01-02T00:00:00.000Z'),
     );
-    // 2025-12-30 -> 1, 2025-12-31 -> 2, 2026-01-01 -> reset then +1 -> 1,
-    // 2026-01-02 -> 2.
-    expect(out.map(p => p.count)).toEqual([1, 2, 1, 2]);
+    // The counter keeps climbing across Jan 1 instead of resetting:
+    // 2025-12-30 -> 1, 2025-12-31 -> 2, 2026-01-01 -> 3, 2026-01-02 -> 4.
+    expect(out.map(p => p.count)).toEqual([1, 2, 3, 4]);
+    expect(out.map(p => p.date)).toEqual([
+      '2025-12-30',
+      '2025-12-31',
+      '2026-01-01',
+      '2026-01-02',
+    ]);
   });
 });

--- a/src/components/Charts/CumulativeLine/CumulativeLine.tsx
+++ b/src/components/Charts/CumulativeLine/CumulativeLine.tsx
@@ -26,11 +26,10 @@ type CumulativeRow = {x: number; y: number; cmp: number};
 const COMPARISON_DASH: number[] = [4, 4];
 
 /**
- * Cumulative AF-days line. Resets are handled upstream by
- * `buildAfYtdSeries` (returns 0 on Jan 1), so the chart just plots whatever
- * it's handed — including the reset, which surfaces as a downward step.
- * That step is the only time the line goes down; within a calendar year it
- * is monotonically non-decreasing.
+ * Cumulative AF-days line. `buildAfCumulativeSeries` accumulates across the
+ * whole selected range without resetting at year boundaries, so the series
+ * handed in is monotonically non-decreasing and the line only ever climbs
+ * from the bottom-left to the top-right.
  */
 function CumulativeLine({
   points,
@@ -49,7 +48,7 @@ function CumulativeLine({
       points.map((p, i) => ({
         x: i,
         y: p.count,
-        cmp: showComparison ? comparisonPoints?.[i]?.count ?? 0 : 0,
+        cmp: showComparison ? (comparisonPoints?.[i]?.count ?? 0) : 0,
       })),
     [points, comparisonPoints, showComparison],
   );

--- a/src/hooks/useStatistics/useTrendsTabData.ts
+++ b/src/hooks/useStatistics/useTrendsTabData.ts
@@ -2,12 +2,12 @@ import {useMemo} from 'react';
 import {DRINK_KEY_COLORS} from '@libs/Statistics/drinkKeyMeta';
 import {ewma, mannKendall} from '@libs/Statistics/stats';
 import {
-  buildAfYtdSeries,
+  buildAfCumulativeSeries,
   buildWeeklyStackedSeries,
   buildWeeklyUnits,
   shiftRange,
 } from '@libs/Statistics/trends';
-import type {AfYtdPoint} from '@libs/Statistics/trends';
+import type {AfCumulativePoint} from '@libs/Statistics/trends';
 import useStatsContext from '@hooks/useStatsContext';
 import CONST from '@src/CONST';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
@@ -33,9 +33,9 @@ type Stack = {
 
 type TrendsTabData = {
   hero: Hero;
-  afYtd: {
-    points: AfYtdPoint[];
-    comparisonPoints?: AfYtdPoint[];
+  afCumulative: {
+    points: AfCumulativePoint[];
+    comparisonPoints?: AfCumulativePoint[];
     hidden: boolean;
   };
   stack: Stack;
@@ -52,7 +52,8 @@ const ALL_DRINK_KEYS: readonly DrinkKey[] = Object.values(CONST.DRINKS.KEYS);
  * once, then derives:
  *
  *   - Hero weekly-units series (raw + EWMA + band + Mann–Kendall caption).
- *   - Cumulative AF-days YTD series (and its comparison twin when enabled).
+ *   - Cumulative AF-days series over the range (and its comparison twin when
+ *     enabled).
  *   - Per-DrinkKey weekly stack (respecting the active `drinkTypeFilter`).
  *
  * All series are zero-filled and index-aligned with their comparison
@@ -120,16 +121,16 @@ function useTrendsTabData(): TrendsTabData {
     };
   }, [events, range.start, range.end, comparisonRange]);
 
-  // AF-days YTD.
-  const afYtd = useMemo(() => {
+  // Cumulative AF-days.
+  const afCumulative = useMemo(() => {
     const hidden = range.preset === 'W';
     if (hidden) {
-      return {points: [] as AfYtdPoint[], hidden};
+      return {points: [] as AfCumulativePoint[], hidden};
     }
-    const points = buildAfYtdSeries(events, range.start, range.end);
-    let comparisonPoints: AfYtdPoint[] | undefined;
+    const points = buildAfCumulativeSeries(events, range.start, range.end);
+    let comparisonPoints: AfCumulativePoint[] | undefined;
     if (comparisonRange) {
-      const raw = buildAfYtdSeries(
+      const raw = buildAfCumulativeSeries(
         events,
         comparisonRange.start,
         comparisonRange.end,
@@ -144,7 +145,10 @@ function useTrendsTabData(): TrendsTabData {
       } else if (raw.length > 0) {
         const padCount = points.length - raw.length;
         const head = raw[0];
-        const pad: AfYtdPoint[] = Array.from({length: padCount}, () => head);
+        const pad: AfCumulativePoint[] = Array.from(
+          {length: padCount},
+          () => head,
+        );
         comparisonPoints = [...pad, ...raw];
       }
     }
@@ -213,7 +217,7 @@ function useTrendsTabData(): TrendsTabData {
     };
   }, [events, range.start, range.end, drinkTypeFilter, comparisonRange]);
 
-  return {hero, afYtd, stack, isLoading};
+  return {hero, afCumulative, stack, isLoading};
 }
 
 export default useTrendsTabData;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1134,8 +1134,8 @@ export default {
           },
         },
         cumulativeAf: {
-          title: 'Dny bez alkoholu letos',
-          emptyLabel: 'Každý letošní den bez alkoholu se počítá.',
+          title: 'Dny bez alkoholu v čase',
+          emptyLabel: 'Každý den bez alkoholu se počítá.',
         },
         drinkTypeStack: {
           title: 'Mix drinků v čase',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1148,8 +1148,8 @@ export default {
           },
         },
         cumulativeAf: {
-          title: 'Alcohol-free days this year',
-          emptyLabel: 'Every alcohol-free day this year adds up.',
+          title: 'Alcohol-free days over time',
+          emptyLabel: 'Every alcohol-free day adds up.',
         },
         drinkTypeStack: {
           title: 'Drink mix over time',

--- a/src/libs/Statistics/trends/afCumulative.ts
+++ b/src/libs/Statistics/trends/afCumulative.ts
@@ -1,30 +1,31 @@
 import {addDays, format, startOfDay} from 'date-fns';
 import type {DrinkEvent} from '@libs/Statistics/types';
 
-type AfYtdPoint = {
+type AfCumulativePoint = {
   date: string;
   count: number;
 };
 
 /**
  * Cumulative alcohol-free-days series over the inclusive window
- * `[start, end]`, resetting to 0 at each Jan 1. One point per day:
+ * `[start, end]`. The counter accumulates across the entire window and never
+ * resets, including at year boundaries, so the line only ever climbs from the
+ * bottom-left to the top-right. One point per day:
  *
- *   - on Jan 1 the counter resets to 0 before evaluating that day.
  *   - if a day has no drink events in `events`, the counter increments and
  *     the new value is emitted.
  *   - if a day has any drink events, the counter is unchanged.
  *
  * Both branches emit a point so the resulting series is dense and
- * monotonically non-decreasing within each calendar year — the chart's
+ * monotonically non-decreasing across the whole window, the chart's
  * "only-up line" visual. Reads `localDay` directly to avoid re-deriving the
  * session timezone here.
  */
-function buildAfYtdSeries(
+function buildAfCumulativeSeries(
   events: DrinkEvent[],
   start: Date,
   end: Date,
-): AfYtdPoint[] {
+): AfCumulativePoint[] {
   const startDay = startOfDay(start);
   const endDay = startOfDay(end);
   if (endDay.getTime() < startDay.getTime()) {
@@ -36,14 +37,11 @@ function buildAfYtdSeries(
     eventDays.add(event.localDay);
   }
 
-  const out: AfYtdPoint[] = [];
+  const out: AfCumulativePoint[] = [];
   let counter = 0;
   let cursor = startDay;
   while (cursor.getTime() <= endDay.getTime()) {
     const key = format(cursor, 'yyyy-MM-dd');
-    if (key.endsWith('-01-01')) {
-      counter = 0;
-    }
     if (!eventDays.has(key)) {
       counter += 1;
     }
@@ -53,5 +51,5 @@ function buildAfYtdSeries(
   return out;
 }
 
-export default buildAfYtdSeries;
-export type {AfYtdPoint};
+export default buildAfCumulativeSeries;
+export type {AfCumulativePoint};

--- a/src/libs/Statistics/trends/index.ts
+++ b/src/libs/Statistics/trends/index.ts
@@ -1,5 +1,5 @@
-export {default as buildAfYtdSeries} from './afYtd';
-export type {AfYtdPoint} from './afYtd';
+export {default as buildAfCumulativeSeries} from './afCumulative';
+export type {AfCumulativePoint} from './afCumulative';
 export {default as buildWeeklyUnits} from './weeklyUnits';
 export type {WeeklyUnitsPoint} from './weeklyUnits';
 export {default as buildWeeklyStackedSeries} from './weeklyStacked';

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -33,7 +33,7 @@ const CAPTION_KEYS: Record<string, TranslationPaths> = {
 function TrendsTab() {
   const {translate} = useLocalize();
   const themeStyles = useThemeStyles();
-  const {hero, afYtd, stack, isLoading} = useTrendsTabData();
+  const {hero, afCumulative, stack, isLoading} = useTrendsTabData();
   const {openDrillDown} = useStatsDrillDown();
 
   const heroComparisonShown = !!hero.comparison;
@@ -84,19 +84,19 @@ function TrendsTab() {
           />
         </ChartCard>
 
-        {afYtd.hidden ? null : (
+        {afCumulative.hidden ? null : (
           <ChartCard
             title={translate('statistics.tabs.trends.cumulativeAf.title')}
             footer={
-              afYtd.comparisonPoints ? (
+              afCumulative.comparisonPoints ? (
                 <Text style={themeStyles.textMicroSupporting}>
                   {comparisonLegend}
                 </Text>
               ) : undefined
             }>
             <CumulativeLine
-              points={afYtd.points}
-              comparisonPoints={afYtd.comparisonPoints}
+              points={afCumulative.points}
+              comparisonPoints={afCumulative.comparisonPoints}
               emptyLabel={translate(
                 'statistics.tabs.trends.cumulativeAf.emptyLabel',
               )}


### PR DESCRIPTION
## Summary

In Statistics → Trends, the **alcohol-free days** chart reset its counter to zero on every Jan 1. When the selected period crossed into a new year, the line dropped back to the bottom and started climbing again, breaking the "one continuous line" reading.

This change removes the year-boundary reset so the counter accumulates across the **entire selected period** as one continuous line that only ever climbs from bottom-left to top-right, regardless of how many year boundaries the period spans.

## Changes

- **`src/libs/Statistics/trends/afCumulative.ts`** (renamed from `afYtd.ts`): dropped the `if (key.endsWith('-01-01')) { counter = 0; }` reset so the series is monotonically non-decreasing across the whole window.
- **Renamed the data layer** away from the now-inaccurate "YTD" (year-to-date) naming to match the existing `CumulativeLine` component and `cumulativeAf` translation key:
  - `buildAfYtdSeries` → `buildAfCumulativeSeries`
  - `AfYtdPoint` → `AfCumulativePoint`
  - `afYtd.ts` / `afYtd.test.ts` → `afCumulative.ts` / `afCumulative.test.ts`
  - `useTrendsTabData` field `afYtd` → `afCumulative`
- **Labels:** dropped the now-misleading "this year" wording.
  - `en`: "Alcohol-free days this year" → "Alcohol-free days over time"; "Every alcohol-free day this year adds up." → "Every alcohol-free day adds up."
  - `cs_cz`: re-harmonized via the `translate` skill against the glossary ("v čase" mirrors the sibling "over time" key).
- Refreshed the related docstrings (`afCumulative.ts`, `CumulativeLine.tsx`, `useTrendsTabData.ts`).
- Updated the unit test: the former "resets to zero on Jan 1" case now asserts the counter keeps climbing across the year boundary.

## Testing

- `npx jest __tests__/unit/Statistics/trends/afCumulative.test.ts` — pass
- `npx jest __tests__/unit/Translate.test.ts` — pass (key parity)
- `npm run typecheck` (tsc) — pass
- ESLint on changed files — pass
- `npm run react-compiler-compliance-check check-changed` — pass

https://claude.ai/code/session_014k9jfaqZBwZ3SBPbU5F9NA

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9jfaqZBwZ3SBPbU5F9NA)_