### PR TITLE
feat(stats): "Live only" toggle for time-of-day charts

### DIFF
--- a/__tests__/unit/libs/Statistics/events.test.ts
+++ b/__tests__/unit/libs/Statistics/events.test.ts
@@ -2,10 +2,14 @@ import buildDrinkEvents from '@libs/Statistics/events';
 import type {DrinkDefaults} from '@libs/Statistics/events';
 import {sduFrom} from '@libs/Statistics/sdu';
 import type {WeekStart} from '@libs/Statistics/types';
+import CONST from '@src/CONST';
 import type Drinks from '@src/types/onyx/Drinks';
 import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
 import type DrinkingSession from '@src/types/onyx/DrinkingSession';
-import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
+import type {
+  DrinkingSessionType,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx/DrinkingSession';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import type {DrinksToUnits} from '@src/types/onyx/Preferences';
 import type {SelectedTimezone} from '@src/types/onyx/UserData';
@@ -32,6 +36,7 @@ type SessionInput = {
   timezone?: SelectedTimezone;
   blackout?: boolean;
   ongoing?: boolean;
+  type?: DrinkingSessionType;
   drinks?: DrinksList;
 };
 
@@ -55,6 +60,9 @@ function makeMultiUser(
       }
       if (input.ongoing !== undefined) {
         session.ongoing = input.ongoing;
+      }
+      if (input.type !== undefined) {
+        session.type = input.type;
       }
       if (input.drinks !== undefined) {
         session.drinks = input.drinks;
@@ -604,5 +612,54 @@ describe('buildDrinkEvents — memoisation', () => {
     const b = buildDrinkEvents(s2, UNITS, DEFAULTS, UTC, MON);
     expect(b).not.toBe(a);
     expect(b).toEqual(a);
+  });
+});
+
+describe('buildDrinkEvents — sessionType propagation', () => {
+  const drinks = makeDrinks([[Date.UTC(2024, 0, 15, 11), {beer: 1}]]);
+
+  it('stamps live sessions with sessionType "live"', () => {
+    const sessions = makeMultiUser({
+      u1: {
+        s1: {
+          start: Date.UTC(2024, 0, 15, 10),
+          type: CONST.SESSION.TYPES.LIVE,
+          drinks,
+        },
+      },
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events).toHaveLength(1);
+    expect(events[0].sessionType).toBe(CONST.SESSION.TYPES.LIVE);
+  });
+
+  it('stamps edit sessions with sessionType "edit"', () => {
+    const sessions = makeMultiUser({
+      u1: {
+        s1: {
+          start: Date.UTC(2024, 0, 15, 10),
+          type: CONST.SESSION.TYPES.EDIT,
+          drinks,
+        },
+      },
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events[0].sessionType).toBe(CONST.SESSION.TYPES.EDIT);
+  });
+
+  it('treats an ongoing session as live even without an explicit type', () => {
+    const sessions = makeMultiUser({
+      u1: {s1: {start: Date.UTC(2024, 0, 15, 10), ongoing: true, drinks}},
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events[0].sessionType).toBe(CONST.SESSION.TYPES.LIVE);
+  });
+
+  it('leaves sessionType undefined on legacy untyped sessions', () => {
+    const sessions = makeMultiUser({
+      u1: {s1: {start: Date.UTC(2024, 0, 15, 10), drinks}},
+    });
+    const events = buildDrinkEvents(sessions, UNITS, DEFAULTS, UTC, MON);
+    expect(events[0].sessionType).toBeUndefined();
   });
 });

--- a/__tests__/unit/libs/Statistics/filters.test.ts
+++ b/__tests__/unit/libs/Statistics/filters.test.ts
@@ -4,10 +4,12 @@ import {
   drinkTypeSubset,
   excludeBlackouts,
   forUsers,
+  liveSessionsOnly,
   weekdaysOnly,
   weekendsOnly,
 } from '@libs/Statistics/filters';
 import type {DrinkEvent} from '@libs/Statistics/types';
+import CONST from '@src/CONST';
 
 function event(overrides: Partial<DrinkEvent>): DrinkEvent {
   const ts = overrides.ts ?? Date.UTC(2024, 0, 15, 12);
@@ -84,6 +86,38 @@ describe('excludeBlackouts', () => {
 
   it('drops blackout events', () => {
     expect(excludeBlackouts(event({blackoutSession: true}))).toBe(false);
+  });
+});
+
+describe('liveSessionsOnly', () => {
+  it('keeps events from live sessions', () => {
+    expect(
+      liveSessionsOnly(event({sessionType: CONST.SESSION.TYPES.LIVE})),
+    ).toBe(true);
+  });
+
+  it('drops events from edit sessions', () => {
+    expect(
+      liveSessionsOnly(event({sessionType: CONST.SESSION.TYPES.EDIT})),
+    ).toBe(false);
+  });
+
+  it('drops events from legacy untyped sessions', () => {
+    expect(liveSessionsOnly(event({sessionType: undefined}))).toBe(false);
+  });
+
+  it('composes with other filters (AND)', () => {
+    const filter = composeFilters(liveSessionsOnly, drinkTypeSubset(['beer']));
+    expect(
+      filter?.(
+        event({sessionType: CONST.SESSION.TYPES.LIVE, drinkKey: 'beer'}),
+      ),
+    ).toBe(true);
+    expect(
+      filter?.(
+        event({sessionType: CONST.SESSION.TYPES.EDIT, drinkKey: 'beer'}),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/components/Charts/ChartCard/ChartCard.tsx
+++ b/src/components/Charts/ChartCard/ChartCard.tsx
@@ -7,8 +7,6 @@ import useThemeStyles from '@hooks/useThemeStyles';
 type ChartCardProps = {
   title: string;
   subtitle?: string;
-  /** Slot to the right of the title — e.g. a per-chart toggle. */
-  headerAction?: ReactNode;
   /** Slot below the chart — e.g. delta chip or period selector (v2). */
   footer?: ReactNode;
   children: ReactNode;
@@ -18,13 +16,7 @@ type ChartCardProps = {
  * The shell every chart sits in: rounded card with a header, body slot,
  * and optional footer. Theme-aware. No chart-specific knowledge.
  */
-function ChartCard({
-  title,
-  subtitle,
-  headerAction,
-  footer,
-  children,
-}: ChartCardProps) {
+function ChartCard({title, subtitle, footer, children}: ChartCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
 
@@ -38,22 +30,13 @@ function ChartCard({
           borderRadius: 12,
         },
       ]}>
-      <View
-        style={[
-          styles.mb2,
-          styles.flexRow,
-          styles.justifyContentBetween,
-          styles.alignItemsCenter,
-        ]}>
-        <View style={styles.flex1}>
-          <Text style={[styles.textLabelSupporting, styles.textStrong]}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text style={[styles.textMicroSupporting]}>{subtitle}</Text>
-          ) : null}
-        </View>
-        {headerAction ?? null}
+      <View style={styles.mb2}>
+        <Text style={[styles.textLabelSupporting, styles.textStrong]}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={[styles.textMicroSupporting]}>{subtitle}</Text>
+        ) : null}
       </View>
       <View>{children}</View>
       {footer ? <View style={styles.mt3}>{footer}</View> : null}

--- a/src/components/Charts/ChartCard/ChartCard.tsx
+++ b/src/components/Charts/ChartCard/ChartCard.tsx
@@ -7,6 +7,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 type ChartCardProps = {
   title: string;
   subtitle?: string;
+  /** Slot to the right of the title — e.g. a per-chart toggle. */
+  headerAction?: ReactNode;
   /** Slot below the chart — e.g. delta chip or period selector (v2). */
   footer?: ReactNode;
   children: ReactNode;
@@ -16,7 +18,13 @@ type ChartCardProps = {
  * The shell every chart sits in: rounded card with a header, body slot,
  * and optional footer. Theme-aware. No chart-specific knowledge.
  */
-function ChartCard({title, subtitle, footer, children}: ChartCardProps) {
+function ChartCard({
+  title,
+  subtitle,
+  headerAction,
+  footer,
+  children,
+}: ChartCardProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
 
@@ -30,13 +38,22 @@ function ChartCard({title, subtitle, footer, children}: ChartCardProps) {
           borderRadius: 12,
         },
       ]}>
-      <View style={styles.mb2}>
-        <Text style={[styles.textLabelSupporting, styles.textStrong]}>
-          {title}
-        </Text>
-        {subtitle ? (
-          <Text style={[styles.textMicroSupporting]}>{subtitle}</Text>
-        ) : null}
+      <View
+        style={[
+          styles.mb2,
+          styles.flexRow,
+          styles.justifyContentBetween,
+          styles.alignItemsCenter,
+        ]}>
+        <View style={styles.flex1}>
+          <Text style={[styles.textLabelSupporting, styles.textStrong]}>
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text style={[styles.textMicroSupporting]}>{subtitle}</Text>
+          ) : null}
+        </View>
+        {headerAction ?? null}
       </View>
       <View>{children}</View>
       {footer ? <View style={styles.mt3}>{footer}</View> : null}

--- a/src/components/Statistics/StatsFilterToolbar/ComparisonToggle.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/ComparisonToggle.tsx
@@ -15,7 +15,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    alignSelf: 'flex-start',
   },
 });
 

--- a/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
@@ -14,16 +14,16 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    alignSelf: 'flex-start',
   },
 });
 
 /**
- * Tab-level filter chip for the Patterns-tab timing charts (hour-of-day,
- * dow×hour, session duration). Filled when `liveOnly` is on (the default): the
- * charts then exclude manually-logged sessions, whose timestamps are synthetic
- * and whose duration is always zero. Tapping it toggles the shared `liveOnly`
- * state, so every timing chart switches together.
+ * "Live only" filter chip for the Patterns-tab timing charts (hour-of-day,
+ * dow×hour, session duration), shown in that tab's filter toolbar under the
+ * Compare button. Filled when `liveOnly` is on (the default): the charts then
+ * exclude manually-logged sessions, whose timestamps are synthetic and whose
+ * duration is always zero. Tapping it toggles the shared `liveOnly` state, so
+ * every timing chart switches together. Alignment is left to the parent.
  */
 function SessionTypeToggle() {
   const {translate} = useLocalize();

--- a/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
@@ -1,0 +1,60 @@
+import React, {useCallback} from 'react';
+import {StyleSheet} from 'react-native';
+import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useStatsContext from '@hooks/useStatsContext';
+import useTheme from '@hooks/useTheme';
+
+const styles = StyleSheet.create({
+  pill: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'flex-start',
+  },
+});
+
+/**
+ * Per-chart filter chip for the Patterns-tab time-of-day charts. Filled when
+ * `liveOnly` is on (the default): the chart then excludes manually-logged
+ * sessions, whose timestamps are synthetic. Tapping it toggles the shared
+ * `liveOnly` state, so both time charts switch together.
+ */
+function SessionTypeToggle() {
+  const {translate} = useLocalize();
+  const {appColor, border, text, textReversed} = useTheme();
+  const {liveOnly, setLiveOnly} = useStatsContext();
+
+  const toggle = useCallback(() => {
+    setLiveOnly(!liveOnly);
+  }, [liveOnly, setLiveOnly]);
+
+  return (
+    <PressableWithFeedback
+      accessibilityLabel={translate(
+        'statistics.filters.a11y.sessionTypeToggle',
+      )}
+      accessibilityRole="button"
+      accessibilityState={{selected: liveOnly}}
+      onPress={toggle}
+      style={[
+        styles.pill,
+        {
+          backgroundColor: liveOnly ? appColor : 'transparent',
+          borderColor: liveOnly ? appColor : border,
+        },
+      ]}>
+      <Text color={liveOnly ? textReversed : text} fontSize={12}>
+        {translate('statistics.filters.sessionType.liveOnly')}
+      </Text>
+    </PressableWithFeedback>
+  );
+}
+
+SessionTypeToggle.displayName = 'SessionTypeToggle';
+
+export default SessionTypeToggle;

--- a/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/SessionTypeToggle.tsx
@@ -8,9 +8,9 @@ import useTheme from '@hooks/useTheme';
 
 const styles = StyleSheet.create({
   pill: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
@@ -19,10 +19,11 @@ const styles = StyleSheet.create({
 });
 
 /**
- * Per-chart filter chip for the Patterns-tab time-of-day charts. Filled when
- * `liveOnly` is on (the default): the chart then excludes manually-logged
- * sessions, whose timestamps are synthetic. Tapping it toggles the shared
- * `liveOnly` state, so both time charts switch together.
+ * Tab-level filter chip for the Patterns-tab timing charts (hour-of-day,
+ * dow×hour, session duration). Filled when `liveOnly` is on (the default): the
+ * charts then exclude manually-logged sessions, whose timestamps are synthetic
+ * and whose duration is always zero. Tapping it toggles the shared `liveOnly`
+ * state, so every timing chart switches together.
  */
 function SessionTypeToggle() {
   const {translate} = useLocalize();
@@ -48,7 +49,7 @@ function SessionTypeToggle() {
           borderColor: liveOnly ? appColor : border,
         },
       ]}>
-      <Text color={liveOnly ? textReversed : text} fontSize={12}>
+      <Text color={liveOnly ? textReversed : text} fontSize={13}>
         {translate('statistics.filters.sessionType.liveOnly')}
       </Text>
     </PressableWithFeedback>

--- a/src/components/Statistics/StatsFilterToolbar/index.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/index.tsx
@@ -8,6 +8,7 @@ import type {RangePreset} from '@components/StatsContextProvider/types';
 import ComparisonToggle from './ComparisonToggle';
 import DrinkTypeChipRow from './DrinkTypeChipRow';
 import RangeSegmentedControl from './RangeSegmentedControl';
+import SessionTypeToggle from './SessionTypeToggle';
 import StatsRangeNavigator from './StatsRangeNavigator';
 
 const styles = StyleSheet.create({
@@ -26,6 +27,11 @@ const styles = StyleSheet.create({
   rangeWrapper: {
     flex: 1,
   },
+  sessionTypeRow: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
 });
 
 type StatsFilterToolbarProps = {
@@ -35,10 +41,18 @@ type StatsFilterToolbarProps = {
    * Breakdown tab).
    */
   showDrinkTypeFilter?: boolean;
+
+  /**
+   * Whether to show the "Live only" toggle (sits under the Compare button).
+   * Only the Patterns tab opts in, since `liveOnly` only filters that tab's
+   * timing charts.
+   */
+  showSessionTypeToggle?: boolean;
 };
 
 function StatsFilterToolbar({
   showDrinkTypeFilter = true,
+  showSessionTypeToggle = false,
 }: StatsFilterToolbarProps) {
   const {appBG, border} = useTheme();
   const {translate} = useLocalize();
@@ -83,6 +97,11 @@ function StatsFilterToolbar({
         </View>
         <ComparisonToggle value={comparison} onChange={setComparison} />
       </View>
+      {showSessionTypeToggle ? (
+        <View style={styles.sessionTypeRow}>
+          <SessionTypeToggle />
+        </View>
+      ) : null}
       <StatsRangeNavigator
         range={range}
         onPrev={goToPreviousPeriod}

--- a/src/components/Statistics/StatsFilterToolbar/index.tsx
+++ b/src/components/Statistics/StatsFilterToolbar/index.tsx
@@ -27,10 +27,12 @@ const styles = StyleSheet.create({
   rangeWrapper: {
     flex: 1,
   },
-  sessionTypeRow: {
-    width: '100%',
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
+  rightColumn: {
+    // Right-align Compare + Live only so their right edges sit flush.
+    alignItems: 'flex-end',
+    // MUST match RangeSegmentedControl's rowGap so a wrapped period row lines up
+    // with the Live-only button on the second row.
+    rowGap: 6,
   },
 });
 
@@ -95,13 +97,11 @@ function StatsFilterToolbar({
             onChange={handleRangeChange}
           />
         </View>
-        <ComparisonToggle value={comparison} onChange={setComparison} />
-      </View>
-      {showSessionTypeToggle ? (
-        <View style={styles.sessionTypeRow}>
-          <SessionTypeToggle />
+        <View style={styles.rightColumn}>
+          <ComparisonToggle value={comparison} onChange={setComparison} />
+          {showSessionTypeToggle ? <SessionTypeToggle /> : null}
         </View>
-      ) : null}
+      </View>
       <StatsRangeNavigator
         range={range}
         onPrev={goToPreviousPeriod}

--- a/src/components/StatsContextProvider/index.tsx
+++ b/src/components/StatsContextProvider/index.tsx
@@ -43,6 +43,7 @@ type StatsStateContextValue = {
   comparisonRange: {start: Date; end: Date} | null;
   comparison: Comparison;
   drinkTypeFilter: ReadonlySet<DrinkKey>;
+  liveOnly: boolean;
   userIds: readonly UserID[];
 };
 
@@ -59,6 +60,7 @@ type StatsActionsContextValue = {
   revertFromCustom: () => void;
   setComparison: (next: Comparison) => void;
   setDrinkTypeFilter: (next: ReadonlySet<DrinkKey>) => void;
+  setLiveOnly: (next: boolean) => void;
   setUserIds: (next: readonly UserID[]) => void;
 };
 
@@ -255,6 +257,13 @@ function StatsContextProvider({children, now}: StatsContextProviderProps) {
       : EMPTY_DRINK_FILTER,
   );
 
+  // Derived straight from Onyx (not mirrored into useState) so it restores on a
+  // cold load even when Onyx hydrates after this provider mounts — a useState
+  // initializer would capture the default and never catch up. Absent value
+  // defaults to live-only on: the time-of-day charts are only meaningful for
+  // real-time timestamps.
+  const liveOnly = persisted?.liveOnly ?? true;
+
   // periodOffset, comparison and userIds intentionally do NOT rehydrate from
   // Onyx — they are transient view state, reset on every mount.
   const [periodOffset, setPeriodOffset] = useState(0);
@@ -421,9 +430,22 @@ function StatsContextProvider({children, now}: StatsContextProviderProps) {
     Statistics.setFilters({drinkTypeFilter: Array.from(next)});
   }, []);
 
+  // Write-through: Onyx is the source of truth, so persisting the value is all
+  // that's needed — the `persisted` subscription above re-renders with it.
+  const setLiveOnly = useCallback((next: boolean) => {
+    Statistics.setFilters({liveOnly: next});
+  }, []);
+
   const stateValue = useMemo<StatsStateContextValue>(
-    () => ({range, comparisonRange, comparison, drinkTypeFilter, userIds}),
-    [range, comparisonRange, comparison, drinkTypeFilter, userIds],
+    () => ({
+      range,
+      comparisonRange,
+      comparison,
+      drinkTypeFilter,
+      liveOnly,
+      userIds,
+    }),
+    [range, comparisonRange, comparison, drinkTypeFilter, liveOnly, userIds],
   );
 
   const actionsValue = useMemo<StatsActionsContextValue>(
@@ -435,6 +457,7 @@ function StatsContextProvider({children, now}: StatsContextProviderProps) {
       revertFromCustom,
       setComparison,
       setDrinkTypeFilter,
+      setLiveOnly,
       setUserIds,
     }),
     [
@@ -444,6 +467,7 @@ function StatsContextProvider({children, now}: StatsContextProviderProps) {
       goToLatest,
       revertFromCustom,
       setDrinkTypeFilter,
+      setLiveOnly,
     ],
   );
 

--- a/src/components/StatsContextProvider/types.ts
+++ b/src/components/StatsContextProvider/types.ts
@@ -46,6 +46,13 @@ type StatsContextValue = {
   drinkTypeFilter: ReadonlySet<DrinkKey>;
   setDrinkTypeFilter: (next: ReadonlySet<DrinkKey>) => void;
 
+  /**
+   * Restrict the Patterns-tab time-of-day charts to live sessions only.
+   * Persisted; defaults to `true`. Only those charts read it.
+   */
+  liveOnly: boolean;
+  setLiveOnly: (next: boolean) => void;
+
   userIds: readonly UserID[];
   setUserIds: (next: readonly UserID[]) => void;
 };

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1271,6 +1271,9 @@ export default {
       drinkType: {
         all: 'Všechny drinky',
       },
+      sessionType: {
+        liveOnly: 'Jen živé relace',
+      },
       comparison: {
         none: 'Porovnat',
         previousPeriod: 'vs minulé období',
@@ -1291,6 +1294,7 @@ export default {
       a11y: {
         rangeSegmentedControl: 'Výběr časového rozsahu',
         drinkTypeChipRow: 'Filtr typu drinku',
+        sessionTypeToggle: 'Zobrazit jen živé relace',
         comparisonToggle: 'Režim porovnání',
         previousPeriod: 'Předchozí období',
         nextPeriod: 'Další období',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1266,6 +1266,9 @@ export default {
       drinkType: {
         all: 'All drinks',
       },
+      sessionType: {
+        liveOnly: 'Live only',
+      },
       comparison: {
         none: 'Compare',
         previousPeriod: 'vs last period',
@@ -1286,6 +1289,7 @@ export default {
       a11y: {
         rangeSegmentedControl: 'Date range selector',
         drinkTypeChipRow: 'Drink type filter',
+        sessionTypeToggle: 'Show live sessions only',
         comparisonToggle: 'Comparison mode',
         previousPeriod: 'Previous period',
         nextPeriod: 'Next period',

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -1,3 +1,4 @@
+import CONST from '@src/CONST';
 import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
 import type DrinkingSession from '@src/types/onyx/DrinkingSession';
 import type {UserDrinkingSessionsList} from '@src/types/onyx/DrinkingSession';
@@ -235,6 +236,11 @@ function buildDrinkEvents(
           ? (session.end_time - startMs) / 60000
           : undefined;
       const blackoutSession = session.blackout === true;
+      // An in-progress session is live by definition (it counts as live even if
+      // its `type` were somehow unset); otherwise trust the stored `type`.
+      const sessionType = session.ongoing
+        ? CONST.SESSION.TYPES.LIVE
+        : session.type;
       const drinks: DrinksList | undefined = session.drinks;
       if (!drinks) {
         continue;
@@ -310,6 +316,7 @@ function buildDrinkEvents(
             sdu,
             blackoutSession,
             sessionDurationMin,
+            sessionType,
           });
         }
       }

--- a/src/libs/Statistics/filters.ts
+++ b/src/libs/Statistics/filters.ts
@@ -1,3 +1,4 @@
+import CONST from '@src/CONST';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 import type {EventFilter} from './aggregate';
@@ -23,6 +24,15 @@ const weekendsOnly: EventFilter = event => event.isWeekend;
 const weekdaysOnly: EventFilter = event => !event.isWeekend;
 
 const excludeBlackouts: EventFilter = event => !event.blackoutSession;
+
+/**
+ * Keep only events from live (real-time) sessions. Drops edit/manually-logged
+ * sessions — and legacy untyped sessions — because their per-drink timestamps
+ * are synthetic, so time-of-day buckets would be meaningless. A *finished* live
+ * session still has `sessionType === 'live'`, so it is retained.
+ */
+const liveSessionsOnly: EventFilter = event =>
+  event.sessionType === CONST.SESSION.TYPES.LIVE;
 
 function forUsers(ids: readonly UserID[] | ReadonlySet<UserID>): EventFilter {
   const set = ids instanceof Set ? ids : new Set<UserID>(ids);
@@ -64,6 +74,7 @@ export {
   drinkTypeSubset,
   excludeBlackouts,
   forUsers,
+  liveSessionsOnly,
   weekdaysOnly,
   weekendsOnly,
 };

--- a/src/libs/Statistics/index.ts
+++ b/src/libs/Statistics/index.ts
@@ -23,6 +23,7 @@ export {
   drinkTypeSubset,
   excludeBlackouts,
   forUsers,
+  liveSessionsOnly,
   weekdaysOnly,
   weekendsOnly,
 } from './filters';

--- a/src/libs/Statistics/types.ts
+++ b/src/libs/Statistics/types.ts
@@ -1,4 +1,5 @@
 import type {DrinkKey} from '@src/types/onyx/Drinks';
+import type {DrinkingSessionType} from '@src/types/onyx/DrinkingSession';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
 
 /**
@@ -47,6 +48,13 @@ type DrinkEvent = {
   blackoutSession: boolean;
   /** `(end_time - start_time) / 60000`, undefined for ongoing or unended sessions. */
   sessionDurationMin?: number;
+  /**
+   * Source session's `type` ('live' | 'edit'); `undefined` on legacy untyped
+   * sessions. Lets time-of-day charts exclude edit/manually-logged sessions,
+   * whose per-drink timestamps are synthetic (stamped at save, not at the
+   * real moment of consumption).
+   */
+  sessionType?: DrinkingSessionType;
 };
 
 type DayRollup = {

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -7,6 +7,7 @@ import type {HistogramBin} from '@components/Charts/Histogram';
 import {HourPolar} from '@components/Charts/HourPolar';
 import {ChartCard} from '@components/Charts/ChartCard';
 import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
+import SessionTypeToggle from '@components/Statistics/StatsFilterToolbar/SessionTypeToggle';
 import Text from '@components/Text';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
@@ -22,6 +23,7 @@ import {
   countEvents,
   dateRange,
   drinkTypeSubset,
+  liveSessionsOnly,
   percentile,
   sessionDurationMin,
   sumUnits,
@@ -119,7 +121,7 @@ function formatDurationMin(minutes: number): string {
 }
 
 function PatternsTab() {
-  const {range, drinkTypeFilter, userIds} = useStatsContext();
+  const {range, drinkTypeFilter, liveOnly, userIds} = useStatsContext();
   const preferences = useCurrentUserPreferences();
   const {events, isLoading} = useDrinkEvents(
     userIds.length > 0 ? [...userIds] : undefined,
@@ -139,12 +141,21 @@ function PatternsTab() {
     [range, drinkTypeFilter],
   );
 
-  const hourBuckets = useAggregate(events, byHour, sumUnits, eventFilter);
+  // Time-of-day charts default to live sessions only: edit/manually-logged
+  // sessions carry synthetic per-drink timestamps, so their hour buckets are
+  // noise. The per-session histograms below intentionally keep `eventFilter`
+  // (a drink count / session duration is meaningful regardless of session type).
+  const timeOfDayFilter = useMemo(
+    () => composeFilters(eventFilter, liveOnly ? liveSessionsOnly : undefined),
+    [eventFilter, liveOnly],
+  );
+
+  const hourBuckets = useAggregate(events, byHour, sumUnits, timeOfDayFilter);
   const dowHourBuckets = useAggregate(
     events,
     composeBuckets(byDow, byHour),
     sumUnits,
-    eventFilter,
+    timeOfDayFilter,
   );
   const perSessionCounts = useAggregate(
     events,
@@ -189,7 +200,9 @@ function PatternsTab() {
       <ScrollView
         style={[styles.scroll, {backgroundColor: undefined}]}
         contentContainerStyle={styles.scrollContent}>
-        <ChartCard title={translate('statistics.charts.hourOfDay.title')}>
+        <ChartCard
+          title={translate('statistics.charts.hourOfDay.title')}
+          headerAction={<SessionTypeToggle />}>
           <HourPolar
             buckets={hourBuckets}
             accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
@@ -198,7 +211,9 @@ function PatternsTab() {
             isLoading={isLoading}
           />
         </ChartCard>
-        <ChartCard title={translate('statistics.charts.dowHour.title')}>
+        <ChartCard
+          title={translate('statistics.charts.dowHour.title')}
+          headerAction={<SessionTypeToggle />}>
           <DowHourHeatmap
             buckets={dowHourBuckets}
             weekStart={weekStart}

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -7,7 +7,6 @@ import type {HistogramBin} from '@components/Charts/Histogram';
 import {HourPolar} from '@components/Charts/HourPolar';
 import {ChartCard} from '@components/Charts/ChartCard';
 import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
-import SessionTypeToggle from '@components/Statistics/StatsFilterToolbar/SessionTypeToggle';
 import Text from '@components/Text';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
@@ -38,10 +37,6 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: 32,
     paddingHorizontal: 16,
-  },
-  toggleRow: {
-    paddingHorizontal: 16,
-    paddingBottom: 8,
   },
   histogramRow: {
     flexDirection: 'row',
@@ -201,12 +196,7 @@ function PatternsTab() {
 
   return (
     <View style={themeStyles.flex1}>
-      <StatsFilterToolbar />
-      {/* One tab-level control for every timing chart below; pinned above the
-          scroll so it stays reachable while scrolling to the duration chart. */}
-      <View style={styles.toggleRow}>
-        <SessionTypeToggle />
-      </View>
+      <StatsFilterToolbar showSessionTypeToggle />
       <ScrollView
         style={[styles.scroll, {backgroundColor: undefined}]}
         contentContainerStyle={styles.scrollContent}>

--- a/src/screens/Statistics/tabs/PatternsTab.tsx
+++ b/src/screens/Statistics/tabs/PatternsTab.tsx
@@ -39,6 +39,10 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     paddingHorizontal: 16,
   },
+  toggleRow: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
   histogramRow: {
     flexDirection: 'row',
     gap: 8,
@@ -141,21 +145,22 @@ function PatternsTab() {
     [range, drinkTypeFilter],
   );
 
-  // Time-of-day charts default to live sessions only: edit/manually-logged
-  // sessions carry synthetic per-drink timestamps, so their hour buckets are
-  // noise. The per-session histograms below intentionally keep `eventFilter`
-  // (a drink count / session duration is meaningful regardless of session type).
-  const timeOfDayFilter = useMemo(
+  // Timing-derived charts (hour-of-day, dow×hour, session duration) honor the
+  // tab-level "Live only" toggle: edit/manually-logged sessions carry synthetic
+  // per-drink timestamps AND a fixed zero duration (start_time === end_time, no
+  // UI to set an end), so they're noise here. Drinks-per-session keeps the plain
+  // `eventFilter` — a drink count is meaningful for any session type.
+  const timeFilter = useMemo(
     () => composeFilters(eventFilter, liveOnly ? liveSessionsOnly : undefined),
     [eventFilter, liveOnly],
   );
 
-  const hourBuckets = useAggregate(events, byHour, sumUnits, timeOfDayFilter);
+  const hourBuckets = useAggregate(events, byHour, sumUnits, timeFilter);
   const dowHourBuckets = useAggregate(
     events,
     composeBuckets(byDow, byHour),
     sumUnits,
-    timeOfDayFilter,
+    timeFilter,
   );
   const perSessionCounts = useAggregate(
     events,
@@ -167,7 +172,7 @@ function PatternsTab() {
     events,
     bySessionId,
     sessionDurationMin,
-    eventFilter,
+    timeFilter,
   );
 
   const drinkBins = useMemo(
@@ -197,12 +202,15 @@ function PatternsTab() {
   return (
     <View style={themeStyles.flex1}>
       <StatsFilterToolbar />
+      {/* One tab-level control for every timing chart below; pinned above the
+          scroll so it stays reachable while scrolling to the duration chart. */}
+      <View style={styles.toggleRow}>
+        <SessionTypeToggle />
+      </View>
       <ScrollView
         style={[styles.scroll, {backgroundColor: undefined}]}
         contentContainerStyle={styles.scrollContent}>
-        <ChartCard
-          title={translate('statistics.charts.hourOfDay.title')}
-          headerAction={<SessionTypeToggle />}>
+        <ChartCard title={translate('statistics.charts.hourOfDay.title')}>
           <HourPolar
             buckets={hourBuckets}
             accessibilityLabel={translate('statistics.charts.hourOfDay.title')}
@@ -211,9 +219,7 @@ function PatternsTab() {
             isLoading={isLoading}
           />
         </ChartCard>
-        <ChartCard
-          title={translate('statistics.charts.dowHour.title')}
-          headerAction={<SessionTypeToggle />}>
+        <ChartCard title={translate('statistics.charts.dowHour.title')}>
           <DowHourHeatmap
             buckets={dowHourBuckets}
             weekStart={weekStart}

--- a/src/types/onyx/StatisticsFilters.ts
+++ b/src/types/onyx/StatisticsFilters.ts
@@ -29,6 +29,13 @@ type StatisticsFilters = {
 
   /** Drink-type subset; empty array means "all drinks". Persisted as array (Onyx-friendly); hydrated into a Set at the provider boundary. */
   drinkTypeFilter: DrinkKey[];
+
+  /**
+   * Restrict the time-of-day charts (Patterns tab) to live sessions only,
+   * excluding manually-logged sessions whose timestamps are synthetic.
+   * `undefined` hydrates as `true` (default-on) at the provider boundary.
+   */
+  liveOnly?: boolean;
 };
 
 export default StatisticsFilters;


### PR DESCRIPTION
### Details

The Statistics → **Patterns** charts that are derived from session *timing* — **Hour of day**, **Day-of-week × hour**, and **Session duration** — are unreliable for **edit / manually-logged** sessions:

- Their per-drink timestamps are synthetic (stamped at save time, not at the real moment of consumption), so they inject phantom spikes into the hour buckets.
- Their duration is structurally **zero**: `getNewSessionToEdit` sets `start_time === end_time`, the date editor only picks a single calendar day (no end-time UI), and adding drinks never moves `end_time`. So every edit session piles into the shortest-duration bin and misrepresents how long sessions actually last. Only **live** sessions get a real `end_time = Date.now()` on save.

This adds a single tab-level **"Live only"** toggle (default **on**), pinned above the Patterns charts, that restricts the three timing charts to **live** sessions. A *finished* live session still has `type === 'live'`, so it's kept; **edit** and **legacy-untyped** sessions are excluded. **Drinks per session** intentionally ignores the toggle — a drink count is meaningful for any session type ("I had 4 beers" = 4 drinks).

Clean rule: charts that depend on *when / how long* honor the toggle; the chart that only counts *how many* does not.

What's in the change:

- `DrinkEvent.sessionType`, stamped in `buildDrinkEvents` (`ongoing ? LIVE : type`)
- `liveSessionsOnly` `EventFilter` (`sessionType === LIVE`) + barrel export
- Persisted `liveOnly` flag in `STATISTICS_FILTERS`, exposed via `StatsContext`. It's **derived straight from `useOnyx`** rather than mirrored into `useState`, so it restores correctly on a web cold load even when Onyx hydrates after the provider mounts (the existing `useState`-mirrored filters like `preset`/`drinkTypeFilter` have a pre-existing race here on web — left untouched to keep this change contained).
- `SessionTypeToggle` chip, rendered once as a tab-level control above the Patterns scroll; `PatternsTab` applies the live-only filter to hour-of-day, dow×hour, and session-duration aggregations (`timeFilter`), and keeps drinks-per-session on the plain `eventFilter`.
- English copy added to `en.ts`; Czech filled via the `translate` skill against the `cs_cz` glossary (canonical *živá relace*).

Follow-up issue (do not auto-close): https://github.com/PetrCala/Kiroku/issues/1309 — verify/backfill `DrinkingSession.type` on legacy sessions, since live-only silently drops untyped ones.

### Tests

1. Open Statistics → **Patterns**.
2. Verify a single **Live only** toggle sits above the charts, filled/active by default, and that the chart card headers have no per-card chips.
3. With both a live and an edit session in the selected range, verify the **Hour of day**, **Day-of-week × hour**, and **Session duration** charts exclude the edit-session data while live-only is on (no synthetic hour spike; no zero-duration pile-up).
4. Toggle **Live only** off → verify all three timing charts now include the edit sessions, and toggle back on → they're excluded again.
5. Verify the **Drinks per session** histogram is unchanged by the toggle (it always includes all sessions).
6. Toggle off, reload the page → verify the toggle comes back **off** (the `liveOnly` state persists via Onyx `statisticsFilters`).
7. Verify the Overview / Trends / Breakdown totals are unaffected (still count all sessions).

Automated: `npm run test -- Statistics` (new coverage for `sessionType` propagation and the `liveSessionsOnly` filter), `Translate.test.ts` parity, `typecheck`, lint, and the React Compiler compliance check all pass.

- [x] Verify that no errors appear in the JS console *(verified on web; the only console error observed was a transient HMR hook-count warning while live-editing, which does not occur on a fresh load)*

### Offline tests

The toggle is pure client-side filtering over already-loaded session data and persists through Onyx (offline-first). No network calls are involved.

1. Go offline.
2. Open Statistics → Patterns, toggle **Live only** off/on → verify the timing charts re-filter instantly and the state persists across a reload while still offline.

### QA Steps

1. Open Statistics → **Patterns**.
2. Confirm a single **Live only** toggle is present and active by default above the charts.
3. Log some drinks via a **live** session and via an **edit** (past) session on different hours, then confirm the **Hour of day**, **Day-of-week × hour**, and **Session duration** charts only reflect the live session while **Live only** is on.
4. Toggle off → confirm the three timing charts now include the edit session.
5. Confirm the **Drinks per session** histogram is unaffected by the toggle.
6. Reload the app → confirm the toggle state is remembered.
7. Confirm Overview / Trends / Breakdown numbers are unchanged by the toggle.

- [x] Verify that no errors appear in the JS console

### Screenshots/Videos

<details>
<summary>Android</summary>

<!-- pending device QA -->

</details>

<details>
<summary>iOS</summary>

<!-- pending device QA -->

</details>