### PR TITLE
Adapt chart x-axis tick labels to the selected range span

### DIFF
--- a/__tests__/unit/components/Charts/dateTicks.test.ts
+++ b/__tests__/unit/components/Charts/dateTicks.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+
+import buildDateTicks from '@components/Charts/BaseChart/dateTicks';
+
+describe('buildDateTicks', () => {
+  describe('day mode (span ≤ 31 days)', () => {
+    test('daily series keeps evenly-spaced MMM d ticks', () => {
+      const out = buildDateTicks({
+        firstKey: '2026-06-01',
+        lastKey: '2026-06-30',
+        length: 30,
+        unit: 'day',
+      });
+      expect(out.indices).toEqual([0, 7, 15, 22, 29]);
+      expect(out.labelFor(0)).toBe('Jun 1');
+      expect(out.labelFor(7)).toBe('Jun 8');
+      expect(out.labelFor(29)).toBe('Jun 30');
+    });
+
+    test('weekly series labels each tick with its Monday', () => {
+      // 2026-W19..W22 — Mondays May 4 through May 25; span 28 days.
+      const out = buildDateTicks({
+        firstKey: '2026-W19',
+        lastKey: '2026-W22',
+        length: 4,
+        unit: 'week',
+      });
+      expect(out.indices).toEqual([0, 1, 2, 3]);
+      expect(out.indices.map(i => out.labelFor(i))).toEqual([
+        'May 4',
+        'May 11',
+        'May 18',
+        'May 25',
+      ]);
+    });
+  });
+
+  describe('month mode (32 days – 3 years)', () => {
+    test('snaps to month starts within one year and downsamples to 5', () => {
+      const out = buildDateTicks({
+        firstKey: '2025-01-01',
+        lastKey: '2025-12-31',
+        length: 365,
+        unit: 'day',
+      });
+      // 12 month boundaries → even spread of 5 keeping first and last.
+      expect(out.indices).toEqual([0, 90, 181, 243, 334]);
+      expect(out.indices.map(i => out.labelFor(i))).toEqual([
+        'Jan',
+        'Apr',
+        'Jul',
+        'Sep',
+        'Dec',
+      ]);
+      // Single-year ranges never carry a year suffix.
+      for (const index of out.indices) {
+        expect(out.labelFor(index)).not.toContain("'");
+      }
+    });
+
+    test('year-crossing weekly window suffixes years and labels by boundary month', () => {
+      // 2025-W46 (Mon Nov 10 2025) .. 2026-W19 (Mon May 4 2026) — a 6M-style
+      // trailing window straddling Jan 1.
+      const out = buildDateTicks({
+        firstKey: '2025-W46',
+        lastKey: '2026-W19',
+        length: 26,
+        unit: 'week',
+      });
+      expect(out.indices).toEqual([3, 7, 15, 20, 24]);
+      expect(out.indices.map(i => out.labelFor(i))).toEqual([
+        "Dec '25",
+        "Jan '26",
+        "Mar '26",
+        "Apr '26",
+        "May '26",
+      ]);
+      // Index 15 is the week of Mon Feb 23 2026 — the label must come from
+      // the Mar 1 boundary, not the week key's Monday.
+      expect(out.labelFor(15)).toBe("Mar '26");
+    });
+
+    test('multi-year range keeps months with a year suffix', () => {
+      const out = buildDateTicks({
+        firstKey: '2024-07-01',
+        lastKey: '2026-06-12',
+        length: 712,
+        unit: 'day',
+      });
+      expect(out.indices).toHaveLength(5);
+      const labels = out.indices.map(i => out.labelFor(i));
+      expect(labels[0]).toBe("Jul '24");
+      expect(labels[labels.length - 1]).toBe("Jun '26");
+      for (const label of labels) {
+        expect(label).toMatch(/^[A-Z][a-z]{2} '\d{2}$/);
+      }
+    });
+
+    test('falls back to day ticks when fewer than 3 month starts exist', () => {
+      // 45 days, only Feb 1 and Mar 1 boundaries.
+      const out = buildDateTicks({
+        firstKey: '2026-01-20',
+        lastKey: '2026-03-05',
+        length: 45,
+        unit: 'day',
+      });
+      expect(out.indices).toEqual([0, 11, 22, 33, 44]);
+      expect(out.labelFor(0)).toBe('Jan 20');
+      expect(out.labelFor(44)).toBe('Mar 5');
+    });
+
+    test('weekly snapping maps boundaries to unique increasing indices', () => {
+      // 2026-W01 starts Mon Dec 29 2025; Jan 1 falls in week 0, Feb 1
+      // (a Sunday) in the week of Mon Jan 26 (index 4), Mar 1 in index 8.
+      const out = buildDateTicks({
+        firstKey: '2026-W01',
+        lastKey: '2026-W10',
+        length: 10,
+        unit: 'week',
+      });
+      expect(out.indices).toEqual([0, 4, 8]);
+      expect(out.indices.map(i => out.labelFor(i))).toEqual([
+        'Jan',
+        'Feb',
+        'Mar',
+      ]);
+      // The Dec 29 series start is not a tick boundary, so all boundaries
+      // share 2026 and no year suffix appears.
+    });
+  });
+
+  describe('year mode (span > 3 years)', () => {
+    test('ticks on Jan 1 with yyyy labels', () => {
+      const out = buildDateTicks({
+        firstKey: '2021-03-15',
+        lastKey: '2026-06-12',
+        length: 1916,
+        unit: 'day',
+      });
+      expect(out.indices.map(i => out.labelFor(i))).toEqual([
+        '2022',
+        '2023',
+        '2024',
+        '2025',
+        '2026',
+      ]);
+      const sorted = [...out.indices].sort((a, b) => a - b);
+      expect(out.indices).toEqual(sorted);
+    });
+  });
+
+  describe('guards', () => {
+    test('empty series yields no ticks', () => {
+      const out = buildDateTicks({
+        firstKey: '',
+        lastKey: '',
+        length: 0,
+        unit: 'day',
+      });
+      expect(out.indices).toEqual([]);
+      expect(out.labelFor(0)).toBe('');
+    });
+
+    test('unparseable keys yield no ticks', () => {
+      const out = buildDateTicks({
+        firstKey: 'not-a-date',
+        lastKey: 'also-not',
+        length: 10,
+        unit: 'day',
+      });
+      expect(out.indices).toEqual([]);
+      expect(out.labelFor(0)).toBe('');
+    });
+
+    test('single point gets one MMM d tick', () => {
+      const out = buildDateTicks({
+        firstKey: '2026-06-12',
+        lastKey: '2026-06-12',
+        length: 1,
+        unit: 'day',
+      });
+      expect(out.indices).toEqual([0]);
+      expect(out.labelFor(0)).toBe('Jun 12');
+    });
+  });
+});

--- a/src/components/Charts/BaseChart/axisFormatters.ts
+++ b/src/components/Charts/BaseChart/axisFormatters.ts
@@ -1,24 +1,3 @@
-import {format, parseISO} from 'date-fns';
-
-/**
- * ISO-week label (`2026-W22`) → week-start `MMM d` (`May 4`). Includes the day
- * so adjacent weeks in the same month don't render identical ticks (e.g.
- * `May · May · May`). Falls back to the raw value if it can't be parsed.
- */
-function formatWeekTick(isoWeek: string): string {
-  const date = parseISO(isoWeek);
-  return Number.isNaN(date.getTime()) ? isoWeek : format(date, 'MMM d');
-}
-
-/**
- * ISO date (`2026-05-15`) → `MMM d` (`May 15`). Day-level so ticks within a
- * single month stay distinct. Falls back to the raw value if unparseable.
- */
-function formatDayTick(dateKey: string): string {
-  const date = parseISO(dateKey);
-  return Number.isNaN(date.getTime()) ? dateKey : format(date, 'MMM d');
-}
-
 /** Round a numeric axis tick to a whole number. */
 function roundTick(value: number): string {
   return String(Math.round(value));
@@ -57,4 +36,4 @@ function valueTicks(max: number, count = 4): number[] {
   return Array.from(new Set(ticks));
 }
 
-export {formatDayTick, formatWeekTick, roundTick, tickIndices, valueTicks};
+export {roundTick, tickIndices, valueTicks};

--- a/src/components/Charts/BaseChart/dateTicks.ts
+++ b/src/components/Charts/BaseChart/dateTicks.ts
@@ -1,0 +1,171 @@
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  differenceInCalendarDays,
+  differenceInCalendarISOWeeks,
+  format,
+  parseISO,
+  startOfMonth,
+  startOfYear,
+} from 'date-fns';
+import {tickIndices} from './axisFormatters';
+
+/** Granularity of the dense series feeding the chart. */
+type DateTickUnit = 'day' | 'week';
+
+type DateTicks = {
+  /** Integer x tickValues — indices into the dense series. */
+  indices: number[];
+  /** Tick value → label. Returns '' for indices without a label. */
+  labelFor: (value: number) => string;
+};
+
+type BuildDateTicksParams = {
+  /** First key of the series — `yyyy-MM-dd` (day) or `RRRR-'W'II` (week). */
+  firstKey: string;
+  /** Last key of the series, same format as `firstKey`. */
+  lastKey: string;
+  /** Series length. Keys are assumed dense between `firstKey` and `lastKey`. */
+  length: number;
+  unit: DateTickUnit;
+};
+
+type Boundary = {index: number; date: Date};
+
+/** Snapped modes need at least this many boundaries to read as an axis. */
+const MIN_SNAPPED_TICKS = 3;
+const MAX_TICKS = 5;
+
+/** Spans at or under a month keep day-level `MMM d` ticks. */
+const DAY_MODE_MAX_DAYS = 31;
+/** Spans over this many years drop months entirely and tick on Jan 1. */
+const YEAR_MODE_MIN_YEARS = 3;
+
+/** The date a series index represents: index 0 is `start`, then one unit per step. */
+function dateAtIndex(start: Date, index: number, unit: DateTickUnit): Date {
+  return unit === 'day' ? addDays(start, index) : addWeeks(start, index);
+}
+
+/** Evenly-spaced `MMM d` ticks — the legacy behavior, kept for short spans. */
+function evenDayTicks(
+  start: Date,
+  length: number,
+  unit: DateTickUnit,
+): DateTicks {
+  const indices = tickIndices(length);
+  const labels = new Map<number, string>();
+  for (const index of indices) {
+    labels.set(index, format(dateAtIndex(start, index, unit), 'MMM d'));
+  }
+  return {indices, labelFor: value => labels.get(Math.round(value)) ?? ''};
+}
+
+/** Calendar boundaries (month or year starts) within `[start, end]`, in order. */
+function boundaryDates(start: Date, end: Date, mode: 'month' | 'year'): Date[] {
+  let cursor = mode === 'month' ? startOfMonth(start) : startOfYear(start);
+  if (cursor.getTime() < start.getTime()) {
+    cursor = mode === 'month' ? addMonths(cursor, 1) : addYears(cursor, 1);
+  }
+  const out: Date[] = [];
+  while (cursor.getTime() <= end.getTime()) {
+    out.push(cursor);
+    cursor = mode === 'month' ? addMonths(cursor, 1) : addYears(cursor, 1);
+  }
+  return out;
+}
+
+/**
+ * Adaptive x ticks for a dense, gap-filled date series. Picks a label
+ * granularity from the span so ticks stay informative at every zoom:
+ *
+ *   - ≤ 31 days        → `MMM d` at evenly-spaced indices (legacy behavior).
+ *   - up to 3 years    → month starts, `MMM` — or `MMM ''yy` when the
+ *                        surviving ticks straddle a year boundary.
+ *   - over 3 years     → year starts (Jan 1), `yyyy`.
+ *
+ * In the snapped (month/year) modes tick positions sit on real calendar
+ * boundaries — a tick reads "here is where March starts" — and are
+ * downsampled to at most {@link MAX_TICKS}, always keeping the first and
+ * last boundary. When a snapped mode would yield fewer than
+ * {@link MIN_SNAPPED_TICKS} boundaries (e.g. a ~6-week range), it falls
+ * back to the day-level rendering, which is always distinct.
+ *
+ * Labels for weekly series come from the boundary date itself, not the
+ * week key's Monday — the week containing Sun Mar 1 starts Mon Feb 23, and
+ * "Feb" would be the wrong label for a March tick.
+ *
+ * Precondition: the series is dense — index `i` maps to `firstKey + i`
+ * days/weeks. All chart series builders gap-fill, so this holds upstream.
+ */
+function buildDateTicks(params: BuildDateTicksParams): DateTicks {
+  const {firstKey, lastKey, length, unit} = params;
+  if (length <= 0) {
+    return {indices: [], labelFor: () => ''};
+  }
+
+  // For weeks, anchor on the ISO week's Monday; the series covers through
+  // the last week's Sunday.
+  const start = unit === 'day' ? parseISO(firstKey) : parseISO(`${firstKey}-1`);
+  const lastStart =
+    unit === 'day' ? parseISO(lastKey) : parseISO(`${lastKey}-1`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(lastStart.getTime())) {
+    return {indices: [], labelFor: () => ''};
+  }
+  const end = unit === 'day' ? lastStart : addDays(lastStart, 6);
+
+  const spanDays = differenceInCalendarDays(end, start) + 1;
+  if (spanDays <= DAY_MODE_MAX_DAYS) {
+    return evenDayTicks(start, length, unit);
+  }
+  const mode = end > addYears(start, YEAR_MODE_MIN_YEARS) ? 'year' : 'month';
+
+  // Snap to calendar boundaries and map each onto its series index.
+  const seen = new Set<number>();
+  let boundaries: Boundary[] = [];
+  for (const date of boundaryDates(start, end, mode)) {
+    const raw =
+      unit === 'day'
+        ? differenceInCalendarDays(date, start)
+        : differenceInCalendarISOWeeks(date, start);
+    const index = Math.min(Math.max(raw, 0), length - 1);
+    if (!seen.has(index)) {
+      seen.add(index);
+      boundaries.push({index, date});
+    }
+  }
+
+  if (boundaries.length < MIN_SNAPPED_TICKS) {
+    return evenDayTicks(start, length, unit);
+  }
+  if (boundaries.length > MAX_TICKS) {
+    boundaries = tickIndices(boundaries.length, MAX_TICKS).map(
+      i => boundaries[i],
+    );
+  }
+
+  const crossesYear =
+    boundaries[0].date.getFullYear() !==
+    boundaries[boundaries.length - 1].date.getFullYear();
+  let pattern: string;
+  if (mode === 'year') {
+    pattern = 'yyyy';
+  } else if (crossesYear) {
+    pattern = "MMM ''yy";
+  } else {
+    pattern = 'MMM';
+  }
+
+  const labels = new Map<number, string>();
+  for (const {index, date} of boundaries) {
+    labels.set(index, format(date, pattern));
+  }
+  return {
+    indices: boundaries.map(b => b.index),
+    labelFor: value => labels.get(Math.round(value)) ?? '',
+  };
+}
+
+export default buildDateTicks;
+export type {DateTicks, DateTickUnit};

--- a/src/components/Charts/CumulativeLine/CumulativeLine.tsx
+++ b/src/components/Charts/CumulativeLine/CumulativeLine.tsx
@@ -2,11 +2,10 @@ import {useMemo} from 'react';
 import {DashPathEffect} from '@shopify/react-native-skia';
 import {BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
 import {
-  formatDayTick,
   roundTick,
-  tickIndices,
   valueTicks,
 } from '@components/Charts/BaseChart/axisFormatters';
+import buildDateTicks from '@components/Charts/BaseChart/dateTicks';
 
 type CumulativeLinePoint = {date: string; count: number};
 
@@ -48,7 +47,7 @@ function CumulativeLine({
       points.map((p, i) => ({
         x: i,
         y: p.count,
-        cmp: showComparison ? (comparisonPoints?.[i]?.count ?? 0) : 0,
+        cmp: showComparison ? comparisonPoints?.[i]?.count ?? 0 : 0,
       })),
     [points, comparisonPoints, showComparison],
   );
@@ -71,7 +70,16 @@ function CumulativeLine({
     return max;
   }, [data, showComparison]);
 
-  const xTicks = useMemo(() => tickIndices(points.length), [points.length]);
+  const dateTicks = useMemo(
+    () =>
+      buildDateTicks({
+        firstKey: points[0]?.date ?? '',
+        lastKey: points[points.length - 1]?.date ?? '',
+        length: points.length,
+        unit: 'day',
+      }),
+    [points],
+  );
   const yTicks = useMemo(() => valueTicks(maxCount), [maxCount]);
 
   return (
@@ -84,9 +92,8 @@ function CumulativeLine({
       height={height}
       axis={{
         font: axisFont,
-        tickValues: {x: xTicks, y: yTicks},
-        formatXLabel: index =>
-          formatDayTick(points[Math.round(index)]?.date ?? ''),
+        tickValues: {x: dateTicks.indices, y: yTicks},
+        formatXLabel: dateTicks.labelFor,
         formatYLabel: roundTick,
       }}
       loading={isLoading}>

--- a/src/components/Charts/StackedArea/StackedArea.tsx
+++ b/src/components/Charts/StackedArea/StackedArea.tsx
@@ -7,11 +7,10 @@ import {
   useChartFont,
 } from '@components/Charts/BaseChart';
 import {
-  formatWeekTick,
   roundTick,
-  tickIndices,
   valueTicks,
 } from '@components/Charts/BaseChart/axisFormatters';
+import buildDateTicks from '@components/Charts/BaseChart/dateTicks';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
 
 type StackedAreaProps = {
@@ -105,7 +104,16 @@ function StackedArea({
     return max;
   }, [data, trackedKeys, showComparison]);
 
-  const xTicks = useMemo(() => tickIndices(weeks.length), [weeks.length]);
+  const dateTicks = useMemo(
+    () =>
+      buildDateTicks({
+        firstKey: weeks[0] ?? '',
+        lastKey: weeks[weeks.length - 1] ?? '',
+        length: weeks.length,
+        unit: 'week',
+      }),
+    [weeks],
+  );
   const yTicks = useMemo(() => valueTicks(maxStack), [maxStack]);
 
   return (
@@ -118,8 +126,8 @@ function StackedArea({
       height={height}
       axis={{
         font: axisFont,
-        tickValues: {x: xTicks, y: yTicks},
-        formatXLabel: index => formatWeekTick(weeks[Math.round(index)] ?? ''),
+        tickValues: {x: dateTicks.indices, y: yTicks},
+        formatXLabel: dateTicks.labelFor,
         formatYLabel: roundTick,
       }}
       loading={isLoading}>

--- a/src/components/Charts/TrendLine/TrendLine.tsx
+++ b/src/components/Charts/TrendLine/TrendLine.tsx
@@ -3,11 +3,10 @@ import {View} from 'react-native';
 import {DashPathEffect} from '@shopify/react-native-skia';
 import {Bar, BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
 import {
-  formatWeekTick,
   roundTick,
-  tickIndices,
   valueTicks,
 } from '@components/Charts/BaseChart/axisFormatters';
+import buildDateTicks from '@components/Charts/BaseChart/dateTicks';
 import {PressableWithoutFeedback} from '@components/Pressable';
 
 type TrendLineProps = {
@@ -95,7 +94,16 @@ function TrendLine({
     return max;
   }, [data, showEwma, showComparison]);
 
-  const xTicks = useMemo(() => tickIndices(weeks.length), [weeks.length]);
+  const dateTicks = useMemo(
+    () =>
+      buildDateTicks({
+        firstKey: weeks[0] ?? '',
+        lastKey: weeks[weeks.length - 1] ?? '',
+        length: weeks.length,
+        unit: 'week',
+      }),
+    [weeks],
+  );
   const yTicks = useMemo(() => valueTicks(maxY), [maxY]);
 
   const hasTapTargets = !!onWeekPress && weeks.length > 0;
@@ -110,8 +118,8 @@ function TrendLine({
       height={height}
       axis={{
         font: axisFont,
-        tickValues: {x: xTicks, y: yTicks},
-        formatXLabel: index => formatWeekTick(weeks[Math.round(index)] ?? ''),
+        tickValues: {x: dateTicks.indices, y: yTicks},
+        formatXLabel: dateTicks.labelFor,
         formatYLabel: roundTick,
       }}
       loading={isLoading}>


### PR DESCRIPTION
## Summary

The Trends charts (alcohol-free days line, weekly units trend, drink mix stack) always format x-axis ticks as `MMM d` at evenly-spaced data indices. That reads fine for ≤1-month ranges but loses all meaning on long ones — a 5-year "All" range shows five arbitrary mid-month dates.

This PR introduces an adaptive tick builder that picks label granularity from the span of the plotted series:

| Range span | Format | Example ticks |
|---|---|---|
| ≤ 31 days | `MMM d` | Jun 1 · Jun 8 · Jun 16 |
| 32 days – 3 years, same year | `MMM` | Jan · Apr · Jul · Sep · Dec |
| 32 days – 3 years, crossing Jan 1 | `MMM 'yy` | Dec '25 · Jan '26 · Mar '26 |
| > 3 years | `yyyy` | 2022 · 2023 · 2024 · 2025 · 2026 |

In the month/year modes, tick positions **snap to real calendar boundaries** (1st of month / Jan 1) instead of evenly-spaced indices, so a tick reads "here is where March starts". Boundaries are downsampled to at most 5, always keeping the first and last.

## Implementation

- **`src/components/Charts/BaseChart/dateTicks.ts`** (new): `buildDateTicks({firstKey, lastKey, length, unit})` → `{indices, labelFor}`. Works for both dense daily series (`yyyy-MM-dd`) and dense ISO-week series (`RRRR-'W'II`); derives the span from the series itself, so no range props need threading into the charts.
  - **Fallback:** when a snapped mode would yield fewer than 3 boundaries (e.g. a 6-week custom range with 1–2 month starts), it falls back to day-level `MMM d` ticks, which are always distinct — never "Feb · Feb · Mar".
  - **Boundary-month labeling:** weekly ticks are labeled from the boundary date, not the week key's Monday — the week containing Sun Mar 1 starts Mon Feb 23, and "Feb" would be the wrong label for a March tick.
  - **Year suffix** is keyed off the surviving tick boundaries: a Dec 12 → Jun 12 window whose ticks are Jan…Jun (all one year) stays clean `MMM`; the `'yy` suffix appears exactly when labels would otherwise be ambiguous.
- **`CumulativeLine` / `TrendLine` / `StackedArea`**: swap `tickIndices` + inline `formatXLabel` for the new helper (~10-line diff each).
- **`axisFormatters.ts`**: drop `formatDayTick` / `formatWeekTick` (no remaining consumers); keep `tickIndices` (now used by `dateTicks.ts`), `roundTick`, `valueTicks`.
- **`__tests__/unit/components/Charts/dateTicks.test.ts`** (new): covers every mode, the fallback, downsampling a 12-month range, a year-crossing 6M weekly window (including the Feb-Monday/March-boundary labeling case), weekly snap dedupe, and the empty/unparseable/single-point guards.

## Testing

- `npx jest __tests__/unit/components/Charts` — 6 suites, 25 tests, all pass
- `npm run typecheck` (tsc) — pass
- ESLint on changed files — pass
- `npm run react-compiler-compliance-check check-changed` — pass
- Prettier — clean

https://claude.ai/code/session_014k9jfaqZBwZ3SBPbU5F9NA

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9jfaqZBwZ3SBPbU5F9NA)_