### PR TITLE
Make the fullscreen calendar's infinite scroll continuous

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "web"],
+      "port": 8082
+    }
+  ]
+}

--- a/__tests__/unit/buildWeekListItems.test.ts
+++ b/__tests__/unit/buildWeekListItems.test.ts
@@ -1,0 +1,163 @@
+import buildWeekListItems from '@components/SessionsCalendar/buildWeekListItems';
+import {deriveCalendarMonth} from '@components/SessionsCalendar/deriveCalendarMonth';
+import type {CalendarMonthData} from '@components/SessionsCalendar/deriveCalendarMonth';
+import type {Preferences} from '@src/types/onyx';
+
+const FAR_FLOOR = new Date(2010, 0, 1);
+
+function makePreferences(): Preferences {
+  return {
+    first_day_of_week: 'Monday',
+    units_to_colors: {orange: 10, yellow: 5},
+    drinks_to_units: {beer: 1},
+    session_color_palette: {
+      green: '#00ff00',
+      yellow: '#ffff00',
+      orange: '#ff8800',
+      red: '#ff0000',
+      black: '#000000',
+    },
+    theme: 'system',
+  } as unknown as Preferences;
+}
+
+/** A sessionless derived month — geometry only, like a freshly loaded month. */
+function makeMonth(year: number, month: number): CalendarMonthData {
+  return deriveCalendarMonth({
+    year,
+    month,
+    monthEntriesByDay: undefined,
+    effectivePreferences: makePreferences(),
+    endClamp: null,
+  });
+}
+
+describe('buildWeekListItems', () => {
+  test('a pending month and its later real version produce identical keys and row counts', () => {
+    const march = makeMonth(2026, 2);
+    const april = makeMonth(2026, 3);
+
+    // After the data lands: March and April are both real.
+    const loaded = buildWeekListItems({
+      months: [march, april],
+      renderFromDate: null,
+      pendingMonthCount: 0,
+      absoluteFloor: FAR_FLOOR,
+    });
+    // Before the data lands: April is the floor, March renders pending.
+    const pendingBuild = buildWeekListItems({
+      months: [april],
+      renderFromDate: null,
+      pendingMonthCount: 1,
+      absoluteFloor: FAR_FLOOR,
+    });
+
+    const aprilLabelIndex = loaded.items.findIndex(
+      item => item.key === 'label-2026-3',
+    );
+    const marchRealKeys = loaded.items
+      .slice(0, aprilLabelIndex)
+      .map(item => item.key);
+    const marchPendingItems = pendingBuild.items.slice(
+      0,
+      pendingBuild.firstRealIndex,
+    );
+
+    // The in-place swap guarantee: identical keys, in order, same row count.
+    expect(marchPendingItems.map(item => item.key)).toEqual(marchRealKeys);
+    expect(marchPendingItems.every(item => item.pending)).toBe(true);
+    // The pending label still shows the real month name.
+    expect(marchPendingItems[0]).toMatchObject({
+      kind: 'label',
+      label: 'Mar 2026',
+    });
+    // And the real build has nothing pending.
+    expect(loaded.items.some(item => item.pending)).toBe(false);
+    expect(loaded.firstRealIndex).toBe(0);
+  });
+
+  test('sticky header indices point at the label items', () => {
+    const result = buildWeekListItems({
+      months: [makeMonth(2026, 2), makeMonth(2026, 3)],
+      renderFromDate: null,
+      pendingMonthCount: 0,
+      absoluteFloor: FAR_FLOOR,
+    });
+    expect(result.stickyHeaderIndices.length).toBe(2);
+    result.stickyHeaderIndices.forEach(index => {
+      expect(result.items[index].kind).toBe('label');
+    });
+  });
+
+  test('pending months never cross the absolute floor', () => {
+    const result = buildWeekListItems({
+      months: [makeMonth(2026, 3)],
+      renderFromDate: null,
+      pendingMonthCount: 5,
+      // Floor at Feb 2026 — only Feb and Mar may render pending.
+      absoluteFloor: new Date(2026, 1, 1),
+    });
+    const pendingLabels = result.items.filter(
+      item => item.kind === 'label' && item.pending,
+    );
+    expect(pendingLabels.map(item => item.key)).toEqual([
+      'label-2026-1',
+      'label-2026-2',
+    ]);
+  });
+
+  test('renderFromDate adds dimmed (non-pending, data-less) months and indexes them as scroll targets', () => {
+    const result = buildWeekListItems({
+      months: [makeMonth(2026, 3)],
+      renderFromDate: new Date(2026, 1, 1),
+      pendingMonthCount: 0,
+      absoluteFloor: FAR_FLOOR,
+    });
+
+    expect(result.items.some(item => item.pending)).toBe(false);
+    expect(result.firstRealIndex).toBe(0);
+    const firstLabel = result.items[0];
+    expect(firstLabel).toMatchObject({kind: 'label', monthKey: '2026-02'});
+    const firstWeek = result.items[1];
+    expect(firstWeek.kind).toBe('week');
+    if (firstWeek.kind === 'week') {
+      expect(firstWeek.dayData.size).toBe(0);
+    }
+    // Dimmed months are valid centering targets (the pre-tracking open fix).
+    expect(result.firstWeekIndexByMonth.has('2026-02')).toBe(true);
+    expect(result.firstWeekIndexByMonth.has('2026-03')).toBe(true);
+    expect(result.firstWeekIndexByMonth.has('2026-04')).toBe(true);
+  });
+
+  test('pending months win over renderFromDate (zones never overlap)', () => {
+    const result = buildWeekListItems({
+      months: [makeMonth(2026, 3)],
+      renderFromDate: new Date(2026, 1, 1),
+      pendingMonthCount: 1,
+      absoluteFloor: FAR_FLOOR,
+    });
+
+    // Only March renders below the floor — as a pending month; the dimmed
+    // zone (which would have added February) is skipped.
+    const belowFloorLabels = result.items.filter(
+      item => item.kind === 'label' && item.monthKey !== '2026-04',
+    );
+    expect(belowFloorLabels.map(item => item.key)).toEqual(['label-2026-2']);
+    expect(belowFloorLabels[0].pending).toBe(true);
+    // Pending months are not centering targets.
+    expect(result.firstWeekIndexByMonth.has('2026-03')).toBe(false);
+    expect(result.firstRealIndex).toBeGreaterThan(0);
+    expect(result.items[result.firstRealIndex].pending).toBe(false);
+  });
+
+  test('no months yields an empty list', () => {
+    const result = buildWeekListItems({
+      months: [],
+      renderFromDate: null,
+      pendingMonthCount: 3,
+      absoluteFloor: FAR_FLOOR,
+    });
+    expect(result.items).toEqual([]);
+    expect(result.firstRealIndex).toBe(0);
+  });
+});

