### PR TITLE
fix(calendar): open friends' profile calendar on the current month

### DIFF
--- a/__tests__/unit/libs/SessionsCalendarUtils.test.ts
+++ b/__tests__/unit/libs/SessionsCalendarUtils.test.ts
@@ -2,7 +2,13 @@
  * @jest-environment node
  */
 
-import {computeLoadTarget} from '@libs/SessionsCalendarUtils';
+import {startOfMonth, subMonths} from 'date-fns';
+import {
+  canSyncGlobalLastViewedDate,
+  computeLoadTarget,
+  getCompactCalendarLoadTarget,
+  selectCalendarVisibleSource,
+} from '@libs/SessionsCalendarUtils';
 
 const BUFFER = 2;
 
@@ -67,5 +73,144 @@ describe('computeLoadTarget', () => {
     const earliestVisible = new Date(2026, BUFFER, 1);
     const target = computeLoadTarget(earliestVisible, floor, null, BUFFER);
     expect(target).not.toBeNull();
+  });
+});
+
+// Rule 1 (data is always rendered): paging the compact calendar must widen the
+// loaded window so the month about to be shown is always inside it — never
+// blank until the user moves again. `getCompactCalendarLoadTarget` is the seam
+// the page-back handler drives `loadUpTo` with.
+describe('getCompactCalendarLoadTarget', () => {
+  test('returns the start of `bufferMonths` before the next visible month', () => {
+    const nextVisible = new Date(2026, 5, 17); // mid-June 2026
+    const target = getCompactCalendarLoadTarget(nextVisible, 3);
+    // June − 3 months = March, snapped to the 1st.
+    expect(target.getFullYear()).toBe(2026);
+    expect(target.getMonth()).toBe(2);
+    expect(target.getDate()).toBe(1);
+  });
+
+  test('always covers the month about to be shown (target <= its month start)', () => {
+    // The Rule 1 invariant: for any buffer, the returned floor is at or before
+    // the visible month, so `loadUpTo(target)` includes it in the derived range.
+    const nextVisible = new Date(2026, 5, 30);
+    [0, 1, 3, 12].forEach(buffer => {
+      const target = getCompactCalendarLoadTarget(nextVisible, buffer);
+      expect(target.getTime()).toBeLessThanOrEqual(
+        startOfMonth(nextVisible).getTime(),
+      );
+      // …and exactly `buffer` months below it.
+      expect(target.getTime()).toBe(
+        startOfMonth(subMonths(nextVisible, buffer)).getTime(),
+      );
+    });
+  });
+
+  test('a zero buffer still covers the visible month itself', () => {
+    const nextVisible = new Date(2026, 5, 30);
+    const target = getCompactCalendarLoadTarget(nextVisible, 0);
+    expect(target.getTime()).toBe(startOfMonth(nextVisible).getTime());
+  });
+
+  test('a negative buffer is clamped to zero (never pages forward)', () => {
+    const nextVisible = new Date(2026, 5, 30);
+    const target = getCompactCalendarLoadTarget(nextVisible, -4);
+    expect(target.getTime()).toBe(startOfMonth(nextVisible).getTime());
+  });
+
+  test('crosses year boundaries correctly', () => {
+    const nextVisible = new Date(2026, 1, 10); // February 2026
+    const target = getCompactCalendarLoadTarget(nextVisible, 3); // → November 2025
+    expect(target.getFullYear()).toBe(2025);
+    expect(target.getMonth()).toBe(10);
+    expect(target.getDate()).toBe(1);
+  });
+});
+
+// Rule 2 (per-user independence): the single global last-viewed date may only
+// be honoured for the signed-in user's OWN calendar, and a freshly-viewed user
+// always opens on today — one user's last-shown month never leaks onto another.
+describe('selectCalendarVisibleSource', () => {
+  test('self with a last-viewed date restores from it', () => {
+    expect(
+      selectCalendarVisibleSource({
+        isSelf: true,
+        hasLastViewed: true,
+        localBelongsToViewedUser: true,
+      }),
+    ).toBe('lastViewed');
+  });
+
+  test('self without a last-viewed date uses the local navigated month', () => {
+    expect(
+      selectCalendarVisibleSource({
+        isSelf: true,
+        hasLastViewed: false,
+        localBelongsToViewedUser: true,
+      }),
+    ).toBe('local');
+  });
+
+  test('self with no last-viewed and no local month falls back to today', () => {
+    expect(
+      selectCalendarVisibleSource({
+        isSelf: true,
+        hasLastViewed: false,
+        localBelongsToViewedUser: false,
+      }),
+    ).toBe('today');
+  });
+
+  test('a friend NEVER restores from the global last-viewed date', () => {
+    // The core Rule 2 guarantee: even when a global last-viewed date exists
+    // (set by the signed-in user, or by a previously-viewed friend), another
+    // user's calendar must not inherit it.
+    const friendCombinations = [
+      {hasLastViewed: true, localBelongsToViewedUser: true},
+      {hasLastViewed: true, localBelongsToViewedUser: false},
+      {hasLastViewed: false, localBelongsToViewedUser: true},
+      {hasLastViewed: false, localBelongsToViewedUser: false},
+    ];
+    friendCombinations.forEach(combo => {
+      expect(selectCalendarVisibleSource({isSelf: false, ...combo})).not.toBe(
+        'lastViewed',
+      );
+    });
+  });
+
+  test('a freshly-viewed user (no local month tagged for them) opens on today', () => {
+    // Reused screen instance, friend A → friend B: B has no local month yet and
+    // (being a friend) ignores the global key, so B opens on today.
+    expect(
+      selectCalendarVisibleSource({
+        isSelf: false,
+        hasLastViewed: true,
+        localBelongsToViewedUser: false,
+      }),
+    ).toBe('today');
+  });
+
+  test('a friend keeps their own in-visit navigated month', () => {
+    expect(
+      selectCalendarVisibleSource({
+        isSelf: false,
+        hasLastViewed: true,
+        localBelongsToViewedUser: true,
+      }),
+    ).toBe('local');
+  });
+});
+
+describe('canSyncGlobalLastViewedDate', () => {
+  test('a read-only (friend) surface may not write or clear the global key', () => {
+    expect(canSyncGlobalLastViewedDate(true)).toBe(false);
+  });
+
+  test("the signed-in user's own calendar may sync the global key", () => {
+    expect(canSyncGlobalLastViewedDate(false)).toBe(true);
+  });
+
+  test('an unset read-only flag defaults to writable (own calendar)', () => {
+    expect(canSyncGlobalLastViewedDate(undefined)).toBe(true);
   });
 });

--- a/__tests__/unit/libs/SessionsCalendarUtils.test.ts
+++ b/__tests__/unit/libs/SessionsCalendarUtils.test.ts
@@ -4,7 +4,6 @@
 
 import {startOfMonth, subMonths} from 'date-fns';
 import {
-  canSyncGlobalLastViewedDate,
   computeLoadTarget,
   getCompactCalendarLoadTarget,
   selectCalendarVisibleSource,
@@ -127,90 +126,65 @@ describe('getCompactCalendarLoadTarget', () => {
   });
 });
 
