### PR TITLE
fix(web): drop phantom tab-bar inset that floated the FAB and search button high

### DIFF
--- a/src/hooks/useBottomTabBarHeight/index.ts
+++ b/src/hooks/useBottomTabBarHeight/index.ts
@@ -1,12 +1,17 @@
-import variables from '@src/styles/variables';
-
 /**
- * Web fallback: the custom JS tab bar (see `BottomTabBar`) is exactly
- * `variables.bottomTabHeight` tall, so scroll content insets by that amount.
- * Native overrides this in `index.native.ts` with the real measured bar height.
+ * Web: the custom JS tab bar (see `BottomTabBar`) is a normal-flow sibling
+ * below the scene in `@react-navigation/bottom-tabs`' `BottomTabView` column,
+ * NOT an overlay. The scene already ends at the top of the bar, so content
+ * needs no extra clearance. Returning the bar height here would double-inset
+ * every consumer (FAB/search offset, scroll `paddingBottom`, offline-indicator
+ * margin), stacking a bar-sized dead band above the bar; this is the same bug
+ * fixed on Android (see `index.android.ts`).
+ *
+ * iOS keeps the measured height (`index.native.ts`) because there the bar
+ * genuinely overlays the scene.
  */
 function useBottomTabBarHeight(): number {
-  return variables.bottomTabHeight;
+  return 0;
 }
 
 export default useBottomTabBarHeight;


### PR DESCRIPTION
### Details

On web, the Home FAB and the Social "Friend Requests" search button floated a full tab-bar height (~72px) too far above the bottom tab bar. Same class of bug previously fixed on Android.

**Root cause.** The web variant of `useBottomTabBarHeight` returned `variables.bottomTabHeight` (72), on the assumption that the bottom tab bar *overlays* the scene (so content must inset to clear it). That's true on iOS, but **not** on web: the custom web JS bar (`BottomTabBar`) is rendered as a normal-flow sibling *below* the scene in `@react-navigation/bottom-tabs`' `BottomTabView` flex column (`screens` is `flex:1`, the bar is a fixed-height sibling). The scene therefore already ends at the top of the bar.

Returning the bar height double-inset every consumer of the hook, stacking a 72px dead band above the bar:
- `HomeScreen` FAB `bottom: bottomTabBarHeight + 16` and ScrollView `paddingBottom`
- `SocialScreen` search FAB `bottom: bottomTabBarHeight + 16` and scene `paddingBottom`
- `StatisticsScreen` / `StatisticsTabs` / `SettingsScreen` scroll `paddingBottom`
- the `OfflineIndicator` `marginBottom` on all four roots

**Fix.** Return `0` from the web variant, matching the Android variant (`index.android.ts`), which already documents this exact double-inset. iOS is untouched — `index.native.ts` keeps the real measured height because the native bar genuinely overlays the scene. Metro resolution keeps the three variants platform-isolated (`index.ts` web, `index.android.ts` Android, `index.native.ts` iOS).

Net effect on web: FAB/search now clear the bar by 16px, scroll content reaches the bar, and the offline indicator sits just above it.

### Tests

Verified locally against `npm run web` (dev backend, signed in), measuring real DOM geometry:

1. Open the app on web and land on **Home**.
2. Verify the `+` FAB sits just above the bottom tab bar (not floating high).
   - Measured: FAB bottom edge `y=632` (`bottom: 16px`), tab bar top `y=648` → **16px** gap (was ~88px).
3. Go to **Friends → Friend Requests** tab.
4. Verify the 🔍 search FAB sits just above the tab bar.
   - Measured: search FAB bottom `y=632` (`bottom: 16px`), tab bar top `y=648` → **16px** gap.
5. Verify Home/Social scroll content reaches the bar (no ~72px empty band at the bottom).

- [x] Verify that no errors appear in the JS console

Local gates: `prettier` clean, `typecheck-tsgo` passes, react-compiler compliance passes (hook modified).

### Offline tests

- No offline behavior change. This is a pure layout/measurement fix; the `OfflineIndicator` simply sits 72px lower (correctly, just above the bar) when offline.
- [x] Verify that no errors appear in the JS console

### QA Steps

1. On **web** (staging), sign in and open Home.
2. Confirm the `+` FAB sits a small, consistent gap above the bottom tab bar — not floating ~one tab-bar-height above it.
3. Open Friends → Friend Requests; confirm the search (🔍) button sits the same small gap above the bar.
4. Scroll the Home calendar / Friends list to the bottom; confirm content reaches the bar with no large empty band.
5. Sanity-check **iOS** and **Android** are unchanged (FAB/search still clear their native bars correctly).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors
- [x] I verified that comments were added to code that is not self explanatory (the web variant now documents the normal-flow-sibling reasoning, cross-referencing the Android variant)
- [x] No copy/text changes (no localization needed)
- [x] Verified the impacted screens (Home, Social, Statistics, Settings) all consume the hook and are corrected by this change
- [x] I verified all code is DRY (single-line behavior change shared via the existing platform-split hook)

### Screenshots/Videos

<details>
<summary>Web (the platform fixed)</summary>

Home FAB and Friends search button now sit 16px above the bottom tab bar (verified by DOM measurement; before: ~88px gap).

</details>

<details>
<summary>Android</summary>

No change (already returns 0; bar is a normal-flow sibling there too).

</details>

<details>
<summary>iOS</summary>

No change (keeps the measured overlay height).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)