--- a/__tests__/unit/deriveCalendarMonth.test.ts
+++ b/__tests__/unit/deriveCalendarMonth.test.ts
@@ -1,0 +1,192 @@
+import {
+  deriveCalendarMonth,
+  getDerivedCalendarMonth,
+  groupSessionsByMonth,
+} from '@components/SessionsCalendar/deriveCalendarMonth';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+import type DrinkingSessionKeyValue from '@src/types/utils/databaseUtils';
+
+const GREEN = '#00ff00';
+
+function makePreferences(): Preferences {
+  return {
+    first_day_of_week: 'Monday',
+    units_to_colors: {orange: 10, yellow: 5},
+    drinks_to_units: {
+      small_beer: 0.5,
+      beer: 1,
+      cocktail: 1.5,
+      other: 1,
+      strong_shot: 1,
+      weak_shot: 0.5,
+      wine: 1,
+    },
+    session_color_palette: {
+      green: GREEN,
+      yellow: '#ffff00',
+      orange: '#ff8800',
+      red: '#ff0000',
+      black: '#000000',
+    },
+    theme: 'system',
+  } as unknown as Preferences;
+}
+
+/** One-session day map for a fixed day, shaped like `groupSessionsByMonth`'s
+ *  inner per-month value. */
+function makeMonthEntries(
+  dayKey: DateString,
+  beerCount: number,
+): Map<DateString, DrinkingSessionKeyValue[]> {
+  const startTime = new Date(`${dayKey}T12:00:00Z`).getTime();
+  const session = {
+    id: 's1',
+    start_time: startTime,
+    timezone: 'UTC',
+    drinks: {[startTime]: {beer: beerCount}},
+  } as unknown as DrinkingSessionKeyValue['session'];
+  return new Map([[dayKey, [{sessionId: 's1', session}]]]);
+}
+
+describe('deriveCalendarMonth', () => {
+  test('derives markings, units, entries, and the month total for a whole month', () => {
+    const month = deriveCalendarMonth({
+      year: 2026,
+      month: 2, // March
+      monthEntriesByDay: makeMonthEntries('2026-03-10' as DateString, 2),
+      effectivePreferences: makePreferences(),
+      endClamp: null,
+    });
+
+    expect(month.monthKey).toBe('2026-03');
+    // Every day of March carries cell data; sober days are green with no units.
+    expect(month.dayData.size).toBe(31);
+    expect(month.dayData.get('2026-03-01' as DateString)).toEqual({
+      marking: {color: GREEN},
+    });
+    // The session day carries the session marking and its units.
+    const sessionCell = month.dayData.get('2026-03-10' as DateString);
+    expect(sessionCell?.units).toBe(2);
+    expect(sessionCell?.marking.color).toBeDefined();
+    // Only session days enter `entriesByDay`; the total sums the month.
+    expect([...month.entriesByDay.keys()]).toEqual(['2026-03-10']);
+    expect(month.totalUnits).toBe(2);
+    // Whole-month grid: every week row has 7 cells.
+    expect(month.weeks.length).toBeGreaterThanOrEqual(5);
+    month.weeks.forEach(week => expect(week.days).toHaveLength(7));
+  });
+
+  test('clamps the current month at endClamp', () => {
+    const month = deriveCalendarMonth({
+      year: 2026,
+      month: 2,
+      monthEntriesByDay: undefined,
+      effectivePreferences: makePreferences(),
+      endClamp: new Date(2026, 2, 10),
+    });
+
+    // Days 1–10 only — nothing after the clamp is derived or rendered.
+    expect(month.dayData.size).toBe(10);
+    expect(month.dayData.has('2026-03-10' as DateString)).toBe(true);
+    expect(month.dayData.has('2026-03-11' as DateString)).toBe(false);
+  });
+});
+
+describe('groupSessionsByMonth', () => {
+  test('groups by the zoned day, not the raw UTC timestamp', () => {
+    // Both sessions share the same UTC instant near a month boundary; their
+    // timezones pull them into different calendar months.
+    const utcInstant = Date.UTC(2026, 1, 28, 23, 0); // Feb 28 2026, 23:00 UTC
+    const sessions = {
+      auckland: {
+        start_time: utcInstant,
+        timezone: 'Pacific/Auckland', // UTC+13 → already March 1 locally
+        drinks: {},
+      },
+      newYork: {
+        start_time: utcInstant,
+        timezone: 'America/New_York', // UTC−5 → still Feb 28 locally
+        drinks: {},
+      },
+    } as unknown as DrinkingSessionList;
+
+    const groups = groupSessionsByMonth(sessions, 'UTC');
+
+    expect(groups.get('2026-03')?.get('2026-03-01' as DateString)).toHaveLength(
+      1,
+    );
+    expect(groups.get('2026-02')?.get('2026-02-28' as DateString)).toHaveLength(
+      1,
+    );
+  });
+
+  test('falls back to the default timezone when the session has none', () => {
+    const utcInstant = Date.UTC(2026, 1, 28, 23, 0);
+    const sessions = {
+      s1: {start_time: utcInstant, drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const groups = groupSessionsByMonth(sessions, 'Pacific/Auckland');
+    expect(groups.has('2026-03')).toBe(true);
+  });
+});
+
+describe('getDerivedCalendarMonth cache', () => {
+  test('same inputs return the same object; changed inputs recompute', () => {
+    const prefs = makePreferences();
+    const entries = makeMonthEntries('2026-03-10' as DateString, 1);
+    const baseArgs = {
+      year: 2026,
+      month: 2,
+      monthEntriesByDay: entries,
+      effectivePreferences: prefs,
+      endClamp: null,
+    };
+
+    const first = getDerivedCalendarMonth(baseArgs);
+    // Identical inputs (by identity) → cached object.
+    expect(getDerivedCalendarMonth({...baseArgs})).toBe(first);
+
+    // New session group (a session changed) → recompute.
+    const changedEntries = makeMonthEntries('2026-03-10' as DateString, 1);
+    expect(
+      getDerivedCalendarMonth({...baseArgs, monthEntriesByDay: changedEntries}),
+    ).not.toBe(first);
+
+    // New preferences object (palette/threshold change) → recompute.
+    expect(
+      getDerivedCalendarMonth({
+        ...baseArgs,
+        effectivePreferences: makePreferences(),
+      }),
+    ).not.toBe(first);
+
+    // Different endClamp day (today rolled over) → recompute.
+    const clampedA = getDerivedCalendarMonth({
+      ...baseArgs,
+      endClamp: new Date(2026, 2, 10),
+    });
+    const clampedB = getDerivedCalendarMonth({
+      ...baseArgs,
+      endClamp: new Date(2026, 2, 11),
+    });
+    expect(clampedA).not.toBe(clampedB);
+    // …but the same clamp day hits the cache again.
+    expect(
+      getDerivedCalendarMonth({...baseArgs, endClamp: new Date(2026, 2, 10)}),
+    ).toBe(clampedA);
+  });
+
+  test('a month without sessions caches across calls with undefined groups', () => {
+    const prefs = makePreferences();
+    const args = {
+      year: 2026,
+      month: 0,
+      monthEntriesByDay: undefined,
+      effectivePreferences: prefs,
+      endClamp: null,
+    };
+    expect(getDerivedCalendarMonth(args)).toBe(getDerivedCalendarMonth(args));
+  });
+});

--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 
 import {act, renderHook} from '@testing-library/react-native';
-import {addMonths, differenceInMonths, subMonths} from 'date-fns';
+import {addMonths, differenceInMonths, startOfMonth, subMonths} from 'date-fns';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
+import * as Calendar from '@userActions/Calendar';
 import type {
   DrinkingSession,
   DrinkingSessionList,
@@ -12,16 +13,23 @@ import type {DateString} from '@src/types/onyx/OnyxCommon';
 import type * as OnyxModule from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 
-jest.mock('@hooks/useResolvedPalette', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
+jest.mock('@hooks/useResolvedPalette', () => {
+  // A single stable palette object: the hook keys its month-derivation cache
+  // on the `{...preferences, session_color_palette: palette}` identity, so a
+  // fresh palette per render would defeat the cache the identity tests below
+  // assert on (the real hook returns a stable resolved palette too).
+  const stablePalette = {
     green: '#00ff00',
     yellow: '#ffff00',
     orange: '#ff8800',
     red: '#ff0000',
     black: '#000000',
-  })),
-}));
+  };
+  return {
+    __esModule: true,
+    default: jest.fn(() => stablePalette),
+  };
+});
 
 jest.mock('@userActions/Calendar', () => ({
   __esModule: true,
@@ -58,6 +66,7 @@ const TEST_UID = 'user-123';
 beforeEach(() => {
   // Default: friend profile (no canonical floor). Self-path tests opt in.
   mockUserDataList = undefined;
+  jest.clearAllMocks();
 });
 
 function makePreferences(): Preferences {
@@ -335,5 +344,193 @@ describe('useLazyMarkedDates ongoing overlay', () => {
     );
     expect(result.current.unitsMap.size).toBe(0);
     expect(result.current.sessionEntriesByDay.size).toBe(0);
+  });
+});
+
+describe('useLazyMarkedDates incremental derivation', () => {
+  test('widening keeps previously derived month objects referentially identical', () => {
+    // Stable inputs across re-renders — the per-month cache is keyed on the
+    // session-group and effective-preferences identities.
+    const prefs = makePreferences();
+    const windowEdge = subMonths(new Date(), 12);
+    const sessions = {
+      s1: {start_time: windowEdge.getTime(), timezone: 'UTC', drinks: {}},
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, prefs),
+    );
+
+    act(() => {
+      result.current.loadUpTo(subMonths(new Date(), 12));
+    });
+    const before = new Map(
+      result.current.calendarMonths.map(month => [month.monthKey, month]),
+    );
+
+    act(() => {
+      result.current.loadUpTo(subMonths(new Date(), 24));
+    });
+    const after = result.current.calendarMonths;
+
+    // The widen appended older months…
+    expect(after.length).toBeGreaterThan(before.size);
+    // …and every month that was already derived kept its identity, so the
+    // week-list's memoized rows for those months never re-render.
+    let overlapCount = 0;
+    after.forEach(month => {
+      const previous = before.get(month.monthKey);
+      if (!previous) {
+        return;
+      }
+      overlapCount += 1;
+      expect(month).toBe(previous);
+    });
+    expect(overlapCount).toBe(before.size);
+  });
+
+  test('a live-drink overlay re-derives only the overlay month', () => {
+    const prefs = makePreferences();
+    const today = new Date();
+    const previousMonth = subMonths(today, 1);
+    const sessions = {
+      old: {
+        id: 'old',
+        start_time: previousMonth.getTime(),
+        timezone: 'UTC',
+        drinks: {[previousMonth.getTime()]: {beer: 1}},
+      },
+    } as unknown as DrinkingSessionList;
+
+    const initialProps: {overlay?: DrinkingSession} = {overlay: undefined};
+    const {result, rerender} = renderHook(
+      ({overlay}: {overlay?: DrinkingSession}) =>
+        useLazyMarkedDates(TEST_UID, sessions, prefs, overlay),
+      {initialProps},
+    );
+
+    act(() => {
+      result.current.loadUpTo(previousMonth);
+    });
+    const before = new Map(
+      result.current.calendarMonths.map(month => [month.monthKey, month]),
+    );
+
+    const overlay = {
+      id: 'live-1',
+      ongoing: true,
+      start_time: today.getTime(),
+      timezone: 'UTC',
+      drinks: {[today.getTime()]: {beer: 2}},
+    } as unknown as DrinkingSession;
+    rerender({overlay});
+
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const currentMonthKey = `${today.getFullYear()}-${pad(today.getMonth() + 1)}`;
+
+    result.current.calendarMonths.forEach(month => {
+      const previous = before.get(month.monthKey);
+      if (!previous) {
+        return;
+      }
+      if (month.monthKey === currentMonthKey) {
+        // The overlay's month is a patched clone carrying the live units.
+        expect(month).not.toBe(previous);
+        expect(month.totalUnits).toBe(2);
+      } else {
+        // Every other month keeps identity — a drink tap repaints one month.
+        expect(month).toBe(previous);
+      }
+    });
+  });
+
+  test('deriveFullRangeToFloor derives to the canonical floor without writing the depth lever', () => {
+    jest.useFakeTimers();
+    try {
+      const earliest = subMonths(new Date(), 10);
+      mockUserDataList = {
+        [TEST_UID]: {earliest_session_at: earliest.getTime()},
+      };
+      const prefs = makePreferences();
+      const sessions = {
+        s1: {start_time: earliest.getTime(), timezone: 'UTC', drinks: {}},
+      } as unknown as DrinkingSessionList;
+
+      const {result} = renderHook(() =>
+        useLazyMarkedDates(TEST_UID, sessions, prefs, undefined, {
+          deriveFullRangeToFloor: true,
+        }),
+      );
+
+      // The whole tracked range is derived up front (no loadUpTo needed):
+      // months from the earliest tracked month through the current one.
+      expect(result.current.calendarMonths.length).toBe(11);
+      expect(getLoadedFrom(result).getTime()).toBe(
+        startOfMonth(earliest).getTime(),
+      );
+
+      // …and the persisted depth lever was never touched (the full-range
+      // derivation must not pollute the compact calendar's / Statistics'
+      // shared depth).
+      jest.advanceTimersByTime(1000);
+      expect(
+        Calendar.setSessionsCalendarMonthsLoadedForUser,
+      ).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('deriveFullRangeToFloor is a no-op without a canonical floor (friend)', () => {
+    const prefs = makePreferences();
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, {}, prefs, undefined, {
+        deriveFullRangeToFloor: true,
+      }),
+    );
+    // No floor to derive to — only the current month, as without the option.
+    expect(result.current.calendarMonths.length).toBe(1);
+  });
+
+  test('merged outputs keep their contracts (green sober days, units, sparse month totals)', () => {
+    const prefs = makePreferences();
+    const today = new Date();
+    const sessions = {
+      s1: {
+        id: 's1',
+        start_time: today.getTime(),
+        timezone: 'UTC',
+        drinks: {[today.getTime()]: {beer: 1}},
+      },
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, prefs),
+    );
+
+    act(() => {
+      // Widen one month so a guaranteed sober day (the 1st of the previous
+      // month) is in range regardless of today's date.
+      result.current.loadUpTo(subMonths(new Date(), 1));
+    });
+
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const todayKey =
+      `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}` as DateString;
+    const monthKey = todayKey.slice(0, 7);
+    const previousMonth = subMonths(today, 1);
+    const soberKey =
+      `${previousMonth.getFullYear()}-${pad(previousMonth.getMonth() + 1)}-01` as DateString;
+
+    // Session day: marked, in unitsMap, in the (sparse) month totals.
+    expect(result.current.markedDates[todayKey]).toBeDefined();
+    expect(result.current.unitsMap.get(todayKey)).toBe(1);
+    expect(result.current.monthlyTotalsMap.get(monthKey)).toBe(1);
+    // Sober in-range day: green marking, no units entry, no month-total entry.
+    expect(result.current.markedDates[soberKey]).toEqual({color: '#00ff00'});
+    expect(result.current.unitsMap.has(soberKey)).toBe(false);
+    expect(result.current.monthlyTotalsMap.has(soberKey.slice(0, 7))).toBe(
+      false,
+    );
   });
 });

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -1,17 +1,15 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef} from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import {View} from 'react-native';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef} from '@shopify/flash-list';
-import {format, parseISO, startOfDay} from 'date-fns';
+import {parseISO, startOfMonth} from 'date-fns';
 import lodashDebounce from 'lodash/debounce';
 import type {DateData} from 'react-native-calendars';
 import {LocaleConfig} from 'react-native-calendars';
