### PR TITLE
feat(skills): add release-notes skill for store-facing What's New text

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: release-notes
+description: Generate store-facing "What's New" release notes for Kiroku by comparing the last publicly shipped version on each store (App Store / Google Play) against current master. Use whenever the user wants release notes, what's-new text, a store changelog, copy for promoting a build to public release, or a user-facing summary of what changed since some version, for either or both platforms. Trigger even on loose phrasing like "we're pushing to the Play Store, write the notes" or "what's new since 0.3.13?". Not for the automated CI TestFlight changelog (scripts/generateReleaseNotes.sh owns that).
+---
+
+# Release Notes
+
+Produce paste-ready store release notes ("What's New") per platform and locale by summarizing every user-visible change between the last publicly shipped version and the release being shipped (usually current master).
+
+The two stores almost always have **different baselines**: Google Play production lags the App Store, sometimes by several minor versions. Treat each platform as its own comparison with its own notes. The notes are pasted manually into the consoles, so the deliverable is text in the final response, formatted per the template below.
+
+## Inputs
+
+You need, per requested platform, the last **publicly available** version:
+
+- **iOS**: if the user doesn't supply it, read it live: `node scripts/asc.mjs status` and take the version in `READY_FOR_SALE` state.
+- **Android**: there is no Play Console API wired up; the user must supply it. If they only know the minor (for example "0.3.10-something"), pass the bare minor to the script. It resolves to that minor's last build, and you must state that assumption next to the output so the user can correct it.
+
+Version format mapping: the App Store displays `0.3.13.1`, which is internal version `0.3.13-1` (the deploy converts dashes to dots for iOS). The script accepts either form.
+
+The "to" side defaults to `master`. Run `git fetch origin master:master` first if the local ref may be stale (or pass `origin/master` explicitly).
+
+## Step 1: Collect the changes
+
+```bash
+bash .claude/skills/release-notes/scripts/collect_changes.sh <from-version> [<to-ref>]
+```
+
+The script resolves the version to a commit (release tags only exist as `X-N-staging` and old ones get pruned, so it anchors on the version-bump commit messages: `chore: release X-N` for the current era, `Version update: X-N` for releases up to ~0.3.11), then prints a header (resolved span, commit counts) followed by the commit subjects oldest-first, with release bumps, merges, deps, CI, docs, and test noise already filtered out.
+
+If resolution fails (very old or rewritten history), find the commit by hand via `git log -S '"version": "X.Y.Z' -- package.json` and pass questions back to the user only if that also fails.
+
+## Step 2: Write the notes
+
+Work from the subject list, but write for a store visitor, not a developer:
+
+- **User-visible changes only.** Skip refactors, tooling, and internal fixes that survived the filter. A fix earns a mention only if a user could have hit the bug.
+- **Group thematically.** A multi-minor span (typical for Android) can contain hundreds of commits; collapse them into roughly 4 to 7 themes ("Redesigned navigation", "Faster startup", "Live session improvements"), each one short line. Lead with the change a user would notice first.
+- **Plain language.** No commit references, no PR numbers, no library names, no jargon. "Fixed a crash when editing a session" beats "fix(session): guard undefined drinks".
+- **Voice.** Friendly and concise. No em-dashes anywhere, in any locale (repo copy rule). Bullets start with a dash and a capital letter.
+- **Don't leak unreleased plans.** Only describe what is actually in the target ref.
+
+Produce every set of notes in **both locales: `en-US` and `cs`**. Write the Czech yourself following the voice and glossary in `src/languages/context/cs_cz.md`. These are marketing copy, not UI strings, so the `translate` skill machinery (en.ts keys) does not apply.
+
+## Store constraints
+
+| Store                    | Limit per locale | Aim for                            |
+| ------------------------ | ---------------- | ---------------------------------- |
+| Google Play release note | 500 chars, hard  | 350 to 480 chars                   |
+| App Store "What's New"   | 4000 chars       | under 1200 chars                   |
+| TestFlight changelog     | 4000 chars       | reuse the App Store text if needed |
+
+For Google Play, print the character count next to each locale block; exceeding 500 makes the console reject the paste.
+
+## Output format
+
+ALWAYS use this template in the final response:
+
+```markdown
+## Android (Google Play): 0.3.10-25 -> 0.3.15-95
+
+### en-US (412/500 chars)
+
+- ...
+
+### cs (438/500 chars)
+
+- ...
+
+## iOS (App Store): 0.3.13.1 -> 0.3.15-95
+
+### en-US
+
+- ...
+
+### cs
+
+- ...
+```
+
+State any baseline assumption (for example a bare minor resolved to its last build) directly under the platform heading.
+
+## Where the text goes (and does not go)
+
+- **Google Play**: pasted manually into the Play Console. CI never uploads changelogs (`skip_upload_changelogs: true` in the Fastfile), so this is the only path.
+- **App Store**: pasted into App Store Connect for the release being prepared. Do not edit `fastlane/metadata/*/release_notes.txt` as a delivery mechanism: the deploy's `deliver` call overrides release notes with the auto-generated `TESTFLIGHT_CHANGELOG` env var, so file edits do not stick as a source of truth.
+
+## Relationship to the CI script
+
+`scripts/generateReleaseNotes.sh` is the automated, single-release-hop TestFlight note (previous tag to HEAD, Haiku, 300 chars). It serves a different cadence and stays as is. If you change commit-filtering rules here or there, keep the two consistent.

