### PR TITLE
i18n(moderation): backfill Czech for profanity filter (#763) + report flow (#765)

### DIFF
--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -74,6 +74,12 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 | session intensity: light    | **mírná** (relace)                                | lehká          |
 | session intensity: moderate | **střední** (relace)                              |                |
 | session intensity: heavy    | **náročná** (relace)                              | silná, těžká   |
+| report (verb)               | **nahlásit**                                      |                |
+| report (noun)               | **hlášení**                                       |                |
+| inappropriate               | **nevhodné / nevhodný / nevhodná**                |                |
+| harassment                  | **obtěžování**                                    |                |
+| bullying                    | **šikana**                                        |                |
+| moderation team             | **moderátorský tým**                              |                |
 
 ## Do-not-translate (keep verbatim)
 

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -454,6 +454,8 @@ export default {
     error: {
       hasInvalidCharacter: 'Neplatný znak',
       containsReservedWord: 'Toto jméno obsahuje vyhrazené slovo.',
+      containsProfanity:
+        'Toto jméno obsahuje nevhodné výrazy. Zvolte prosím jiné.',
       characterLimitExceedCounter: ({length, limit}) =>
         `Byl překročen limit znaků (${length}/${limit})`,
       characterLimit: ({limit}: CharacterLimitParams) =>
@@ -999,6 +1001,23 @@ export default {
     body: 'Váš účet byl pozastaven kvůli porušení našich pravidel komunity. Pokud si myslíte, že jde o omyl, kontaktujte podporu.',
     contactSupport: 'Kontaktovat podporu',
   },
+  reportUserScreen: {
+    title: 'Nahlásit',
+    prompt:
+      'Proč tohoto uživatele nahlašujete? Vaše hlášení je soukromé a bude předáno našemu moderátorskému týmu.',
+    reasons: {
+      inappropriateName: 'Nevhodné jméno',
+      inappropriatePhoto: 'Nevhodná profilová fotografie',
+      harassment: 'Obtěžování nebo šikana',
+      other: 'Něco jiného',
+    },
+    descriptionLabel: 'Přidejte podrobnosti (volitelné)',
+    alsoBlock: 'Také zablokovat tohoto uživatele',
+    submit: 'Odeslat hlášení',
+    successTitle: 'Hlášení přijato',
+    successMessage:
+      'Děkujeme za upozornění. Náš moderátorský tým tohoto uživatele prověří.',
+  },
   manageAccountScreen: {
     title: 'Správa účtu',
     dangerZone: {
@@ -1036,6 +1055,7 @@ export default {
     unitsConsumed: ({unitCount}: UnitCountParams) =>
       `${Str.pluralize('Zkonzumovaná jednotka', 'Zkonzumovaných jednotek', unitCount)}`,
     manageFriend: 'Spravovat přítele',
+    report: 'Nahlásit',
     unfriendPrompt: 'Opravdu chcete tohoto uživatele odebrat z přátel?',
     unfriend: 'Odebrat z přátel',
     blockUser: 'Zablokovat uživatele',


### PR DESCRIPTION
## Summary

English strings for two content-moderation features were merged without the corresponding Czech translations (the `translate` skill backfill step was skipped in both feature PRs). Czech was falling back to English for these strings. This PR fills the gap.

**Keys added to `src/languages/cs_cz.ts`:**

- `personalDetails.error.containsProfanity` — shown when a display name / username contains profanity (#763)
- `reportUserScreen.*` (full block: `title`, `prompt`, `reasons.{inappropriateName,inappropriatePhoto,harassment,other}`, `descriptionLabel`, `alsoBlock`, `submit`, `successTitle`, `successMessage`) — the report-user screen (#765)
- `profileScreen.report` — the "Report" action label on a user's profile (#765)

**Glossary additions to `src/languages/context/cs_cz.md`:**

New terms settled during translation and added so future strings stay consistent: `report` (verb/noun), `inappropriate`, `harassment`, `bullying`, `moderation team`.

## Consistency

- `alsoBlock` reuses the established block terminology (`Zablokovat`) from the already-translated block feature (PR #1178).
- Register is vykání throughout; sentence case; single `…` ellipsis; no em-dashes.
- `submit` (`'Odeslat hlášení'`) matches the identical key in `reportBugScreen`.

## Test plan

- [x] `npm run test -- __tests__/unit/Translate.test.ts` — 6/6 pass (teardown `TypeError` is known harmless noise)
- [x] `npm run typecheck-tsgo` — clean
- [x] `npx prettier --write src/languages/cs_cz.ts` — no changes (already formatted)
- [x] `npm run lint-changed` — no lintable files in diff

Closes #763 (i18n leg)
Closes #765 (i18n leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)