-import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import SwipeBackGestureDetector from '@components/SwipeBackGestureDetector';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
-import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -21,14 +19,25 @@ import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import DateUtils from '@libs/DateUtils';
 import setCalendarLocale from '@libs/setCalendarLocale';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
-import buildMonthSections from './buildMonthSections';
-import type {MonthSection, MonthWeek} from './buildMonthSections';
+import buildWeekListItems from './buildWeekListItems';
+import type {ListItem} from './buildWeekListItems';
+import type {CalendarMonthData} from './deriveCalendarMonth';
 import WeekRow from './WeekRow';
+import WeekRowSkeleton from './WeekRowSkeleton';
 
 // Trigger `onRequestOlder` when the lowest visible item is within this
-// many weeks of index 0. Generous so the parent's prefetch starts well
-// before the user catches up to the loaded floor.
+// many weeks of the first real (non-pending) item. Generous so the parent's
+// prefetch starts well before the user catches up to the loaded floor; being
+// anywhere inside the pending-skeleton zone always triggers.
 const LOAD_AHEAD_BUFFER_WEEKS = 12;
+
+// How many months of pending skeletons to render above the loaded floor while
+// older data can still arrive (`canLoadOlder`). ~1.5 viewports of runway — the
+// parent's 6-month widen chunk refills faster than a user can cross it, so the
+// list reads as "loading" rather than ending at a hard edge. Their keys and
+// geometry are identical to the real months that replace them, so the swap is
+// an in-place repaint with zero scroll jump.
+const PENDING_SKELETON_MONTHS = 3;
 
 // Fraction of the window height left empty below the latest week so
 // `scrollToIndex({viewPosition: 0.5})` can pull a near-latest target toward
