### PR TITLE
fix(web): confine portaled modals to the desktop phone-frame

### DIFF
--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -60,7 +60,7 @@ function ReanimatedModal({
   const [isVisibleState, setIsVisibleState] = useState(isVisible);
   const [isContainerOpen, setIsContainerOpen] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
-  const {windowWidth, windowHeight} = useWindowDimensions();
+  const {windowHeight} = useWindowDimensions();
 
   const backHandlerListener = useRef<NativeEventSubscription | null>(null);
   const handleRef = useRef<number | undefined>(undefined);
@@ -151,11 +151,18 @@ function ReanimatedModal({
 
   const backdropStyle: ViewStyle = useMemo(
     () => ({
-      width: windowWidth,
+      // Fill the real window rather than `windowWidth`. On web above the
+      // responsive breakpoint the app renders inside a centered ~480px "phone
+      // frame" and `windowWidth` is clamped to it (index.web.js), but the modal
+      // portals to `document.body` outside that frame — a 480px backdrop would
+      // dim only the left of the window and leave the rest of the overlay
+      // uncovered. `'100%'` fills the portal's full-window container and is a
+      // no-op on native and narrow web, where it already equals `windowWidth`.
+      width: '100%',
       height: windowHeight,
       backgroundColor: backdropColor,
     }),
-    [windowWidth, windowHeight, backdropColor],
+    [windowHeight, backdropColor],
   );
 
   const onOpenCallBack = useCallback(() => {

--- a/src/styles/utils/generators/ModalStyleUtils.ts
+++ b/src/styles/utils/generators/ModalStyleUtils.ts
@@ -22,6 +22,16 @@ function getCenteredModalStyles(
     width: isSmallScreenWidth
       ? '100%'
       : windowWidth - modalStyles.marginHorizontal * 2,
+    // On web above the responsive breakpoint we render the app inside a centered
+    // ~480px "phone frame" (web/index.html + index.web.js clamp `windowWidth` to
+    // that frame). But `react-native-web`'s Modal portals to `document.body`,
+    // outside the `#root` frame, so a `width: '100%'` container resolves against
+    // the *real* browser window and the modal spills across the whole screen.
+    // Cap it at the reported (frame-clamped) width so the modal's own
+    // `alignItems: 'center'` centers it over the frame. This is a no-op on native
+    // and on narrow web, where the reported width already equals the real
+    // container width.
+    maxWidth: windowWidth,
   };
 }
 
@@ -213,6 +223,13 @@ const createModalStyleUtils: StyleUtilGenerator<GetModalStylesStyleUtil> = ({
         };
         modalContainerStyle = {
           width: '100%',
+          // Cap at the reported (frame-clamped) width so the docked sheet stays
+          // within the centered ~480px web "phone frame" instead of stretching
+          // across the whole browser window (the modal is portaled to
+          // `document.body`, outside `#root`). The `alignItems: 'center'` above
+          // centers it over the frame. No-op on native and narrow web — see
+          // `getCenteredModalStyles`.
+          maxWidth: windowWidth,
           borderTopLeftRadius: variables.componentBorderRadiusLarge,
           borderTopRightRadius: variables.componentBorderRadiusLarge,
           paddingTop: variables.componentBorderRadiusLarge,


### PR DESCRIPTION
## Problem

On desktop web, the mandatory **"Verify your email"** gate spanned the entire browser window instead of the centered ~480px mobile "phone frame" that every other screen uses.


## Root cause

Kiroku renders the web app inside a centered ~480px **phone frame** above the 800px breakpoint: `web/index.html` sizes `#root` to `480px; margin: 0 auto`, and `index.web.js` clamps the reported viewport width (`Dimensions.get('window')` → `useWindowDimensions`) to match, so all the mobile-first layout "believes" it's on a 480px screen.

But `react-native-web`'s `Modal` **portals its content to `document.body`** (via `ModalPortal`), *outside* `#root`. `ModalContent` then makes that portal `position: fixed; inset: 0` — i.e. the **real** browser window. So:

- A modal container styled `width: '100%'` resolves against the real window (1280px), not the 480px frame, and spills across the whole screen.
- The shared backdrop was sized `width: windowWidth` (the **clamped** 480), so it only dimmed the left 480px of the window.

This affected every body-portaled "fill" modal: `CENTERED` / `CENTERED_UNSWIPEABLE` (the verify-email gate) and the `BOTTOM_DOCKED` session-start sheet. Navigation screens (incl. RHP sub-screens) were unaffected — they render inside `#root`.

## Fix

Three minimal, self-documenting changes:

1. **`getCenteredModalStyles`** (`CENTERED` + `CENTERED_UNSWIPEABLE`): add `maxWidth: windowWidth`.
2. **`BOTTOM_DOCKED`** container: add `maxWidth: windowWidth`.
3. **`ReanimatedModal` backdrop**: size to `width: '100%'` (fills the real-window portal) instead of the clamped `windowWidth`.

Each caps the container at the *reported* (frame-clamped) width, so the modals' existing `alignItems: 'center'` centers them exactly over the frame, and the backdrop dims the whole window symmetrically.

All three are **no-ops on native and on narrow web**, where the reported width already equals the real container width (`'100%'` === `windowWidth`).

## Testing

Verified live against `npm run web` at 1280×800 (frame active) and 375×812 (mobile):

- **Verify-email modal**: was `left:0 / w:1280`; now `left:400 / w:480`, exactly matching `#root`. Backdrop now `left:0 / w:1280` (was 480).
- **Session-start sheet** (`BOTTOM_DOCKED`): was full-width; now `left:400 / w:480`, centered over the frame, docked bottom.
- **Mobile (375px)**: modal is full-width (`maxWidth` is a no-op) — no regression below the breakpoint.
- Gates: `typecheck-tsgo`, `lint-changed`, `react-compiler-compliance-check check-changed` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)