### PR TITLE
[DIAGNOSTIC — DO NOT MERGE] Bisect Statistics first-open cold-import cost (release measurement)

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -33,7 +33,6 @@ import useIdlePrefetch from '@hooks/useIdlePrefetch';
 import useAutoUpdateTimezone from '@hooks/useAutoUpdateTimezone';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
-import prefetchStatisticsBundle from '@screens/Statistics/prefetchStatisticsBundle';
 import {useFirebase} from '@context/global/FirebaseContext';
 import OnboardingGuard from '@libs/Navigation/guards/OnboardingGuard';
 import TermsReConsentGuard from '@libs/Navigation/guards/TermsReConsentGuard';
@@ -96,9 +95,13 @@ const modalScreenListeners = {
   },
 };
 
-// Module graphs warmed once the authenticated app is idle, so the first open
-// of these screens is a cache hit instead of a cold parse on the critical path.
-const IDLE_PREFETCHERS = [prefetchStatisticsBundle];
+// [StatsProfile] DIAGNOSTIC (diagnostic branch only — restore to
+// `[prefetchStatisticsBundle]` before any merge). Emptied on purpose: with the
+// idle prewarm active, `import('./StatisticsTabs')` is already a cache hit by
+// the time Statistics opens (measured TOTAL=0.1 ms), so it hides the cold
+// parse. Disabling the prewarm reproduces the post-#1299 world where the parse
+// fires on open, so StatisticsScreen's bisection can measure the true cold cost.
+const IDLE_PREFETCHERS: ReadonlyArray<() => unknown> = [];
 
 function AuthScreensContent() {
   const styles = useThemeStyles();

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -40,22 +40,54 @@ function StatisticsScreen() {
 
   // Only kick off the chart-bundle import once the screen has settled, so its
   // parse and the subsequent heavy mount never compete with the first paint.
+  //
+  // [StatsProfile] TEMPORARY diagnostic (diagnostic branch only — remove before
+  // any merge). Instead of one `import('./StatisticsTabs')`, cold-import the
+  // static graph in pieces and time each. Every import() below is the first
+  // evaluation of that subtree, so the deltas are additive and sum to the full
+  // cold first-open cost, attributing it to react-native-tab-view vs the
+  // OverviewTab component graph vs the StatisticsTabs shell itself. The final
+  // import resolves the real default export used to mount the tabs.
+  //
+  // Emitted via BOTH `console.warn` and `console.error`: babel
+  // `transform-remove-console` keeps `warn`/`error` (only `log`/`debug` are
+  // stripped), and both reach the device log (`nativeLoggingHook` → os_log /
+  // logcat) on a release/adhoc build, where they show in Console.app's default
+  // view. (`Log.*` routes through `console.debug`, which is stripped, and
+  // Kiroku has no in-app log viewer.) The dev-only Skia-warning override in
+  // `suppressSkiaPathDeprecationWarnings` only filters `[react-native-skia]`
+  // path-migration messages, so it never touches this line. Filter the device
+  // log for `StatsProfile`.
   useEffect(() => {
     if (!isReady) {
       return undefined;
     }
     let cancelled = false;
-    import('./StatisticsTabs')
-      .then(mod => {
-        if (cancelled) {
-          return;
-        }
-        setTabs(() => mod.default);
-      })
-      .catch(() => {
-        // Dynamic import only fails when the underlying module itself throws —
-        // there is no network round-trip in Metro's single-bundle build.
-      });
+    (async () => {
+      const t0 = performance.now();
+      await import('react-native-tab-view');
+      const t1 = performance.now();
+      await import('@components/TopTabBar');
+      const t2 = performance.now();
+      await import('@libs/skiaWeb');
+      const t3 = performance.now();
+      await import('./tabs/OverviewTab');
+      const t4 = performance.now();
+      const mod = await import('./StatisticsTabs');
+      const t5 = performance.now();
+      const line = `[StatsProfile] cold import bisection (ms): tab-view=${(t1 - t0).toFixed(1)} TopTabBar=${(t2 - t1).toFixed(1)} skiaWeb=${(t3 - t2).toFixed(1)} OverviewTab=${(t4 - t3).toFixed(1)} StatisticsTabs-shell=${(t5 - t4).toFixed(1)} | TOTAL=${(t5 - t0).toFixed(1)}`;
+      // eslint-disable-next-line no-console
+      console.warn(line);
+      // eslint-disable-next-line no-console
+      console.error(line);
+      if (cancelled) {
+        return;
+      }
+      setTabs(() => mod.default);
+    })().catch(() => {
+      // Dynamic import only fails when the underlying module itself throws —
+      // there is no network round-trip in Metro's single-bundle build.
+    });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## What this is

**Diagnostic instrumentation only. Do not merge.** This branch exists so the first-open cost of the Statistics tab can be measured in a **release** build, where Hermes runs precompiled bytecode instead of the dev-time parse that produced the original ~1560 ms figure.

It is the measurement step for the follow-up to the idle-prewarm removal (PR #1299). The goal of the parent task is to decide whether the `import('./StatisticsTabs')` parse is still worth optimizing **in release** — the rule of thumb being that under ~300-400 ms behind the existing skeleton is acceptable and warrants no production change.

## What the instrumentation does

`StatisticsScreen.tsx`'s single `import('./StatisticsTabs')` is temporarily replaced with a sequential, **cold** import bisection. Each `import()` is the first evaluation of that subtree, so the deltas are additive and sum to the full cold first-open cost — one run *attributes* the cost rather than just totaling it:

```
[StatsProfile] cold import bisection (ms): tab-view=.. TopTabBar=.. skiaWeb=.. OverviewTab=.. StatisticsTabs-shell=.. | TOTAL=..
```

The final import still resolves the real default export used to mount the tabs, so screen behavior is unchanged.

## How to measure (iOS adhoc on a device — recommended)

The adhoc build **is** a Release-configuration build (`build_type: 'Release'`, Hermes bytecode, `__DEV__` off), so it's the real first-open cost, not the dev parse. Apply the **`Ready To Build - iOS`** label to this PR — `testBuild.yml` builds the iOS adhoc app and posts an install link. Install it on a device. (Or build locally: `npm run ios -- --mode Release`.)

The line is emitted via **both `console.warn` and `console.error`**: babel `transform-remove-console` keeps `warn`/`error` in release (only `log`/`debug` are stripped), and both reach the iOS device log (`nativeLoggingHook` → os_log), so they show in **macOS Console.app**. (`Log.*` routes through `console.debug` — stripped — and Kiroku has no in-app log viewer; the dev-only Skia-warning override only filters `react-native-skia` path-migration messages, so it never touches this line.)

In the app: sign in, land on Home, then open the **Statistics** bottom tab. Do **not** open Social first — it shares `react-native-tab-view` and would pre-warm it, deflating the `tab-view` bucket.

To read it: in **Console.app**, select your device → **Start streaming** → type `StatsProfile` in the search bar (filters by message text). Warn/error show in the default view; no need to enable debug messages.

**Interpreting the line:**
- **`TOTAL`** is the headline (equivalent to the original ~1560 ms dev number). Under ~300-400 ms → already fine behind the skeleton → close with **no production change**.
- If `TOTAL` is still heavy, the breakdown points at the fix: large **`tab-view`** → swap `react-native-tab-view`/`react-native-pager-view` for a lighter top-tab; large **`OverviewTab`** → trim its component graph; large **`StatisticsTabs-shell`** → the module body itself.
- **`skiaWeb`** should be ≈ 0 (confirms the native stub is a true no-op).

**Sanity check:** run it once in a **dev** build too; `TOTAL` should land near 1560 ms, confirming the bisection is faithful before trusting the release split.

## Static findings already confirmed (no measurement needed)

- `src/libs/skiaWeb.ts` (native) is literally `Promise.resolve()` — no transitive Skia at import. ✅
- A transitive static-import trace from `StatisticsTabs.tsx` (iOS resolution, 426 local modules) contains **zero** `victory-native` / `@shopify/react-native-skia` / `BaseChart`. The `lazy()` tabs + lazy `Sparkline` deferral genuinely keep the heavy chart stack out of the first-open chunk. ✅
- `StatisticsScreenSkeleton` does **not** import `react-native-tab-view` (the grep hit was a comment), so `react-native-tab-view` genuinely is part of the cold first-open cost — the prime suspect, confirmed present.

## Next step

Once the release numbers are captured, either:
- **(a)** `TOTAL` is acceptable → close this, no production change; or
- **(b)** open a *separate, clean* PR (instrumentation removed) that cuts the dominant bucket, with before/after release `[StatsProfile]` numbers.

https://claude.ai/code/session_01E8vanDh5xg5fRAK2zzYqNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8vanDh5xg5fRAK2zzYqNc)_