### PR TITLE
fix(stats): count a midnight-crossing session as one drinking day

### DIFF
--- a/__tests__/unit/BadgesUtils.test.ts
+++ b/__tests__/unit/BadgesUtils.test.ts
@@ -7,10 +7,12 @@ import type {DrinkEvent} from '@libs/Statistics';
 
 /** Minimal DrinkEvent fixture — only localDay/units/sessionId matter here. */
 function ev(localDay: string, units: number, sessionId?: string): DrinkEvent {
+  const ts = Date.parse(`${localDay}T12:00:00Z`);
   return {
     userId: 'u1',
     sessionId: sessionId ?? `s-${localDay}`,
-    ts: Date.parse(`${localDay}T12:00:00Z`),
+    ts,
+    anchorTs: ts,
     localDay,
     localIsoWeek: '2026-W01',
     localMonth: localDay.slice(0, 7),

--- a/__tests__/unit/Statistics/trends/afCumulative.test.ts
+++ b/__tests__/unit/Statistics/trends/afCumulative.test.ts
@@ -6,10 +6,12 @@ import buildAfCumulativeSeries from '@libs/Statistics/trends/afCumulative';
 import type {DrinkEvent} from '@libs/Statistics';
 
 function event(localDay: string): DrinkEvent {
+  const ts = new Date(`${localDay}T12:00:00.000Z`).getTime();
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: new Date(`${localDay}T12:00:00.000Z`).getTime(),
+    ts,
+    anchorTs: ts,
     localDay,
     localIsoWeek: '2026-W01',
     localMonth: localDay.slice(0, 7),

--- a/__tests__/unit/Statistics/trends/weeklyStacked.test.ts
+++ b/__tests__/unit/Statistics/trends/weeklyStacked.test.ts
@@ -17,10 +17,12 @@ const ALL_KEYS: readonly DrinkKey[] = [
 ];
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? new Date('2026-04-08T12:00:00.000Z').getTime();
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: new Date('2026-04-08T12:00:00.000Z').getTime(),
+    ts,
+    anchorTs: ts,
     localDay: '2026-04-08',
     localIsoWeek: '2026-W15',
     localMonth: '2026-04',

--- a/__tests__/unit/Statistics/trends/weeklyUnits.test.ts
+++ b/__tests__/unit/Statistics/trends/weeklyUnits.test.ts
@@ -6,10 +6,12 @@ import buildWeeklyUnits from '@libs/Statistics/trends/weeklyUnits';
 import type {DrinkEvent} from '@libs/Statistics';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2026-04-08',
     localIsoWeek: '2026-W15',
     localMonth: '2026-04',

--- a/__tests__/unit/bucketToFilter.test.ts
+++ b/__tests__/unit/bucketToFilter.test.ts
@@ -5,10 +5,12 @@ import {
 } from '@src/screens/Statistics/drilldown/bucketToFilter';
 
 function makeEvent(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2025-06-12',
     localIsoWeek: '2025-W24',
     localMonth: '2025-06',

--- a/__tests__/unit/libs/Statistics/aggregate.test.ts
+++ b/__tests__/unit/libs/Statistics/aggregate.test.ts
@@ -9,10 +9,12 @@ import {countEvents, sumUnits} from '@libs/Statistics/reducers';
 import type {DrinkEvent} from '@libs/Statistics/types';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2024-01-15',
     localIsoWeek: '2024-W03',
     localMonth: '2024-01',

--- a/__tests__/unit/libs/Statistics/bucketers.test.ts
+++ b/__tests__/unit/libs/Statistics/bucketers.test.ts
@@ -16,10 +16,12 @@ import {
 import type {DrinkEvent} from '@libs/Statistics/types';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2024-05-15',
     localIsoWeek: '2024-W20',
     localMonth: '2024-05',

--- a/__tests__/unit/libs/Statistics/events.test.ts
+++ b/__tests__/unit/libs/Statistics/events.test.ts
@@ -404,15 +404,12 @@ describe('buildDrinkEvents — day-of-week rotation', () => {
   it('isWeekend stays calendar-bound regardless of weekStart', () => {
     const sat = Date.UTC(2024, 0, 13, 12);
     const mon = Date.UTC(2024, 0, 15, 12);
+    // Each session is anchored to its own start day, so isWeekend reflects the
+    // start: a Saturday session is weekend, a Monday session is not.
     const sessions = makeMultiUser({
       u1: {
-        s1: {
-          start: sat,
-          drinks: makeDrinks([
-            [sat, {beer: 1}],
-            [mon, {beer: 1}],
-          ]),
-        },
+        sat: {start: sat, drinks: makeDrinks([[sat, {beer: 1}]])},
+        mon: {start: mon, drinks: makeDrinks([[mon, {beer: 1}]])},
       },
     });
     const monStart = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
@@ -499,6 +496,54 @@ describe('buildDrinkEvents — calendar edge cases', () => {
     expect(events[1].localHour).toBe(1);
     expect(events[0].localDay).toBe('2024-10-27');
     expect(events[1].localDay).toBe('2024-10-27');
+  });
+});
+
+describe('buildDrinkEvents — session-start anchoring', () => {
+  it('anchors a midnight-crossing session to the day it started', () => {
+    // Session starts 23:00 on Jan 15; the second drink lands 01:00 on Jan 16.
+    // Both belong to the one night out that started on Jan 15.
+    const start = Date.UTC(2024, 0, 15, 23);
+    const afterMidnight = Date.UTC(2024, 0, 16, 1);
+    const sessions = makeMultiUser({
+      u1: {
+        s1: {
+          start,
+          drinks: makeDrinks([
+            [start, {beer: 1}],
+            [afterMidnight, {beer: 1}],
+          ]),
+        },
+      },
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events).toHaveLength(2);
+    // Calendar identity is the session start for both drinks.
+    expect(events.map(e => e.localDay)).toEqual(['2024-01-15', '2024-01-15']);
+    expect(events.every(e => e.anchorTs === start)).toBe(true);
+    // But the hour and the raw ts stay on each real drink time.
+    expect(events.map(e => e.localHour)).toEqual([23, 1]);
+    expect(events.map(e => e.ts)).toEqual([start, afterMidnight]);
+  });
+
+  it('anchors a month-crossing session to the month it started', () => {
+    // Starts 23:30 Jan 31, second drink 00:30 Feb 1 → both count in January.
+    const start = Date.UTC(2024, 0, 31, 23, 30);
+    const afterMidnight = Date.UTC(2024, 1, 1, 0, 30);
+    const sessions = makeMultiUser({
+      u1: {
+        s1: {
+          start,
+          drinks: makeDrinks([
+            [start, {beer: 1}],
+            [afterMidnight, {beer: 1}],
+          ]),
+        },
+      },
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events.map(e => e.localMonth)).toEqual(['2024-01', '2024-01']);
+    expect(events.map(e => e.localDay)).toEqual(['2024-01-31', '2024-01-31']);
   });
 });
 

--- a/__tests__/unit/libs/Statistics/filters.test.ts
+++ b/__tests__/unit/libs/Statistics/filters.test.ts
@@ -10,10 +10,12 @@ import {
 import type {DrinkEvent} from '@libs/Statistics/types';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? Date.UTC(2024, 0, 15, 12);
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: Date.UTC(2024, 0, 15, 12),
+    ts,
+    anchorTs: ts,
     localDay: '2024-01-15',
     localIsoWeek: '2024-W03',
     localMonth: '2024-01',

--- a/__tests__/unit/libs/Statistics/overview.test.ts
+++ b/__tests__/unit/libs/Statistics/overview.test.ts
@@ -8,9 +8,11 @@ import {
   pickGranularity,
 } from '@libs/Statistics/overview';
 import {byMonth} from '@libs/Statistics/bucketers';
+import buildDrinkEvents from '@libs/Statistics/events';
 import type {Range} from '@components/StatsContextProvider/types';
 import type {RangePreset} from '@src/types/onyx/StatisticsFilters';
 import type {DrinkEvent} from '@libs/Statistics/types';
+import type {SelectedTimezone} from '@src/types/onyx/UserData';
 
 const THRESHOLDS = {yellow: 5, orange: 10};
 
@@ -20,10 +22,12 @@ function event(
   units: number,
   overrides?: Partial<DrinkEvent>,
 ): DrinkEvent {
+  const ts = overrides?.ts ?? new Date(`${localDay}T12:00:00`).getTime();
   return {
     userId: 'u1',
     sessionId: `s-${localDay}`,
-    ts: new Date(`${localDay}T12:00:00`).getTime(),
+    ts,
+    anchorTs: ts,
     localDay,
     localIsoWeek: '2026-W01',
     localMonth: localDay.slice(0, 7),
@@ -324,6 +328,50 @@ describe('buildOverviewModel', () => {
     );
     expect(model.current.elapsedDays).toBe(0);
     expect(model.subPeriods).toEqual([]);
+  });
+});
+
+describe('buildPeriodSummary — session-start anchoring (end-to-end)', () => {
+  it('counts a midnight-crossing session as a single drinking day', () => {
+    // The motivating bug: one night out (23:00 + 01:00 next day) must read as
+    // one drinking day, not two. Build real events, then summarize the month.
+    const start = Date.UTC(2024, 0, 15, 23);
+    const afterMidnight = Date.UTC(2024, 0, 16, 1);
+    const events = buildDrinkEvents(
+      {
+        u1: {
+          s1: {
+            start_time: start,
+            drinks: {
+              [start]: {beer: 1},
+              [afterMidnight]: {beer: 1},
+            },
+          },
+        },
+      },
+      {
+        small_beer: 0.5,
+        beer: 1,
+        cocktail: 1.5,
+        other: 1,
+        strong_shot: 1,
+        weak_shot: 0.5,
+        wine: 1.5,
+      },
+      undefined,
+      'UTC' as SelectedTimezone,
+      1,
+    );
+    const summary = buildPeriodSummary(
+      events,
+      new Date(2024, 0, 1, 0, 0, 0),
+      new Date(2024, 0, 31, 23, 59, 59),
+      new Date(2024, 1, 15, 12, 0, 0),
+      THRESHOLDS,
+    );
+    expect(summary.sessions).toBe(1);
+    expect(summary.drinkingDays).toBe(1);
+    expect(summary.afDays).toBe(summary.elapsedDays - 1);
   });
 });
 

--- a/__tests__/unit/libs/Statistics/overviewSelectors.test.ts
+++ b/__tests__/unit/libs/Statistics/overviewSelectors.test.ts
@@ -5,10 +5,12 @@ import {
 import type {DrinkEvent} from '@libs/Statistics/types';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? new Date('2026-05-25T12:00:00Z').getTime();
   return {
     userId: 'u1',
     sessionId: 's-default',
-    ts: new Date('2026-05-25T12:00:00Z').getTime(),
+    ts,
+    anchorTs: ts,
     localDay: '2026-05-25',
     localIsoWeek: '2026-W22',
     localMonth: '2026-05',

--- a/__tests__/unit/libs/Statistics/reducers.test.ts
+++ b/__tests__/unit/libs/Statistics/reducers.test.ts
@@ -17,10 +17,12 @@ import {
 import type {DrinkEvent} from '@libs/Statistics/types';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2024-01-15',
     localIsoWeek: '2024-W03',
     localMonth: '2024-01',

--- a/__tests__/unit/useAggregate.test.ts
+++ b/__tests__/unit/useAggregate.test.ts
@@ -11,12 +11,13 @@ import {
 } from '@libs/Statistics';
 import type {DrinkEvent} from '@libs/Statistics';
 
-
 function makeEvent(overrides: Partial<DrinkEvent>): DrinkEvent {
+  const ts = overrides.ts ?? 0;
   return {
     userId: 'u1',
     sessionId: 's1',
-    ts: 0,
+    ts,
+    anchorTs: ts,
     localDay: '2025-06-12',
     localIsoWeek: '2025-W24',
     localMonth: '2025-06',
@@ -143,9 +144,7 @@ describe('useAggregate', () => {
 
   test('cancels deferred aggregate work on unmount', () => {
     const cancel = jest.fn();
-    runAfterSpy.mockImplementation(
-      () => ({cancel, then: () => {}}) as never,
-    );
+    runAfterSpy.mockImplementation(() => ({cancel, then: () => {}}) as never);
 
     const {unmount} = renderHook(() => useAggregate(EVENTS, byDay, sumUnits));
     unmount();

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -104,6 +104,50 @@ function localPartsFor(
   return resolveLocalParts(ts, sessionTz);
 }
 
+/** Calendar identity shared by every drink in a session (its `start_time`). */
+type AnchorParts = {
+  localDay: string;
+  localMonth: string;
+  localIsoWeek: string;
+  localDow: number;
+  isWeekend: boolean;
+};
+
+/**
+ * Derive a session's calendar identity once from its `start_time`. Every drink
+ * in the session inherits these day/week/month/dow fields, so a session that
+ * crosses midnight (or a month/year boundary) counts on the day it *started* —
+ * matching the calendar and the user's "one night out" mental model. The
+ * per-drink `localHour` is kept on the real drink time by the caller.
+ *
+ * `stored` is `session.drinksTimeParts.byTs[startMs]` when the start coincides
+ * with a logged drink (zero `Intl`); otherwise the start is resolved fresh via
+ * the cached UTC-offset path (one probe per timezone/month). Returns `null`
+ * only when the timestamp cannot be resolved at all.
+ *
+ * NOTE: this single function is the seam a future "day boundary at 6/7am"
+ * rule would replace — shift `startMs` before resolving and nothing else needs
+ * to change.
+ */
+function anchorPartsForSession(
+  startMs: number,
+  sessionTz: string,
+  weekStart: WeekStart,
+  stored: unknown,
+): AnchorParts | null {
+  const parts = localPartsFor(startMs, sessionTz, stored);
+  if (!parts) {
+    return null;
+  }
+  return {
+    localDay: parts.localDay,
+    localMonth: parts.localMonth,
+    localIsoWeek: parts.localIsoWeek,
+    localDow: (parts.calendarDow - weekStart + 7) % 7,
+    isWeekend: parts.calendarDow === 0 || parts.calendarDow === 6,
+  };
+}
+
 /**
  * Single-slot last-call cache. Onyx values come in with stable identity
  * until structurally changed, so identity equality on the object inputs is
@@ -202,6 +246,22 @@ function buildDrinkEvents(
         session.drinksTimeParts?.tz === sessionTz
           ? session.drinksTimeParts.byTs
           : undefined;
+      // The whole session is anchored to its start day; every drink below
+      // inherits these calendar fields (only `localHour` stays per-drink).
+      let anchor: AnchorParts | null;
+      try {
+        anchor = anchorPartsForSession(
+          startMs,
+          sessionTz,
+          weekStart,
+          storedByTs?.[startMs],
+        );
+      } catch {
+        continue;
+      }
+      if (!anchor) {
+        continue;
+      }
       for (const [tsKey, drinksAtTs] of Object.entries(drinks)) {
         const ts = Number(tsKey);
         if (!Number.isFinite(ts)) {
@@ -219,10 +279,9 @@ function buildDrinkEvents(
         if (!parts) {
           continue;
         }
-        const {localDay, localMonth, localHour, localIsoWeek, calendarDow} =
-          parts;
-        const localDow = (calendarDow - weekStart + 7) % 7;
-        const isWeekend = calendarDow === 0 || calendarDow === 6;
+        // Only the hour is taken from the drink's own time; day/week/month/dow
+        // come from the session anchor.
+        const {localHour} = parts;
         for (const drinkKeyRaw of Object.keys(drinksAtTs)) {
           const drinkKey = drinkKeyRaw as DrinkKey;
           const entry = normalizeEntry(
@@ -238,12 +297,13 @@ function buildDrinkEvents(
             userId,
             sessionId,
             ts,
-            localDay,
-            localIsoWeek,
-            localMonth,
+            anchorTs: startMs,
+            localDay: anchor.localDay,
+            localIsoWeek: anchor.localIsoWeek,
+            localMonth: anchor.localMonth,
             localHour,
-            localDow,
-            isWeekend,
+            localDow: anchor.localDow,
+            isWeekend: anchor.isWeekend,
             drinkKey,
             count: entry.count,
             units,

--- a/src/libs/Statistics/filters.ts
+++ b/src/libs/Statistics/filters.ts
@@ -4,9 +4,11 @@ import type {EventFilter} from './aggregate';
 
 /**
  * Inclusive on both ends. `startMs` and `endMs` are JavaScript milliseconds.
+ * Windows by the session anchor (`start_time`), not the per-drink `ts`, so a
+ * midnight-crossing session falls entirely in the window of the day it started.
  */
 function dateRange(startMs: number, endMs: number): EventFilter {
-  return event => event.ts >= startMs && event.ts <= endMs;
+  return event => event.anchorTs >= startMs && event.anchorTs <= endMs;
 }
 
 function drinkTypeSubset(

--- a/src/libs/Statistics/overview/windowAggregates.ts
+++ b/src/libs/Statistics/overview/windowAggregates.ts
@@ -28,7 +28,10 @@ function collectWindowAggregates(
   const unitsBySubPeriod = new Map<string, number>();
   const sessionIds = new Set<string>();
   for (const event of events) {
-    if (event.ts < startMs || event.ts > endMs) {
+    // Window by the session's anchor (start_time), not the per-drink `ts`, so a
+    // session that crosses midnight/month-end is counted whole on the day it
+    // started — never split across, nor double-counted into, two windows.
+    if (event.anchorTs < startMs || event.anchorTs > endMs) {
       continue;
     }
     sessionIds.add(event.sessionId);

--- a/src/libs/Statistics/types.ts
+++ b/src/libs/Statistics/types.ts
@@ -18,17 +18,24 @@ type DrinkEvent = {
   sessionId: string;
   /** ms, per-drink timestamp (the `DrinksList` key), not the session start. */
   ts: number;
-  /** `yyyy-MM-dd` in the session's timezone. */
+  /**
+   * ms, the owning session's `start_time` — the calendar anchor for every
+   * `local*` day/week/month/dow field below and the timestamp all windowing
+   * keys off, so a session that crosses midnight counts on the day it started
+   * (matching the calendar). `localHour` is the exception: it stays on `ts`.
+   */
+  anchorTs: number;
+  /** `yyyy-MM-dd` of the session's `start_time`, in the session's timezone. */
   localDay: string;
-  /** ISO-8601 week label `yyyy-Www` in the session's timezone. */
+  /** ISO-8601 week label `yyyy-Www` of the session's `start_time`. */
   localIsoWeek: string;
-  /** `yyyy-MM` in the session's timezone. */
+  /** `yyyy-MM` of the session's `start_time`, in the session's timezone. */
   localMonth: string;
-  /** 0..23 in the session's timezone. */
+  /** 0..23 of *this drink* (`ts`), in the session's timezone. */
   localHour: number;
-  /** 0..6, rotated so 0 = the user's `WeekStart`. */
+  /** 0..6 of the session's `start_time`, rotated so 0 = the user's `WeekStart`. */
   localDow: number;
-  /** Calendar Saturday/Sunday membership, independent of `WeekStart`. */
+  /** Session `start_time`'s calendar Sat/Sun membership, independent of `WeekStart`. */
   isWeekend: boolean;
   drinkKey: DrinkKey;
   /** Entry count (>=1). */


### PR DESCRIPTION
## Problem

A single session that crosses midnight was counted as **two** drinking days. Example: a user starts a session at 11pm, logs a drink, logs another at 1am, ends the session. At month end they see **29/31** alcohol-free, implying two drinking days, even though they had **one night out** and expect **30/31**.

Root cause: the statistics layer attributed each *individual drink* to the calendar day of its own timestamp, while the **calendar** and the **per-day session counter** already bucket a session by its `start_time` (see the comment in `sessionCounts.ts`: *"a single session spanning midnight counts once for the day it started"*). So the app shipped **two contradictory day-attribution models**, and the same session showed as one colored day on the calendar but two drinking days in the stats.

## Change

Anchor the whole session to its start day at the single source, `buildDrinkEvents`:

- New helper `anchorPartsForSession` computes a session's calendar identity once from `start_time`. Every drink inherits `localDay` / `localMonth` / `localIsoWeek` / `localDow` / `isWeekend` from it.
- `localHour` stays on the **real** drink time (the hour-of-day chart genuinely wants "when do I actually drink").
- New `anchorTs` field (= `start_time`). The two `ts`-based windows — `collectWindowAggregates` and `filters.dateRange` — now key off `anchorTs`, so a session is counted **whole** on the day it started, never split across nor double-counted into two windows. This also fixes month-boundary leakage (a Jan 31 → Feb 1 session no longer counts units *and the session itself* into both months).

Because every downstream consumer reads these precomputed fields, the fix propagates automatically to the home overview, the Statistics screen, badges/streaks, the drill-down, the dow/hour heatmap, and the weekly/monthly trend series — no per-consumer changes needed.

## Why this is safe

- **Unifies, not invents.** It makes the stats layer agree with the model the calendar already used, dropping the app from two day-attribution models to one. Already-aligned surfaces (calendar coloring, per-day session counter, the live-session home overlay) are unchanged.
- **Monotonic toward more alcohol-free days.** Merging a midnight-crossing session onto one day frees the other day to be alcohol-free, so dry streaks only grow and **no earned badge is ever revoked**.
- **Hour-of-day unaffected**, since `localHour` stays real.
- The `anchorPartsForSession` helper is the single seam a future "day boundary at 6/7am" rule would replace.

## Tests

- New regression coverage: midnight-crossing and month-crossing attribution at the event level (`events.test.ts`), plus an end-to-end "one night out = one drinking day" assertion (`overview.test.ts`).
- Updated the `isWeekend` test to reflect anchoring and threaded `anchorTs` through every `DrinkEvent` fixture factory.
- **283 tests pass** across the Statistics, trends, Badges, drill-down, and home-consumer suites. `typecheck-tsgo` clean, `scripts/lint.sh` clean, prettier clean.

## Reviewer notes

- **Known nuance (no UI impact today):** a Friday-night-into-Saturday session is now classified as Friday/weekday and shows in the dow/hour heatmap under Friday at the real (1am) hour. `weekendsOnly`/`weekdaysOnly` are not surfaced in any current UI; the future 6/7am boundary resolves the cosmetic heatmap oddity.
- **Out of scope:** there is a **pre-existing, unrelated** failure in `StatsContextProvider.test.tsx` (a date-preset `customEnd` off-by-one), reproducible on `master` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)