### PR TITLE
fix(web): point app-dev.kiroku.cz at the dev backend via the adhoc env

### DIFF
--- a/.github/workflows/deployWeb.yml
+++ b/.github/workflows/deployWeb.yml
@@ -5,9 +5,14 @@ name: Deploy web
 # - push to `production` -> build-web        -> live deploy to the prod project
 #                                                (hosting target `app` =
 #                                                 kiroku-app-prod / app.kiroku.cz)
-# - push to `staging`    -> build-web-dev     -> live deploy to the dev project
+# - push to `staging`    -> build-web-adhoc   -> live deploy to the dev project
 #                                                (hosting target `app` =
-#                                                 kiroku-app-dev)
+#                                                 kiroku-app-dev / app-dev.kiroku.cz).
+#                                                The adhoc env points the build at
+#                                                the DEV Firebase project AND the
+#                                                DEV kiroku-api — a production-grade
+#                                                build on the dev backend, so the
+#                                                dev-only test account can sign in.
 # - PR labeled `Ready To Build - Web`         -> build-web-dev -> preview channel
 #   (or manual dispatch with a PR number)        `pr-<number>` on the dev site,
 #                                                URL commented on the PR
@@ -59,20 +64,22 @@ jobs:
           else
             {
               echo "PROJECT=dev"
-              echo "BUILD_SCRIPT=build-web-dev"
+              echo "BUILD_SCRIPT=build-web-adhoc"
             } >> "$GITHUB_OUTPUT"
           fi
 
-      # build-web reads .env.production; build-web-dev reads .env.development.
-      # Stage the matching file from secrets (the dev/staging site is fed the
-      # staging env so it points at the staging API roots).
+      # build-web reads .env.production; build-web-adhoc reads .env.adhoc.
+      # Stage the matching file from secrets. app-dev.kiroku.cz is fed the adhoc
+      # env so the running app targets the DEV Firebase project + DEV kiroku-api
+      # (not prod, as STAGING_ENV_FILE did) — a production-grade build on the dev
+      # backend.
       - name: Stage .env.production from secret
         if: ${{ github.ref_name == 'production' }}
         run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
 
-      - name: Stage .env.development from staging secret
+      - name: Stage .env.adhoc from secret
         if: ${{ github.ref_name == 'staging' }}
-        run: echo "${{ secrets.STAGING_ENV_FILE }}" > .env.development
+        run: echo "${{ secrets.ADHOC_ENV_FILE }}" > .env.adhoc
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "web:framed": "echo '▶ Device simulator: http://localhost:8082/simulator.html' && npm run web",
     "build-web": "tsx ./node_modules/.bin/webpack-cli --config config/webpack/webpack.common.ts --env file=.env.production",
     "build-web-dev": "tsx ./node_modules/.bin/webpack-cli --config config/webpack/webpack.common.ts --env file=.env.development",
+    "build-web-adhoc": "tsx ./node_modules/.bin/webpack-cli --config config/webpack/webpack.common.ts --env file=.env.adhoc",
     "web-server": "http-server ./dist -c-1 --port 8080",
     "test:e2e:web": "playwright test --project=chromium --config=e2e/web/playwright.config.ts",
     "test:e2e:web:ui": "playwright test --ui --project=chromium --config=e2e/web/playwright.config.ts"


### PR DESCRIPTION
## Problem

The `staging` push path in `deployWeb.yml` deploys to the **dev** hosting bucket (`kiroku-app-dev` → app-dev.kiroku.cz) but built the bundle from **`STAGING_ENV_FILE`**, which points at the **prod** Firebase project (`alcohol-tracker-db`).

That left **app-dev split-brained**:
- **Auth + Firebase config** → prod project
- **kiroku-api** → dev root (`getKirokuApiRoot()` in [`ApiUtils.ts`](src/libs/ApiUtils.ts) returns `DEV_ROOT` for every non-`PROD` env)

Consequences: the dev-only test account (`test123@seznam.cz`) gets "password incorrect" on app-dev (it only exists in the dev project), and prod tokens get sent to the dev kiroku-api.

## Fix

Feed app-dev the **adhoc** env. `.env.adhoc` targets the **dev** Firebase project *and* (being non-prod) the **dev** kiroku-api, so both halves are dev — a production-grade build (no `IS_IN_DEVELOPMENT` debug surfaces) on the dev backend, with a clear purple **"ADHOC"** environment badge so testers never mistake it for prod.

- Add a `build-web-adhoc` npm script (reads `.env.adhoc`).
- `staging` push path now stages `.env.adhoc` from `ADHOC_ENV_FILE` and runs `build-web-adhoc`.

Verified `.env.adhoc` has full web Firebase key parity with `.env.development` (only extra in dev is `USE_EMULATORS`, which we don't want on a deployed build). Web `getEnvironment` reads `Config.ENVIRONMENT` verbatim, so adhoc needs no code changes. The "skip email verification (dev only)" QA affordance is gated `IS_IN_DEVELOPMENT || IS_IN_STAGING || IS_IN_ADHOC`, so it's preserved.

## Scope notes

- **PR web previews are unchanged** — they stay on `DEV_ENV_FILE` / `build-web-dev` because the Playwright harness is tuned for `ENVIRONMENT=development` (SKIP_ONBOARDING, dev gates). Both still hit the dev project, so SSO/authorized-domain config is shared.
- `STAGING_ENV_FILE` is now unused by web but **kept** — mobile staging builds in `platformDeploy.yml` still use it.

## Out-of-band follow-ups (done separately by maintainer)

1. Add `app-dev.kiroku.cz` to the **dev** Firebase project's Auth → Authorized domains.
2. Add `app-dev.kiroku.cz` to the dev web OAuth client's authorized origins / redirect URIs (needed for Google Sign-In on app-dev).
3. Confirm the `ADHOC_ENV_FILE` GitHub secret is current and contains the web keys (`GOOGLE_WEB_CLIENT_ID` etc.) — CI builds from the secret, not the local `.env.adhoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)