### PR TITLE
fix(settings): back from About slides forward instead of dismissing

### DIFF
--- a/src/screens/Settings/AboutScreen.tsx
+++ b/src/screens/Settings/AboutScreen.tsx
@@ -137,7 +137,7 @@ function AboutScreen() {
       <HeaderWithBackButton
         title={translate('settingsScreen.about')}
         shouldShowBackButton={shouldUseNarrowLayout}
-        onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS)}
+        onBackButtonPress={() => Navigation.goBack()}
       />
       <ScrollView contentContainerStyle={styles.pt3}>
         <View style={[styles.flex1]}>

--- a/src/screens/Settings/ManageSubscriptionScreen.tsx
+++ b/src/screens/Settings/ManageSubscriptionScreen.tsx
@@ -14,7 +14,6 @@ import Navigation from '@libs/Navigation/Navigation';
 import SupporterUtils from '@libs/SupporterUtils';
 import * as UserUtils from '@libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
 import type {SupporterStatus} from '@src/types/onyx/UserData';
 
 // Both stores require subscription cancellation in the OS settings, not in-app
@@ -39,7 +38,7 @@ function ManageSubscriptionScreen() {
   const isVisible = SupporterUtils.isSupporterTierVisible();
   useEffect(() => {
     if (!isVisible) {
-      Navigation.goBack(ROUTES.SETTINGS);
+      Navigation.goBack();
     }
   }, [isVisible]);
 
@@ -145,7 +144,7 @@ function ManageSubscriptionScreen() {
     <ScreenWrapper testID={ManageSubscriptionScreen.displayName}>
       <HeaderWithBackButton
         title={translate('supporter.manageSubscription.title')}
-        onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS)}
+        onBackButtonPress={() => Navigation.goBack()}
       />
       <ScrollView contentContainerStyle={[styles.pt3, styles.ph5, styles.pb5]}>
         <Section

--- a/src/screens/Settings/SupportKirokuScreen.tsx
+++ b/src/screens/Settings/SupportKirokuScreen.tsx
@@ -78,7 +78,7 @@ function SupportKirokuScreen() {
   const isVisible = SupporterUtils.isSupporterTierVisible();
   useEffect(() => {
     if (!isVisible) {
-      Navigation.goBack(ROUTES.SETTINGS);
+      Navigation.goBack();
     }
   }, [isVisible]);
 
@@ -501,7 +501,7 @@ function SupportKirokuScreen() {
     <ScreenWrapper testID={SupportKirokuScreen.displayName}>
       <HeaderWithBackButton
         title={translate('supporter.paywallScreen.title')}
-        onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS)}
+        onBackButtonPress={() => Navigation.goBack()}
       />
       <ScrollView contentContainerStyle={[styles.pt3, styles.ph5, styles.pb5]}>
         {renderBody()}


### PR DESCRIPTION
## Problem

Pressing **Back** from the **Settings → About** screen plays a *forward* slide animation (a screen sliding in from the right) instead of dismissing the panel. The Settings tab appears to "go forward" rather than the About panel closing.

## Root cause

`AboutScreen` passed `ROUTES.SETTINGS` as a **fallback route** to `Navigation.goBack`:

```tsx
onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS)}
```

In Kiroku's bottom-tab architecture, the Settings menu (`SettingsScreen.tsx`) is a **bottom-tab** screen, while `Settings_About` lives in the **RHP** modal stack. So About is the *first and only* route in that stack. That triggers this branch in `Navigation.goBack`:

```tsx
if (shouldEnforceFallback || (isFirstRouteInNavigator && fallbackRoute)) {
  navigate(fallbackRoute, CONST.NAVIGATION.TYPE.UP);
}
```

`navigate(ROUTES.SETTINGS, TYPE.UP)` only dismisses the modal when `topmostCentralPaneRoute?.name === targetName`. But `SCREENS.SETTINGS.ROOT` maps to **no central pane** (`TAB_TO_CENTRAL_PANE_MAPPING` → `[]`), so that check is never true. The action falls through to a `PUSH` of a fresh bottom-tab navigator on top of the still-open RHP — hence the forward slide.

Every other settings screen (Account, Preferences, Privacy, Help, …) calls plain `Navigation.goBack()` with no fallback and dismisses correctly.

## Fix

Drop the `ROUTES.SETTINGS` fallback so `goBack` falls through to a plain modal dismiss. Applied to all three screens that used the pattern:

- `AboutScreen` — back button (the reported bug)
- `ManageSubscriptionScreen` — back button + defensive bounce-back guard
- `SupportKirokuScreen` — back button + defensive bounce-back guard

The supporter screens are behind the dormant supporter tier but had the same latent bug. Removed the now-unused `ROUTES` import from `ManageSubscriptionScreen`.

## Testing

- `npx prettier --write` — clean
- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed
- `npm run lint-changed` — passed

Behavior to verify on a narrow layout: open **Settings → About**, press Back → the panel should dismiss (slide away), not slide a new screen in from the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)