--- a/.claude/skills/release-notes/scripts/collect_changes.sh
+++ b/.claude/skills/release-notes/scripts/collect_changes.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+# Resolve a Kiroku public store version to its git commit and list the
+# user-relevant commit subjects from that commit up to a target ref.
+#
+# Usage:
+#   collect_changes.sh <from-version> [<to-ref>]
+#
+#   <from-version> accepts:
+#     0.3.13.1   App Store display format (last dot is really a build dash)
+#     0.3.13-1   internal package.json format
+#     0.3.10     bare minor: resolves to the LAST build of that minor
+#   <to-ref> defaults to master.
+#
+# Resolution order (release tags only exist as X-N-staging and get pruned,
+# so commit messages are the durable anchor):
+#   1. "chore: release X-N"   (release-please era, ~0.3.11+)
+#   2. "Version update: X-N"  (older era, <= ~0.3.11)
+#   3. tag "X-N-staging"
+
+FROM_INPUT="${1:?usage: collect_changes.sh <from-version> [<to-ref>]}"
+TO_REF="${2:-master}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+# --- Normalize the version string -------------------------------------------
+if [[ "$FROM_INPUT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)$ ]]; then
+  # App Store display format 0.3.13.1 -> 0.3.13-1
+  VERSION="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+elif [[ "$FROM_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
+  VERSION="$FROM_INPUT"
+elif [[ "$FROM_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Bare minor: pick the highest build number of that minor on TO_REF.
+  ESC="${FROM_INPUT//./\\.}"
+  LAST_BUILD=$(git log "$TO_REF" --format=%s \
+      --grep="^chore: release ${ESC}-[0-9]*\$" \
+      --grep="^Version update: ${ESC}-[0-9]*\$" |
+    sed -E 's/^(chore: release |Version update: )//' |
+    sort -V | tail -1)
+  if [ -z "$LAST_BUILD" ]; then
+    echo "error: no release commits found for minor ${FROM_INPUT} on ${TO_REF}" >&2
+    exit 1
+  fi
+  VERSION="$LAST_BUILD"
+  echo "note: bare minor ${FROM_INPUT} resolved to its last build ${VERSION}" >&2
+else
+  echo "error: unrecognized version format '${FROM_INPUT}'" >&2
+  exit 1
+fi
+
+# --- Resolve the version to a commit -----------------------------------------
+ESC="${VERSION//./\\.}"
+FROM_COMMIT=$(git rev-list -1 "$TO_REF" --grep="^chore: release ${ESC}\$")
+if [ -z "$FROM_COMMIT" ]; then
+  FROM_COMMIT=$(git rev-list -1 "$TO_REF" --grep="^Version update: ${ESC}\$")
+fi
+if [ -z "$FROM_COMMIT" ]; then
+  FROM_COMMIT=$(git rev-parse -q --verify "refs/tags/${VERSION}-staging^{commit}" || true)
+fi
+if [ -z "$FROM_COMMIT" ]; then
+  echo "error: could not resolve ${VERSION} to a commit on ${TO_REF}" >&2
+  echo "       (tried 'chore: release ${VERSION}', 'Version update: ${VERSION}'," >&2
+  echo "        and tag ${VERSION}-staging)" >&2
+  exit 1
+fi
+
+# --- Collect and filter commit subjects --------------------------------------
+# Filters mirror scripts/generateReleaseNotes.sh plus obvious non-user-facing
+# prefixes. Keep the two in sync if you change either.
+NOISE='^(chore: release |Version update: |Merge |chore\(deps|build\(deps|ci[(:]|docs[(:]|test[(:])'
+
+TOTAL=$(git rev-list --count "${FROM_COMMIT}..${TO_REF}")
+SUBJECTS=$(git log --reverse --format=%s "${FROM_COMMIT}..${TO_REF}" |
+  grep -vE "$NOISE" || true)
+RELEVANT=$(printf '%s' "$SUBJECTS" | grep -c . || true)
+
+echo "FROM_VERSION=${VERSION}"
+echo "FROM_COMMIT=$(git log -1 --format='%h %s' "$FROM_COMMIT")"
+echo "TO_REF=${TO_REF} ($(git log -1 --format='%h, %cs' "$TO_REF"))"
+echo "TO_VERSION=$(git show "${TO_REF}:package.json" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).version))')"
+echo "TOTAL_COMMITS=${TOTAL}"
+echo "RELEVANT_COMMITS=${RELEVANT}"
+echo "---"
+printf '%s\n' "$SUBJECTS"


### PR DESCRIPTION
### Details

Adds a `release-notes` Claude skill at `.claude/skills/release-notes/` that generates paste-ready store release notes by comparing the last publicly shipped version on each store against current master. The two stores usually have different baselines (Play production lags the App Store by several minors), so each platform gets its own comparison and its own notes.

What's in it:

- **`SKILL.md`**: the workflow. Baseline resolution (iOS via `scripts/asc.mjs status` when not supplied; Android user-supplied, bare minors allowed with a stated assumption), thematic summarization rules (user-visible changes only, 4-7 themes for multi-minor spans), store constraints (Google Play 500-char hard limit per locale with printed char counts, App Store under ~1200), both locales (`en-US` + `cs` per the `cs_cz.md` glossary), the no-em-dash copy rule, and the delivery gotcha: fastlane's `deliver` overrides `fastlane/metadata/*/release_notes.txt` with the auto `TESTFLIGHT_CHANGELOG`, so curated notes must be pasted into the consoles manually.
- **`scripts/collect_changes.sh`**: the deterministic part. Resolves a store version (`0.3.13.1`, `0.3.13-1`, or bare `0.3.10`) to its git commit across both bump-message eras (`chore: release X-N` and the older `Version update: X-N`; release tags are staging-only and pruned, so commit messages are the durable anchor), then emits noise-filtered commit subjects oldest-first. Filter rules mirror `scripts/generateReleaseNotes.sh` (the CI TestFlight note generator, which is unchanged and serves a different cadence).

### Tests

Evaluated with the skill-creator harness before trimming the scaffolding out of the PR: three realistic prompts (Android-only with a fuzzy "0.3.10-something" baseline, iOS-only with `0.3.13.1`, and both platforms at once), each run once with the skill and once without, then graded by independent agents with programmatic verification (char counts, em-dash scan, feature claims checked against the actual commit spans).

1. With skill: **18/18 assertions passed**, ~164s avg per run.
2. Without skill: 14/18, ~257s avg. Failures: missing Czech locale blocks in 2 of 3 runs, unstated baseline assumption, App Store text over the conciseness target.
3. `collect_changes.sh` smoke-tested directly: `0.3.13.1` resolves to `0.3.13-1` (513b419e8), bare `0.3.10` resolves to `0.3.10-25` via the `Version update:` era, garbage input exits 1 with a clear error.

### Offline tests

N/A (developer tooling only; no app code touched).

### QA Steps

N/A (no staging-observable change). Reviewer sanity check: `bash .claude/skills/release-notes/scripts/collect_changes.sh 0.3.13.1 | head` from the repo root prints the resolved span header and filtered subjects.

### PR Author Checklist

Tooling-only PR (Claude skill: markdown + shell). The app-code checklist items (platforms, console errors, localization via `LocaleContextProvider`, styles, deeplinks) do not apply: no `src/` code is touched.

- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] New files have a description of what they do at the top
- [x] Code follows DRY and ETC principles (version-resolution logic lives once, in the bundled script)

### Screenshots/Videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)