### PR TITLE
feat(i18n): enforce translation completeness in CI

### DIFF
--- a/.github/workflows/translationSync.yml
+++ b/.github/workflows/translationSync.yml
@@ -1,0 +1,71 @@
+name: Translation Sync Check
+
+# ============================================================
+# Non-blocking guard: when a PR changes the English source of truth
+# (src/languages/en.ts) but does NOT touch a locale file, warn that the
+# translations may be stale and the /translate skill should be run.
+#
+# ADVISORY ONLY — it emits a GitHub ::warning:: annotation and always exits 0,
+# so it never blocks a merge. The hard, always-on gate is the deterministic
+# parity / shape / untranslated unit test in __tests__/unit/Translate.test.ts
+# (runs in test.yml). Locales are discovered from src/languages/context/*.md,
+# so adding a new language needs no change here.
+# ============================================================
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
+    paths: ['src/languages/**']
+
+concurrency:
+  group: ${{ github.ref }}-translation-sync
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Warn on untranslated English changes
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Warn if en.ts changed without a matching locale update
+        run: |
+          shopt -s nullglob
+          changed="$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')"
+
+          # Nothing to do unless the English source of truth itself changed.
+          if ! grep -qx 'src/languages/en.ts' <<<"$changed"; then
+            echo "src/languages/en.ts not changed in this PR — nothing to check."
+            exit 0
+          fi
+
+          # Discover locales from their context files (self-maintaining: a new
+          # language only needs src/languages/context/<locale>.md to be covered).
+          missing=()
+          for ctx in src/languages/context/*.md; do
+            locale="$(basename "$ctx" .md)"
+            if [ "$locale" = "_TEMPLATE" ]; then
+              continue
+            fi
+            if ! grep -qx "src/languages/${locale}.ts" <<<"$changed"; then
+              missing+=("$locale")
+            fi
+          done
+
+          if [ "${#missing[@]}" -eq 0 ]; then
+            echo "All locale files were updated alongside en.ts."
+            exit 0
+          fi
+
+          for locale in "${missing[@]}"; do
+            echo "::warning title=Translations may be out of sync::src/languages/en.ts changed but src/languages/${locale}.ts was not updated. Run the /translate skill to fill or refresh ${locale}, then verify with: npm run test -- __tests__/unit/Translate.test.ts"
+          done

--- a/__tests__/unit/Translate.test.ts
+++ b/__tests__/unit/Translate.test.ts
@@ -66,6 +66,65 @@ describe('translate', () => {
   });
 });
 
+/**
+ * The shape of a flattened translation value. English is the source of truth,
+ * so every locale must use the same shape for a given key (a plain string can
+ * never silently replace an interpolation function or a string array). The
+ * loose `satisfies TranslationBase` typing on the locale files does not catch
+ * this, so we assert it here.
+ */
+function valueShape(value: unknown): 'string' | 'array' | 'function' | 'other' {
+  if (typeof value === 'function') {
+    return 'function';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  return 'other';
+}
+
+/**
+ * Flattened key paths whose value is *intentionally* identical to English in
+ * every locale (brand names, format strings, universal abbreviations). These
+ * are exempt from the "untranslated value" check below. Add a key here only
+ * when the English text genuinely needs no translation — never to silence a
+ * string that simply hasn't been translated yet.
+ */
+const UNTRANSLATED_ALLOWLIST = new Set<string>([
+  // Brand / proper nouns & product names
+  'common.google',
+  'common.apple',
+  'connectedAccounts.providers.google',
+  'connectedAccounts.providers.apple',
+  'supporter.tierName',
+  'supporter.badgeAccessibilityLabel',
+  'bottomTabBar.menu',
+  'onboarding.title',
+  // Format / placeholder strings
+  'common.dateFormat',
+  'common.phoneNumberPlaceholder',
+  // Universal abbreviations (time, version, range)
+  'common.am',
+  'common.pm',
+  'common.na',
+  'timePeriods.abbreviated.second',
+  'timePeriods.abbreviated.minute',
+  'timePeriods.abbreviated.hour',
+  'timePeriods.abbreviated.day',
+  'timePeriods.abbreviated.month',
+  'settingsScreen.aboutScreen.versionLetter',
+  'statistics.filters.range.M',
+  'statistics.filters.range.sixM',
+  // Correct Czech happens to be identical to the English word
+  'common.ok',
+  'common.role',
+  'statistics.tabs.trends.weeklyTrend.legend.trend',
+  'errors.auth.networkRequestFailed.title',
+]);
+
 describe('Translation Keys', () => {
   function traverseKeyPath(
     source: TranslationFlatObject,
@@ -89,19 +148,24 @@ describe('Translation Keys', () => {
     return pathArray;
   }
 
-  const excludeLanguages = [CONST.LOCALES.EN, CONST.LOCALES.CS_CZ];
+  // Exclude only the source-of-truth locale. Every other locale in
+  // `CONST.LOCALES` is checked for full parity against English, so a feature PR
+  // that adds English keys without translating them cannot merge green.
+  const excludeLanguages = [CONST.LOCALES.EN];
   const languages = Object.keys(originalTranslations.default).filter(
     ln => !excludeLanguages.some(excludeLanguage => excludeLanguage === ln),
   );
   const mainLanguage = originalTranslations.default.en;
   const mainLanguageKeys = traverseKeyPath(mainLanguage);
+  const mainLanguageFlat = mainLanguage as Record<string, unknown>;
 
   languages.forEach(ln => {
-    const languageKeys = traverseKeyPath(
+    const languageObject =
       originalTranslations.default[
         ln as keyof typeof originalTranslations.default
-      ],
-    );
+      ];
+    const languageKeys = traverseKeyPath(languageObject);
+    const languageFlat = languageObject as Record<string, unknown>;
 
     it(`Does ${ln} locale have all the keys`, () => {
       const hasAllKeys = arrayDifference(mainLanguageKeys, languageKeys);
@@ -123,6 +187,49 @@ describe('Translation Keys', () => {
         Error(`🏹 [ ${hasAllKeys.join(', ')} ] are unused keys in ${ln}.js`);
       }
       expect(hasAllKeys).toEqual([]);
+    });
+
+    it(`Does ${ln} locale use the same value shape as en`, () => {
+      const shapeMismatches = Object.keys(mainLanguageFlat).filter(key => {
+        // Missing keys are already reported by the parity test above; only
+        // compare keys the locale actually provides.
+        if (!(key in languageFlat)) {
+          return false;
+        }
+        return (
+          valueShape(mainLanguageFlat[key]) !== valueShape(languageFlat[key])
+        );
+      });
+      if (shapeMismatches.length) {
+        console.debug(
+          `🏹 [ ${shapeMismatches.join(', ')} ] have a different value shape in ${ln}.js than en.js (string vs function vs array)`,
+        );
+      }
+      expect(shapeMismatches).toEqual([]);
+    });
+
+    it(`Does ${ln} locale have no untranslated (English) values`, () => {
+      const untranslated = Object.keys(mainLanguageFlat).filter(key => {
+        const enValue = mainLanguageFlat[key];
+        const localeValue = languageFlat[key];
+        // Only string leaves are checked. Functions/arrays are guarded by the
+        // shape + parity tests; comparing their source is brittle.
+        if (typeof enValue !== 'string' || typeof localeValue !== 'string') {
+          return false;
+        }
+        if (UNTRANSLATED_ALLOWLIST.has(key)) {
+          return false;
+        }
+        // A non-empty value identical to English is almost certainly a string
+        // that was copied over but never translated.
+        return enValue.trim().length > 0 && enValue === localeValue;
+      });
+      if (untranslated.length) {
+        console.debug(
+          `🏹 [ ${untranslated.join(', ')} ] are identical to en in ${ln}.js (likely untranslated). Translate them, or add the key to UNTRANSLATED_ALLOWLIST if the English text genuinely needs no translation.`,
+        );
+      }
+      expect(untranslated).toEqual([]);
     });
   });
 });

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1863,6 +1863,11 @@ export default {
         message:
           'Při blokování tohoto uživatele došlo k problému. Zkuste to prosím znovu.',
       },
+      couldNotReportUser: {
+        title: 'Nepodařilo se nahlásit uživatele',
+        message:
+          'Při nahlašování uživatele došlo k problému. Zkuste to prosím znovu.',
+      },
       couldNotUnfriend: {
         title: 'Nepodařilo se odebrat z přátel',
         message:


### PR DESCRIPTION
### Details

Non-English locales could silently de-sync from `en.ts`, and nothing in CI caught it:

- `cs_cz.ts` ends with `satisfies TranslationBase` (a loose `{[k: string]: ...}`), **not** `satisfies typeof en` — so `typecheck` does not catch missing keys.
- The parity loop in `__tests__/unit/Translate.test.ts` excluded both `EN` and `CS_CZ`, and those are the only two locales, so it iterated **zero** times (dormant).
- `TranslationContext.test.ts` only checks that a context file exists, not completeness.

Net effect: a feature PR could add English keys, never translate them, and merge green — the strings silently fell back to English at runtime.

This PR closes the gap with a two-tier approach. We enforce the *invariant the `translate` skill maintains*, not the act of running it.

**Tier 1 — deterministic gate** in `__tests__/unit/Translate.test.ts` (folded into the already-required `test.yml`; path-agnostic so it can't be skipped, free, fast):
- **Key parity** — `excludeLanguages` now excludes only `EN`, so every non-English locale is checked for missing + orphan keys (auto-covers future locales).
- **Value-shape parity** — asserts `typeof en[key] === typeof locale[key]`, so a plain string can't silently replace an interpolation function or array (a drift the loose typing allows).
- **Untranslated detection** — every non-English string leaf must differ from English unless its flattened key path is in `UNTRANSLATED_ALLOWLIST` (seeded with the legitimately-identical values: brands, `OK`/`N/A`, time/version abbreviations, format strings). Function/array leaves are skipped.

**Tier 2 — advisory warning** in `.github/workflows/translationSync.yml`: on PRs touching `src/languages/**`, if `en.ts` changed but a locale file did not, emit a **non-blocking** `::warning::` pointing at `/translate`. Always exits 0. Locales are auto-discovered from `src/languages/context/*.md`, so adding a language needs no workflow edit.

**Drift the gate caught:** after rebasing onto `master`, the new parity check flagged that the #765 moderation backfill left `errors.user.couldNotReportUser.{title,message}` untranslated in `cs_cz`. This PR fills those two keys via the Czech glossary (vykání, parallel to the sibling `couldNot*` error messages). The rest of the report-flow Czech is already on master from #763/#765.

#### Reviewer notes
- One allowlist judgment call: `onboarding.title` is allowlisted (`'Onboarding'` kept verbatim in Czech, as the surrounding keys were already translated). Drop it from the allowlist if it should be translated.
- **Branch protection:** Tier 1 only becomes a hard gate if `test` is a **required** status check; Tier 2 (`translationSync`) must **not** be required.

### Tests

1. `npm run test -- __tests__/unit/Translate.test.ts` → **10/10 pass** (parity, shape, untranslated all green).
2. Drift detection is proven organically: against master's `cs_cz`, the parity check named the 2 missing `couldNotReportUser` keys; after filling, green.
3. `npm run typecheck-tsgo` → clean. Prettier → clean on all changed files.
4. `translationSync.yml` validated with `actionlint`; logic dry-run correct for en-only (warns), en+locale (silent), and locale-only (skips) scenarios.

- [x] Verify that no errors appear in the JS console (N/A — test/CI-only change, no runtime app code)

### Offline tests

N/A — CI/test tooling and translation-string change only; no runtime, network, or offline behavior is affected.

### QA Steps

No staging QA needed — no user-facing behavior change beyond two newly-translated Czech error strings.
1. (Optional) In Czech locale, trigger a failed user-report; verify the error title/message render in Czech.

- [x] Verify that no errors appear in the JS console (N/A)

### PR Author Checklist

- [x] Any new/modified copy is localized via `src/languages/*` (English source untouched; Czech filled against the glossary)
- [x] Comments explain "why" (the loose-typing / dormant-loop rationale) where not self-evident
- [x] New file (`translationSync.yml`) has a header describing what it does and the non-blocking contract
- [x] Code is DRY and reuses existing helpers (`arrayDifference`, `flattenObject`)
- [ ] iOS / Android platform runs — N/A (no native or UI code touched)

### Screenshots/Videos

N/A — no UI changes.