### PR TITLE
fix(auth): sign out on 401 (revoked/invalid token) from kiroku-api

### DIFF
--- a/__tests__/unit/libs/HttpUtils401SignOut.test.ts
+++ b/__tests__/unit/libs/HttpUtils401SignOut.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+/**
+ * kiroku-api returns a plain HTTP 401 when the caller's Firebase ID token is
+ * revoked/disabled/invalid — distinct from `jsonCode` 407 (merely expired),
+ * which the Reauthentication middleware refreshes and replays. A refresh cannot
+ * recover a revoked token, so `HttpUtils` force-signs-out on a 401 that carried
+ * a `Bearer` token. These tests pin that behavior:
+ *  - an authenticated 401 signs out once and still rejects the request,
+ *  - a burst of concurrent 401s collapses into a single sign-out,
+ *  - non-401 failures and 401s with no `Bearer` (legacy transport) do NOT sign out.
+ */
+import type {WRITE_COMMANDS as WriteCommands} from '@libs/API/types';
+import type HttpUtilsType from '@libs/HttpUtils';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {connect: jest.fn(), disconnect: jest.fn()},
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({
+    currentUser: {getIdToken: jest.fn(() => Promise.resolve('valid-token'))},
+  }),
+}));
+
+jest.mock('@userActions/Session', () => ({
+  signOut: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@libs/ApiUtils', () => ({
+  getKirokuApiRoot: () => 'https://api.test',
+  getCommandURL: () => 'https://legacy.test/cmd',
+}));
+
+jest.mock('@userActions/Network', () => ({setTimeSkew: jest.fn()}));
+jest.mock('@userActions/UpdateRequired', () => ({alertUser: jest.fn()}));
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    alert: jest.fn(),
+    hmmm: jest.fn(),
+  },
+}));
+
+function mockFetchStatus(status: number, statusText: string) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: {get: () => null},
+    json: () => Promise.resolve({}),
+  };
+  global.fetch = jest.fn(() =>
+    Promise.resolve(response),
+  ) as unknown as typeof fetch;
+}
+
+describe('HttpUtils 401 (revoked token) sign-out', () => {
+  let HttpUtils: typeof HttpUtilsType;
+  let signOut: jest.Mock;
+  let WRITE_COMMANDS: typeof WriteCommands;
+
+  beforeEach(() => {
+    // Fresh module registry so the module-private "is signing out" guard resets
+    // between tests (it re-arms asynchronously, after sign-out settles).
+    jest.resetModules();
+    HttpUtils = (require('@libs/HttpUtils') as {default: typeof HttpUtilsType})
+      .default;
+    signOut = (require('@userActions/Session') as {signOut: jest.Mock}).signOut;
+    WRITE_COMMANDS = (
+      require('@libs/API/types') as {WRITE_COMMANDS: typeof WriteCommands}
+    ).WRITE_COMMANDS;
+    signOut.mockClear();
+    signOut.mockReturnValue(Promise.resolve());
+  });
+
+  it('signs out once and still rejects when an authenticated request gets a 401', async () => {
+    mockFetchStatus(401, 'Unauthorized');
+
+    await expect(
+      HttpUtils.xhr(WRITE_COMMANDS.OPEN_APP, {}),
+    ).rejects.toMatchObject({name: 'HttpsError', status: '401'});
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses a burst of concurrent 401s into a single sign-out', async () => {
+    mockFetchStatus(401, 'Unauthorized');
+    // Keep sign-out pending so the guard never re-arms mid-burst.
+    signOut.mockReturnValue(new Promise<void>(() => {}));
+
+    const results = await Promise.allSettled([
+      HttpUtils.xhr(WRITE_COMMANDS.OPEN_APP, {}),
+      HttpUtils.xhr(WRITE_COMMANDS.OPEN_APP, {}),
+      HttpUtils.xhr(WRITE_COMMANDS.OPEN_APP, {}),
+    ]);
+
+    expect(results.every(r => r.status === 'rejected')).toBe(true);
+    expect(signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT sign out on a non-401 server failure', async () => {
+    mockFetchStatus(500, 'Internal Server Error');
+
+    await expect(
+      HttpUtils.xhr(WRITE_COMMANDS.OPEN_APP, {}),
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('does NOT sign out on a 401 with no Bearer token (legacy transport)', async () => {
+    mockFetchStatus(401, 'Unauthorized');
+
+    // A command absent from the kiroku-api route map falls through to the legacy
+    // FormData transport, which sends no Authorization header.
+    await expect(HttpUtils.xhr('NotAKirokuCommand', {})).rejects.toMatchObject({
+      status: '401',
+    });
+
+    expect(signOut).not.toHaveBeenCalled();
+  });
+});

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -350,6 +350,11 @@ const CONST = {
     UNDEFINED: 'undefined',
   },
   HTTP_STATUS: {
+    // The Firebase ID token was revoked/disabled/invalid (NOT merely expired —
+    // that is `JSON_CODE.NOT_AUTHENTICATED` 407, which the Reauthentication
+    // middleware refreshes and replays). A 401 means a token refresh cannot
+    // recover the session, so the client force-signs-out (see HttpUtils).
+    UNAUTHORIZED: 401,
     // The resource already exists — e.g. provisioning an already-provisioned
     // user. Expected/benign for idempotent retries, not a service failure.
     CONFLICT: 409,

--- a/src/libs/HttpUtils.ts
+++ b/src/libs/HttpUtils.ts
@@ -6,7 +6,9 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {RequestType} from '@src/types/onyx/Request';
 import type Response from '@src/types/onyx/Response';
+import Log from './Log';
 import * as NetworkActions from './actions/Network';
+import * as Session from './actions/Session';
 import * as UpdateRequired from './actions/UpdateRequired';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from './API/types';
 import {getKirokuRoute} from './API/kirokuRoutes';
@@ -31,6 +33,37 @@ Onyx.connect({
 
 // We use the AbortController API to terminate pending request in `cancelPendingRequests`
 let cancellationController = new AbortController();
+
+// A 401 from kiroku-api means the caller's Firebase ID token was
+// revoked/disabled/invalid — NOT merely expired (that is `jsonCode` 407, which
+// the Reauthentication middleware refreshes and replays). A token refresh cannot
+// recover a revoked token, so the only correct response is to sign the user out
+// and let the app fall back to the login screen.
+//
+// `Session.signOut` flips Firebase auth state, which unmounts `AuthScreens` and
+// runs `cleanupSession()` (it clears the persisted-request queue, the
+// lastUpdateID baseline, and cached user data) — the exact path the in-app
+// "Sign out" button uses, so we never hand-roll a new one.
+//
+// A burst of in-flight requests (e.g. the SequentialQueue replay) can each see a
+// 401 at once; this flag collapses the burst into a single sign-out. It re-arms
+// once the sign-out settles, so a later session whose token is revoked is handled
+// again. A 401 only arrives on an actual server response, so this never fires
+// while offline.
+let isHandlingRevokedToken = false;
+
+function handleRevokedToken() {
+  if (isHandlingRevokedToken) {
+    return;
+  }
+  isHandlingRevokedToken = true;
+  Log.warn(
+    '[HttpUtils] kiroku-api returned 401 (revoked/invalid token); signing out',
+  );
+  Session.signOut(getFirebaseAuth()).finally(() => {
+    isHandlingRevokedToken = false;
+  });
+}
 
 // Some existing old commands (6+ years) exempted from the auth writes count check
 const exemptedCommandsWithAuthWrites: string[] = [
@@ -120,6 +153,18 @@ function processHTTPRequest(
             status: response.status.toString(),
             title: 'API request throttled',
           });
+        }
+
+        // A 401 on a request that carried a `Bearer` token is a revoked/invalid
+        // Firebase ID token: force a clean sign-out. We still fall through to the
+        // generic throw below so the failing request rolls back its optimistic
+        // data like any other failure. The `Bearer` guard scopes this to
+        // authenticated kiroku-api calls and ignores any unrelated legacy 401.
+        if (
+          response.status === CONST.HTTP_STATUS.UNAUTHORIZED &&
+          headers?.Authorization
+        ) {
+          handleRevokedToken();
         }
 
         throw new HttpsError({


### PR DESCRIPTION
## What

On an HTTP **401** from kiroku-api (revoked / disabled / invalid Firebase ID token), force a clean **sign-out + redirect to login**. A token refresh can't recover a revoked token, so the previous behavior (falling through to a generic network error) left the dead session lingering.

Implements the recommendation in #781.

## Why this layer

kiroku-api returns two distinct auth failures:

- **`{jsonCode: 407}`** (`NOT_AUTHENTICATED`) — the ID token is merely *expired*. Already handled: `Middleware/Reauthentication.ts` force-refreshes via `getIdToken(true)` and replays. **Left untouched** (its one-retry loop guard is preserved).
- **HTTP `401`** — the token is *revoked/invalid/disabled*. This throws at the raw-transport layer in `HttpUtils.ts` *before* the response is parsed into `{jsonCode}`, so it never reaches the Reauthentication middleware. That's the gap.

The 401 is detected in `HttpUtils.processHTTPRequest` (where the numeric `response.status` is directly available, mirroring the existing `UpdateRequired.alertUser()` precedent in the same function) rather than catching the resulting `HttpsError` higher up. No import cycle: `actions/Session` does not import the request pipeline.

## Behavior

- Reuses the existing sign-out path — `Session.signOut(getFirebaseAuth())` — which flips Firebase auth state, unmounting `AuthScreens` and running `cleanupSession()` (clears the persisted-request queue, the `lastUpdateID` baseline, and cached user data). No hand-rolled redirect.
- A module-level guard collapses a **burst of concurrent 401s** (e.g. the `SequentialQueue` replay) into a **single** sign-out; it re-arms after sign-out settles so a future session is handled again.
- The `Bearer`-header guard scopes the sign-out to **authenticated kiroku-api calls**, so any unrelated legacy 401 is ignored.
- A 401 only arrives on an actual server response, so this never fires while offline. Not conflated with 407 (expired→refresh) or 426 (`UPDATE_REQUIRED`, already handled).

## Changes

- `src/CONST.ts` — add `HTTP_STATUS.UNAUTHORIZED = 401` (there was no 401 constant; `JSON_CODE.NOT_AUTHENTICATED` is 407, a different thing).
- `src/libs/HttpUtils.ts` — detect the authenticated 401 and trigger the guarded sign-out; still throw the `HttpsError` so optimistic data rolls back like any other failure.
- `__tests__/unit/libs/HttpUtils401SignOut.test.ts` — new coverage: authenticated 401 → one sign-out + still rejects; concurrent 401 burst → single sign-out; non-401 failure → no sign-out; 401 with no Bearer (legacy transport) → no sign-out.

No user-facing strings added (the only new string is a dev log line), so no translation pass is needed.

## Verification

- `npm run typecheck` (tsc, CI gate) ✅
- `npm run typecheck-tsgo` ✅
- `./scripts/lint.sh` on changed files ✅
- New test suite ✅ (4/4) and the `__tests__/actions` suites that load the real request pipeline ✅ (46/46, confirming the new `Session` import doesn't break module eval)

Part of the `feature/realtime-cutover` epic. Closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)