### PR TITLE
fix(stats): count ongoing sessions in the monthly overview

### DIFF
--- a/__tests__/unit/libs/Statistics/events.test.ts
+++ b/__tests__/unit/libs/Statistics/events.test.ts
@@ -239,7 +239,7 @@ describe('buildDrinkEvents — drink entry shapes', () => {
 });
 
 describe('buildDrinkEvents — session filtering', () => {
-  it('excludes ongoing sessions', () => {
+  it('includes ongoing sessions so live activity counts toward stats', () => {
     const sessions = makeMultiUser({
       u1: {
         live: {
@@ -254,8 +254,11 @@ describe('buildDrinkEvents — session filtering', () => {
       },
     });
     const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
-    expect(events).toHaveLength(1);
-    expect(events[0].sessionId).toBe('done');
+    expect(events).toHaveLength(2);
+    expect(events.map(event => event.sessionId).sort()).toEqual([
+      'done',
+      'live',
+    ]);
   });
 
   it('skips sessions with non-finite start_time', () => {

--- a/src/hooks/useHomeStats.ts
+++ b/src/hooks/useHomeStats.ts
@@ -39,9 +39,27 @@ function useHomeStats(visibleDate: DateData): MonthlyStats {
   // Overlay the live session's units (visible month only). Gated on focus
   // because the buffer mutates on every drink tap while Home stays mounted
   // behind the live-session screen.
+  //
+  // `buildDrinkEvents` now includes `ongoing` sessions, so once the live
+  // session has been echoed into the cached snapshot it is already counted in
+  // `current.totalUnits`. Overlaying its buffer on top would then double-count
+  // it, so skip the overlay when that session id is already in `events` (the
+  // not-yet-cached case keeps the overlay, which is the fresher source).
   const drinksToUnits = preferences?.drinks_to_units;
+  const liveSessionId = ongoingSessionData?.id;
+  const liveAlreadyInEvents = useMemo(
+    () =>
+      !!liveSessionId &&
+      events.some(event => event.sessionId === liveSessionId),
+    [events, liveSessionId],
+  );
   const liveExtraUnits = useMemo(() => {
-    if (!isFocused || !drinksToUnits || !ongoingSessionData?.ongoing) {
+    if (
+      liveAlreadyInEvents ||
+      !isFocused ||
+      !drinksToUnits ||
+      !ongoingSessionData?.ongoing
+    ) {
       return 0;
     }
     return calculateThisMonthUnits(
@@ -49,7 +67,13 @@ function useHomeStats(visibleDate: DateData): MonthlyStats {
       [ongoingSessionData],
       drinksToUnits,
     );
-  }, [isFocused, ongoingSessionData, visibleDate, drinksToUnits]);
+  }, [
+    liveAlreadyInEvents,
+    isFocused,
+    ongoingSessionData,
+    visibleDate,
+    drinksToUnits,
+  ]);
 
   return {isLoading, current, previous, subPeriods, liveExtraUnits};
 }

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -126,7 +126,10 @@ let lastCall: {
  * iterate users → sessions → drink timestamps → drink type entries → emit
  * one `DrinkEvent` per (timestamp, drink type).
  *
- * - Excludes `ongoing` sessions and sessions with non-finite `start_time`.
+ * - Excludes only sessions with non-finite `start_time`. In-progress
+ *   (`ongoing`) sessions ARE included so a live session counts toward the
+ *   monthly stats just as it does on the calendar (the owner's even-fresher
+ *   live buffer is overlaid separately in `useHomeStats`).
  * - `localDow` is rotated so 0 = `weekStart`; `isWeekend` is the absolute
  *   calendar Sat/Sun.
  * - Both the legacy `number` entry shape and the v2-A
@@ -174,7 +177,7 @@ function buildDrinkEvents(
     }
     for (const sessionId of Object.keys(userSessions)) {
       const session: DrinkingSession | undefined = userSessions[sessionId];
-      if (!session || session.ongoing === true) {
+      if (!session) {
         continue;
       }
       const startMs = Number(session.start_time);


### PR DESCRIPTION
## Problem

For a user with an in-progress (`ongoing`) drinking session in the current month, the **monthly stats overview** disagreed with the **calendar grid**:

- Calendar grid: **5 sessions / 18.6 units**
- Stats overview: **4 sessions / 15.6 units**

The gap was exactly one session. Investigating prod data for one such user, the 5th June session was `ongoing: true` (a live session, 3 beers = 3.0 units). The calendar (`groupSessionsByMonth`) buckets *every* session by `start_time`, including ongoing ones, while the stats pipeline's `buildDrinkEvents` explicitly skipped `ongoing === true` — so the ongoing session showed on the calendar but vanished from the headline.

## Decision

We *want* the ongoing session to count toward the headline — it makes the monthly numbers feel live/real-time and matches the calendar. So this aligns the stats overview with the calendar rather than the other way around.

## Changes

- **`src/libs/Statistics/events.ts`** — `buildDrinkEvents` no longer excludes `ongoing` sessions (only the non-finite `start_time` guard remains). This is the single shared event source, so the ongoing session now contributes to both the units total and the distinct-session count in the overview (and consistently across the Statistics surfaces built on the same stream).
- **`src/hooks/useHomeStats.ts`** — guards against double-counting on the owner's own Home screen. The owner has an even-fresher live buffer (`ONGOING_SESSION_DATA`) overlaid as `liveExtraUnits`. Now that the event stream can also include that same session (once it's echoed into the cached snapshot), the overlay is deduped by session id: if the live session is already in `events`, the overlay is skipped; if it isn't cached yet, the overlay still applies (it's the fresher source).
- **`__tests__/unit/libs/Statistics/events.test.ts`** — flipped the "excludes ongoing sessions" case to assert ongoing sessions are now included.

## Scope notes

- `buildSessionCountsByDay` (`sessionCounts.ts`) keeps its own `ongoing` guard — it has no runtime consumer (barrel export + its own test only) and isn't part of the overview pipeline, so it's left untouched to avoid changing an unused utility's contract.
- The overview pipeline (`buildPeriodSummary` / `collectWindowAggregates`) is unchanged — it counts whatever events it's given, so the behavior change is entirely upstream in `buildDrinkEvents`.

## Testing

- `__tests__/unit/libs/Statistics` — 173 passing (incl. updated event-filtering case)
- `npm run typecheck` (tsc, CI gate) — clean
- React Compiler compliance (changed files) — pass
- `lint-changed` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
