### PR TITLE
copy(login): reword hero slogan

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1495,7 +1495,7 @@ export default {
   },
   login: {
     hero: {
-      header: 'Track your everyday alcohol adventures',
+      header: 'Keep track of your alcohol adventures',
       body: 'Welcome to Kiroku, where you can track, monitor, and share your alcohol consumption',
     },
     email: 'Email',


### PR DESCRIPTION
## Summary

Reword the English login hero slogan:

- **Before:** "Track your everyday alcohol adventures"
- **After:** "Keep track of your alcohol adventures"

## Details

- The slogan lives only in `src/languages/en.ts` (`login.hero.header`); it isn't duplicated in store metadata, README, or any other file.
- No locale backfill needed: the existing Czech translation (`Mějte přehled o svých alkoholových dobrodružstvích`) already maps to the new wording, so the translation-completeness gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)