### PR TITLE
feat(home): open last-session banner to that session's summary

### DIFF
--- a/src/hooks/useLastSession.ts
+++ b/src/hooks/useLastSession.ts
@@ -9,9 +9,12 @@ import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import {timestampToDateString} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
+import type {DrinkingSessionId} from '@src/types/onyx/DrinkingSession';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 
 type LastSessionView = {
+  /** Collection key of the session, for single-session summary navigation. */
+  sessionId: DrinkingSessionId;
   /** Day-granularity relative time, e.g. "Today", "Yesterday", "3 days ago". */
   when: string;
   /** Formatted total units, e.g. "4.5". */
@@ -40,10 +43,11 @@ function useLastSession(): LastSessionView | null {
   const drinksToUnits = preferences?.drinks_to_units;
 
   return useMemo(() => {
-    const session = DSUtils.getLastSession(drinkingSessionData);
-    if (!session) {
+    const lastSession = DSUtils.getLastSession(drinkingSessionData);
+    if (!lastSession) {
       return null;
     }
+    const {sessionId, session} = lastSession;
 
     const date = new Date(session.start_time);
     const now = new Date();
@@ -69,6 +73,7 @@ function useLastSession(): LastSessionView | null {
     }
 
     return {
+      sessionId,
       when,
       units: formatUnits(
         DSUtils.calculateTotalUnits(session.drinks, drinksToUnits),

--- a/src/libs/DrinkingSessionUtils.ts
+++ b/src/libs/DrinkingSessionUtils.ts
@@ -216,22 +216,29 @@ function getOngoingSessionId(
 
 /**
  * Returns the most recent COMPLETED session (latest `start_time`), excluding
- * any ongoing/in-progress session. `undefined` when there are none.
+ * any ongoing/in-progress session, together with its collection key
+ * (`sessionId`). `undefined` when there are none.
+ *
+ * The key is returned explicitly because the session's own `id` field is only
+ * populated locally and cannot be relied on — callers that need to navigate to
+ * a specific session use this `sessionId`.
  */
 function getLastSession(
   drinkingSessions: DrinkingSessionList | null | undefined,
-): DrinkingSession | undefined {
+): {sessionId: DrinkingSessionId; session: DrinkingSession} | undefined {
   if (isEmptyObject(drinkingSessions)) {
     return undefined;
   }
 
-  let latest: DrinkingSession | undefined;
-  Object.values(drinkingSessions).forEach(session => {
+  let latest:
+    | {sessionId: DrinkingSessionId; session: DrinkingSession}
+    | undefined;
+  Object.entries(drinkingSessions).forEach(([sessionId, session]) => {
     if (!session || session.ongoing) {
       return;
     }
-    if (!latest || session.start_time > latest.start_time) {
-      latest = session;
+    if (!latest || session.start_time > latest.session.start_time) {
+      latest = {sessionId, session};
     }
   });
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -251,7 +251,7 @@ function HomeScreen({route}: HomeScreenProps) {
           })}
           onPress={() =>
             Navigation.navigate(
-              ROUTES.DAY_OVERVIEW.getRoute(user.uid, lastSession.dateString),
+              ROUTES.DRINKING_SESSION_SUMMARY.getRoute(lastSession.sessionId),
             )
           }
         />


### PR DESCRIPTION
## What

Tapping the **"last session"** banner on the home screen now opens that single session's **summary** (`ROUTES.DRINKING_SESSION_SUMMARY`) instead of the day-overview scroll list (`ROUTES.DAY_OVERVIEW`).

## Why

The banner is driven by `useLastSession`, which resolves exactly **one** session (the most recent completed one) and shows *its* relative time + units. But the tap landed on a day list of every session on that date — a semantic mismatch with what the banner points at.

- The summary screen is the detail view of precisely that session, so it's the more honest destination.
- The day-overview path isn't lost: the home calendar still opens any day's list directly, so this also gives the banner a job distinct from tapping the calendar.
- Parity is fine: the summary screen already has an owner edit button, and its back logic dismisses cleanly to Home when the previous screen isn't the day overview (the same modal entry already used from the live-session and session-tile flows).

## How

- `getLastSession` now returns the session's **collection key** (`sessionId`) alongside the session. The key is the canonical id used everywhere for navigation; the session's own `id` field is only populated locally and can't be relied on. Switched the scan from `Object.values` to `Object.entries`.
- `useLastSession` surfaces `sessionId` on its view object (kept `dateString` too — harmless and still handy for any future "see the whole day" affordance).
- `HomeScreen` routes the banner `onPress` to `ROUTES.DRINKING_SESSION_SUMMARY.getRoute(sessionId)`.

## Trade-off

If a user had multiple sessions on the same day, the banner now opens only the most recent one rather than the whole day. Since the banner explicitly says "last session," pointing at that one session is the intended behavior, and the calendar still covers the see-the-whole-day case.

## Checks

- `prettier --check` ✓
- `typecheck-tsgo` ✓
- `lint.sh` (seatbelt) ✓
- `react-compiler-compliance-check check-changed` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)