### PR TITLE
fix(web): resolve boot-splash deadlock by relocating the auth-data gate backstop

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -742,6 +742,14 @@ const CONST = {
   // a warm listener (typically <500 ms) and shorter than the safety net.
   BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS: 3 * 1000,
 
+  // Last-resort safety net (SplashScreenHider): force-hide the splash if the
+  // gates never resolve, so a stuck boot can't pin the (untappable) overlay.
+  BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS: 15 * 1000,
+  // Kiroku logs a full gate snapshot if the splash is still up this long, to
+  // name the offender. Must stay BELOW BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS so it
+  // fires while still stuck, just before the net hides the splash.
+  BOOT_SPLASH_STUCK_LOG_TIMEOUT_MS: 14 * 1000,
+
   KEYBOARD_TYPE: {
     VISIBLE_PASSWORD: 'visible-password',
     ASCII_CAPABLE: 'ascii-capable',

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -72,6 +72,7 @@ function Kiroku() {
     splashScreenState,
     setSplashScreenState,
     isAuthDataReady,
+    setIsAuthDataReady,
     setIsLogoHandoffActive,
   } = useContext(SplashScreenStateContext);
   const [lastVisitedPath] = useOnyx(ONYXKEYS.LAST_VISITED_PATH);
@@ -177,11 +178,33 @@ function Kiroku() {
   // For authenticated users, wait for the user's RTDB data (userData +
   // preferences) to hydrate before hiding the splash, so the home screen
   // can paint real content immediately and OnboardingGuard can redirect
-  // without flicker. The signal is set from inside AuthScreens via
-  // `setIsAuthDataReady`. For unauthenticated users this condition is
-  // bypassed — the public stack
-  // is ready as soon as nav + theme are ready.
+  // without flicker. The fast path is set from inside AuthScreens via
+  // `setIsAuthDataReady` once data lands; the bounded backstop below guarantees
+  // it resolves even if AuthScreens never reaches a stable mount. For
+  // unauthenticated users this condition is bypassed — the public stack is
+  // ready as soon as nav + theme are ready.
   const isAuthScreenReady = !isAuthenticated || isAuthDataReady;
+
+  // Backstop for the authenticated splash gate, owned HERE rather than in
+  // AuthScreens. `isAuthDataReady` was previously settable only from inside
+  // AuthScreensContent (the data-arrival effect and its own timeout). But
+  // AuthScreens is lazy-loaded behind <Suspense fallback={null}> and mounts
+  // only after `onAuthStateChanged` fires, whereas the VerifyEmailModal renders
+  // straight from `isAuthenticated` here — so when the AuthScreens chunk-load or
+  // mount loses the boot race (~1 in 8 under load), the modal shows but the
+  // gate's only setter never runs and the splash is pinned forever (web #splash
+  // is z-index 10000 and swallows every click). Tying the backstop to
+  // `isAuthenticated` makes it fire regardless of AuthScreens, so the gate can't
+  // deadlock. The 15s SplashScreenHider net remains as the last resort.
+  useEffect(() => {
+    if (!isAuthenticated || isAuthDataReady) {
+      return undefined;
+    }
+    const timeoutId = setTimeout(() => {
+      setIsAuthDataReady(true);
+    }, CONST.BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS);
+    return () => clearTimeout(timeoutId);
+  }, [isAuthenticated, isAuthDataReady, setIsAuthDataReady]);
 
   const shouldHideSplash = !!(
     shouldInit &&
@@ -234,6 +257,12 @@ function Kiroku() {
     Log.info('App launched', false, {Platform});
   }, []);
 
+  // If the splash is still up this long, it's stuck. Log a full snapshot of the
+  // gate inputs so the offender is obvious, then SplashScreenHider's 15s net
+  // force-hides just after. Fires one tick before the net so it captures the
+  // still-stuck state; on a healthy boot the splash hides in a couple seconds
+  // and this never runs. All gates are already in scope here, so the breadcrumb
+  // lives with the data rather than being plumbed into the overlay.
   useEffect(() => {
     if (splashScreenState !== CONST.BOOT_SPLASH_STATE.VISIBLE) {
       return undefined;
@@ -244,24 +273,42 @@ function Kiroku() {
         {
           propsToLog: {
             appState: AppState.currentState,
+            shouldInit,
+            isNavigationReady,
+            hasCheckedAutoLogin,
+            authenticationChecked,
+            isThemeReady,
+            preferredThemeStatus: preferredThemeMetadata.status,
+            isAuthenticated,
+            isAuthDataReady,
+            isAuthScreenReady,
+            shouldShowVerifyEmailModal,
+            isOnyxMigrated,
             updateRequired,
             updateAvailable,
-            isAuthenticated,
-            isThemeReady,
             preferredTheme,
             lastVisitedPath,
           },
         },
         false,
       );
-    }, 30 * 1000);
+    }, CONST.BOOT_SPLASH_STUCK_LOG_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, [
     splashScreenState,
+    shouldInit,
+    isNavigationReady,
+    hasCheckedAutoLogin,
+    authenticationChecked,
+    isThemeReady,
+    preferredThemeMetadata.status,
+    isAuthenticated,
+    isAuthDataReady,
+    isAuthScreenReady,
+    shouldShowVerifyEmailModal,
+    isOnyxMigrated,
     updateRequired,
     updateAvailable,
-    isAuthenticated,
-    isThemeReady,
     preferredTheme,
     lastVisitedPath,
   ]);

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -16,6 +16,7 @@ import BootSplash from '@libs/BootSplash';
 import * as FeatureFlags from '@libs/FeatureFlags';
 import Log from '@libs/Log';
 import colors from '@src/styles/theme/colors';
+import CONST from '@src/CONST';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
@@ -24,7 +25,7 @@ import type {
 // Force-hide the splash if shouldHideSplash hasn't fired by this point.
 // Protects against deadlocks where a gating condition (e.g. hasCheckedAutoLogin)
 // never flips and the user is left staring at the yellow overlay indefinitely.
-const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
+const FORCE_HIDE_TIMEOUT_MS = CONST.BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS;
 
 // Storyboard asset is 108pt (108/216/324 at 1×/2×/3×). The JS overlay
 // renders the logo at the same size so the native → JS handoff is seamless.

--- a/src/components/SplashScreenHider/index.tsx
+++ b/src/components/SplashScreenHider/index.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useRef} from 'react';
 import BootSplash from '@libs/BootSplash';
 import Log from '@libs/Log';
+import CONST from '@src/CONST';
 import type {
   SplashScreenHiderProps,
   SplashScreenHiderReturnType,
@@ -10,7 +11,13 @@ import type {
 // shouldHideSplash hasn't fired by this point. On web this matters doubly --
 // the #splash div sits at z-index 10000 and swallows every pointer event, so a
 // gating condition that never flips leaves the app visible but untappable.
-const FORCE_HIDE_TIMEOUT_MS = 15 * 1000;
+//
+// This is the LAST resort, not the primary fix: the authenticated splash gate
+// (`isAuthDataReady`) has its own bounded backstop in Kiroku.tsx, so a healthy
+// boot resolves well before this fires. Kiroku.tsx logs the full gate snapshot
+// one tick before this (the "[BootSplash] splash screen is still visible"
+// alert), so a trip here always has an accompanying breadcrumb of the offender.
+const FORCE_HIDE_TIMEOUT_MS = CONST.BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS;
 
 function SplashScreenHider({
   onHide = () => {},

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -121,12 +121,19 @@ function AuthScreensContent() {
     StyleUtils,
   );
 
-  // Signal "auth data ready" to the boot splash gate in Kiroku.tsx. The
-  // splash hides only once these two fields have arrived from the live
-  // listener — matches HomeScreen's own render gate so the user sees the
-  // splash continuously until real content can paint.
+  // Signal "auth data ready" to the boot splash gate in Kiroku.tsx — the fast
+  // path. The splash hides as soon as these two fields arrive from the live
+  // listener, matching HomeScreen's own render gate so the user sees the splash
+  // continuously until real content can paint.
   // `useCurrentUserData` returns {} (truthy) while loading; the auth-ready gate
   // below must treat the empty object as "not loaded", so map empty → undefined.
+  //
+  // The bounded BACKSTOP for this gate does NOT live here — it lives in
+  // Kiroku.tsx, tied to `isAuthenticated`. AuthScreens is lazy-loaded and mounts
+  // only after auth resolves, so a backstop placed here could never fire if the
+  // chunk-load/mount itself is what stalls (the splash-deadlock root cause). The
+  // gate owner must guarantee its own resolution; this component only supplies
+  // the earlier, data-driven signal when it can.
   const currentUserData = useCurrentUserData();
   const userData = isEmptyObject(currentUserData) ? undefined : currentUserData;
   const preferences = useCurrentUserPreferences();
@@ -137,17 +144,6 @@ function AuthScreensContent() {
     }
     setIsAuthDataReady(true);
   }, [userData, preferences, setIsAuthDataReady]);
-  // Safety: if the listener doesn't deliver both fields within the
-  // timeout (offline cold start, slow network, or missing fields in the
-  // user's RTDB document), flip the gate anyway. HomeScreen renders
-  // skeletons until real data arrives, so this falls back to a brief
-  // skeleton flash instead of leaving the user staring at the splash.
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setIsAuthDataReady(true);
-    }, CONST.BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS);
-    return () => clearTimeout(timeoutId);
-  }, [setIsAuthDataReady]);
   // Reset on sign-out (AuthScreens unmounts) so a subsequent sign-in
   // re-gates the splash on fresh data.
   useEffect(() => () => setIsAuthDataReady(false), [setIsAuthDataReady]);


