### PR TITLE
ci(deploy): remind to bump in-app version gate after production deploy

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -349,9 +349,20 @@ jobs:
       - name: 'Announces the deploy in the #announce Discord channel'
         shell: bash
         run: |
+          APP_VERSION="${{ inputs.APP_VERSION }}"
+          # The in-app version gate uses the marketing version (MAJOR.MINOR.PATCH),
+          # so drop the build suffix (e.g. 0.3.16-14 -> 0.3.16).
+          CLI_VERSION="${APP_VERSION%-*}"
+          DESCRIPTION="Successfully deployed Kiroku [${{ inputs.RELEASE_TAG }}](https://github.com/PetrCala/Kiroku/releases/tag/${{ inputs.RELEASE_TAG }}) to ${{ inputs.DEPLOY_ENVIRONMENT }}"
+          # Production builds are NOT live for users yet: iOS sits in 'Pending Developer
+          # Release' (automatic_release: false) and Android promotes to the beta track.
+          # Remind a human to bump the in-app version gate once the build actually ships.
+          if [[ "${{ inputs.SHOULD_DEPLOY_PRODUCTION }}" == "true" ]]; then
+            DESCRIPTION="${DESCRIPTION}\n\n📌 Reminder: once v${CLI_VERSION} is live on BOTH the App Store (manually release from 'Pending Developer Release') and Google Play, bump the in-app update prompt with: \`kiroku-cli app-version set --latest ${CLI_VERSION}\`"
+          fi
           curl -s -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{\"content\":\"\",\"embeds\":[{\"title\":\"Deploy Successful\",\"color\":3066993,\"description\":\"Successfully deployed Kiroku [${{ inputs.RELEASE_TAG }}](https://github.com/PetrCala/Kiroku/releases/tag/${{ inputs.RELEASE_TAG }}) to ${{ inputs.DEPLOY_ENVIRONMENT }}\",\"footer\":{\"text\":\"GitHub Actions\",\"icon_url\":\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\"}}]}"
+            -d "{\"content\":\"\",\"embeds\":[{\"title\":\"Deploy Successful\",\"color\":3066993,\"description\":\"${DESCRIPTION}\",\"footer\":{\"text\":\"GitHub Actions\",\"icon_url\":\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\"}}]}"
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -358,7 +358,7 @@ jobs:
           # Release' (automatic_release: false) and Android promotes to the beta track.
           # Remind a human to bump the in-app version gate once the build actually ships.
           if [[ "${{ inputs.SHOULD_DEPLOY_PRODUCTION }}" == "true" ]]; then
-            DESCRIPTION="${DESCRIPTION}\n\n📌 Reminder: once v${CLI_VERSION} is live on BOTH the App Store (manually release from 'Pending Developer Release') and Google Play, bump the in-app update prompt with: \`kiroku-cli app-version set --latest ${CLI_VERSION}\`"
+            DESCRIPTION="${DESCRIPTION}\n\n📌 Production build is not live yet. It's awaiting manual release:\n• App Store: release it from 'Pending Developer Release'\n• Google Play: promote it from the beta track to production\n\nOnce v${CLI_VERSION} is downloadable on both, bump the in-app update prompt:\n\`kiroku-cli app-version set --latest ${CLI_VERSION}\`"
           fi
           curl -s -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## What

After a **production** deploy succeeds, append a reminder to the `#announce` Discord embed posted by the `postDiscordMessageOnSuccess` job in [`.github/workflows/platformDeploy.yml`](.github/workflows/platformDeploy.yml). The reminder tells the deployer to bump the in-app "latest version" gate **once the build is actually live on both stores**.

The appended block (production only):

> 📌 Production build is not live yet. It's awaiting manual release:
> • App Store: release it from 'Pending Developer Release'
> • Google Play: promote it from the beta track to production
>
> Once v0.3.16 is downloadable on both, bump the in-app update prompt:
> `kiroku-cli app-version set --latest 0.3.16`

## Why a reminder, not an automated step

A finished production pipeline does **not** mean users can download the build yet:

- **iOS** uses `automatic_release: false` (`fastlane/Fastfile`) — after Apple approves, the build sits in *Pending Developer Release* until a human clicks Release.
- **Android** promotes to the **beta** track (`track_promote_to: 'beta'`), so it still needs a manual beta → production promotion.

So writing the version gate at CI-success time would advertise/force a version users can't install. We keep a human in the loop and just remind them.

## Details

- Scoped to production via `inputs.SHOULD_DEPLOY_PRODUCTION`; staging deploys are unchanged (verified the conditional locally).
- The build suffix is stripped (`0.3.16-14` -> `0.3.16`) so the value is a copy-pasteable `MAJOR.MINOR.PATCH`, matching what the client gate and the stores use.
- No restructuring of the job: the existing single Discord step now builds its `description` in bash and conditionally appends the reminder.
- Reminder copy is a lead line + a two-item checklist + the command on its own line, and explicitly notes Android's manual beta → production promotion (not just the iOS release step).
- Validated the generated JSON parses (newlines, bullets, emoji, and the backtick code span all render correctly) under `shell: bash`; ran prettier (no changes); no em-dashes in the Discord copy per repo voice rules.

## ⚠️ Dependency / hand-off

The reminder references a **new** kiroku-cli command (`kiroku-cli app-version set --latest <semver>`) that is being added in a **separate task** — it does not exist on `kiroku-cli` master yet. **That kiroku-cli `app-version` command must merge first for this reminder to be actionable.** The command/flag names here follow kiroku-cli's existing namespace convention (e.g. `kiroku-cli email broadcast`, `kiroku-cli reports list`); if the final command differs, update the message string accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)