### PR TITLE
fix(web): splash force-hide safety net + document the live-dev-server e2e loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ The skill provides guidance on:
 
 - **Unit Tests**: Jest with React Native Testing Library
 - **Performance Tests**: Reassure framework
+- **Web E2E (Playwright)**: smoke suite in `e2e/web`. When iterating on web changes, run it against the live `npm run web` dev server (hot reload; a targeted test re-runs in seconds thanks to the cached sign-in) instead of pushing through the `deployWeb.yml` preview-channel CI loop, which costs 30+ minutes per attempt. Setup, worktree symlinks, and timings: `e2e/web/README.md`.
 
 ## Special Considerations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ The skill provides guidance on:
 
 - **Unit Tests**: Jest with React Native Testing Library
 - **Performance Tests**: Reassure framework
-- **Web E2E (Playwright)**: smoke suite in `e2e/web`. When iterating on web changes, run it against the live `npm run web` dev server (hot reload; a targeted test re-runs in seconds thanks to the cached sign-in) instead of pushing through the `deployWeb.yml` preview-channel CI loop, which costs 30+ minutes per attempt. Setup, worktree symlinks, and timings: `e2e/web/README.md`.
+- **Web E2E (Playwright)**: smoke suite in `e2e/web`; iterate against the live `npm run web` dev server (hot reload, cached sign-in), not the ~30-min `deployWeb.yml` CI loop. See `e2e/web/README.md`.
 
 ## Special Considerations
 

--- a/e2e/web/README.md
+++ b/e2e/web/README.md
@@ -22,3 +22,35 @@ post-#1224 phone frame (#1219): above the 800px breakpoint the app renders its
 mobile layout centered in a ~480px column rather than leaving an empty central
 pane. The sign-in session is cached once per worker (`.auth/user.json`) so
 navigation tests skip the login flow.
+
+## Fast iteration (live dev server)
+
+The suite is designed for a hot-reload loop against `npm run web` -- no
+production rebuild or preview deploy per change:
+
+1. Start the dev server once (`npm run web`; the Playwright config auto-starts
+   it if nothing is on :8082, and reuses it if something is). A warm webpack
+   cache compiles in ~30 s; after that, `src/` edits hot-rebuild in ~2 s.
+2. Run tests against it: `npm run test:e2e:web` (full suite a few minutes the
+   first time, including the one-time sign-in). The session is cached in
+   `.auth/user.json`, so subsequent runs skip login -- a targeted run such as
+   `npx playwright test --config=e2e/web/playwright.config.ts -g "Statistics"`
+   completes in seconds.
+3. Iterate: edit `src/`, wait for the webpack recompile line, re-run the
+   targeted test.
+
+Working from a git worktree: symlink the shared checkout's `node_modules`,
+`.env.development`, and `e2e/web/.env.e2e` into the worktree first -- the dev
+server and this config read all three.
+
+To reproduce a CI failure locally, point the suite at the preview channel
+itself: `PLAYWRIGHT_BASE_URL=https://kiroku-app-dev--pr-<n>-<hash>.web.app npm
+run test:e2e:web`. Failures land in `e2e/web/test-results/` with a screenshot,
+video, and error context.
+
+Environment caveat: `npm run web` authenticates against the **dev** Firebase
+project (`.env.development`), while CI preview channels are built from the
+staging env secret. A test account must exist in whichever backend the build
+under test points at. Dev-only console noise (e.g. React dev-mode deprecation
+warnings) is filtered via `BENIGN_CONSOLE_PATTERNS` in
+`fixtures/consoleErrors.ts`.

--- a/src/components/SplashScreenHider/index.tsx
+++ b/src/components/SplashScreenHider/index.tsx
@@ -1,9 +1,16 @@
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import BootSplash from '@libs/BootSplash';
+import Log from '@libs/Log';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
 } from './types';
