### PR TITLE
feat(statistics): drop weekly-trend caption, rename CZ Patterns tab

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1166,7 +1166,7 @@ export default {
         },
       },
       patterns: {
-        label: 'Vzorce',
+        label: 'Návyky',
         placeholder: 'Kdy a jak (hodina dne a den v týdnu) uvidíte tady.',
       },
       breakdown: {

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -62,13 +62,10 @@ function TrendsTab() {
         <ChartCard
           title={translate('statistics.tabs.trends.weeklyTrend.title')}
           footer={
-            <View style={{rowGap: 8}}>
-              <WeeklyTrendLegend
-                showTrend={heroShowTrend}
-                showComparison={heroComparisonShown}
-              />
-              <Text style={themeStyles.textMicroSupporting}>{heroCaption}</Text>
-            </View>
+            <WeeklyTrendLegend
+              showTrend={heroShowTrend}
+              showComparison={heroComparisonShown}
+            />
           }>
           <TrendLine
             weeks={hero.weeks}


### PR DESCRIPTION
## Summary
- Remove the descriptive caption sentence rendered below the **weekly units** trend graph in the Statistics → Trends tab. The legend stays, and the sentence is retained as the chart's `accessibilityLabel` so screen readers still announce the trend.
- Rename the Czech Statistics **Patterns** tab label from `Vzorce` → `Návyky`.

## Details
- `src/screens/Statistics/tabs/TrendsTab.tsx`: footer of the weekly-trend `ChartCard` is now just `<WeeklyTrendLegend />`; the `heroCaption` `<Text>` is gone. `heroCaption` is still computed and used as the `TrendLine` accessibility label, so the `captions.*` translation keys remain in use (untouched).
- `src/languages/cs_cz.ts`: `statistics.tabs.patterns.label` → `Návyky`.

## Notes
- No type-affecting changes. Prettier + lint-changed pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)