### PR DESCRIPTION
### Details

The web boot splash occasionally (~1 in 8 authenticated page loads) never hides; before the 15s force-hide net it stayed up indefinitely.

**Diagnosis (which gate sticks).** Reproduced via a Playwright reload/new-context loop against the live `npm run web` dev server, instrumenting every `shouldHideSplash` input. The stuck gate is **`isAuthDataReady` → `isAuthScreenReady`** — not `isThemeReady`, and not `splashScreenState` (nothing ever sets `READY_TO_BE_HIDDEN`). Definitive capture of a stuck load:

```
shouldInit:true  authenticationChecked:true  isThemeReady:true  isAuthenticated:true
shouldShowVerifyEmailModal:true   ← modal shown (matches the observed correlation)
isAuthDataReady:false → isAuthScreenReady:false → shouldHideSplash:false   ← STUCK
```

**Root cause.** The only code that sets `isAuthDataReady = true` lived inside `AuthScreensContent` (the data-arrival effect and a 3s cap). But `AuthScreens` is `lazy()` behind `<Suspense fallback={null}>` and mounts only *after* `onAuthStateChanged` fires, whereas `VerifyEmailModal` is computed independently in `Kiroku.tsx` straight from `isAuthenticated`. So when the lazy `AuthScreens` chunk-load/mount loses the boot race, the modal renders but the gate's only setter never runs → `isAuthDataReady` is pinned `false` forever (web `#splash` is z-index 10000 and swallows every click). The 3s backstop couldn't help — it lived inside the very component that failed to mount. The premise "modal shown ⇒ the 3s cap already ran" was wrong: the modal and the backstop have independent mount paths.

