### PR TITLE
fix(verify-email): center the verify-email modal content vertically

### DIFF
--- a/src/components/VerifyEmailModal.tsx
+++ b/src/components/VerifyEmailModal.tsx
@@ -276,7 +276,7 @@ function VerifyEmailModal() {
       );
     }
     return (
-      <View>
+      <View style={styles.flex1}>
         <View
           style={[
             styles.flexGrow1,


### PR DESCRIPTION
### Details

The email-verification gate (`VerifyEmailModal`) rendered all of its content jammed at the **top** of the screen instead of centered, with a large empty area below it (most noticeable on web, where the phone-frame modal is reliably full-height).

**Root cause:** the modal's outer container is `flex: 1` and fills the full modal height, but the default *verify* branch wrapped its content in a bare `<View>` with no flex style. That wrapper collapsed to content height, so the parent's default `justifyContent: flex-start` parked it at the top, and the inner `flexGrow1` + `justifyContentCenter` (which were supposed to center it) had no extra space to distribute and did nothing.

**Fix:** add `styles.flex1` to that wrapper so it fills the modal height — matching the two sibling branches that were already correct (`changeEmail` uses `flex1`, the success branch uses `flexGrow1`). The icon/title/body now center in the available space with the action buttons docked at the bottom, consistent with the canonical `TermsScreenContent` pattern.

This is a one-line layout fix; no logic, copy, or behavior changes. The cause is platform-agnostic (same flex tree on native and web), so the fix applies to all platforms.

### Tests

1. Sign in with an account whose email is **not** verified so the verify-email gate appears.
2. Verify the mail icon, "Verify your email" title, and body text are vertically centered (not clipped at the top edge), with the "I have verified my email" / "Resend email" buttons and links docked toward the bottom.
3. Tap **Wrong email? Use a different one** and verify the "Use a different email" sub-view is also centered with full-width inputs and the "Send verification link" button at the bottom.
4. Resize / try a short and a tall viewport and confirm the content stays vertically balanced.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — pure layout change, no network behavior affected.

### QA Steps

1. Sign in with an unverified-email account to reach the verify-email gate.
2. Confirm the content is vertically centered (header centered, action buttons at the bottom), not stacked at the top.
3. Open **Wrong email? Use a different one** and confirm that sub-view is laid out correctly too.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I verified there are no console errors
- [x] I followed proper code patterns
- [x] If the PR modifies the UI: this is a layout-only spacing fix to an existing modal (no new inputs/components)

### Screenshots/Videos

Verified on web (dev): before — content jammed at the top with empty space below; after — content vertically centered with buttons docked at the bottom. Both the `verify` and `changeEmail` sub-views were checked.

<details>
<summary>Android</summary>

<!-- not separately captured; layout fix is platform-agnostic, verified on web -->

</details>

<details>
<summary>iOS</summary>

<!-- not separately captured; layout fix is platform-agnostic, verified on web -->

</details>