+
+// Mirror of the native hider's safety net: force-hide the splash if
+// shouldHideSplash hasn't fired by this point. On web this matters doubly --
+// the #splash div sits at z-index 10000 and swallows every pointer event, so a
+// gating condition that never flips leaves the app visible but untappable.
+const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
 
 function SplashScreenHider({
   onHide = () => {},
@@ -11,13 +18,36 @@ function SplashScreenHider({
 }: SplashScreenHiderProps): SplashScreenHiderReturnType {
   const hideHasBeenCalled = useRef(false);
 
-  useEffect(() => {
-    if (!shouldHideSplash || hideHasBeenCalled.current) {
+  const hide = useCallback(() => {
+    if (hideHasBeenCalled.current) {
       return;
     }
     hideHasBeenCalled.current = true;
     BootSplash.hide().then(() => onHide());
-  }, [shouldHideSplash, onHide]);
+  }, [onHide]);
+
+  useEffect(() => {
+    if (!shouldHideSplash) {
+      return;
+    }
+    hide();
+  }, [shouldHideSplash, hide]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (hideHasBeenCalled.current) {
+        return;
+      }
+      Log.alert(
+        '[BootSplash] shouldHideSplash never became true, force-hiding splash',
+        {timeoutMs: FORCE_HIDE_TIMEOUT_MS},
+        false,
+      );
+      hide();
+    }, FORCE_HIDE_TIMEOUT_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [hide]);
 
   return null;
 }


### PR DESCRIPTION
### Details

Two changes that came out of investigating why the web Playwright e2e session was iterating so slowly (a rebuild + preview deploy per attempt).

**1. Web splash force-hide safety net (real fix).**
The web `SplashScreenHider` lacked the 15s force-hide that its native sibling already has — and that a `Kiroku.tsx` comment already *claims* exists ("The overlay owns the 15s force-hide safety timeout so a stuck gating condition can't pin the splash forever"). On web that claim was false. If any input to `shouldHideSplash` never flips (a stuck gate, a hydration signal that never settles), the splash stays up forever. Worse than native: the web `#splash` div sits at **z-index 10000 and intercepts every pointer event**, so the app renders underneath but is completely untappable. This mirrors the native hider — force-hide after 15s with the same `Log.alert` breadcrumb.

**2. Document the fast web-e2e iteration loop (docs only).**
The Playwright suite already auto-targets the live `npm run web` dev server when `PLAYWRIGHT_BASE_URL` is unset (and reuses an already-running one). So the intended dev loop is: edit `src/` → HMR rebuild (~2s) → re-run a targeted test against the cached sign-in (~5s) — no production rebuild, no preview deploy. That's ~30 min/iteration faster than round-tripping through `deployWeb.yml`'s preview-channel CI, which is a *merge gate*, not a dev loop. This wasn't discoverable, so sessions used CI as their harness. Added:
- `e2e/web/README.md` — a "Fast iteration (live dev server)" section: the loop, timings, worktree symlink setup, and the dev-vs-staging backend caveat.
- `CLAUDE.md` — a one-line steer under Testing.

No app behavior changes beyond the splash safety net; the e2e test code itself is untouched in this PR.

### Tests

1. Run the web app (`npm run web`) and sign in normally → verify the splash hides on the existing happy path (no regression; `shouldHideSplash` still drives the hide first).
2. The safety net only fires when the normal hide never does, so it can't be exercised by a normal run. Code review against the native sibling (`src/components/SplashScreenHider/index.native.tsx`) is the practical check — same `FORCE_HIDE_TIMEOUT_MS`, same `hideHasBeenCalled` guard, same `Log.alert` call.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A for the doc change. For the splash net: a slow/offline cold start is exactly the scenario the 15s net protects — previously the auth-data gate's own 3s timeout (`BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS`) covered the common offline case; this is the backstop for anything that timeout doesn't.

### QA Steps

1. On staging web, sign in and confirm the app loads to Home as before (splash hides, tabs are tappable).
2. Confirm no `[BootSplash] shouldHideSplash never became true` alert is logged on a normal load (the net should not fire when the happy path works).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors
- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified that any new or modified comments were clear, correct English, and explained "why"
- [x] No new user-facing copy was added (the `Log.alert` string is a dev/diagnostic breadcrumb, not localized UI — consistent with the native sibling)
- [x] I verified all code is DRY and mirrors the existing native implementation rather than inventing a new pattern