@@ -42,31 +51,29 @@ const BOTTOM_SPACER_RATIO = 0.4;
 const VIEWABILITY_CONFIG = {itemVisiblePercentThreshold: 50};
 
 type SessionsCalendarWeekListViewProps = {
-  /** Marked dates payload keyed by `DateString`. */
-  markedDates: MarkedDates;
-  /** Per-day unit count, also keyed by `DateString`. */
-  unitsMap: Map<DateString, number>;
-  /** Per-month unit totals keyed by 'YYYY-MM'. Rendered in the month label. */
-  monthlyTotalsMap: Map<string, number>;
-  /** Earliest day currently loaded (drives the bottom of the list). */
-  loadedFromDate: Date | null;
+  /** Per-month render payloads, ascending. Month objects are referentially
+   *  stable across loaded-window widens (see `useLazyMarkedDates`), so rows of
+   *  already-loaded months never re-render when older months stream in. */
+  calendarMonths: CalendarMonthData[];
+  /** Render-only floor (self): months between it and the data floor render as
+   *  dimmed pre-tracking months (clickable, no data). Pass the data floor (or
+   *  null) to render no extra months. */
+  renderFromDate: Date | null;
+  /** Whether scrolling back can still reveal older data. While true, the list
+   *  renders pending skeleton months above the loaded floor instead of a hard
+   *  edge. */
+  canLoadOlder?: boolean;
   /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed but stay
    *  clickable. Styling-only; the parent decides how far the list renders. */
   trackingStartDate?: string;
-  /** Latest day to render (defaults to today). */
-  endDate?: Date;
-  /** True while the data fetcher is widening the loaded window. The view
-   *  renders a "Loading older months…" row at the top of the list while
-   *  this is true. */
-  isFetchingOlderMonths?: boolean;
   /** Day cell tap handler. */
   onDayPress?: (day: DateData) => void;
   /** Day cell long-press handler (create-session shortcut). */
   onDayLongPress?: (day: DateData) => void;
   /** Called when the user scrolls within `LOAD_AHEAD_BUFFER_WEEKS` of the
-   *  loaded floor; receives the date of the earliest in-range day currently
-   *  visible. The parent decides (via `computeLoadTarget`) whether to
-   *  actually widen the loaded window. */
+   *  loaded floor (or into the pending zone); receives the date of the
+   *  earliest in-range day currently visible. The parent decides (via
+   *  `computeLoadTarget`) whether to actually widen the loaded window. */
   onRequestOlder?: (earliestVisible: Date) => void;
   /** Target month ('YYYY-MM') to center on first render. When omitted, the
    *  list falls back to "latest at bottom". */
@@ -80,21 +87,6 @@ type SessionsCalendarWeekListViewProps = {
   onSwipeBack?: () => void;
 };
 
-type LabelItem = {
-  kind: 'label';
-  key: string;
-  label: string;
-  monthKey: string;
-};
-
-type WeekItem = {
-  kind: 'week';
-  key: string;
-  row: MonthWeek;
-};
-
-type ListItem = LabelItem | WeekItem;
-
 /**
  * Vertical, self-contained-months calendar.
  *
@@ -104,17 +96,19 @@ type ListItem = LabelItem | WeekItem;
  * as the user scrolls past it (Apple-Photos pattern). No custom scroll
  * rail; the platform-native scrollbar carries the timeline-position cue.
  *
+ * While older data can still arrive, the months above the loaded floor render
+ * as skeleton rows (real month labels, placeholder day tiles) so the user
+ * scrolls into "loading" rather than a hard edge; the rows fill in place when
+ * the data lands.
+ *
  * Pure presentational — no Onyx writes, no Firebase reads. The parent owns
  * extending the loaded range via `onRequestOlder`.
  */
 function SessionsCalendarWeekListView({
-  markedDates,
-  unitsMap,
-  monthlyTotalsMap,
-  loadedFromDate,
+  calendarMonths,
+  renderFromDate,
+  canLoadOlder,
   trackingStartDate,
-  endDate,
-  isFetchingOlderMonths,
   onDayPress,
   onDayLongPress,
   onRequestOlder,
@@ -123,7 +117,6 @@ function SessionsCalendarWeekListView({
   onSwipeBack,
 }: SessionsCalendarWeekListViewProps) {
   const styles = useThemeStyles();
-  const theme = useTheme();
   const {translate} = useLocalize();
   const {windowHeight} = useWindowDimensions();
   const [preferredLocale] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
@@ -136,66 +129,31 @@ function SessionsCalendarWeekListView({
     setCalendarLocale(locale);
   }, [locale]);
 
-  const resolvedEnd = useMemo(
-    () => startOfDay(endDate ?? new Date()),
-    [endDate],
-  );
-  const resolvedStart = useMemo(
-    () => (loadedFromDate ? startOfDay(loadedFromDate) : resolvedEnd),
-    [loadedFromDate, resolvedEnd],
+  // The product's 20-year horizon — neither the pending-skeleton zone nor the
+  // pre-tracking dimmed zone renders past it.
+  const absoluteFloor = useMemo(
+    () => startOfMonth(CONST.CALENDAR_PICKER.MIN_DATE),
+    [],
   );
 
-  const monthSections: MonthSection[] = useMemo(
-    () => buildMonthSections({start: resolvedStart, end: resolvedEnd}),
-    [resolvedStart, resolvedEnd],
-  );
-
-  // Flatten the per-month sections into a single list of items. Labels
-  // sit between sections and double as FlashList sticky headers. We also
-  // build a `monthYear → first-week-row index` map in the same pass for
-  // the initial-scroll lookup.
-  const {items, stickyHeaderIndices, firstWeekIndexByMonth} = useMemo(() => {
-    const out: ListItem[] = [];
-    const sticky: number[] = [];
-    const monthIndex = new Map<string, number>();
-
-    monthSections.forEach(section => {
-      const labelDate = new Date(section.year, section.month, 1);
-      const monthKey = `${section.year}-${String(section.month + 1).padStart(2, '0')}`;
-      sticky.push(out.length);
-      out.push({
-        kind: 'label',
-        key: `label-${section.year}-${section.month}`,
-        label: format(labelDate, CONST.DATE.MONTH_YEAR_ABBR_FORMAT, {
-          locale: dateFnsLocale,
+  const {items, stickyHeaderIndices, firstWeekIndexByMonth, firstRealIndex} =
+    useMemo(
+      () =>
+        buildWeekListItems({
+          months: calendarMonths,
+          renderFromDate,
+          pendingMonthCount: canLoadOlder ? PENDING_SKELETON_MONTHS : 0,
+          absoluteFloor,
+          dateFnsLocale,
         }),
-        monthKey,
-      });
-      section.weeks.forEach((week, weekIdx) => {
-        if (weekIdx === 0) {
-          // The first week-row of each section is what we anchor the
-          // initial-scroll lookup against. Key by 'YYYY-MM'.
-          monthIndex.set(monthKey, out.length);
-        }
-        // Section-qualified key — two halves of a calendar week that spans
-        // a month boundary share the same `week.key` (the Monday's ISO
-        // date), so without the section prefix React reconciliation would
-        // see a duplicate and drop one of them. Concretely: October's
-        // last row and November's first row both start Mon 2025-10-27.
-        out.push({
-          kind: 'week',
-          key: `week-${section.year}-${section.month}-${week.key}`,
-          row: week,
-        });
-      });
-    });
-
-    return {
-      items: out,
-      stickyHeaderIndices: sticky,
-      firstWeekIndexByMonth: monthIndex,
-    };
-  }, [monthSections, dateFnsLocale]);
+      [
+        calendarMonths,
+        renderFromDate,
+        canLoadOlder,
+        absoluteFloor,
+        dateFnsLocale,
+      ],
+    );
 
   const dayNames = useMemo(() => {
     // `LocaleConfig` is re-exported from xdate without precise TS types for
@@ -242,7 +200,8 @@ function SessionsCalendarWeekListView({
   }, []);
 
   // Resolve the target index — undefined while data hasn't loaded enough
-  // months yet (the items memo widens as `loadedFromDate` extends).
+  // months yet (the items memo widens as the loaded range extends; pending
+  // months don't count as a landing target).
   const targetIndex = useMemo(() => {
     if (!initialMonthYear) {
       return undefined;
@@ -326,11 +285,12 @@ function SessionsCalendarWeekListView({
   useEffect(() => () => writeLastViewedDay.cancel(), [writeLastViewedDay]);
 
   // Lazy-load older months when the user scrolls within the buffer of the
-  // loaded floor. Walk forward from the lowest visible index to the first
-  // week item with at least one in-range day; surface that day to the
-  // parent so it can decide whether to widen the loaded window. Walking
-  // forward handles label items and leading-blank week rows at the top
-  // of the very first month section.
+  // first real (non-pending) item — anywhere inside the pending-skeleton zone
+  // included. Walk forward from the lowest visible index to the first week
+  // item with at least one in-range day; surface that day to the parent so it
+  // can decide whether to widen the loaded window. Pending rows carry real
+  // dates, so scrolling deep into the skeletons asks for correspondingly
+  // older months.
   const onViewableItemsChanged = useCallback(
     ({viewableItems}: {viewableItems: Array<{index: number | null}>}) => {
       const visibleIndices = viewableItems
@@ -347,10 +307,12 @@ function SessionsCalendarWeekListView({
       // focused on (matching the centered open) rather than a sliver clipped
       // at the top edge. Only once the user has actually scrolled — otherwise
       // an open-and-close without moving would overwrite the origin month.
+      // Pending months don't count: they have no data yet, and pointing the
+      // compact calendar at one would land it on an unloaded month.
       if (hasUserScrolledRef.current) {
         const centerItem =
           items[visibleIndices[Math.floor(visibleIndices.length / 2)]];
-        if (centerItem) {
+        if (centerItem && !centerItem.pending) {
           const centerDay =
             centerItem.kind === 'label'
               ? (`${centerItem.monthKey}-01` as DateString)
@@ -364,7 +326,7 @@ function SessionsCalendarWeekListView({
       if (!onRequestOlder) {
         return;
       }
-      if (minIndex > LOAD_AHEAD_BUFFER_WEEKS) {
+      if (minIndex - firstRealIndex > LOAD_AHEAD_BUFFER_WEEKS) {
         return;
       }
       for (let i = Math.max(0, minIndex); i < items.length; i++) {
@@ -379,13 +341,13 @@ function SessionsCalendarWeekListView({
         }
       }
     },
-    [items, onRequestOlder, writeLastViewedDay],
+    [items, firstRealIndex, onRequestOlder, writeLastViewedDay],
   );
 
   const renderItem = useCallback(
     (args: {item: ListItem}) => {
       if (args.item.kind === 'label') {
-        const total = monthlyTotalsMap.get(args.item.monthKey);
+        const total = args.item.totalUnits;
         return (
           <View style={styles.sessionsCalendarMonthLabel}>
             <Text style={styles.sessionsCalendarMonthLabelText}>
@@ -402,11 +364,13 @@ function SessionsCalendarWeekListView({
           </View>
         );
       }
+      if (args.item.pending) {
+        return <WeekRowSkeleton row={args.item.row} />;
+      }
       return (
         <WeekRow
           row={args.item.row}
-          markedDates={markedDates}
-          unitsMap={unitsMap}
+          dayData={args.item.dayData}
           trackingStartDate={trackingStartDate}
           onDayPress={onDayPress}
           onDayLongPress={onDayLongPress}
@@ -414,9 +378,6 @@ function SessionsCalendarWeekListView({
       );
     },
     [
-      markedDates,
-      unitsMap,
-      monthlyTotalsMap,
       trackingStartDate,
       onDayPress,
       onDayLongPress,
@@ -433,32 +394,10 @@ function SessionsCalendarWeekListView({
   // Distinct recycling pools (and per-type size estimates) for the two row
   // shapes — a one-line month label vs. a full week grid-row. v2 keys its
   // running height estimate by type, so this also sharpens the offset math that
-  // `initialScrollIndex`/`scrollToIndex` rely on.
+  // `initialScrollIndex`/`scrollToIndex` rely on. Pending rows share the
+  // 'week' pool deliberately: their geometry is pixel-identical, which keeps
+  // the offset math consistent across the skeleton→data swap.
   const getItemType = useCallback((item: ListItem) => item.kind, []);
-
-  // FlashList renders this above the first item in the list — i.e. above
-  // the oldest loaded week. It only shows while a data fetch is in flight,
-  // signaling "more months are on the way" when the user has scrolled past
-  // the prefetch buffer and is waiting on the network.
-  const listHeader = useMemo(() => {
-    if (!isFetchingOlderMonths) {
-      return null;
-    }
-    return (
-      <View style={styles.sessionsCalendarLoadingRow}>
-        <ActivityIndicator size="small" color={theme.spinner} />
-        <Text style={styles.sessionsCalendarLoadingRowText}>
-          {translate('calendar.loadingOlderMonths')}
-        </Text>
-      </View>
-    );
-  }, [
-    isFetchingOlderMonths,
-    styles.sessionsCalendarLoadingRow,
-    styles.sessionsCalendarLoadingRowText,
-    theme.spinner,
-    translate,
-  ]);
 
   // When we have a target, seed `initialScrollIndex` to it so we land close
   // to the right place even before the corrective `scrollToIndex` lands —
@@ -493,7 +432,6 @@ function SessionsCalendarWeekListView({
           initialScrollIndex={initialScrollIndex}
           contentContainerStyle={contentContainerStyle}
           showsVerticalScrollIndicator
-          ListHeaderComponent={listHeader}
           onLoad={handleListLoad}
           onScrollBeginDrag={onScrollBeginDrag}
           onViewableItemsChanged={onViewableItemsChanged}

--- a/src/components/SessionsCalendar/WeekRow.tsx
+++ b/src/components/SessionsCalendar/WeekRow.tsx
@@ -2,17 +2,18 @@ import React, {memo} from 'react';
 import {View} from 'react-native';
 import {parseISO} from 'date-fns';
 import type {DateData} from 'react-native-calendars';
-import type {MarkedDates} from 'react-native-calendars/src/types';
-import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 import useThemeStyles from '@hooks/useThemeStyles';
 import DayComponent from './DayComponent';
 import type {MonthWeek} from './buildMonthSections';
+import type {DayCellData} from './deriveCalendarMonth';
 
 type WeekRowProps = {
   row: MonthWeek;
-  markedDates: MarkedDates;
-  unitsMap: Map<DateString, number>;
+  /** Per-day cell payload for the row's month (marking + units). Month-scoped
+   *  and referentially stable across loaded-window widens, which is what lets
+   *  this component's `memo` hold while older months stream in. */
+  dayData: ReadonlyMap<DateString, DayCellData>;
   /** Earliest tracked day ('yyyy-MM-dd'). Days before it render dimmed but stay
    *  clickable. Styling-only. */
   trackingStartDate?: string;
@@ -44,8 +45,7 @@ function dayKeyToDateData(key: DateString): DateData {
  */
 function WeekRow({
   row,
-  markedDates,
-  unitsMap,
+  dayData,
   trackingStartDate,
   onDayPress,
   onDayLongPress,
@@ -64,13 +64,13 @@ function WeekRow({
             />
           );
         }
-        const marking = markedDates[dayKey] as MarkingProps | undefined;
+        const cell = dayData.get(dayKey);
         return (
           <View key={dayKey} style={styles.sessionsCalendarWeekCell}>
             <DayComponent
               date={dayKeyToDateData(dayKey)}
-              units={unitsMap.get(dayKey)}
-              marking={marking}
+              units={cell?.units}
+              marking={cell?.marking}
               trackingStartDate={trackingStartDate}
               onPress={onDayPress}
               onLongPress={onDayLongPress}

--- a/src/components/SessionsCalendar/WeekRowSkeleton.tsx
+++ b/src/components/SessionsCalendar/WeekRowSkeleton.tsx
@@ -1,0 +1,54 @@
+import React, {memo} from 'react';
+import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+import type {MonthWeek} from './buildMonthSections';
+
+type WeekRowSkeletonProps = {
+  /** The week-row geometry to mirror — blank cells stay blank so the skeleton
+   *  is shaped exactly like the real row that will replace it. */
+  row: MonthWeek;
+};
+
+/**
+ * Placeholder week row shown while a month's data is still on its way
+ * (the "pending" zone above the loaded floor in the fullscreen calendar).
+ * Pixel-identical geometry to `WeekRow` — same row/cell styles, same 44×44
+ * day tiles — so the in-place swap to real data causes no layout shift.
+ * Static cells (`animate={false}`): many of these mount at once during a
+ * fast scroll, matching the `SessionsCalendarSkeleton` precedent.
+ */
+function WeekRowSkeleton({row}: WeekRowSkeletonProps) {
+  const styles = useThemeStyles();
+  return (
+    <View style={styles.sessionsCalendarWeekRow}>
+      {row.days.map((dayKey, idx) => {
+        if (!dayKey) {
+          return (
+            <View
+              // Index is stable within a row of fixed width 7.
+              // eslint-disable-next-line react/no-array-index-key
+              key={`blank-${row.key}-${idx}`}
+              style={styles.sessionsCalendarWeekCellBlank}
+            />
+          );
+        }
+        return (
+          <View key={dayKey} style={styles.sessionsCalendarWeekCell}>
+            <Skeleton
+              width={variables.sessionsCalendarDaySize}
+              height={variables.sessionsCalendarDaySize}
+              radius={variables.componentBorderRadiusNormal}
+              animate={false}
+            />
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+WeekRowSkeleton.displayName = 'WeekRowSkeleton';
+export default memo(WeekRowSkeleton);
+export type {WeekRowSkeletonProps};

--- a/src/components/SessionsCalendar/buildWeekListItems.ts
+++ b/src/components/SessionsCalendar/buildWeekListItems.ts
@@ -1,0 +1,207 @@
+import {format, startOfMonth, subDays, subMonths} from 'date-fns';
+import type {Locale as DateFnsLocale} from 'date-fns';
+import CONST from '@src/CONST';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+import buildMonthSections from './buildMonthSections';
+import type {MonthWeek} from './buildMonthSections';
+import type {CalendarMonthData, DayCellData} from './deriveCalendarMonth';
+import {toMonthKey} from './deriveCalendarMonth';
+
+// Shared empty payload for months that render without derived data (pending
+// skeletons and pre-tracking dimmed months). A single frozen instance keeps
+// row props referentially stable.
+const EMPTY_DAY_DATA: ReadonlyMap<DateString, DayCellData> = new Map();
+
+type LabelItem = {
+  kind: 'label';
+  key: string;
+  label: string;
+  monthKey: string;
+  /** Month's unit total, rendered after the label rule. Undefined for pending
+   *  and pre-tracking months (and hidden when 0). */
+  totalUnits?: number;
+  /** True while the month's data hasn't loaded yet (skeleton state). */
+  pending: boolean;
+};
+
+type WeekItem = {
+  kind: 'week';
+  key: string;
+  row: MonthWeek;
+  /** Per-day cell payload for the row's month. `EMPTY_DAY_DATA` for pending
+   *  and pre-tracking months. */
+  dayData: ReadonlyMap<DateString, DayCellData>;
+  /** True while the month's data hasn't loaded yet — rendered as a skeleton
+   *  row instead of day tiles. */
+  pending: boolean;
+};
+
+type ListItem = LabelItem | WeekItem;
+
+type BuildWeekListItemsArgs = {
+  /** Derived data months, ascending (from `useLazyMarkedDates`). */
+  months: CalendarMonthData[];
+  /** Render-only floor (self): months in `[renderFromDate, data floor)` render
+   *  as dimmed pre-tracking months with no data. Ignored while pending months
+   *  are active (the two zones are mutually exclusive at the call site; the
+   *  guard here is defensive). */
+  renderFromDate: Date | null;
+  /** How many months of pending skeletons to render below the data floor.
+   *  Pass 0 when no older data can arrive. */
+  pendingMonthCount: number;
+  /** Absolute oldest month to render — neither zone crosses it. */
+  absoluteFloor: Date;
+  /** date-fns locale for the month labels — date-fns ignores the global
+   *  default unless `locale` is passed explicitly (see SessionsCalendarView).
+   *  Omitted (e.g. in tests) it falls back to date-fns' default (English). */
+  dateFnsLocale?: DateFnsLocale;
+};
+
+type BuildWeekListItemsResult = {
+  items: ListItem[];
+  /** Indices of the label items (FlashList sticky headers). */
+  stickyHeaderIndices: number[];
+  /** 'YYYY-MM' → index of the month's first week row, for the initial-scroll
+   *  lookup. Pending months are excluded — a centering target must wait for
+   *  its data. */
+  firstWeekIndexByMonth: Map<string, number>;
+  /** Index of the first non-pending item — the viewability trigger measures
+   *  the user's distance from this, so being inside the skeleton zone always
+   *  requests more. */
+  firstRealIndex: number;
+};
+
+/**
+ * Flatten derived months (plus optional pending-skeleton and pre-tracking
+ * zones) into the fullscreen week-list's item array.
+ *
+ * The item key scheme (`label-${year}-${month}`, `week-${year}-${month}-` +
+ * the week's ISO-Monday key) is shared by all three zones and is derived from
+ * pure date math, so a pending month and the real month that later replaces it
+ * produce IDENTICAL keys, row counts, and row heights. Data landing is an
+ * in-place content swap — no insert/remove at the scroll anchor, hence no
+ * jump.
+ */
+function buildWeekListItems({
+  months,
+  renderFromDate,
+  pendingMonthCount,
+  absoluteFloor,
+  dateFnsLocale,
+}: BuildWeekListItemsArgs): BuildWeekListItemsResult {
+  const items: ListItem[] = [];
+  const stickyHeaderIndices: number[] = [];
+  const firstWeekIndexByMonth = new Map<string, number>();
+
+  const pushMonth = (args: {
+    year: number;
+    month: number;
+    weeks: MonthWeek[];
+    dayData: ReadonlyMap<DateString, DayCellData>;
+    pending: boolean;
+    totalUnits?: number;
+  }) => {
+    const monthKey = toMonthKey(args.year, args.month);
+    stickyHeaderIndices.push(items.length);
+    items.push({
+      kind: 'label',
+      key: `label-${args.year}-${args.month}`,
+      label: format(
+        new Date(args.year, args.month, 1),
+        CONST.DATE.MONTH_YEAR_ABBR_FORMAT,
+        {locale: dateFnsLocale},
+      ),
+      monthKey,
+      totalUnits: args.totalUnits,
+      pending: args.pending,
+    });
+    args.weeks.forEach((week, weekIdx) => {
+      if (weekIdx === 0 && !args.pending) {
+        firstWeekIndexByMonth.set(monthKey, items.length);
+      }
+      // Section-qualified key — two halves of a calendar week that spans
+      // a month boundary share the same `week.key` (the Monday's ISO
+      // date), so without the section prefix React reconciliation would
+      // see a duplicate and drop one of them. Concretely: October's
+      // last row and November's first row both start Mon 2025-10-27.
+      items.push({
+        kind: 'week',
+        key: `week-${args.year}-${args.month}-${week.key}`,
+        row: week,
+        dayData: args.dayData,
+        pending: args.pending,
+      });
+    });
+  };
+
+  const dataFloor =
+    months.length > 0 ? new Date(months[0].year, months[0].month, 1) : null;
+
+  // Zone 1 — pending skeleton months, oldest first, directly below the data
+  // floor. Active only while older data can still arrive.
+  if (pendingMonthCount > 0 && dataFloor && dataFloor > absoluteFloor) {
+    let pendingStart = startOfMonth(subMonths(dataFloor, pendingMonthCount));
+    if (pendingStart < absoluteFloor) {
+      pendingStart = absoluteFloor;
+    }
+    buildMonthSections({
+      start: pendingStart,
+      end: subDays(dataFloor, 1),
+    }).forEach(section => {
+      pushMonth({
+        year: section.year,
+        month: section.month,
+        weeks: section.weeks,
+        dayData: EMPTY_DAY_DATA,
+        pending: true,
+      });
+    });
+  }
+
+  const firstRealIndex = items.length;
+
+  // Zone 2 — pre-tracking dimmed months (self): real rows with no data, days
+  // styled dimmed-but-clickable via `trackingStartDate` so the user can add a
+  // past session. Mutually exclusive with zone 1 (self never has pending
+  // months); skipped defensively if both were ever requested.
+  if (
+    pendingMonthCount === 0 &&
+    renderFromDate &&
+    dataFloor &&
+    renderFromDate < dataFloor
+  ) {
+    let dimmedStart = startOfMonth(renderFromDate);
+    if (dimmedStart < absoluteFloor) {
+      dimmedStart = absoluteFloor;
+    }
+    buildMonthSections({
+      start: dimmedStart,
+      end: subDays(dataFloor, 1),
+    }).forEach(section => {
+      pushMonth({
+        year: section.year,
+        month: section.month,
+        weeks: section.weeks,
+        dayData: EMPTY_DAY_DATA,
+        pending: false,
+      });
+    });
+  }
+
+  // Zone 3 — derived data months.
+  months.forEach(monthData => {
+    pushMonth({
+      year: monthData.year,
+      month: monthData.month,
+      weeks: monthData.weeks,
+      dayData: monthData.dayData,
+      pending: false,
+      totalUnits: monthData.totalUnits,
+    });
+  });
+
+  return {items, stickyHeaderIndices, firstWeekIndexByMonth, firstRealIndex};
+}
+
+export default buildWeekListItems;
+export type {ListItem, LabelItem, WeekItem, BuildWeekListItemsArgs};

--- a/src/components/SessionsCalendar/deriveCalendarMonth.ts
+++ b/src/components/SessionsCalendar/deriveCalendarMonth.ts
@@ -1,0 +1,230 @@
+import {endOfMonth} from 'date-fns';
+import {toZonedTime} from 'date-fns-tz';
+import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
+import {sessionsToDayMarking} from '@libs/DataHandling';
+import {resolvePalette} from '@libs/SessionColorPalettes';
+import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
+import type {DateString} from '@src/types/onyx/OnyxCommon';
+import type DrinkingSessionKeyValue from '@src/types/utils/databaseUtils';
+import buildMonthSections from './buildMonthSections';
+import type {MonthWeek} from './buildMonthSections';
+
+// Hand-rolled 'yyyy-MM-dd' (matches CONST.DATE.FNS_FORMAT_STRING). date-fns
+// `format` is ~100× slower and this runs once per day across the whole loaded
+// range — which can be years deep — so it dominated the day-overview mount
+// (e.g. 77 months ≈ 2.3k `format` calls ≈ ~460ms on Hermes). The Date's local
+// fields already carry the right wall-clock day (`toZonedTime` shifted them to
+// the session's zone for the per-session key; the day list is built in local
+// time), so reading them directly is both correct and cheap.
+function toDateKey(date: Date): DateString {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}-${month < 10 ? '0' : ''}${month}-${
+    day < 10 ? '0' : ''
+  }${day}` as DateString;
+}
+
+/** 'YYYY-MM' bucket key for a (year, 0-based month) pair. */
+function toMonthKey(year: number, month: number): string {
+  return `${year}-${month + 1 < 10 ? '0' : ''}${month + 1}`;
+}
+
+/** Per-day cell payload for one calendar day of a derived month. */
+type DayCellData = {
+  /** Marking to paint the day tile with (green "sober" marking for in-range
+   *  days without sessions, session-colored otherwise). */
+  marking: MarkingProps;
+  /** Total units that day. Present only for days that have sessions —
+   *  mirrors the legacy `unitsMap` sparseness. */
+  units?: number;
+};
+
+/**
+ * Everything the calendar needs to render one month, derived once and cached.
+ * Object identity is stable across loaded-window widens (see the cache below),
+ * which is what lets the week-list's row memoization hold while older months
+ * stream in.
+ */
+type CalendarMonthData = {
+  /** 'YYYY-MM'. */
+  monthKey: string;
+  /** Calendar year. */
+  year: number;
+  /** Calendar month (0-11). */
+  month: number;
+  /** Whole-month grid rows (the current month is clamped at today). */
+  weeks: MonthWeek[];
+  /** Cell payload for every in-range day of the month. */
+  dayData: ReadonlyMap<DateString, DayCellData>;
+  /** The month's sessions keyed by day — feeds the day-overview list merge. */
+  entriesByDay: ReadonlyMap<DateString, DrinkingSessionKeyValue[]>;
+  /** Sum of all session units in the month (the label row's total). */
+  totalUnits: number;
+};
+
+type MonthEntriesByDay = ReadonlyMap<DateString, DrinkingSessionKeyValue[]>;
+
+/**
+ * Group a session list by the month of each session's *zoned* day key
+ * ('YYYY-MM' → day → entries). Grouping on the timezone-shifted day (rather
+ * than a raw `start_time` window) is what guarantees a session that lands on
+ * the far side of a month boundary in its own timezone is derived with the
+ * month it actually renders in — this replaces the legacy "window start − 1
+ * day" boundary slop.
+ */
+function groupSessionsByMonth(
+  sessions: DrinkingSessionList,
+  defaultTimezone: string,
+): Map<string, Map<DateString, DrinkingSessionKeyValue[]>> {
+  const byMonth = new Map<string, Map<DateString, DrinkingSessionKeyValue[]>>();
+  Object.entries(sessions).forEach(([sessionId, session]) => {
+    const zonedDate = toZonedTime(
+      session.start_time,
+      session.timezone ?? defaultTimezone,
+    );
+    const dayKey = toDateKey(zonedDate);
+    const monthKey = dayKey.slice(0, 7);
+    let dayMap = byMonth.get(monthKey);
+    if (!dayMap) {
+      dayMap = new Map();
+      byMonth.set(monthKey, dayMap);
+    }
+    const existing = dayMap.get(dayKey);
+    if (existing) {
+      existing.push({sessionId, session});
+    } else {
+      dayMap.set(dayKey, [{sessionId, session}]);
+    }
+  });
+  return byMonth;
+}
+
+type DeriveCalendarMonthArgs = {
+  /** Calendar year. */
+  year: number;
+  /** Calendar month (0-11). */
+  month: number;
+  /** The month's sessions grouped by zoned day key (from
+   *  `groupSessionsByMonth`), or undefined for a session-less month. */
+  monthEntriesByDay: MonthEntriesByDay | undefined;
+  /** Preferences with the resolved palette already substituted in (the hook's
+   *  `effectivePreferences`). */
+  effectivePreferences: Preferences;
+  /** Last day to include — today for the current month, null (= whole month)
+   *  for past months. */
+  endClamp: Date | null;
+};
+
+/**
+ * Derive one month's render payload: grid rows plus per-day markings, units,
+ * session entries, and the month total. Pure — call `getDerivedCalendarMonth`
+ * for the cached variant used on the render path.
+ */
+function deriveCalendarMonth({
+  year,
+  month,
+  monthEntriesByDay,
+  effectivePreferences,
+  endClamp,
+}: DeriveCalendarMonthArgs): CalendarMonthData {
+  const monthStart = new Date(year, month, 1);
+  const sections = buildMonthSections({
+    start: monthStart,
+    end: endClamp ?? endOfMonth(monthStart),
+  });
+  const weeks = sections.length > 0 ? sections[0].weeks : [];
+
+  const paletteGreen = resolvePalette(
+    effectivePreferences.session_color_palette,
+  ).green;
+
+  const dayData = new Map<DateString, DayCellData>();
+  // Only in-range days enter `entriesByDay` — a session dated later today
+  // (or on a future day of the current month) must not surface a day the
+  // grid doesn't render, mirroring the legacy interval filter.
+  const entriesByDay = new Map<DateString, DrinkingSessionKeyValue[]>();
+  let totalUnits = 0;
+
+  weeks.forEach(week => {
+    week.days.forEach(dayKey => {
+      if (!dayKey) {
+        return;
+      }
+      const entries = monthEntriesByDay?.get(dayKey);
+      const marking = entries
+        ? sessionsToDayMarking(
+            entries.map(entry => entry.session),
+            effectivePreferences,
+          )
+        : null;
+      if (!marking) {
+        dayData.set(dayKey, {marking: {color: paletteGreen}});
+        return;
+      }
+      dayData.set(dayKey, {marking: marking.marking, units: marking.units});
+      entriesByDay.set(dayKey, entries ?? []);
+      totalUnits += marking.units;
+    });
+  });
+
+  return {
+    monthKey: toMonthKey(year, month),
+    year,
+    month,
+    weeks,
+    dayData,
+    entriesByDay,
+    totalUnits,
+  };
+}
+
+type CachedMonth = {
+  /** The month's session group at derive time — reference-compared to detect
+   *  session changes (the grouping pass rebuilds all group maps whenever the
+   *  source session list changes identity). */
+  group: MonthEntriesByDay | undefined;
+  value: CalendarMonthData;
+};
+
+// Month-derivation cache. Keyed first on the `effectivePreferences` identity
+// (each mounted calendar builds its own object, so palettes/thresholds — and
+// users — can never cross-contaminate; old branches are GC'd with their
+// preferences object), then on `monthKey|endClampKey`. A loaded-window widen
+// changes neither key nor group references, so previously derived months are
+// returned by identity — the property the week-list's row memoization relies
+// on. Plain module-level memoization keeps the render path free of ref access,
+// which React Compiler would otherwise reject.
+const monthCache = new WeakMap<Preferences, Map<string, CachedMonth>>();
+
+/** Cached `deriveCalendarMonth`. See the cache notes above. */
+function getDerivedCalendarMonth(
+  args: DeriveCalendarMonthArgs,
+): CalendarMonthData {
+  let byMonth = monthCache.get(args.effectivePreferences);
+  if (!byMonth) {
+    byMonth = new Map();
+    monthCache.set(args.effectivePreferences, byMonth);
+  }
+  // Past months derive the same payload regardless of when they're derived;
+  // the current month is clamped at today, so its entry is keyed by that day
+  // and naturally misses (recomputes) after a date rollover.
+  const endClampKey = args.endClamp ? toDateKey(args.endClamp) : '';
+  const cacheKey = `${toMonthKey(args.year, args.month)}|${endClampKey}`;
+  const cached = byMonth.get(cacheKey);
+  if (cached && cached.group === args.monthEntriesByDay) {
+    return cached.value;
+  }
+  const value = deriveCalendarMonth(args);
+  byMonth.set(cacheKey, {group: args.monthEntriesByDay, value});
+  return value;
+}
+
+export {
+  deriveCalendarMonth,
+  getDerivedCalendarMonth,
+  groupSessionsByMonth,
+  toDateKey,
+  toMonthKey,
+};
+export type {CalendarMonthData, DayCellData, DeriveCalendarMonthArgs};

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -96,8 +96,8 @@ function SessionsCalendar({
   const {
     markedDates,
     unitsMap,
-    monthlyTotalsMap,
     sessionEntriesByDay,
+    calendarMonths,
     loadedFrom,
     loadedFromDate,
     loadMoreMonths,
@@ -110,6 +110,12 @@ function SessionsCalendar({
     drinkingSessionData ?? {},
     preferences,
     ongoingOverlay,
+    {
+      // Fullscreen + canonical floor (self): derive the whole tracked range up
+      // front so scrolling back never waits on a widen — the data is all
+      // on-device. Does not touch the persisted depth lever. No-op for friends.
+      deriveFullRangeToFloor: mode === 'fullscreen',
+    },
   );
   const startEditSessionForDate = useStartEditSessionForDate();
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
@@ -191,23 +197,47 @@ function SessionsCalendar({
   // floor as the user scrolls toward the top, letting them reach pre-tracking
   // days (which render blank/dimmed — no fetch) down to `absoluteFloor`.
   const [renderFromDate, setRenderFromDate] = useState<Date | null>(null);
+
+  // When the fullscreen view opens centered on a month *before* the user's
+  // tracking start (e.g. from a compact calendar paged into pre-tracking
+  // months), the target can never enter the data range — the derivation is
+  // capped at the canonical floor. Extend the render floor to cover it so the
+  // centering target exists from the first render; without this the initial
+  // scroll never resolves and the screen would hang on its skeleton. Self-only
+  // (`hasPersistedFloor`): for a friend the floor is unknown, so the target is
+  // reached by widening the fetch window instead (the prefetch effect below).
+  const initialRenderTarget = useMemo(() => {
+    if (mode !== 'fullscreen' || !initialMonthYear || !hasPersistedFloor) {
+      return null;
+    }
+    const target = startOfMonth(parseISO(`${initialMonthYear}-01`));
+    if (target >= minDateFloor) {
+      return null;
+    }
+    return target < absoluteFloor ? absoluteFloor : target;
+  }, [mode, initialMonthYear, hasPersistedFloor, minDateFloor, absoluteFloor]);
+
   const fullscreenRenderFrom = useMemo(() => {
     if (!loadedFromDate) {
       return loadedFromDate;
     }
-    const candidate =
+    let candidate =
       renderFromDate && renderFromDate < loadedFromDate
         ? renderFromDate
         : loadedFromDate;
+    if (initialRenderTarget && initialRenderTarget < candidate) {
+      candidate = initialRenderTarget;
+    }
     return candidate < absoluteFloor ? absoluteFloor : candidate;
-  }, [loadedFromDate, renderFromDate, absoluteFloor]);
+  }, [loadedFromDate, renderFromDate, initialRenderTarget, absoluteFloor]);
 
   // Whether there is older data still to load — drives the day-list's load
-  // trigger and its "loading older" header.
+  // trigger and its "loading older" header, and the week-list's pending
+  // skeleton months.
   //  - Self (canonical floor): stop once the loaded window reaches the earliest
-  //    tracked month. Compared at month granularity (`startOfMonth`) so the
-  //    harmless boundary day baked into `loadedFromDate` (a `startOfMonth − 1
-  //    day`, see `useLazyMarkedDates`) can't trip the guard a day early.
+  //    tracked month (with the fullscreen full-range derivation this is true
+  //    from the first render). Compared at month granularity for robustness —
+  //    `loadedFromDate` is already a `startOfMonth`.
   //  - Friend (no canonical floor): keep loading until the window is exhausted —
   //    the server returns nothing earlier than what we already have.
   const canLoadOlder = hasPersistedFloor
@@ -222,11 +252,11 @@ function SessionsCalendar({
   const handleRequestOlder = (earliestVisible: Date) => {
     const floor = loadedFrom?.current ?? new Date();
     // Self (canonical floor): stop once loaded back to the earliest tracked
-    // month, compared at month granularity so the `startOfMonth − 1 day` baked
-    // into `loadedFromDate` (see `useLazyMarkedDates`) can't trip the guard a
-    // day early. In fullscreen, keep widening the *rendered* range past it so
-    // the user can scroll into the empty pre-tracking months (to add a past
-    // session); those render blank/dimmed for free. Walls at `absoluteFloor`.
+    // month — with the fullscreen full-range derivation that's the case from
+    // the very first call. In fullscreen, keep widening the *rendered* range
+    // past it so the user can scroll into the empty pre-tracking months (to
+    // add a past session); those render blank/dimmed for free. Walls at
+    // `absoluteFloor`.
     if (hasPersistedFloor) {
       if (startOfMonth(floor).getTime() <= minDateFloor.getTime()) {
         if (mode === 'fullscreen') {
@@ -286,6 +316,14 @@ function SessionsCalendar({
     if (hasPrefetchedRef.current) {
       return;
     }
+    // Fullscreen + canonical floor (self): the full tracked range is derived
+    // up front (`deriveFullRangeToFloor`), so there is nothing to prefetch and
+    // no reason to bump the persisted depth lever. The day-list keeps the
+    // prefetch — it still loads lazily. If the floor hydrates late, one
+    // friend-style prefetch may fire first; harmless and parity with before.
+    if (mode === 'fullscreen' && hasPersistedFloor) {
+      return;
+    }
     hasPrefetchedRef.current = true;
     // If the user opened an enlarged view (fullscreen calendar or day-overview
     // scroll) on a month older than our default 12-month buffer, deepen the
@@ -301,7 +339,7 @@ function SessionsCalendar({
         loadUpTo(targetFloor);
       }
     }
-  }, [mode, loadUpTo, initialMonthYear, initialDay]);
+  }, [mode, loadUpTo, initialMonthYear, initialDay, hasPersistedFloor]);
 
   const onDayPress = useCallback(
     (dateData: DateData) => {
@@ -404,12 +442,10 @@ function SessionsCalendar({
     return (
       <>
         <SessionsCalendarWeekListView
-          markedDates={markedDates}
-          unitsMap={unitsMap}
-          monthlyTotalsMap={monthlyTotalsMap}
-          loadedFromDate={fullscreenRenderFrom}
+          calendarMonths={calendarMonths}
+          renderFromDate={fullscreenRenderFrom}
+          canLoadOlder={canLoadOlder}
           trackingStartDate={minDate}
-          isFetchingOlderMonths={isFetchingOlderMonths}
           onDayPress={onDayPress}
           onDayLongPress={dayLongPressHandler}
           onRequestOlder={handleRequestOlder}

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -2,62 +2,58 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import {toZonedTime} from 'date-fns-tz';
 import type {
   DrinkingSession,
-  DrinkingSessionArray,
   DrinkingSessionList,
   Preferences,
 } from '@src/types/onyx';
-import type DrinkingSessionKeyValue from '@src/types/utils/databaseUtils';
 import CONST from '@src/CONST';
-import {
-  differenceInCalendarMonths,
-  eachDayOfInterval,
-  isWithinInterval,
-  startOfMonth,
-  subDays,
-  subMonths,
-} from 'date-fns';
+import {differenceInCalendarMonths, startOfMonth, subMonths} from 'date-fns';
 import {sessionsToDayMarking} from '@libs/DataHandling';
 import useResolvedPalette from '@hooks/useResolvedPalette';
 import lodashDebounce from 'lodash/debounce';
-import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as Calendar from '@userActions/Calendar';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
+import {
+  getDerivedCalendarMonth,
+  groupSessionsByMonth,
+  toDateKey,
+  toMonthKey,
+} from '@components/SessionsCalendar/deriveCalendarMonth';
+import type {
+  CalendarMonthData,
+  DayCellData,
+} from '@components/SessionsCalendar/deriveCalendarMonth';
+import type DrinkingSessionKeyValue from '@src/types/utils/databaseUtils';
 import type {UserID, DateString} from '@src/types/onyx/OnyxCommon';
 
-// Hand-rolled 'yyyy-MM-dd' (matches CONST.DATE.FNS_FORMAT_STRING). date-fns
-// `format` is ~100× slower and this runs once per day across the whole loaded
-// range — which can be years deep — so it dominated the day-overview mount
-// (e.g. 77 months ≈ 2.3k `format` calls ≈ ~460ms on Hermes). The Date's local
-// fields already carry the right wall-clock day (`toZonedTime` shifted them to
-// the session's zone for the per-session key; the day list is built in local
-// time), so reading them directly is both correct and cheap.
-function toDateKey(date: Date): DateString {
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  return `${year}-${month < 10 ? '0' : ''}${month}-${
-    day < 10 ? '0' : ''
-  }${day}` as DateString;
-}
+type UseLazyMarkedDatesOptions = {
+  /** Derive the whole tracked range (down to the canonical
+   *  `earliest_session_at` floor) immediately, instead of the lazily widened
+   *  `loadedMonths` window. Used by the fullscreen calendar for the signed-in
+   *  user, whose sessions are all on-device — scrolling back then never waits
+   *  on a widen. Does NOT touch the persisted depth lever (`loadUpTo` still
+   *  governs that), so the compact calendar's and Statistics' shared depth
+   *  stay exactly as driven by their own usage. No-op for users without the
+   *  canonical floor (friends). */
+  deriveFullRangeToFloor?: boolean;
+};
 
 /**
  * Custom hook to derive a calendar's markedDates and per-day unit counts from a
  * session list and the user's preferences.
  *
- * `markedDates` is computed synchronously via `useMemo` — when any input
- * changes (sessions, preferences, the loaded month range), the next render
- * already carries the new payload. The earlier state-based pipeline left the
- * home calendar stale after a palette change because the state update path
- * had several failure modes (focus gating, batched setState during overlay
- * navigation, react-native-calendars memoization races). Synchronous
- * derivation is the same pattern the palette-picker preview uses, which is
- * why that path was reliable.
+ * Derivation is per-month and cached (see `deriveCalendarMonth`): widening the
+ * loaded window only derives the newly exposed months, and previously derived
+ * months keep referential identity — the fullscreen week-list's row memoization
+ * depends on this. The merged outputs (`markedDates`, `unitsMap`,
+ * `monthlyTotalsMap`, `sessionEntriesByDay`) are reassembled from the cached
+ * months via cheap reference copies, preserving the original contracts for the
+ * compact calendar (react-native-calendars) and the day-overview list.
  *
  * `loadMoreMonths(N)` extends the visible range by N months by bumping
- * `loadedMonths` state, which triggers the memo to recompute.
+ * `loadedMonths` state, which triggers the assembly memo to recompute.
  *
  * @param userID  ID of the user whose sessions/preferences these are
  * @param sessions Session list to render
@@ -68,17 +64,20 @@ function toDateKey(date: Date): DateString {
  *   never receive it). Live drinks live only in `ONGOING_SESSION_DATA`, not the
  *   cached snapshot — see `DrinkingSession.flushLiveSessionPersist`. Overlaid as
  *   a cheap single-day patch so the heavy index passes stay off the per-tap path.
+ * @param options See `UseLazyMarkedDatesOptions`.
  */
 function useLazyMarkedDates(
   userID: UserID,
   sessions: DrinkingSessionList,
   preferences: Preferences,
   ongoingOverlay?: DrinkingSession,
+  options?: UseLazyMarkedDatesOptions,
 ) {
   const [monthsLoaded, monthsLoadedMeta] = useOnyx(
     `${ONYXKEYS.COLLECTION.SESSIONS_CALENDAR_MONTHS_BY_USER_ID}${userID}`,
   );
   const defaultTimezone = CONST.DEFAULT_TIME_ZONE.selected;
+  const deriveFullRangeToFloor = options?.deriveFullRangeToFloor === true;
 
   // Resume the user's saved scroll depth (or 0 if this is the first visit).
   // Same logic for auth user and friends — state is per-UID now.
@@ -128,65 +127,34 @@ function useLazyMarkedDates(
     return null;
   }, [hasPersistedFloor, persistedEarliest]);
 
-  const cappedMonths = useMemo(() => {
+  // Months between today and the canonical floor — null when there is no
+  // canonical floor (friends).
+  const monthsToEarliest = useMemo<number | null>(() => {
     if (!earliestTracked) {
-      return loadedMonths;
+      return null;
     }
-    const monthsToEarliest = Math.max(
-      0,
-      differenceInCalendarMonths(new Date(), earliestTracked),
-    );
-    return Math.min(loadedMonths, monthsToEarliest);
-  }, [loadedMonths, earliestTracked]);
+    return Math.max(0, differenceInCalendarMonths(new Date(), earliestTracked));
+  }, [earliestTracked]);
 
-  // First pass — rebuild the session-by-day index only when sessions or the
-  // visible range change. Preferences are *not* a dependency here: a palette
-  // or threshold change must not trigger the O(N) session filter+index pass.
-  const {sessionIndex, sessionEntriesByDay, dayKeys, loadedFromDate} =
-    useMemo(() => {
-      const today = new Date();
-      const start = subDays(startOfMonth(subMonths(today, cappedMonths)), 1);
-      const end = today;
+  const cappedMonths =
+    monthsToEarliest === null
+      ? loadedMonths
+      : Math.min(loadedMonths, monthsToEarliest);
 
-      const index = new Map<DateString, DrinkingSessionArray>();
-      // Parallel index that keeps the session IDs alongside each session, so
-      // consumers that render session tiles (the day-overview scroll) don't
-      // have to re-derive IDs. Built in the same pass — the marking/units
-      // passes below keep using `index` unchanged.
-      const entriesByDay = new Map<DateString, DrinkingSessionKeyValue[]>();
-      Object.entries(sessions)
-        .filter(([, session]) =>
-          isWithinInterval(session.start_time, {start, end}),
-        )
-        .forEach(([sessionId, session]) => {
-          const sessionDate = toZonedTime(
-            session.start_time,
-            session.timezone ?? defaultTimezone,
-          );
-          const dayKey = toDateKey(sessionDate);
-          const existing = index.get(dayKey);
-          if (existing) {
-            existing.push(session);
-          } else {
-            index.set(dayKey, [session]);
-          }
-          const existingEntries = entriesByDay.get(dayKey);
-          if (existingEntries) {
-            existingEntries.push({sessionId, session});
-          } else {
-            entriesByDay.set(dayKey, [{sessionId, session}]);
-          }
-        });
+  // Depth the derivation actually builds. `deriveFullRangeToFloor` (fullscreen
+  // self) jumps straight to the canonical floor without touching the persisted
+  // lever; everyone else uses the lazily widened window.
+  const effectiveMonths =
+    deriveFullRangeToFloor && monthsToEarliest !== null
+      ? monthsToEarliest
+      : cappedMonths;
 
-      const days = eachDayOfInterval({start, end}).map(toDateKey);
-
-      return {
-        sessionIndex: index,
-        sessionEntriesByDay: entriesByDay,
-        dayKeys: days,
-        loadedFromDate: start,
-      };
-    }, [sessions, cappedMonths, defaultTimezone]);
+  // First pass — regroup the sessions by zoned month/day only when the source
+  // list changes. Widening the loaded window doesn't touch this O(N) pass.
+  const sessionsByMonth = useMemo(
+    () => groupSessionsByMonth(sessions, defaultTimezone),
+    [sessions, defaultTimezone],
+  );
 
   // Whether scrolling back can still reveal older data. Only meaningful when the
   // viewed user has NO canonical floor (a friend): `sessions` is the windowed
@@ -205,8 +173,8 @@ function useLazyMarkedDates(
   //
   // The comparison is against the FETCH floor (`useDrinkingSessionsFetch` reads
   // `start_time >= startOfMonth(subMonths(now, max(SESSIONS_INITIAL_FETCH_MONTHS,
-  // monthsLoaded)))`), NOT `loadedFromDate`: the latter is `startOfMonth − 1 day`,
-  // which lands in the previous month and would report exhaustion a month early.
+  // monthsLoaded)))`), NOT the render floor — the fetch window is what bounds
+  // what the server could have returned.
   // For self this is unused — the persisted floor drives the guards directly.
   // Plain derivation: React Compiler memoizes it from the captured reads
   // (`hasPersistedFloor`, `sessions`, `loadedMonths`), so no manual `useMemo`.
@@ -238,72 +206,101 @@ function useLazyMarkedDates(
   // Substitute the resolved palette into the preferences object so downstream
   // pure functions (sessionsToDayMarking → convertUnitsToColors) use it without
   // needing to know about the toggle. Unit thresholds and drink mappings stay
-  // the viewed user's — only the palette is swapped.
+  // the viewed user's — only the palette is swapped. Also the month-cache
+  // branch key: a fresh object here invalidates every cached month, which is
+  // exactly right for a palette/threshold change.
   const effectivePreferences = useMemo(
     () => ({...preferences, session_color_palette: palette}),
     [preferences, palette],
   );
 
-  // Second pass — build markedDates + unitsMap + monthlyTotalsMap from the
-  // pre-built index. This is the only memo that needs `preferences`; on a
-  // palette change it walks the day list (~30 entries) instead of
-  // re-filtering N sessions. `monthlyTotalsMap` is keyed by 'YYYY-MM'.
+  // Second pass — assemble the loaded range from cached per-month derivations.
+  // On a widen only the newly exposed months actually derive; everything else
+  // is reference-copied, so this memo is O(loaded days) of Map sets at worst.
   const paletteGreen = palette.green;
-  const {markedDatesMap, unitsMap, monthlyTotalsMap} = useMemo(() => {
-    const newMarkedDatesMap = new Map<DateString, MarkingProps>();
+  const {
+    calendarMonths,
+    markedDates,
+    unitsMap,
+    monthlyTotalsMap,
+    sessionEntriesByDay,
+    loadedFromDate,
+  } = useMemo(() => {
+    const today = new Date();
+    // Hoisted const, not inlined in the return literal: inside the object
+    // literal TS 5.x loses the date-fns generic inference (the literal is the
+    // useMemo type-inference source) and degrades the property to `any`.
+    const rangeStart = startOfMonth(subMonths(today, effectiveMonths));
+    const months: CalendarMonthData[] = [];
+    const newMarkedDates: MarkedDates = {};
     const newUnitsMap = new Map<DateString, number>();
     const newMonthlyTotalsMap = new Map<string, number>();
+    const newSessionEntriesByDay = new Map<
+      DateString,
+      DrinkingSessionKeyValue[]
+    >();
 
-    dayKeys.forEach(dayKey => {
-      const dailySessions = sessionIndex.get(dayKey) ?? [];
-      const newMarking = sessionsToDayMarking(
-        dailySessions,
+    for (let monthsBack = effectiveMonths; monthsBack >= 0; monthsBack--) {
+      const monthStart = startOfMonth(subMonths(today, monthsBack));
+      const monthData = getDerivedCalendarMonth({
+        year: monthStart.getFullYear(),
+        month: monthStart.getMonth(),
+        monthEntriesByDay: sessionsByMonth.get(
+          toMonthKey(monthStart.getFullYear(), monthStart.getMonth()),
+        ),
         effectivePreferences,
-      );
-      if (!newMarking) {
-        newMarkedDatesMap.set(dayKey, {color: paletteGreen});
-        return;
+        endClamp: monthsBack === 0 ? today : null,
+      });
+      months.push(monthData);
+      monthData.dayData.forEach((cell, dayKey) => {
+        newMarkedDates[dayKey] = cell.marking;
+        if (cell.units !== undefined) {
+          newUnitsMap.set(dayKey, cell.units);
+        }
+      });
+      monthData.entriesByDay.forEach((entries, dayKey) => {
+        newSessionEntriesByDay.set(dayKey, entries);
+      });
+      if (monthData.entriesByDay.size > 0) {
+        newMonthlyTotalsMap.set(monthData.monthKey, monthData.totalUnits);
       }
-      newMarkedDatesMap.set(dayKey, newMarking.marking);
-      newUnitsMap.set(dayKey, newMarking.units);
-      // dayKey is 'YYYY-MM-DD' — slice the month bucket directly without
-      // re-parsing the date.
-      const monthKey = dayKey.slice(0, 7);
-      newMonthlyTotalsMap.set(
-        monthKey,
-        (newMonthlyTotalsMap.get(monthKey) ?? 0) + newMarking.units,
-      );
-    });
+    }
 
     return {
-      markedDatesMap: newMarkedDatesMap,
+      calendarMonths: months,
+      markedDates: newMarkedDates,
       unitsMap: newUnitsMap,
       monthlyTotalsMap: newMonthlyTotalsMap,
+      sessionEntriesByDay: newSessionEntriesByDay,
+      loadedFromDate: rangeStart,
     };
-  }, [sessionIndex, dayKeys, effectivePreferences, paletteGreen]);
-
-  const markedDates: MarkedDates = useMemo(
-    () => Object.fromEntries(markedDatesMap),
-    [markedDatesMap],
-  );
+  }, [sessionsByMonth, effectiveMonths, effectivePreferences]);
 
   // Overlay the live (in-progress) session on top of the base outputs. The live
   // buffer's drinks are deliberately kept out of `cachedDrinkingSessions` (the
   // server skips the cache echo while `sessionIsLive && ongoing`), so without
   // this the day tile / day-overview / month totals show the session flagged
   // ongoing but with 0 units until it is finalized. Patches only the overlay
-  // session's single day — the O(N)/Intl index pass and the O(D) marking pass
-  // above stay keyed on `sessions`, so a drink tap costs one day's recompute
-  // plus shallow map clones, not a full re-index. When there is no live session
-  // the base outputs are returned untouched (refs stable, zero overhead).
+  // session's single day — and, for the per-month sections, only that day's
+  // month — so a drink tap costs one day's recompute plus shallow clones, not a
+  // full re-index. Every other month keeps referential identity. When there is
+  // no live session the base outputs are returned untouched (refs stable, zero
+  // overhead).
   const {
+    calendarMonths: overlaidCalendarMonths,
     markedDates: overlaidMarkedDates,
     unitsMap: overlaidUnitsMap,
     monthlyTotalsMap: overlaidMonthlyTotalsMap,
     sessionEntriesByDay: overlaidSessionEntriesByDay,
   } = useMemo(() => {
     if (!ongoingOverlay?.ongoing || !ongoingOverlay.id) {
-      return {markedDates, unitsMap, monthlyTotalsMap, sessionEntriesByDay};
+      return {
+        calendarMonths,
+        markedDates,
+        unitsMap,
+        monthlyTotalsMap,
+        sessionEntriesByDay,
+      };
     }
 
     const overlayId = ongoingOverlay.id;
@@ -331,6 +328,9 @@ function useLazyMarkedDates(
       patchedEntries.map(entry => entry.session),
       effectivePreferences,
     );
+    const patchedCell: DayCellData = newMarking
+      ? {marking: newMarking.marking, units: newMarking.units}
+      : {marking: {color: paletteGreen}};
     const newUnits = newMarking?.units ?? 0;
     const oldUnits = unitsMap.get(dayKey) ?? 0;
 
@@ -346,10 +346,27 @@ function useLazyMarkedDates(
     const nextSessionEntriesByDay = new Map(sessionEntriesByDay);
     nextSessionEntriesByDay.set(dayKey, patchedEntries);
 
+    const nextCalendarMonths = calendarMonths.map(monthData => {
+      if (monthData.monthKey !== monthKey) {
+        return monthData;
+      }
+      const nextDayData = new Map(monthData.dayData);
+      nextDayData.set(dayKey, patchedCell);
+      const nextEntriesByDay = new Map(monthData.entriesByDay);
+      nextEntriesByDay.set(dayKey, patchedEntries);
+      return {
+        ...monthData,
+        dayData: nextDayData,
+        entriesByDay: nextEntriesByDay,
+        totalUnits: monthData.totalUnits - oldUnits + newUnits,
+      };
+    });
+
     return {
+      calendarMonths: nextCalendarMonths,
       markedDates: {
         ...markedDates,
-        [dayKey]: newMarking ? newMarking.marking : {color: paletteGreen},
+        [dayKey]: patchedCell.marking,
       },
       unitsMap: nextUnitsMap,
       monthlyTotalsMap: nextMonthlyTotalsMap,
@@ -357,6 +374,7 @@ function useLazyMarkedDates(
     };
   }, [
     ongoingOverlay,
+    calendarMonths,
     markedDates,
     unitsMap,
     monthlyTotalsMap,
@@ -422,6 +440,10 @@ function useLazyMarkedDates(
     unitsMap: overlaidUnitsMap,
     monthlyTotalsMap: overlaidMonthlyTotalsMap,
     sessionEntriesByDay: overlaidSessionEntriesByDay,
+    // Per-month render payloads for the fullscreen week-list, ascending. Month
+    // objects keep referential identity across widens (and across live-drink
+    // taps, for all but the overlay's month).
+    calendarMonths: overlaidCalendarMonths,
     loadedFrom,
     loadedFromDate,
     loadMoreMonths,
@@ -439,3 +461,4 @@ function useLazyMarkedDates(
 }
 
 export default useLazyMarkedDates;
+export type {UseLazyMarkedDatesOptions};


### PR DESCRIPTION
### Details

The fullscreen sessions calendar (opened from the month header on Home/Profile) didn't feel continuous: scrolling back in time hit a hard top edge that read as "partially loaded" rather than "loading" (with no loading affordance at all on your own calendar), every window widen rebuilt and re-rendered the entire list at once, and a fast scroll down could briefly blank the screen while FlashList re-laid-out a wholly replaced data array.

Three changes make the scroll continuous:

1. **Incremental per-month derivation.** New `deriveCalendarMonth.ts` derives each month's markings/units/entries once and caches it (keyed on the effective-preferences identity, the month, and the month's session group). `useLazyMarkedDates` assembles the loaded range from this cache, so a widen only derives the newly exposed months and previously derived month objects keep referential identity — `WeekRow.memo` now actually holds across widens, and a live-drink tap re-renders only the overlay's month. The merged outputs (`markedDates`, `unitsMap`, `monthlyTotalsMap`, `sessionEntriesByDay`) are unchanged contracts for the compact calendar and the day-overview list.
2. **Skeleton months instead of a hard edge.** While older data can still arrive (`canLoadOlder`), the week-list renders pending months above the loaded floor: real month labels with placeholder day tiles (`WeekRowSkeleton`, pixel-identical geometry). Their item keys are identical to the real rows that replace them, so data lands as an in-place swap with no scroll jump. The "Loading older months…" header row is removed from the week list (the day-overview list keeps its own).
3. **Self derives the full tracked range at fullscreen open.** The signed-in user's sessions are all on-device (`app/open`), so the fullscreen calendar now derives down to `earliest_session_at` immediately (`deriveFullRangeToFloor` option) — scrolling back never waits on a widen. The persisted depth lever (`SESSIONS_CALENDAR_MONTHS_BY_USER_ID`, shared with Statistics) is deliberately not written by this path.

Also fixed along the way:

- Opening the fullscreen calendar centered on a pre-tracking month no longer hangs on the screen skeleton (the render-only floor is seeded so the centering target exists).
- The legacy "window start − 1 day" boundary slop is replaced by zoned-month session grouping (`toZonedTime` day keys), which is strictly more correct for sessions near month boundaries in non-local timezones.
- A TS 5.x inference quirk where a date-fns call inlined in the `useMemo` return literal degraded `loadedFromDate` to `any` (tsgo masked it; it surfaced 15 `no-unsafe-*` lint errors downstream).

Note for reviewers: `eslint.seatbelt.tsv` is untouched (no new grandfathered violations), and React Compiler compliance passes for all 10 changed React files. The future self windowed-fetch migration (#1214) slots into the friend path — changes 1 and 2 carry over as-is; change 3 is a flag flip back.

### Tests

1. Sign in, go to Home, tap the calendar's month header to open the fullscreen calendar
2. Verify it opens centered on the current month with day markings and month totals
3. Scroll up (back in time) quickly all the way to your earliest tracked month — verify the scroll is continuous: no "Loading older months…" row, no placeholder tiles, no hard edge that later pops in
4. Verify days before your tracking start render dimmed, and that holding at the top keeps extending dimmed months
5. Scroll back down to today quickly — verify no blank flashes and that sticky month labels track correctly
6. Close the fullscreen calendar — verify the compact calendar still shows the month you came from
7. Open a friend's profile (friend with a long history) and their fullscreen calendar via the month header
8. Scroll up past the loaded window — verify placeholder (skeleton) day tiles appear under real month labels, then fill in place with the friend's data without the view jumping
9. Keep scrolling until the friend's history is exhausted — verify the list ends cleanly with dimmed pre-history months and no spinner
10. Long-press a day on your own fullscreen calendar — verify the edit shortcut still works; tap a day — verify the drill-down sheet opens
11. Open a day-overview scroll (tap a day on the compact calendar) — verify it behaves as before, including its "Loading older months…" header on friends
12. Start a live session and add a drink — verify the day's tile and the month total update on your calendars

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Open a friend's fullscreen calendar, go offline, scroll up past the loaded floor
2. Verify skeleton months render and stay (no crash, no spinner) — the data genuinely may exist
3. Go back online — verify the skeleton months fill in place once the widened read lands (reconnect refetch)

### QA Steps

Same as Tests, on staging.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
- [ ] I ran the tests on **all platforms** & verified they passed on:
  - [ ] Android
  - [ ] iOS
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method of the `LocaleContextProvider`
    - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in the Discord and approved by a Kiroku head developer team
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods from the `LocaleContextProvider`
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized).
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Kiroku head development team members
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/PetrCala/Kiroku/blob/master/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `ProfileImage`, I verified the components using `ProfileImage` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified that all code follows the ETC (easy-to-change) principle
- [x] I verified any variables that can be defined as constants (i.e., in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages and relevant docstrings have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing `StyleUtils` function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `ProfileImage` is modified, I verified that `ProfileImage` is working as expected in all cases)
- [ ] If the PR modifies a component or screen that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [ ] I verified that all the inputs inside a form are aligned with each other.
  - [ ] I added `design` label and/or tagged `@Kiroku/design` so the design team can review the changes.
- [ ] If a new screen is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the screen.
- [ ] If the `master` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