> Note: the 15s `SplashScreenHider` force-hide net itself already landed on `master` via #1273; this PR fixes the *underlying race* so that net stops firing, and folds its timeout into a shared constant.

**Fix.**
- `Kiroku.tsx` — relocate the authenticated-data backstop here, tied to `isAuthenticated` (exists regardless of `AuthScreens`), so the gate always resolves within `BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS`. Also extend the existing `[BootSplash] splash screen is still visible` alert to log the full gate snapshot, fired at `BOOT_SPLASH_STUCK_LOG_TIMEOUT_MS` (one tick before the net), so any future stall names the offending input — the breadcrumb lives where the gates are already in scope, no plumbing.
- `AuthScreens.tsx` — remove the misplaced 3s timeout (now redundant); keep the fast data-arrival signal and the sign-out reset.
- `CONST.ts` / `SplashScreenHider` (web + native) — extract the coupled force-hide (15s) and stuck-log (14s) timeouts into named, co-located constants so they can't drift; the hiders now reference `BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS` instead of an inline literal.

The 15s net stays as the last resort, but the relocated 3s gate resolves first, so it no longer fires.

### Tests

1. `npm run web`, sign in normally on web → splash hides and Home/the verify-email modal is tappable (no regression; the fast data path still drives the hide).
2. Reload an authenticated page many times → splash hides every time within a few seconds; no `[BootSplash]` alert in the console.
3. Deadlock repro (the bug this fixes): temporarily make the authenticated-data signal never fire (disable `setIsAuthDataReady(true)` in `AuthScreens.tsx`), reload authenticated → with this change the splash still hides at ~auth+3s via the normal `[BootSplash] hiding` path. On `master` it hangs until the 15s net.

- [x] Verify that no errors appear in the JS console

### Offline tests

A slow/offline cold start is exactly the scenario the bounded backstop and the 15s net protect: when the user's data can't hydrate, the gate flips on the cap and Home renders skeletons rather than leaving the user on the splash. No network dependency in the changed logic.

### QA Steps

1. On staging web, sign in and confirm the app loads to Home (splash hides, tabs/modal are tappable).
2. Reload the authenticated page repeatedly and confirm the splash always clears within a few seconds and no `[BootSplash] splash screen is still visible` / `shouldHideSplash never became true` alert is logged.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors
- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified that any new or modified comments were clear, correct English, and explained "why"
- [x] No new user-facing copy was added (the `Log.alert` strings are dev/diagnostic breadcrumbs, not localized UI)
- [x] I verified all code is DRY (coupled timeouts extracted to shared CONST; web hider mirrors native)
- [x] typecheck (tsgo), React Compiler compliance (changed files), and lint all pass

### Notes for reviewer

- Rebased onto current `master` (which now includes #1273's force-hide net); the only conflict was the web hider adding the same net, resolved to the const-referencing version.
- A scratch Playwright repro harness (`e2e/web/repro-splash.mjs`) was used during investigation but is intentionally left out of this PR.