### PR TITLE
feat(stats): rename Overview sections to Consumption and Heavy days

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1088,8 +1088,8 @@ export default {
         },
         sections: {
           highlights: 'Hlavní body',
-          load: 'Zátěž',
-          risk: 'Riziko',
+          consumption: 'Konzumace',
+          heavyDays: 'Náročné dny',
         },
         kpi: {
           afDays: {label: 'Dny bez alkoholu'},

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1082,8 +1082,8 @@ export default {
         },
         sections: {
           highlights: 'Highlights',
-          load: 'Load',
-          risk: 'Risk',
+          consumption: 'Consumption',
+          heavyDays: 'Heavy days',
         },
         kpi: {
           afDays: {label: 'Alcohol-free days'},

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -246,12 +246,12 @@ function OverviewTab() {
         </View>
 
         <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.load')}
+          {sectionLabel('statistics.tabs.overview.sections.consumption')}
           <KpiCardGroup cards={loadCards} isLoading={isLoading} />
         </View>
 
         <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.risk')}
+          {sectionLabel('statistics.tabs.overview.sections.heavyDays')}
           <KpiCardGroup cards={riskCards} isLoading={isLoading} />
         </View>
 


### PR DESCRIPTION
## What

Renames the two lower section headers on the **Statistics → Overview** tab to drop the clinical *Load* / *Risk* framing in favor of clearer, less judgmental labels.

| Section | Before | After | Czech |
|---|---|---|---|
| (middle) | Load | **Consumption** | Konzumace |
| (bottom) | Risk | **Heavy days** | Náročné dny |

Onyx keys renamed to match: `sections.load → sections.consumption`, `sections.risk → sections.heavyDays`.

## Why

- *Load* and *Risk* read as clinical and judgmental.
- The bottom section's metrics (`days over {yellow}`, `days over {orange}`, `% days over {yellow}`) are all **day counts / share of days that crossed a threshold** — i.e. *how often you had a heavy day*, not a risk score. "Heavy days" describes exactly that.
- "Heavy days" reuses the vocabulary already on the same screen (the distribution chart's `heavy` / *Náročná*), so the surfaces stay consistent.

## Scope

Label/key rename only. No metric, layout, or behavior changes.

- `src/languages/en.ts` — source strings + key rename
- `src/languages/cs_cz.ts` — Czech mirror
- `src/screens/Statistics/tabs/OverviewTab.tsx` — updated `translate()` key references

## Checks

- `npm run typecheck-tsgo` ✅
- `npm run lint-changed` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- Prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)