-// Rule 2 (per-user independence): the single global last-viewed date may only
-// be honoured for the signed-in user's OWN calendar, and a freshly-viewed user
-// always opens on today — one user's last-shown month never leaks onto another.
+// Rule 2 (per-user independence): the last-viewed date is keyed PER VIEWED USER,
+// so the caller passes `hasLastViewed` derived from that user's own slot
+// (`map[userID]`). Both the signed-in user and a friend restore from their own
+// slot; a user with no slot (cleared on cold launch) opens on today; and one
+// user's slot can never reach another's calendar.
 describe('selectCalendarVisibleSource', () => {
-  test('self with a last-viewed date restores from it', () => {
+  test('restores from the per-user last-viewed date when present', () => {
+    // Holds regardless of whether a local month is also tagged for this user —
+    // the restored scroll position wins. Same precedence for self and friends.
     expect(
       selectCalendarVisibleSource({
-        isSelf: true,
         hasLastViewed: true,
         localBelongsToViewedUser: true,
       }),
     ).toBe('lastViewed');
-  });
-
-  test('self without a last-viewed date uses the local navigated month', () => {
     expect(
       selectCalendarVisibleSource({
-        isSelf: true,
+        hasLastViewed: true,
+        localBelongsToViewedUser: false,
+      }),
+    ).toBe('lastViewed');
+  });
+
+  test('uses the local navigated month when there is no last-viewed date but the local month belongs to this user', () => {
+    expect(
+      selectCalendarVisibleSource({
         hasLastViewed: false,
         localBelongsToViewedUser: true,
       }),
     ).toBe('local');
   });
 
-  test('self with no last-viewed and no local month falls back to today', () => {
+  test('a freshly-viewed user (no last-viewed slot, no local month) opens on today', () => {
+    // Cold-launch cleared every slot, and a reused screen instance (friend A →
+    // friend B) leaves the local month tagged for the previous user, so B opens
+    // on today.
     expect(
       selectCalendarVisibleSource({
-        isSelf: true,
         hasLastViewed: false,
         localBelongsToViewedUser: false,
       }),
     ).toBe('today');
   });
 
-  test('a friend NEVER restores from the global last-viewed date', () => {
-    // The core Rule 2 guarantee: even when a global last-viewed date exists
-    // (set by the signed-in user, or by a previously-viewed friend), another
-    // user's calendar must not inherit it.
-    const friendCombinations = [
-      {hasLastViewed: true, localBelongsToViewedUser: true},
-      {hasLastViewed: true, localBelongsToViewedUser: false},
-      {hasLastViewed: false, localBelongsToViewedUser: true},
-      {hasLastViewed: false, localBelongsToViewedUser: false},
-    ];
-    friendCombinations.forEach(combo => {
-      expect(selectCalendarVisibleSource({isSelf: false, ...combo})).not.toBe(
-        'lastViewed',
-      );
+  test("Rule 2: a user's slot never leaks into another — viewing a user with no slot opens on today, while the other still restores", () => {
+    // The independence is structural: the caller derives `hasLastViewed` from
+    // `map[viewedUserID]`, so user B (no slot) can never inherit user A's date.
+    const lastViewedByUser: Record<string, string> = {userA: '2026-01-15'};
+
+    const viewingB = selectCalendarVisibleSource({
+      hasLastViewed: !!lastViewedByUser.userB,
+      localBelongsToViewedUser: false,
     });
-  });
+    expect(viewingB).toBe('today');
 
-  test('a freshly-viewed user (no local month tagged for them) opens on today', () => {
-    // Reused screen instance, friend A → friend B: B has no local month yet and
-    // (being a friend) ignores the global key, so B opens on today.
-    expect(
-      selectCalendarVisibleSource({
-        isSelf: false,
-        hasLastViewed: true,
-        localBelongsToViewedUser: false,
-      }),
-    ).toBe('today');
-  });
-
-  test('a friend keeps their own in-visit navigated month', () => {
-    expect(
-      selectCalendarVisibleSource({
-        isSelf: false,
-        hasLastViewed: true,
-        localBelongsToViewedUser: true,
-      }),
-    ).toBe('local');
-  });
-});
-
-describe('canSyncGlobalLastViewedDate', () => {
-  test('a read-only (friend) surface may not write or clear the global key', () => {
-    expect(canSyncGlobalLastViewedDate(true)).toBe(false);
-  });
-
-  test("the signed-in user's own calendar may sync the global key", () => {
-    expect(canSyncGlobalLastViewedDate(false)).toBe(true);
-  });
-
-  test('an unset read-only flag defaults to writable (own calendar)', () => {
-    expect(canSyncGlobalLastViewedDate(undefined)).toBe(true);
+    const viewingA = selectCalendarVisibleSource({
+      hasLastViewed: !!lastViewedByUser.userA,
+      localBelongsToViewedUser: false,
+    });
+    expect(viewingA).toBe('lastViewed');
   });
 });

--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -3,6 +3,7 @@
 import {act, renderHook} from '@testing-library/react-native';
 import {addMonths, differenceInMonths, startOfMonth, subMonths} from 'date-fns';
 import useLazyMarkedDates from '@hooks/useLazyMarkedDates';
+import {getCompactCalendarLoadTarget} from '@libs/SessionsCalendarUtils';
 import * as Calendar from '@userActions/Calendar';
 import type {
   DrinkingSession,
@@ -263,6 +264,64 @@ describe('useLazyMarkedDates friend window (no canonical floor) — Kiroku #1197
     // earliest loaded session's month (~12).
     const depth = differenceInMonths(new Date(), getLoadedFrom(result));
     expect(depth).toBeGreaterThanOrEqual(23);
+  });
+});
+
+describe('useLazyMarkedDates compact paging covers the visible month (Rule 1)', () => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  test('paging back to an older month makes its data present without a second move', () => {
+    // A friend (no canonical floor) with a single session 5 months back, built
+    // at noon UTC so the zoned day key is timezone-stable. Fresh, the derived
+    // window is only the current month — the older month's data is NOT on
+    // screen yet, which is exactly the "blank until you move again" state Rule 1
+    // forbids when you page to it.
+    const targetStart = startOfMonth(subMonths(new Date(), 5));
+    const targetYear = targetStart.getFullYear();
+    const targetMonth = targetStart.getMonth(); // 0-based
+    const sessionInstant = Date.UTC(targetYear, targetMonth, 15, 12, 0, 0);
+    const targetMonthKey = `${targetYear}-${pad(targetMonth + 1)}`;
+    const sessionDayKey = `${targetMonthKey}-15` as DateString;
+    const sessions = {
+      s1: {
+        id: 's1',
+        start_time: sessionInstant,
+        timezone: 'UTC',
+        drinks: {[sessionInstant]: {beer: 1}},
+      },
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    // Precondition: the older month is outside the initial derived window, so
+    // its session is not yet rendered.
+    expect(
+      result.current.calendarMonths.some(
+        month => month.monthKey === targetMonthKey,
+      ),
+    ).toBe(false);
+    expect(result.current.markedDates[sessionDayKey]).toBeUndefined();
+
+    // Page back to that month: the compact handler drives `loadUpTo` with the
+    // look-ahead load target for the month about to become visible.
+    act(() => {
+      result.current.loadUpTo(getCompactCalendarLoadTarget(targetStart, 3));
+    });
+
+    // The loaded floor now covers the visible month (at or below its start) and
+    // its data is on screen — no further in-calendar navigation needed.
+    expect(getLoadedFrom(result).getTime()).toBeLessThanOrEqual(
+      targetStart.getTime(),
+    );
+    expect(
+      result.current.calendarMonths.some(
+        month => month.monthKey === targetMonthKey,
+      ),
+    ).toBe(true);
+    expect(result.current.markedDates[sessionDayKey]).toBeDefined();
+    expect(result.current.unitsMap.get(sessionDayKey)).toBe(1);
   });
 });
 

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -90,9 +90,12 @@ const ONYXKEYS = {
   //   /** Indicates which locale should be used */
   NVP_PREFERRED_LOCALE: 'nvp_preferredLocale',
 
-  /** The day a user last viewed in an enlarged calendar / day-overview scroll.
-   *  Consumed once by the home & profile calendars on focus so navigating back
-   *  lands on the date the user was looking at. Reset on app launch. */
+  /** Per-viewed-user map of the day last seen in an enlarged calendar /
+   *  day-overview scroll, keyed by the viewed user's ID. Consumed by the home &
+   *  profile calendars so navigating back lands on the date the user was looking
+   *  at — for the signed-in user AND for friends, each independently (one user's
+   *  entry never affects another's; Rule 2). Reset (whole map) on app launch so
+   *  every user's calendar opens on today the first time it's viewed per session. */
   NVP_LAST_VIEWED_CALENDAR_DATE: 'nvp_lastViewedCalendarDate',
 
   //   /** Does this user have push notifications enabled for this device? */
@@ -306,7 +309,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.FOCUS_MODE_NOTIFICATION]: boolean;
   [ONYXKEYS.PUSH_NOTIFICATIONS_ENABLED]: boolean;
   [ONYXKEYS.NVP_PREFERRED_LOCALE]: OnyxTypes.Locale;
-  [ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE]: DateString;
+  [ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE]: Record<string, DateString>;
   [ONYXKEYS.ONGOING_SESSION_DATA]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.EDIT_SESSION_DATA]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.IS_CREATING_NEW_SESSION]: boolean;

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -15,8 +15,6 @@ import {dateStringToDate} from '@libs/DataHandling';
 import DateUtils from '@libs/DateUtils';
 import Str from '@libs/common/str';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
-import * as App from '@userActions/App';
-import {canSyncGlobalLastViewedDate} from '@libs/SessionsCalendarUtils';
 import CONST from '@src/CONST';
 import type {Preferences} from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
@@ -85,9 +83,13 @@ type DayOverviewListViewProps = {
    *  screen uses it to open the add-session picker on the viewed month. */
   onVisibleDayChange?: (day: DateString) => void;
   /** Render the session tiles non-interactively (viewing another user's
-   *  history). Also suppresses the "last viewed day" persistence so browsing a
-   *  friend's days doesn't repoint the current user's own compact calendar. */
+   *  history). */
   isReadOnly?: boolean;
+  /** Records the day the viewer is looking at (debounced) into the viewed user's
+   *  own per-user last-viewed slot, so backing out restores that user's calendar
+   *  position. Per-user keyed by the parent, so it never repoints another user's
+   *  calendar (Rule 2). */
+  onRecordLastViewedDay?: (day: DateString) => void;
   /** When true, each session tile shows its edit affordance. Driven by the
    *  day-overview screen's Edit/Done header toggle (self only). */
   isEditModeOn?: boolean;
@@ -116,6 +118,7 @@ function DayOverviewListView({
   initialDay,
   onInitialScrollReady,
   onVisibleDayChange,
+  onRecordLastViewedDay,
   isReadOnly,
   isEditModeOn,
   onSwipeBack,
@@ -300,14 +303,13 @@ function DayOverviewListView({
   const recordVisibleDay = useMemo(
     () =>
       lodashDebounce((day: DateString) => {
-        // Read-only (friend) browsing must not repoint the current user's own
-        // compact calendar, which restores from this NVP.
-        if (canSyncGlobalLastViewedDate(isReadOnly)) {
-          App.setLastViewedCalendarDate(day);
-        }
+        // The parent binds the write to the viewed user's own per-user slot, so
+        // this records for the signed-in user and friends alike, with no
+        // cross-user leak (Rule 2).
+        onRecordLastViewedDay?.(day);
         onVisibleDayChange?.(day);
       }, LAST_VIEWED_DEBOUNCE_MS),
-    [onVisibleDayChange, isReadOnly],
+    [onVisibleDayChange, onRecordLastViewedDay],
   );
   useEffect(() => () => recordVisibleDay.cancel(), [recordVisibleDay]);
 

--- a/src/components/SessionsCalendar/DayOverviewListView.tsx
+++ b/src/components/SessionsCalendar/DayOverviewListView.tsx
@@ -16,6 +16,7 @@ import DateUtils from '@libs/DateUtils';
 import Str from '@libs/common/str';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import * as App from '@userActions/App';
+import {canSyncGlobalLastViewedDate} from '@libs/SessionsCalendarUtils';
 import CONST from '@src/CONST';
 import type {Preferences} from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
@@ -301,7 +302,7 @@ function DayOverviewListView({
       lodashDebounce((day: DateString) => {
         // Read-only (friend) browsing must not repoint the current user's own
         // compact calendar, which restores from this NVP.
-        if (!isReadOnly) {
+        if (canSyncGlobalLastViewedDate(isReadOnly)) {
           App.setLastViewedCalendarDate(day);
         }
         onVisibleDayChange?.(day);

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -18,6 +18,7 @@ import * as App from '@userActions/App';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import DateUtils from '@libs/DateUtils';
 import setCalendarLocale from '@libs/setCalendarLocale';
+import {canSyncGlobalLastViewedDate} from '@libs/SessionsCalendarUtils';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 import buildWeekListItems from './buildWeekListItems';
 import type {ListItem} from './buildWeekListItems';
@@ -286,7 +287,7 @@ function SessionsCalendarWeekListView({
   const writeLastViewedDay = useMemo(
     () =>
       lodashDebounce((day: DateString) => {
-        if (!isReadOnly) {
+        if (canSyncGlobalLastViewedDate(isReadOnly)) {
           App.setLastViewedCalendarDate(day);
         }
       }, 250),

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -85,6 +85,11 @@ type SessionsCalendarWeekListViewProps = {
    *  this to a navigation back so the fullscreen view feels dismissable on
    *  Android (which has no built-in stack swipe-back). */
   onSwipeBack?: () => void;
+  /** Read-only (a friend's) calendar. When true, scrolling must NOT record the
+   *  last-viewed day: `NVP_LAST_VIEWED_CALENDAR_DATE` is a single global key the
+   *  signed-in user's OWN compact calendar restores from, so a friend's scroll
+   *  would repoint home/self onto the friend's month (mirrors `DayOverviewListView`). */
+  isReadOnly?: boolean;
 };
 
 /**
@@ -115,6 +120,7 @@ function SessionsCalendarWeekListView({
   initialMonthYear,
   onInitialScrollReady,
   onSwipeBack,
+  isReadOnly,
 }: SessionsCalendarWeekListViewProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -275,12 +281,16 @@ function SessionsCalendarWeekListView({
 
   // Record the month the user is looking at so the compact calendar can sync
   // to it on back-navigation. Debounced so a fast scroll writes once at rest.
+  // Read-only (friend) browsing must not repoint the current user's own compact
+  // calendar, which restores from this global NVP (mirrors `DayOverviewListView`).
   const writeLastViewedDay = useMemo(
     () =>
       lodashDebounce((day: DateString) => {
-        App.setLastViewedCalendarDate(day);
+        if (!isReadOnly) {
+          App.setLastViewedCalendarDate(day);
+        }
       }, 250),
-    [],
+    [isReadOnly],
   );
   useEffect(() => () => writeLastViewedDay.cancel(), [writeLastViewedDay]);
 

--- a/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
+++ b/src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx
@@ -14,11 +14,9 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import ONYXKEYS from '@src/ONYXKEYS';
 import CONST from '@src/CONST';
-import * as App from '@userActions/App';
 import {roundToTwoDecimalPlaces} from '@libs/NumberUtils';
 import DateUtils from '@libs/DateUtils';
 import setCalendarLocale from '@libs/setCalendarLocale';
-import {canSyncGlobalLastViewedDate} from '@libs/SessionsCalendarUtils';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 import buildWeekListItems from './buildWeekListItems';
 import type {ListItem} from './buildWeekListItems';
@@ -86,11 +84,11 @@ type SessionsCalendarWeekListViewProps = {
    *  this to a navigation back so the fullscreen view feels dismissable on
    *  Android (which has no built-in stack swipe-back). */
   onSwipeBack?: () => void;
-  /** Read-only (a friend's) calendar. When true, scrolling must NOT record the
-   *  last-viewed day: `NVP_LAST_VIEWED_CALENDAR_DATE` is a single global key the
-   *  signed-in user's OWN compact calendar restores from, so a friend's scroll
-   *  would repoint home/self onto the friend's month (mirrors `DayOverviewListView`). */
-  isReadOnly?: boolean;
+  /** Records the day the viewer is looking at (debounced) into the viewed user's
+   *  own per-user last-viewed slot, so backing out restores that user's calendar
+   *  position. Per-user keyed by the parent, so it never repoints another user's
+   *  calendar (Rule 2). */
+  onRecordLastViewedDay?: (day: DateString) => void;
 };
 
 /**
@@ -121,7 +119,7 @@ function SessionsCalendarWeekListView({
   initialMonthYear,
   onInitialScrollReady,
   onSwipeBack,
-  isReadOnly,
+  onRecordLastViewedDay,
 }: SessionsCalendarWeekListViewProps) {
   const styles = useThemeStyles();
   const {translate} = useLocalize();
@@ -280,18 +278,17 @@ function SessionsCalendarWeekListView({
     [windowHeight],
   );
 
-  // Record the month the user is looking at so the compact calendar can sync
-  // to it on back-navigation. Debounced so a fast scroll writes once at rest.
-  // Read-only (friend) browsing must not repoint the current user's own compact
-  // calendar, which restores from this global NVP (mirrors `DayOverviewListView`).
+  // Record the month the user is looking at so the compact calendar can sync to
+  // it on back-navigation. Debounced so a fast scroll writes once at rest. The
+  // parent binds the write to the viewed user's own per-user slot, so this
+  // records for the signed-in user and friends alike, with no cross-user leak
+  // (Rule 2).
   const writeLastViewedDay = useMemo(
     () =>
       lodashDebounce((day: DateString) => {
-        if (canSyncGlobalLastViewedDate(isReadOnly)) {
-          App.setLastViewedCalendarDate(day);
-        }
+        onRecordLastViewedDay?.(day);
       }, 250),
-    [isReadOnly],
+    [onRecordLastViewedDay],
   );
   useEffect(() => () => writeLastViewedDay.cancel(), [writeLastViewedDay]);
 

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -8,13 +8,7 @@ import React, {
 } from 'react';
 import {useIsFocused} from '@react-navigation/native';
 import type {DateData} from 'react-native-calendars';
-import {
-  differenceInMonths,
-  format,
-  parseISO,
-  startOfMonth,
-  subMonths,
-} from 'date-fns';
+import {format, parseISO, startOfMonth, subMonths} from 'date-fns';
 import {
   dateStringToDate,
   dateToDateData,
@@ -23,7 +17,10 @@ import {
 } from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
-import {computeLoadTarget} from '@libs/SessionsCalendarUtils';
+import {
+  computeLoadTarget,
+  getCompactCalendarLoadTarget,
+} from '@libs/SessionsCalendarUtils';
 import CONST from '@src/CONST';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
@@ -57,6 +54,14 @@ const INITIAL_PREFETCH_MONTHS = 12;
 // want to scroll into them to add a past session. Extend the *rendered* range
 // by this many months at a time as they approach the top — no fetch involved.
 const RENDER_AHEAD_MONTHS = 12;
+
+// Compact-calendar page-back look-ahead. Paging left always widens the loaded
+// window (via `loadUpTo`) to at least the month about to be shown plus this
+// many months below it, so the windowed friend fetch is pre-warmed and the new
+// month never renders blank until the user moves again (Rule 1). `loadUpTo` is
+// monotonic and capped at the user's earliest tracked month for self, so the
+// buffer never derives empty pre-tracking months.
+const COMPACT_LOAD_AHEAD_BUFFER_MONTHS = 3;
 
 function SessionsCalendar({
   userID,
@@ -100,7 +105,6 @@ function SessionsCalendar({
     calendarMonths,
     loadedFrom,
     loadedFromDate,
-    loadMoreMonths,
     loadUpTo,
     hasPersistedFloor,
     isWindowExhausted,
@@ -137,15 +141,21 @@ function SessionsCalendar({
   }, [drinkingSessionData, persistedEarliest]);
 
   const handleLeftArrowPress = (subtractMonth: () => void) => {
-    const monthsAway = differenceInMonths(
-      new Date(visibleDate.timestamp),
-      new Date(loadedFrom?.current ?? new Date()),
-    );
-    if (monthsAway <= 1) {
-      loadMoreMonths(1);
-    }
-
     const previousMonth = getPreviousMonth(visibleDate);
+    // Proactively widen the loaded window so the month about to become visible
+    // (plus a small look-ahead buffer that pre-warms the windowed friend fetch)
+    // is always inside the derived/fetched range. Replaces the old reactive
+    // `monthsAway <= 1 ? loadMoreMonths(1)` step, which locked the floor
+    // one-to-one with the visible month and left a friend's just-paged month
+    // blank until a debounced refetch landed (Rule 1: data is always rendered,
+    // with no in-calendar navigation needed for it to appear). `loadUpTo` is
+    // monotonic, so re-requesting the same depth on a later press is a no-op.
+    loadUpTo(
+      getCompactCalendarLoadTarget(
+        new Date(previousMonth.timestamp),
+        COMPACT_LOAD_AHEAD_BUFFER_MONTHS,
+      ),
+    );
     onDateChange(previousMonth);
 
     subtractMonth();

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -452,6 +452,7 @@ function SessionsCalendar({
           initialMonthYear={initialMonthYear}
           onInitialScrollReady={onInitialScrollReady}
           onSwipeBack={Navigation.goBack}
+          isReadOnly={!isSelf}
         />
         {longPressDrillDown}
       </>

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import * as DS from '@userActions/DrinkingSession';
+import * as App from '@userActions/App';
 import {
   computeLoadTarget,
   getCompactCalendarLoadTarget,
@@ -172,6 +173,16 @@ function SessionsCalendar({
   const handleJumpToCurrent = () => {
     onDateChange(dateToDateData(new Date()));
   };
+
+  // Record the day the viewer is looking at in this user's enlarged calendar /
+  // day-overview scroll, into that user's OWN per-user last-viewed slot. Bound
+  // to the viewed `userID`, so a friend's scroll restores the friend's profile
+  // (and the signed-in user's restores home/self) without ever repointing
+  // another user's calendar (Rule 2: per-user independence is structural).
+  const recordLastViewedDay = useCallback(
+    (day: DateString) => App.setLastViewedCalendarDate(userID, day),
+    [userID],
+  );
 
   // Coalesce scroll-driven `loadUpTo` calls — store the deepest target we've
   // already requested, skip subsequent triggers that aren't deeper. Avoids
@@ -441,6 +452,7 @@ function SessionsCalendar({
         initialDay={initialDay}
         onInitialScrollReady={onInitialScrollReady}
         onVisibleDayChange={onVisibleDayChange}
+        onRecordLastViewedDay={recordLastViewedDay}
         isReadOnly={isReadOnly}
         isEditModeOn={isEditModeOn}
         onSwipeBack={Navigation.goBack}
@@ -462,7 +474,7 @@ function SessionsCalendar({
           initialMonthYear={initialMonthYear}
           onInitialScrollReady={onInitialScrollReady}
           onSwipeBack={Navigation.goBack}
-          isReadOnly={!isSelf}
+          onRecordLastViewedDay={recordLastViewedDay}
         />
         {longPressDrillDown}
       </>

--- a/src/libs/SessionsCalendarUtils.ts
+++ b/src/libs/SessionsCalendarUtils.ts
@@ -63,23 +63,27 @@ function getCompactCalendarLoadTarget(
 type CalendarVisibleSource = 'lastViewed' | 'local' | 'today';
 
 /**
- * Pick the source for a profile/home calendar's visible month, enforcing
- * per-user independence (Rule 2):
- *   - The single global `NVP_LAST_VIEWED_CALENDAR_DATE` may only be honoured for
- *     the signed-in user's OWN calendar (`isSelf`); a friend never restores from
- *     it, so one user's last-shown month can't leak onto another's calendar.
- *   - A user viewed for the first time since launch (no local month tagged for
- *     them) opens on today.
+ * Pick the source for a profile/home calendar's visible month.
+ *
+ * `NVP_LAST_VIEWED_CALENDAR_DATE` is keyed PER VIEWED USER, so independence
+ * (Rule 2) is structural: the caller derives `hasLastViewed` from that user's
+ * OWN entry (`map[userID]`), and one user's entry can never reach another's
+ * calendar. Precedence:
+ *   - the viewed user's own last-viewed date, when present (restores both the
+ *     signed-in user's and a friend's last-scrolled position);
+ *   - otherwise the locally-navigated month, while it still belongs to the
+ *     viewed user;
+ *   - otherwise today (a user viewed for the first time since launch — their
+ *     entry was cleared by the cold-launch reset).
  *
  * Pure and value-free so it can be unit-tested without `DataHandling`/`DateData`
  * dependencies; the caller maps the returned source to a concrete date.
  */
 function selectCalendarVisibleSource(params: {
-  isSelf: boolean;
   hasLastViewed: boolean;
   localBelongsToViewedUser: boolean;
 }): CalendarVisibleSource {
-  if (params.isSelf && params.hasLastViewed) {
+  if (params.hasLastViewed) {
     return 'lastViewed';
   }
   if (params.localBelongsToViewedUser) {
@@ -88,20 +92,9 @@ function selectCalendarVisibleSource(params: {
   return 'today';
 }
 
-/**
- * Whether a calendar surface may persist to (or clear) the single global
- * `NVP_LAST_VIEWED_CALENDAR_DATE`. Only the signed-in user's OWN (non
- * read-only) calendar may, so browsing another user's history never repoints —
- * or wipes — the current user's own restored month (Rule 2).
- */
-function canSyncGlobalLastViewedDate(isReadOnly: boolean | undefined): boolean {
-  return !isReadOnly;
-}
-
 export {
   computeLoadTarget,
   getCompactCalendarLoadTarget,
   selectCalendarVisibleSource,
-  canSyncGlobalLastViewedDate,
 };
 export type {CalendarVisibleSource};

--- a/src/libs/SessionsCalendarUtils.ts
+++ b/src/libs/SessionsCalendarUtils.ts
@@ -1,4 +1,4 @@
-import {differenceInCalendarMonths} from 'date-fns';
+import {differenceInCalendarMonths, startOfMonth, subMonths} from 'date-fns';
 
 /**
  * Decide whether a fullscreen-calendar scroll should trigger another
@@ -35,5 +35,73 @@ function computeLoadTarget(
   return target;
 }
 
-// eslint-disable-next-line import/prefer-default-export
-export {computeLoadTarget};
+/**
+ * The loaded-window floor a compact (paged) calendar must reach so the month
+ * about to become visible — plus a small look-ahead buffer that pre-warms the
+ * windowed friend fetch — is always inside the derived/fetched range.
+ *
+ * Driving every page-back through `loadUpTo(getCompactCalendarLoadTarget(...))`
+ * is what makes the newly shown month's data appear immediately, instead of
+ * blank until the user pages again (Rule 1: data is always rendered, no
+ * in-calendar navigation needed for it to appear). `loadUpTo` is monotonic and,
+ * for the signed-in user, capped at their earliest tracked month, so requesting
+ * a buffer never derives empty pre-tracking months — it only guarantees
+ * coverage of the visible month.
+ *
+ * @param nextVisibleMonth Any day inside the month that is about to be shown.
+ * @param bufferMonths How many extra months below it to pre-load (clamped at 0).
+ * @returns The start of `bufferMonths` before `nextVisibleMonth`.
+ */
+function getCompactCalendarLoadTarget(
+  nextVisibleMonth: Date,
+  bufferMonths: number,
+): Date {
+  return startOfMonth(subMonths(nextVisibleMonth, Math.max(0, bufferMonths)));
+}
+
+/** Which value a profile/home calendar should open on. */
+type CalendarVisibleSource = 'lastViewed' | 'local' | 'today';
+
+/**
+ * Pick the source for a profile/home calendar's visible month, enforcing
+ * per-user independence (Rule 2):
+ *   - The single global `NVP_LAST_VIEWED_CALENDAR_DATE` may only be honoured for
+ *     the signed-in user's OWN calendar (`isSelf`); a friend never restores from
+ *     it, so one user's last-shown month can't leak onto another's calendar.
+ *   - A user viewed for the first time since launch (no local month tagged for
+ *     them) opens on today.
+ *
+ * Pure and value-free so it can be unit-tested without `DataHandling`/`DateData`
+ * dependencies; the caller maps the returned source to a concrete date.
+ */
+function selectCalendarVisibleSource(params: {
+  isSelf: boolean;
+  hasLastViewed: boolean;
+  localBelongsToViewedUser: boolean;
+}): CalendarVisibleSource {
+  if (params.isSelf && params.hasLastViewed) {
+    return 'lastViewed';
+  }
+  if (params.localBelongsToViewedUser) {
+    return 'local';
+  }
+  return 'today';
+}
+
+/**
+ * Whether a calendar surface may persist to (or clear) the single global
+ * `NVP_LAST_VIEWED_CALENDAR_DATE`. Only the signed-in user's OWN (non
+ * read-only) calendar may, so browsing another user's history never repoints —
+ * or wipes — the current user's own restored month (Rule 2).
+ */
+function canSyncGlobalLastViewedDate(isReadOnly: boolean | undefined): boolean {
+  return !isReadOnly;
+}
+
+export {
+  computeLoadTarget,
+  getCompactCalendarLoadTarget,
+  selectCalendarVisibleSource,
+  canSyncGlobalLastViewedDate,
+};
+export type {CalendarVisibleSource};

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -559,19 +559,22 @@ async function setLoadingText(
   await Onyx.merge(ONYXKEYS.APP_LOADING_TEXT, text);
 }
 
-/** Record the day the user is currently looking at in an enlarged calendar /
- *  day-overview scroll. The home & profile calendars consume this once on
- *  focus so backing out lands on the same date. */
-function setLastViewedCalendarDate(date: DateString) {
-  Onyx.set(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, date);
+/** Record the day the viewer is currently looking at in `userID`'s enlarged
+ *  calendar / day-overview scroll. Stored per viewed user so backing out to that
+ *  user's profile (or home, for self) lands on the same date, while a different
+ *  user's calendar is never repointed (Rule 2). Merge (not set) so other users'
+ *  entries are preserved. */
+function setLastViewedCalendarDate(userID: UserID, date: DateString) {
+  Onyx.merge(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, {[userID]: date});
 }
 
-/** Clear the consumed last-viewed date so subsequent focuses don't re-apply
- *  it. The cold-launch reset lives in the `Calendar.resetCalendarStateForColdLaunch`
- *  action (the `initialKeyStates` null is a no-op — Onyx drops null defaults);
- *  this is for in-app clears, e.g. manual month navigation. */
-function clearLastViewedCalendarDate() {
-  Onyx.set(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, null);
+/** Clear `userID`'s consumed last-viewed date so subsequent focuses don't
+ *  re-apply it (e.g. after manual month navigation on that user's calendar). The
+ *  nested null deletes only that user's entry, leaving every other user's
+ *  untouched. The cold-launch reset of the WHOLE map lives in
+ *  `Calendar.resetCalendarStateForColdLaunch`. */
+function clearLastViewedCalendarDate(userID: UserID) {
+  Onyx.merge(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE, {[userID]: null});
 }
 
 export {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -67,11 +67,16 @@ function HomeScreen({route}: HomeScreenProps) {
   // the FAB both clear it by this much (plus a small margin).
   const bottomTabBarHeight = useBottomTabBarHeight();
   const user = auth.currentUser;
+  // Hoisted to a simple local so the per-user last-viewed lookup and the
+  // manual memo/callback dependencies below reference a stable identifier
+  // (the React Compiler can't preserve memoization keyed on a `user?.uid`
+  // optional-chain expression directly).
+  const uid = user?.uid;
   const [loadingText] = useOnyx(ONYXKEYS.APP_LOADING_TEXT);
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
-  const [lastViewedCalendarDate] = useOnyx(
-    ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE,
-  );
+  const [lastViewedByUser] = useOnyx(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE);
+  // The signed-in user's OWN last-viewed day (the home calendar is always self).
+  const lastViewedForUser = uid ? lastViewedByUser?.[uid] : undefined;
   // `useCurrentUserData` returns {} (truthy) while loading; the readiness gates
   // and header below treat `undefined` as "not loaded", so map empty → undefined.
   const currentUserData = useCurrentUserData();
@@ -92,20 +97,26 @@ function HomeScreen({route}: HomeScreenProps) {
   // Deriving it (rather than syncing via an effect) means it's already correct
   // on the first render after the modal dismisses — home updates while still
   // hidden underneath, so the user never sees the month flip from today. The
-  // NVP is reset on app launch, so a cold start shows today.
+  // per-user map is reset on app launch, so a cold start shows today.
   const visibleDate = useMemo<DateData>(
     () =>
-      lastViewedCalendarDate
-        ? dateToDateData(dateStringToDate(lastViewedCalendarDate))
+      lastViewedForUser
+        ? dateToDateData(dateStringToDate(lastViewedForUser))
         : localVisibleDate,
-    [lastViewedCalendarDate, localVisibleDate],
+    [lastViewedForUser, localVisibleDate],
   );
 
-  // Manual month navigation overrides the synced value.
-  const onDateChange = useCallback((nextDate: DateData) => {
-    setLocalVisibleDate(nextDate);
-    App.clearLastViewedCalendarDate();
-  }, []);
+  // Manual month navigation overrides the synced value — clear this user's own
+  // per-user slot.
+  const onDateChange = useCallback(
+    (nextDate: DateData) => {
+      setLocalVisibleDate(nextDate);
+      if (uid) {
+        App.clearLastViewedCalendarDate(uid);
+      }
+    },
+    [uid],
+  );
 
   const monthlyStats = useHomeStats(visibleDate);
 

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -11,10 +11,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import * as App from '@userActions/App';
 import * as Profile from '@userActions/Profile';
 import {dateToDateData, dateStringToDate, objKeys} from '@libs/DataHandling';
-import {
-  canSyncGlobalLastViewedDate,
-  selectCalendarVisibleSource,
-} from '@libs/SessionsCalendarUtils';
+import {selectCalendarVisibleSource} from '@libs/SessionsCalendarUtils';
 import SessionsCalendar from '@components/SessionsCalendar';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import {getCommonFriendsCount} from '@libs/FriendUtils';
@@ -97,58 +94,45 @@ function ProfileScreen({route}: ProfileScreenProps) {
     userID,
     date: dateToDateData(new Date()),
   }));
-  const [lastViewedCalendarDate] = useOnyx(
-    ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE,
-  );
-  // The calendar's visible month: the last-viewed day from an enlarged calendar
-  // when present, otherwise the locally-navigated month. Derived (not synced via
-  // an effect) so it's already correct on the first render after the modal
-  // dismisses — the profile updates while still hidden underneath, so the user
-  // never sees the month flip. Reset on app launch → today.
+  const [lastViewedByUser] = useOnyx(ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE);
+  // This user's OWN last-viewed day (narrow primitive so the memo below only
+  // re-runs when THIS user's entry changes, not on any other user's).
+  const lastViewedForUser = lastViewedByUser?.[userID];
+  // The calendar's visible month: the viewed user's last-scrolled day from an
+  // enlarged calendar when present, otherwise the locally-navigated month,
+  // otherwise today. Derived (not synced via an effect) so it's already correct
+  // on the first render after the modal dismisses — the profile updates while
+  // still hidden underneath, so the user never sees the month flip.
   //
-  // `NVP_LAST_VIEWED_CALENDAR_DATE` is a single global (non-user-scoped) key, so
-  // only the signed-in user's OWN calendar may restore from it. A friend's
-  // profile must always open on the current month — otherwise the last-viewed
-  // month of a different friend (or of home/self) leaks in, and that stale month
-  // also renders empty (it falls outside the fetched window). Friends therefore
-  // ignore the NVP entirely and fall back to today. The local month only applies
-  // while it still belongs to the user on screen; on a user change it's stale, so
-  // we fall back to today (covers a reused screen instance, friend A → friend B).
+  // `NVP_LAST_VIEWED_CALENDAR_DATE` is keyed PER VIEWED USER, so this restores a
+  // friend's last position the same way it does the signed-in user's, while one
+  // user's entry can never leak onto another's calendar (Rule 2 — structural,
+  // since we only ever read `[userID]`). The whole map is cleared on app launch,
+  // so a user viewed for the first time this session opens on today. The local
+  // month only applies while it still belongs to the user on screen; on a user
+  // change it's stale, so we fall back to today (reused instance, friend A → B).
   const visibleDateData = useMemo(() => {
     const source = selectCalendarVisibleSource({
-      isSelf,
-      hasLastViewed: !!lastViewedCalendarDate,
+      hasLastViewed: !!lastViewedForUser,
       localBelongsToViewedUser: localVisible.userID === userID,
     });
-    if (source === 'lastViewed' && lastViewedCalendarDate) {
-      return dateToDateData(dateStringToDate(lastViewedCalendarDate));
+    if (source === 'lastViewed' && lastViewedForUser) {
+      return dateToDateData(dateStringToDate(lastViewedForUser));
     }
     if (source === 'local') {
       return localVisible.date;
     }
     return dateToDateData(new Date());
-  }, [
-    isSelf,
-    lastViewedCalendarDate,
-    localVisible.date,
-    localVisible.userID,
-    userID,
-  ]);
-  // Manual month navigation overrides the synced value. Re-tag with the current
-  // user so the derivation keeps using it for this visit only.
+  }, [lastViewedForUser, localVisible.date, localVisible.userID, userID]);
+  // Manual month navigation overrides the restored scroll position. Re-tag with
+  // the current user so the derivation keeps using it for this visit, and clear
+  // ONLY this user's own per-user slot (never another user's; Rule 2).
   const onDateChange = useCallback(
     (date: DateData) => {
       setLocalVisible({userID, date});
-      // Only the signed-in user's OWN calendar may touch the single global
-      // last-viewed key. A friend paging their calendar must NOT clear it, or it
-      // would wipe the current user's own restored month (Rule 2: one user's
-      // calendar never affects another's). For a friend's profile the read-only
-      // flag is `!isSelf === true`, so the clear is skipped.
-      if (canSyncGlobalLastViewedDate(!isSelf)) {
-        App.clearLastViewedCalendarDate();
-      }
+      App.clearLastViewedCalendarDate(userID);
     },
-    [isSelf, userID],
+    [userID],
   );
   const profileStats = useUserMonthlyStats({
     userID,

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -95,13 +95,32 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // an effect) so it's already correct on the first render after the modal
   // dismisses — the profile updates while still hidden underneath, so the user
   // never sees the month flip. Reset on app launch → today.
+  //
+  // `NVP_LAST_VIEWED_CALENDAR_DATE` is a single global (non-user-scoped) key, so
+  // only the signed-in user's OWN calendar may restore from it. A friend's
+  // profile must always open on the current month — otherwise the last-viewed
+  // month of a different friend (or of home/self) leaks in, and that stale month
+  // also renders empty (it falls outside the fetched window). Friends therefore
+  // ignore the NVP entirely and fall back to today.
   const visibleDateData = useMemo(
     () =>
-      lastViewedCalendarDate
+      isSelf && lastViewedCalendarDate
         ? dateToDateData(dateStringToDate(lastViewedCalendarDate))
         : localVisibleDateData,
-    [lastViewedCalendarDate, localVisibleDateData],
+    [isSelf, lastViewedCalendarDate, localVisibleDateData],
   );
+  // If React Navigation ever reuses this screen instance across a `userID`
+  // change (friend A → friend B), local state would carry A's manually-paged
+  // month. Snap a friend's calendar back to today whenever the viewed user
+  // changes. A fresh mount already inits to today, so this only matters for the
+  // reused-instance edge; it's keyed on `userID` (not focus) so paging within a
+  // single visit is preserved.
+  useEffect(() => {
+    if (isSelf) {
+      return;
+    }
+    setLocalVisibleDateData(dateToDateData(new Date()));
+  }, [userID, isSelf]);
   // Manual month navigation overrides the synced value.
   const onDateChange = useCallback((date: DateData) => {
     setLocalVisibleDateData(date);

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -11,6 +11,10 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import * as App from '@userActions/App';
 import * as Profile from '@userActions/Profile';
 import {dateToDateData, dateStringToDate, objKeys} from '@libs/DataHandling';
+import {
+  canSyncGlobalLastViewedDate,
+  selectCalendarVisibleSource,
+} from '@libs/SessionsCalendarUtils';
 import SessionsCalendar from '@components/SessionsCalendar';
 import SessionsCalendarCompactSkeleton from '@components/SessionsCalendar/SessionsCalendarCompactSkeleton';
 import {getCommonFriendsCount} from '@libs/FriendUtils';
@@ -111,10 +115,15 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // while it still belongs to the user on screen; on a user change it's stale, so
   // we fall back to today (covers a reused screen instance, friend A → friend B).
   const visibleDateData = useMemo(() => {
-    if (isSelf && lastViewedCalendarDate) {
+    const source = selectCalendarVisibleSource({
+      isSelf,
+      hasLastViewed: !!lastViewedCalendarDate,
+      localBelongsToViewedUser: localVisible.userID === userID,
+    });
+    if (source === 'lastViewed' && lastViewedCalendarDate) {
       return dateToDateData(dateStringToDate(lastViewedCalendarDate));
     }
-    if (localVisible.userID === userID) {
+    if (source === 'local') {
       return localVisible.date;
     }
     return dateToDateData(new Date());
@@ -130,9 +139,16 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const onDateChange = useCallback(
     (date: DateData) => {
       setLocalVisible({userID, date});
-      App.clearLastViewedCalendarDate();
+      // Only the signed-in user's OWN calendar may touch the single global
+      // last-viewed key. A friend paging their calendar must NOT clear it, or it
+      // would wipe the current user's own restored month (Rule 2: one user's
+      // calendar never affects another's). For a friend's profile the read-only
+      // flag is `!isSelf === true`, so the clear is skipped.
+      if (canSyncGlobalLastViewedDate(!isSelf)) {
+        App.clearLastViewedCalendarDate();
+      }
     },
-    [userID],
+    [isSelf, userID],
   );
   const profileStats = useUserMonthlyStats({
     userID,

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -84,9 +84,15 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
   const [friendCount, setFriendCount] = useState(0);
   const [commonFriendCount, setCommonFriendCount] = useState(0);
-  const [localVisibleDateData, setLocalVisibleDateData] = useState(
-    dateToDateData(new Date()),
-  );
+  // The locally-navigated month, tagged with the user it was navigated for. The
+  // tag lets the derivation below fall back to today when the viewed user
+  // changes (the reused-instance edge) without an effect — `setState` in an
+  // effect trips `react-hooks/set-state-in-effect`, and a render-phase reset
+  // would read a ref during render (rejected by the React Compiler).
+  const [localVisible, setLocalVisible] = useState(() => ({
+    userID,
+    date: dateToDateData(new Date()),
+  }));
   const [lastViewedCalendarDate] = useOnyx(
     ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE,
   );
@@ -101,31 +107,33 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // profile must always open on the current month — otherwise the last-viewed
   // month of a different friend (or of home/self) leaks in, and that stale month
   // also renders empty (it falls outside the fetched window). Friends therefore
-  // ignore the NVP entirely and fall back to today.
-  const visibleDateData = useMemo(
-    () =>
-      isSelf && lastViewedCalendarDate
-        ? dateToDateData(dateStringToDate(lastViewedCalendarDate))
-        : localVisibleDateData,
-    [isSelf, lastViewedCalendarDate, localVisibleDateData],
-  );
-  // If React Navigation ever reuses this screen instance across a `userID`
-  // change (friend A → friend B), local state would carry A's manually-paged
-  // month. Snap a friend's calendar back to today whenever the viewed user
-  // changes. A fresh mount already inits to today, so this only matters for the
-  // reused-instance edge; it's keyed on `userID` (not focus) so paging within a
-  // single visit is preserved.
-  useEffect(() => {
-    if (isSelf) {
-      return;
+  // ignore the NVP entirely and fall back to today. The local month only applies
+  // while it still belongs to the user on screen; on a user change it's stale, so
+  // we fall back to today (covers a reused screen instance, friend A → friend B).
+  const visibleDateData = useMemo(() => {
+    if (isSelf && lastViewedCalendarDate) {
+      return dateToDateData(dateStringToDate(lastViewedCalendarDate));
     }
-    setLocalVisibleDateData(dateToDateData(new Date()));
-  }, [userID, isSelf]);
-  // Manual month navigation overrides the synced value.
-  const onDateChange = useCallback((date: DateData) => {
-    setLocalVisibleDateData(date);
-    App.clearLastViewedCalendarDate();
-  }, []);
+    if (localVisible.userID === userID) {
+      return localVisible.date;
+    }
+    return dateToDateData(new Date());
+  }, [
+    isSelf,
+    lastViewedCalendarDate,
+    localVisible.date,
+    localVisible.userID,
+    userID,
+  ]);
+  // Manual month navigation overrides the synced value. Re-tag with the current
+  // user so the derivation keeps using it for this visit only.
+  const onDateChange = useCallback(
+    (date: DateData) => {
+      setLocalVisible({userID, date});
+      App.clearLastViewedCalendarDate();
+    },
+    [userID],
+  );
   const profileStats = useUserMonthlyStats({
     userID,
     visibleDate: visibleDateData,


### PR DESCRIPTION
### Details

When opening **another user's** profile, the embedded compact calendar opened on whatever year/month was *last viewed* — possibly from a different friend, or from your own home calendar — instead of the current month. Worse, that stale month rendered **empty**: the dots/markers didn't appear until you paged the month arrows or opened an enlarged view (day-overview / fullscreen calendar), which is what finally triggered a data load.

**Root cause.** The compact calendar's visible month is derived from a single **global, non-user-scoped** Onyx key, `NVP_LAST_VIEWED_CALENDAR_DATE`. Both `HomeScreen` and every `ProfileScreen` prefer this value over their local "today" state, and enlarged views write it on scroll. So the last-viewed month from one context (another friend, or self) leaked into the next friend's profile. The "no data" symptom was a consequence: a far-back stale month falls *outside* `useDrinkingSessionsFetch`'s mount window (most-recent N months, which always includes today), so it has no markers until a widen is triggered.

**Fix — make the key self-only.** Friends' calendars always default to the current month and ignore the global key; friends' enlarged views never write it.

- `src/screens/Profile/ProfileScreen.tsx` — the `visibleDateData` derivation consults `lastViewedCalendarDate` only when `isSelf`; friends fall back to `localVisibleDateData` (today). A reset effect keyed on `userID` snaps a friend's calendar back to today across a reused screen-instance user change, while preserving manual paging within a single visit.
- `src/components/SessionsCalendar/index.tsx` — passes `isReadOnly={!isSelf}` to the fullscreen week-list.
- `src/components/SessionsCalendar/SessionsCalendarWeekListView.tsx` — gates its last-viewed write on `!isReadOnly`, mirroring the guard `DayOverviewListView` already has. This also stops a friend's fullscreen scroll from polluting your own home/self calendar.

No new fetch is required: today's month is always inside the mount window, and `ProfileScreen` already blocks rendering until that fetch resolves, so the calendar appears with its markers.

`HomeScreen` and the **self** profile are intentionally unchanged — they keep restoring the last-viewed date.

### Tests

1. Open Friend A's profile → tap the month header to open the fullscreen calendar → scroll back several months → close.
2. Open Friend B's profile and verify the compact calendar shows **today's month** (not Friend A's month) **with its markers**, without paging the arrows.
3. From Friend A's profile, go back to Home and verify Home did **not** inherit Friend A's scrolled month. Likewise your own profile opens on today after viewing a friend's enlarged calendar.
4. On your **own** home/self calendar, scroll an enlarged view, then back out, and verify it still lands on the month you were looking at (self restore is preserved).
5. On a friend's profile, page the compact month arrows and tap a day to open the day-overview; verify month navigation and data loading still work within the visit.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. While offline, open a friend's profile (previously cached) and verify the calendar opens on the current month and does not crash. (Cross-user reads can't be queued offline; the existing graceful loading/empty state is unchanged by this PR.)

- [ ] Verify that no errors appear in the JS console

### QA Steps

1. Sign in. Visit Friend A's profile, expand the calendar, scroll back, close.
2. Visit Friend B's profile → calendar must open on the current month with markers, no arrow-paging needed.
3. Return to Home / your own profile → must open on the current month after browsing a friend's enlarged calendar.
4. On your own calendar, scroll an enlarged view and back out → must still restore to the viewed month.

- [ ] Verify that no errors appear in the JS console

### Notes for reviewers

- Static gates run locally: `prettier` (clean), `typecheck-tsgo` (clean), `react-compiler-compliance-check check-changed` (passes), and the calendar unit suites `buildWeekListItems` / `deriveCalendarMonth` / `useLazyMarkedDates` (28/28). Full `lint`/`typecheck` (tsc) run in CI.
- The reset uses a `useEffect` rather than a render-phase ref read because the React Compiler rejects ref access during render ("Cannot access refs during render"). A fresh screen per profile navigation already shows today, so the effect only matters for the reused-instance edge.
- Live browser verification was not run from this worktree: port 8082 was held by another active dev server, and a second concurrent webpack instance would share `node_modules/.cache/webpack` with it. Manual web QA still recommended per the Tests steps above.

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- not captured -->

</details>

<details>
<summary>iOS</summary>

<!-- not captured -->

</details>
