### PR TITLE
feat(entitlements): premium-feature gating framework + gate custom color palette

### DIFF
--- a/__tests__/unit/Entitlements.test.ts
+++ b/__tests__/unit/Entitlements.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment node
+ */
+
+import {getFeatureAccess, getPremiumFeatureKeys} from '@libs/Entitlements';
+import type {FeatureAccessContext, PremiumFeatureKey} from '@libs/Entitlements';
+
+// A controlled registry so the resolver matrix can cover free, plus, and
+// availability-flagged features independent of the real app registry.
+// `FeatureFlags.isEnabled` reads `CONST.FEATURES` from this same mock.
+jest.mock('@src/CONST', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- ES module interop flag required for default-export mocks.
+  __esModule: true,
+  default: {
+    FEATURES: {
+      FLAG_ON: true,
+      FLAG_OFF: false,
+    },
+    PREMIUM_FEATURES: {
+      FREE_FEATURE: {tier: 'free'},
+      PLUS_FEATURE: {tier: 'plus'},
+      PLUS_FLAG_ON: {tier: 'plus', availabilityFlag: 'FLAG_ON'},
+      PLUS_FLAG_OFF: {tier: 'plus', availabilityFlag: 'FLAG_OFF'},
+    },
+  },
+}));
+
+// The real `PremiumFeatureKey` type is derived from the real CONST, which the
+// runtime mock can't change. Cast test keys through this helper.
+function resolve(feature: string, context: Partial<FeatureAccessContext> = {}) {
+  const fullContext: FeatureAccessContext = {
+    isSupporter: false,
+    isSupporterStatusLoading: false,
+    devOverride: undefined,
+    gatesActive: true,
+    ...context,
+  };
+  return getFeatureAccess(feature as PremiumFeatureKey, fullContext);
+}
+
+describe('libs/Entitlements.getPremiumFeatureKeys', () => {
+  it('returns the registered feature keys', () => {
+    expect(getPremiumFeatureKeys()).toEqual([
+      'FREE_FEATURE',
+      'PLUS_FEATURE',
+      'PLUS_FLAG_ON',
+      'PLUS_FLAG_OFF',
+    ]);
+  });
+});
+
+describe('libs/Entitlements.getFeatureAccess', () => {
+  describe('availability flag (step 1, beats everything)', () => {
+    it('marks the feature unavailable when its flag is off', () => {
+      expect(resolve('PLUS_FLAG_OFF')).toEqual({
+        isAvailable: false,
+        isLocked: false,
+        requiresPlus: false,
+        tier: 'plus',
+        isResolving: false,
+      });
+    });
+
+    it('stays unavailable even with a dev unlock override', () => {
+      const access = resolve('PLUS_FLAG_OFF', {
+        devOverride: 'unlocked',
+        isSupporter: true,
+      });
+      expect(access.isAvailable).toBe(false);
+      expect(access.isLocked).toBe(false);
+    });
+
+    it('behaves like a normal plus feature when its flag is on', () => {
+      expect(
+        resolve('PLUS_FLAG_ON', {gatesActive: true, isSupporter: false}),
+      ).toEqual({
+        isAvailable: true,
+        isLocked: true,
+        requiresPlus: true,
+        tier: 'plus',
+        isResolving: false,
+      });
+    });
+  });
+
+  describe('dev override (step 2, beats tier/gates/supporter)', () => {
+    it('unlocks a locked plus feature', () => {
+      const access = resolve('PLUS_FEATURE', {
+        devOverride: 'unlocked',
+        gatesActive: true,
+        isSupporter: false,
+      });
+      expect(access.isLocked).toBe(false);
+      expect(access.isAvailable).toBe(true);
+      expect(access.requiresPlus).toBe(true);
+    });
+
+    it('locks a feature even for a supporter', () => {
+      const access = resolve('PLUS_FEATURE', {
+        devOverride: 'locked',
+        gatesActive: true,
+        isSupporter: true,
+      });
+      expect(access.isLocked).toBe(true);
+      expect(access.isResolving).toBe(false);
+    });
+
+    it('overrides while supporter status is still loading', () => {
+      const access = resolve('PLUS_FEATURE', {
+        devOverride: 'unlocked',
+        isSupporterStatusLoading: true,
+      });
+      expect(access.isResolving).toBe(false);
+      expect(access.isLocked).toBe(false);
+    });
+  });
+
+  describe('free tier (step 3)', () => {
+    it('is always unlocked and never requires plus', () => {
+      const access = resolve('FREE_FEATURE', {
+        gatesActive: true,
+        isSupporter: false,
+      });
+      expect(access).toEqual({
+        isAvailable: true,
+        isLocked: false,
+        requiresPlus: false,
+        tier: 'free',
+        isResolving: false,
+      });
+    });
+  });
+
+  describe('plus tier, gates inactive (step 4 — ships free)', () => {
+    it('is an unlocked placeholder that still requires plus', () => {
+      expect(
+        resolve('PLUS_FEATURE', {gatesActive: false, isSupporter: false}),
+      ).toEqual({
+        isAvailable: true,
+        isLocked: false,
+        requiresPlus: true,
+        tier: 'plus',
+        isResolving: false,
+      });
+    });
+
+    it('ignores a loading status (no resolving) when gates are inactive', () => {
+      const access = resolve('PLUS_FEATURE', {
+        gatesActive: false,
+        isSupporterStatusLoading: true,
+      });
+      expect(access.isResolving).toBe(false);
+      expect(access.isLocked).toBe(false);
+    });
+  });
+
+  describe('plus tier, gates active, status loading (step 5 — no flicker)', () => {
+    it('is unlocked and resolving regardless of supporter flag', () => {
+      const access = resolve('PLUS_FEATURE', {
+        gatesActive: true,
+        isSupporterStatusLoading: true,
+        isSupporter: false,
+      });
+      expect(access).toEqual({
+        isAvailable: true,
+        isLocked: false,
+        requiresPlus: true,
+        tier: 'plus',
+        isResolving: true,
+      });
+    });
+  });
+
+  describe('plus tier, gates active, status loaded (step 6)', () => {
+    it('locks a non-supporter', () => {
+      const access = resolve('PLUS_FEATURE', {
+        gatesActive: true,
+        isSupporter: false,
+      });
+      expect(access.isLocked).toBe(true);
+      expect(access.isResolving).toBe(false);
+    });
+
+    it('unlocks a supporter', () => {
+      const access = resolve('PLUS_FEATURE', {
+        gatesActive: true,
+        isSupporter: true,
+      });
+      expect(access.isLocked).toBe(false);
+      expect(access.requiresPlus).toBe(true);
+    });
+  });
+});

--- a/__tests__/unit/Translate.test.ts
+++ b/__tests__/unit/Translate.test.ts
@@ -101,6 +101,7 @@ const UNTRANSLATED_ALLOWLIST = new Set<string>([
   'connectedAccounts.providers.apple',
   'supporter.tierName',
   'supporter.badgeAccessibilityLabel',
+  'premiumFeatures.plusBadge',
   'bottomTabBar.menu',
   'onboarding.title',
   // Format / placeholder strings
@@ -119,6 +120,7 @@ const UNTRANSLATED_ALLOWLIST = new Set<string>([
   'settingsScreen.aboutScreen.versionLetter',
   'statistics.filters.range.M',
   'statistics.filters.range.sixM',
+  'testTools.override.auto',
   // Correct Czech happens to be identical to the English word
   'common.ok',
   'common.role',

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -121,6 +121,19 @@ const CONST = {
     // masked by the flying splash logo.
     LOGO_FLY_IN: false,
   },
+  // Registry of features gated behind a subscription tier. Read via the pure
+  // `getFeatureAccess` resolver (`@libs/Entitlements`) and the `useFeatureAccess`
+  // hook — never branch on this object directly at call sites.
+  //
+  // - `tier`: `'free'` is always unlocked; `'plus'` is locked only when the
+  //   premium gates are active (dev/staging today, production at v1.1) AND the
+  //   user is not a supporter.
+  // - `availabilityFlag` (optional): a `CONST.FEATURES` key. When that flag is
+  //   off the feature is treated as not-in-build (unavailable), which wins over
+  //   every gate, including the dev override.
+  PREMIUM_FEATURES: {
+    CUSTOM_COLOR_PALETTE: {tier: 'plus'},
+  },
   APP_UPDATE: {
     // How long the dismiss update button should hide the window for
     DISMISS_TIME: 1000 * 60 * 60 * 24 * 1, // 1 day

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -130,6 +130,10 @@ const ONYXKEYS = {
   /** Is the test tools modal open? */
   IS_TEST_TOOLS_MODAL_OPEN: 'isTestToolsModalOpen',
 
+  /** Developer-only premium-feature gating overrides (Test Tools panel). Only
+   *  read/written outside production — see `@libs/actions/FeatureAccess`. */
+  FEATURE_ACCESS_OVERRIDES: 'featureAccessOverrides',
+
   /** Whether we should show the compose input or not */
   SHOULD_SHOW_COMPOSE_INPUT: 'shouldShowComposeInput',
 
@@ -315,6 +319,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.APP_LOADING_TEXT]: string;
   [ONYXKEYS.IS_LOADING_APP]: boolean;
   [ONYXKEYS.IS_TEST_TOOLS_MODAL_OPEN]: boolean;
+  [ONYXKEYS.FEATURE_ACCESS_OVERRIDES]: OnyxTypes.FeatureAccessOverrides;
   [ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT]: boolean;
   [ONYXKEYS.APP_UPDATE_DISMISSED]: Timestamp;
   [ONYXKEYS.VERIFY_EMAIL_SENT]: Timestamp;

--- a/src/components/FeatureGate.tsx
+++ b/src/components/FeatureGate.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {View} from 'react-native';
+import useFeatureAccess from '@hooks/useFeatureAccess';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useTheme from '@hooks/useTheme';
+import type {PremiumFeatureKey} from '@libs/Entitlements';
+import Navigation from '@libs/Navigation/Navigation';
+import variables from '@styles/variables';
+import ROUTES from '@src/ROUTES';
+import Icon from './Icon';
+import * as KirokuIcons from './Icon/KirokuIcons';
+import PlusBadge from './PlusBadge';
+import PressableWithoutFeedback from './Pressable/PressableWithoutFeedback';
+
+type FeatureGateMode = 'badge' | 'hide' | 'overlay';
+
+type FeatureGateProps = {
+  /** The registered premium feature whose access decides the rendering. */
+  feature: PremiumFeatureKey;
+
+  /**
+   * How to present a locked feature:
+   * - `badge` (default): render children with a trailing Plus badge.
+   * - `hide`: render nothing while locked.
+   * - `overlay`: dim children behind a lock + route to the paywall on press.
+   */
+  mode?: FeatureGateMode;
+
+  /** The feature content. */
+  children: React.ReactNode;
+};
+
+/**
+ * Declarative wrapper around `useFeatureAccess` for guarding a feature surface.
+ * Not in the build (`!isAvailable`) renders nothing. While the decision is
+ * still resolving, children render plainly (no badge/lock) so nothing flickers
+ * locked on cold boot.
+ */
+function FeatureGate({feature, mode = 'badge', children}: FeatureGateProps) {
+  const styles = useThemeStyles();
+  const theme = useTheme();
+  const {translate} = useLocalize();
+  const {isAvailable, isLocked, isResolving} = useFeatureAccess(feature);
+
+  if (!isAvailable) {
+    return null;
+  }
+
+  // Optimistically unlocked while resolving — never present the locked state
+  // until we have a definitive answer.
+  if (isResolving || !isLocked) {
+    if (mode === 'badge') {
+      return (
+        <View style={[styles.flexRow, styles.alignItemsCenter]}>
+          {children}
+          {!isResolving ? <PlusBadge locked={false} /> : null}
+        </View>
+      );
+    }
+    return children;
+  }
+
+  if (mode === 'hide') {
+    return null;
+  }
+
+  if (mode === 'overlay') {
+    return (
+      <PressableWithoutFeedback
+        accessibilityLabel={translate(
+          'premiumFeatures.upsellAccessibilityLabel',
+        )}
+        onPress={() => Navigation.navigate(ROUTES.SETTINGS_SUPPORT)}
+        style={[styles.flexRow, styles.alignItemsCenter]}>
+        <View style={[styles.flex1, styles.opacitySemiTransparent]}>
+          {children}
+        </View>
+        <View
+          style={[
+            styles.alignItemsCenter,
+            styles.justifyContentCenter,
+            styles.ml2,
+          ]}>
+          <Icon
+            src={KirokuIcons.Lock}
+            fill={theme.icon}
+            width={variables.iconSizeNormal}
+            height={variables.iconSizeNormal}
+          />
+        </View>
+      </PressableWithoutFeedback>
+    );
+  }
+
+  // Default 'badge' mode while locked: children + locked Plus badge.
+  return (
+    <View style={[styles.flexRow, styles.alignItemsCenter]}>
+      {children}
+      <PlusBadge locked />
+    </View>
+  );
+}
+
+FeatureGate.displayName = 'FeatureGate';
+
+export default FeatureGate;
+export type {FeatureGateMode, FeatureGateProps};

--- a/src/components/PlusBadge.tsx
+++ b/src/components/PlusBadge.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+import useLocalize from '@hooks/useLocalize';
+import SupporterUtils from '@libs/SupporterUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
+import Badge from './Badge';
+import * as KirokuIcons from './Icon/KirokuIcons';
+
+type PlusBadgeProps = {
+  /** When locked, shows a lock icon; otherwise a star. */
+  locked?: boolean;
+
+  /** Extra styles forwarded to the underlying badge. */
+  badgeStyles?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Small "Plus" pill marking a paid feature. Pressable — it routes to the
+ * Support Kiroku paywall so locked rows double as an upsell entry point.
+ *
+ * Renders `null` when premium gates are inactive (production until v1.1), so no
+ * Plus iconography ever ships while the gated features are free. Mirrors the
+ * return-null discipline of `SupporterBadge`.
+ */
+function PlusBadge({locked = false, badgeStyles}: PlusBadgeProps) {
+  const {translate} = useLocalize();
+
+  if (!SupporterUtils.arePremiumGatesActive()) {
+    return null;
+  }
+
+  return (
+    <Badge
+      pressable
+      text={translate('premiumFeatures.plusBadge')}
+      icon={locked ? KirokuIcons.Lock : KirokuIcons.Star}
+      badgeStyles={badgeStyles}
+      onPress={() => Navigation.navigate(ROUTES.SETTINGS_SUPPORT)}
+    />
+  );
+}
+
+PlusBadge.displayName = 'PlusBadge';
+
+export default PlusBadge;

--- a/src/components/TestToolsModal/index.tsx
+++ b/src/components/TestToolsModal/index.tsx
@@ -3,27 +3,52 @@ import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
 import Modal from '@components/Modal';
+import {PressableWithFeedback} from '@components/Pressable';
+import ScrollView from '@components/ScrollView';
+import Switch from '@components/Switch';
 import Text from '@components/Text';
 import useEnvironment from '@hooks/useEnvironment';
 import useLocalize from '@hooks/useLocalize';
+import useStyleUtils from '@hooks/useStyleUtils';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {getPremiumFeatureKeys} from '@libs/Entitlements';
+import type {FeatureOverride} from '@src/types/onyx/FeatureAccessOverrides';
+import * as FeatureAccess from '@userActions/FeatureAccess';
 import toggleTestToolsModal from '@userActions/TestTool';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
+// Auto = no override (resolver decides); the other two force the state.
+const OVERRIDE_OPTIONS: Array<{
+  key: 'auto' | FeatureOverride;
+  value: FeatureOverride | null;
+}> = [
+  {key: 'auto', value: null},
+  {key: 'locked', value: 'locked'},
+  {key: 'unlocked', value: 'unlocked'},
+];
+
 /**
  * Developer-only debug panel. Opened via the CustomDevMenu entry
- * (⌘D → Open Test Preferences) or by the four-finger tap gesture wired up
- * in ScreenWrapper. Today this is a placeholder — the action and Onyx flag
- * are real but the panel just explains what it's for. Real toggles (feature
- * flags, environment overrides, forced network states, etc.) can be added
- * directly to the View below.
+ * (⌘D → Open Test Preferences) or by the four-finger tap gesture wired up in
+ * ScreenWrapper. Hosts the premium-feature gating overrides ("Simulate Plus" +
+ * per-feature lock/unlock) so the locked/upsell paths are exercisable without a
+ * rebuild. Every write is no-op in production (see `@userActions/FeatureAccess`).
  */
 function TestToolsModal() {
   const styles = useThemeStyles();
+  const StyleUtils = useStyleUtils();
+  const theme = useTheme();
   const {translate} = useLocalize();
   const {environment} = useEnvironment();
   const [isVisible] = useOnyx(ONYXKEYS.IS_TEST_TOOLS_MODAL_OPEN);
+  const [overrides] = useOnyx(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, {
+    canBeMissing: true,
+  });
+
+  const accent = theme.appColor;
+  const featureKeys = getPremiumFeatureKeys();
 
   const handleClose = useCallback(() => {
     if (isVisible) {
@@ -36,16 +61,94 @@ function TestToolsModal() {
       isVisible={!!isVisible}
       type={CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
       onClose={handleClose}>
-      <View style={[styles.p5, styles.gap4]}>
+      <ScrollView contentContainerStyle={[styles.p5, styles.gap4]}>
         <Text style={styles.textHeadlineH1}>
           {translate('testTools.title')}
         </Text>
         <Text style={[styles.textNormal, styles.textSupporting]}>
           {translate('testTools.intro')}
         </Text>
-        <Text style={[styles.textNormal, styles.textSupporting]}>
-          {translate('testTools.placeholderNotice')}
-        </Text>
+
+        <View
+          style={[
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.justifyContentBetween,
+            styles.gap3,
+          ]}>
+          <View style={styles.flex1}>
+            <Text style={[styles.textNormal, styles.textStrong]}>
+              {translate('testTools.simulatePlus')}
+            </Text>
+            <Text style={[styles.textMicroSupporting, styles.mt1]}>
+              {translate('testTools.simulatePlusDescription')}
+            </Text>
+          </View>
+          <Switch
+            accessibilityLabel={translate('testTools.simulatePlus')}
+            isOn={overrides?.simulateSupporter === true}
+            onToggle={FeatureAccess.setSimulatedSupporter}
+          />
+        </View>
+
+        <View style={styles.gap2}>
+          <Text style={[styles.textNormal, styles.textStrong]}>
+            {translate('testTools.featureOverridesTitle')}
+          </Text>
+          {featureKeys.map(feature => {
+            const current = overrides?.features?.[feature] ?? null;
+            return (
+              <View key={feature} style={styles.gap1}>
+                <Text style={styles.textMicroSupporting}>{feature}</Text>
+                <View style={[styles.flexRow, styles.gap2]}>
+                  {OVERRIDE_OPTIONS.map(option => {
+                    const isActive = current === option.value;
+                    return (
+                      <PressableWithFeedback
+                        key={option.key}
+                        accessibilityLabel={translate(
+                          `testTools.override.${option.key}` as const,
+                        )}
+                        accessibilityState={{selected: isActive}}
+                        onPress={() =>
+                          FeatureAccess.setFeatureOverride(
+                            feature,
+                            option.value,
+                          )
+                        }
+                        style={[
+                          styles.flex1,
+                          styles.alignItemsCenter,
+                          styles.p2,
+                          StyleUtils.getColorAccentRowStyle(
+                            isActive ? accent : null,
+                          ),
+                        ]}>
+                        <Text
+                          style={[
+                            styles.textMicro,
+                            isActive
+                              ? StyleUtils.getColorStyle(accent)
+                              : styles.textSupporting,
+                          ]}>
+                          {translate(
+                            `testTools.override.${option.key}` as const,
+                          )}
+                        </Text>
+                      </PressableWithFeedback>
+                    );
+                  })}
+                </View>
+              </View>
+            );
+          })}
+          <Button
+            small
+            text={translate('testTools.resetOverrides')}
+            onPress={FeatureAccess.clearAllFeatureOverrides}
+          />
+        </View>
+
         <View style={styles.gap2}>
           <Text style={[styles.textNormal, styles.textSupporting]}>
             {`${translate('testTools.environmentLabel')}: ${environment}`}
@@ -60,7 +163,7 @@ function TestToolsModal() {
           text={translate('common.close')}
           onPress={handleClose}
         />
-      </View>
+      </ScrollView>
     </Modal>
   );
 }

--- a/src/hooks/useFeatureAccess.ts
+++ b/src/hooks/useFeatureAccess.ts
@@ -1,0 +1,46 @@
+import {useOnyx} from 'react-native-onyx';
+import {getFeatureAccess} from '@libs/Entitlements';
+import type {FeatureAccess, PremiumFeatureKey} from '@libs/Entitlements';
+import SupporterUtils from '@libs/SupporterUtils';
+import {getCurrentUserSupporterStatus} from '@libs/UserUtils';
+import CONFIG from '@src/CONFIG';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+/**
+ * Resolves a premium feature's access for the current user. Supplies the pure
+ * `getFeatureAccess` resolver with Onyx/CONFIG-derived context:
+ *
+ * - `isSupporter` from `USER_PRIVATE_DATA` (or the dev "Simulate Plus" override).
+ * - `isSupporterStatusLoading` from the Onyx `{status}` metadata so a Plus
+ *   feature never flashes locked while private data hydrates on cold boot.
+ * - `devOverride` from `FEATURE_ACCESS_OVERRIDES`, but ONLY outside production
+ *   (the action layer also refuses to write it in prod — two layers).
+ */
+function useFeatureAccess(feature: PremiumFeatureKey): FeatureAccess {
+  const [privateData, privateDataMetadata] = useOnyx(
+    ONYXKEYS.USER_PRIVATE_DATA,
+    {canBeMissing: true},
+  );
+  const [overrides] = useOnyx(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, {
+    canBeMissing: true,
+  });
+
+  const overridesActive = !CONFIG.IS_IN_PRODUCTION;
+  const simulateSupporter =
+    overridesActive && overrides?.simulateSupporter === true;
+  const isSupporter =
+    getCurrentUserSupporterStatus(privateData).is_supporter ||
+    simulateSupporter;
+  const devOverride = overridesActive
+    ? overrides?.features?.[feature]
+    : undefined;
+
+  return getFeatureAccess(feature, {
+    isSupporter,
+    isSupporterStatusLoading: privateDataMetadata.status === 'loading',
+    devOverride,
+    gatesActive: SupporterUtils.arePremiumGatesActive(),
+  });
+}
+
+export default useFeatureAccess;

--- a/src/hooks/useFeatureAccessGuard.ts
+++ b/src/hooks/useFeatureAccessGuard.ts
@@ -1,0 +1,34 @@
+import {useEffect} from 'react';
+import type {FeatureAccess, PremiumFeatureKey} from '@libs/Entitlements';
+import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
+import type {Route} from '@src/ROUTES';
+import useFeatureAccess from './useFeatureAccess';
+
+/**
+ * Route-level guard for a premium feature. Redirects away ONLY once the
+ * decision has resolved AND the feature is locked (`!isResolving && isLocked`),
+ * so a deep link or stale navigation state can't reach a Plus-only screen, yet
+ * the screen never bounces while supporter status is still hydrating.
+ *
+ * Returns the access object so the screen can render a spinner while
+ * `isResolving` and an empty body while `isLocked` (the redirect is in flight),
+ * mirroring the defense-in-depth pattern in `SupportKirokuScreen`.
+ */
+function useFeatureAccessGuard(
+  feature: PremiumFeatureKey,
+  fallbackRoute: Route = ROUTES.SETTINGS_COLOR_PALETTE,
+): FeatureAccess {
+  const access = useFeatureAccess(feature);
+  const shouldRedirect = !access.isResolving && access.isLocked;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      Navigation.goBack(fallbackRoute);
+    }
+  }, [shouldRedirect, fallbackRoute]);
+
+  return access;
+}
+
+export default useFeatureAccessGuard;

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -887,6 +887,10 @@ export default {
         'Vaše předplatné podporovatele vypršelo. Předplatné si můžete obnovit na obrazovce Podpořit Kiroku.',
     },
   },
+  premiumFeatures: {
+    plusBadge: 'Plus',
+    upsellAccessibilityLabel: 'Funkce Kiroku Plus. Klepnutím se dozvíte více.',
+  },
   accountScreen: {
     title: 'Detaily profilu',
     generalOptions: {
@@ -1497,6 +1501,16 @@ export default {
     intro: 'Vývojářský panel pro úpravy za běhu a ladění.',
     placeholderNotice:
       'Toto je zástupný panel. Skutečné přepínače (feature flagy, přepsání prostředí, vynucené stavy sítě) sem postupně přibudou.',
+    simulatePlus: 'Simulovat Plus',
+    simulatePlusDescription:
+      'Považovat tento účet za podporovatele Kiroku Plus, aby se uzamčené funkce odemkly.',
+    featureOverridesTitle: 'Přepsání prémiových funkcí',
+    override: {
+      auto: 'Auto',
+      locked: 'Zamčeno',
+      unlocked: 'Odemčeno',
+    },
+    resetOverrides: 'Resetovat přepsání',
     environmentLabel: 'Prostředí',
     howToOpen:
       'Otevřete přes ⌘D → Open Test Preferences nebo čtyřprstovým ťuknutím kdekoli v aplikaci.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -881,6 +881,10 @@ export default {
         'Your supporter subscription has expired. Subscribe again from the Support Kiroku screen.',
     },
   },
+  premiumFeatures: {
+    plusBadge: 'Plus',
+    upsellAccessibilityLabel: 'Kiroku Plus feature. Tap to learn more.',
+  },
   accountScreen: {
     title: 'Profile Details',
     generalOptions: {
@@ -1496,6 +1500,16 @@ export default {
     intro: 'Developer-only panel for runtime tweaks and debugging.',
     placeholderNotice:
       'This is a placeholder. Real toggles (feature flags, environment overrides, forced network states) will land here over time.',
+    simulatePlus: 'Simulate Plus',
+    simulatePlusDescription:
+      'Treat this account as a Kiroku Plus supporter so gated features unlock.',
+    featureOverridesTitle: 'Premium feature overrides',
+    override: {
+      auto: 'Auto',
+      locked: 'Locked',
+      unlocked: 'Unlocked',
+    },
+    resetOverrides: 'Reset overrides',
     environmentLabel: 'Environment',
     howToOpen:
       'Open via ⌘D → Open Test Preferences, or a four-finger tap anywhere in the app.',

--- a/src/libs/Entitlements.ts
+++ b/src/libs/Entitlements.ts
@@ -1,0 +1,169 @@
+import CONST from '@src/CONST';
+import * as FeatureFlags from './FeatureFlags';
+import type {FeatureFlag} from './FeatureFlags';
+
+/**
+ * Pure entitlement resolver for premium-feature gating. Side-effect free (no
+ * React, no Onyx, no CONFIG) so the full decision matrix is unit-testable. The
+ * `useFeatureAccess` hook supplies the Onyx/CONFIG-derived context.
+ */
+
+/** Subscription tier a feature is classified under. */
+type Tier = 'free' | 'plus';
+
+/** A registered premium feature, e.g. `'CUSTOM_COLOR_PALETTE'`. */
+type PremiumFeatureKey = keyof typeof CONST.PREMIUM_FEATURES;
+
+/** Shape of a single `CONST.PREMIUM_FEATURES` entry. */
+type PremiumFeatureConfig = {
+  /** The tier this feature requires. */
+  tier: Tier;
+
+  /** Optional `CONST.FEATURES` flag; when off, the feature is not in the build. */
+  availabilityFlag?: FeatureFlag;
+};
+
+/** Forced override applied in non-production builds via the Test Tools panel. */
+type DevOverride = 'locked' | 'unlocked';
+
+/** Onyx/CONFIG-derived inputs the hook threads into the resolver. */
+type FeatureAccessContext = {
+  /** Whether the user holds an active (or grace-period) supporter entitlement. */
+  isSupporter: boolean;
+
+  /** Whether supporter status is still hydrating — never lock while true. */
+  isSupporterStatusLoading: boolean;
+
+  /** Dev-only forced lock/unlock; callers only pass this in non-prod. */
+  devOverride?: DevOverride;
+
+  /** Whether premium gates enforce entitlement in this build. */
+  gatesActive: boolean;
+};
+
+/** The resolved access decision for a feature. */
+type FeatureAccess = {
+  /** Whether the feature exists in this build at all (availability flag). */
+  isAvailable: boolean;
+
+  /** Whether the feature is currently locked behind the paywall. */
+  isLocked: boolean;
+
+  /** Whether this is a paid feature (drives Plus badge / upsell affordances). */
+  requiresPlus: boolean;
+
+  /** The feature's configured tier. */
+  tier: Tier;
+
+  /** Whether the decision is still pending (supporter status hydrating). */
+  isResolving: boolean;
+};
+
+function getPremiumFeatureConfig(
+  feature: PremiumFeatureKey,
+): PremiumFeatureConfig {
+  return CONST.PREMIUM_FEATURES[feature];
+}
+
+/**
+ * Resolve a feature's access from its registry config + the supplied context.
+ *
+ * Evaluation order (first match wins):
+ *  1. Availability flag off  → not in build (unavailable). Beats everything.
+ *  2. Dev override present   → honor it (non-prod only; caller enforces that).
+ *  3. Free tier              → always unlocked.
+ *  4. Plus tier, gates off   → unlocked placeholder (ships free; still "plus").
+ *  5. Plus tier, gates on, status loading → unlocked + resolving (no flicker).
+ *  6. Plus tier, gates on, loaded → locked iff not a supporter.
+ */
+function getFeatureAccess(
+  feature: PremiumFeatureKey,
+  context: FeatureAccessContext,
+): FeatureAccess {
+  const {isSupporter, isSupporterStatusLoading, devOverride, gatesActive} =
+    context;
+  const config = getPremiumFeatureConfig(feature);
+  const requiresPlus = config.tier === 'plus';
+
+  // 1. Not in this build — overrides every gate, including the dev override.
+  if (
+    config.availabilityFlag &&
+    !FeatureFlags.isEnabled(config.availabilityFlag)
+  ) {
+    return {
+      isAvailable: false,
+      isLocked: false,
+      requiresPlus: false,
+      tier: config.tier,
+      isResolving: false,
+    };
+  }
+
+  // 2. Dev override (non-prod only; the hook strips it in production).
+  if (devOverride === 'unlocked' || devOverride === 'locked') {
+    return {
+      isAvailable: true,
+      isLocked: devOverride === 'locked',
+      requiresPlus,
+      tier: config.tier,
+      isResolving: false,
+    };
+  }
+
+  // 3. Free features are always unlocked.
+  if (config.tier === 'free') {
+    return {
+      isAvailable: true,
+      isLocked: false,
+      requiresPlus: false,
+      tier: 'free',
+      isResolving: false,
+    };
+  }
+
+  // 4. Plus feature, gates inactive → unlocked placeholder (ships free).
+  if (!gatesActive) {
+    return {
+      isAvailable: true,
+      isLocked: false,
+      requiresPlus: true,
+      tier: 'plus',
+      isResolving: false,
+    };
+  }
+
+  // 5. Plus feature, gates active, supporter status still hydrating.
+  if (isSupporterStatusLoading) {
+    return {
+      isAvailable: true,
+      isLocked: false,
+      requiresPlus: true,
+      tier: 'plus',
+      isResolving: true,
+    };
+  }
+
+  // 6. Plus feature, gates active, status loaded.
+  return {
+    isAvailable: true,
+    isLocked: !isSupporter,
+    requiresPlus: true,
+    tier: 'plus',
+    isResolving: false,
+  };
+}
+
+/** All registered premium-feature keys (stable order for dev tooling). */
+function getPremiumFeatureKeys(): PremiumFeatureKey[] {
+  return Object.keys(CONST.PREMIUM_FEATURES) as PremiumFeatureKey[];
+}
+
+export {getFeatureAccess, getPremiumFeatureKeys};
+export type {
+  Tier,
+  PremiumFeatureKey,
+  PremiumFeatureConfig,
+  DevOverride,
+  FeatureAccessContext,
+  FeatureAccess,
+};

--- a/src/libs/SupporterUtils.ts
+++ b/src/libs/SupporterUtils.ts
@@ -19,6 +19,23 @@ function isSupporterTierVisible(): boolean {
 }
 
 /**
+ * Whether premium-feature gates ENFORCE entitlement in this build.
+ *
+ * When inactive, every `plus`-tier feature is an unlocked placeholder (it ships
+ * free), so the gating layer is invisible. When active, `plus` features lock for
+ * non-supporters and surface the upsell path.
+ *
+ * Deliberately a separate predicate from `isSupporterTierVisible` even though
+ * both return `!CONFIG.IS_IN_PRODUCTION` today: a staged v1.1 rollout can make
+ * the paywall visible (visibility) before flipping enforcement on (gates), or
+ * vice versa. When that day comes this is the single, well-commented edit — e.g.
+ * `return CONFIG.PREMIUM_GATES_ACTIVE;` behind a dedicated env flag.
+ */
+function arePremiumGatesActive(): boolean {
+  return isSupporterTierVisible();
+}
+
+/**
  * Formats an ISO date string (e.g. a RevenueCat `expirationDate`) into a
  * locale-aware short date. Returns an empty string for missing or unparseable
  * input so callers can treat "no date" and "bad date" identically.
@@ -34,4 +51,8 @@ function formatSupporterDate(iso: string | null | undefined): string {
   return parsed.toLocaleDateString();
 }
 
-export default {isSupporterTierVisible, formatSupporterDate};
+export default {
+  isSupporterTierVisible,
+  arePremiumGatesActive,
+  formatSupporterDate,
+};

--- a/src/libs/actions/FeatureAccess.ts
+++ b/src/libs/actions/FeatureAccess.ts
@@ -1,0 +1,54 @@
+import Onyx from 'react-native-onyx';
+import CONFIG from '@src/CONFIG';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {PremiumFeatureKey} from '@libs/Entitlements';
+import type {FeatureOverride} from '@src/types/onyx/FeatureAccessOverrides';
+
+/**
+ * Developer-only writes for the premium-feature gating overrides surfaced in the
+ * Test Tools panel. Every write is guarded by `!CONFIG.IS_IN_PRODUCTION` so
+ * production can never be influenced even if a caller forgets to gate — this is
+ * the inner of the two layers (the hook also strips overrides in production).
+ */
+
+function isOverrideWriteAllowed(): boolean {
+  return !CONFIG.IS_IN_PRODUCTION;
+}
+
+/**
+ * Force a single feature locked/unlocked, or clear its override (pass `null`).
+ * No-op in production.
+ */
+function setFeatureOverride(
+  feature: PremiumFeatureKey,
+  state: FeatureOverride | null,
+): void {
+  if (!isOverrideWriteAllowed()) {
+    return;
+  }
+  // Onyx.merge drops keys set to `null`, so clearing an override removes the
+  // entry rather than persisting a null.
+  Onyx.merge(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, {
+    features: {[feature]: state},
+  });
+}
+
+/** Toggle simulated supporter status. No-op in production. */
+function setSimulatedSupporter(isSupporter: boolean): void {
+  if (!isOverrideWriteAllowed()) {
+    return;
+  }
+  Onyx.merge(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, {
+    simulateSupporter: isSupporter,
+  });
+}
+
+/** Wipe every override back to auto. No-op in production. */
+function clearAllFeatureOverrides(): void {
+  if (!isOverrideWriteAllowed()) {
+    return;
+  }
+  Onyx.set(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, null);
+}
+
+export {setFeatureOverride, setSimulatedSupporter, clearAllFeatureOverrides};

--- a/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/ColorPaletteScreen.tsx
@@ -14,6 +14,8 @@ import Text from '@components/Text';
 import {PressableWithFeedback} from '@components/Pressable';
 import Icon from '@components/Icon';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import PlusBadge from '@components/PlusBadge';
+import useFeatureAccess from '@hooks/useFeatureAccess';
 import * as Preferences from '@userActions/Preferences';
 import type {SessionColorPalette} from '@src/types/onyx';
 import type {PaletteId} from '@libs/SessionColorPalettes';
@@ -41,6 +43,7 @@ function ColorPaletteScreen() {
   const theme = useTheme();
   const {translate} = useLocalize();
   const preferences = useCurrentUserPreferences();
+  const customAccess = useFeatureAccess('CUSTOM_COLOR_PALETTE');
   const [pendingSelection, setPendingSelection] = useState<
     PaletteId | 'custom' | null
   >(null);
@@ -130,6 +133,16 @@ function ColorPaletteScreen() {
       .finally(() => setSaving(false));
   };
 
+  // Locked (Plus-gated, non-supporter) users are routed to the paywall; everyone
+  // else opens the editor. Used by every entry point into the custom feature.
+  const onOpenCustom = () => {
+    Navigation.navigate(
+      customAccess.isLocked
+        ? ROUTES.SETTINGS_SUPPORT
+        : ROUTES.SETTINGS_COLOR_PALETTE_CUSTOM,
+    );
+  };
+
   const persistedUseOwnForOthers =
     preferences?.use_own_palette_for_others === true;
   const displayUseOwnForOthers =
@@ -150,6 +163,156 @@ function ColorPaletteScreen() {
         Alert.alert(translate('preferencesScreen.error.save'), errorMessage);
       })
       .finally(() => setSavingUseOwnForOthers(false));
+  };
+
+  // The "Custom" entry. Three shapes: a locked upsell row (Plus-gated,
+  // non-supporter), a split select/edit row once a custom palette is saved, or
+  // a plain "create your own" row for first-time users. A trailing Plus badge
+  // marks it as a premium feature when gates are active (it renders null
+  // otherwise, so the row reads as free in production).
+  const renderCustomRow = () => {
+    if (customAccess.isLocked) {
+      return (
+        <PressableWithFeedback
+          accessibilityLabel={translate('colorPaletteScreen.custom.label')}
+          onPress={onOpenCustom}
+          style={[
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.justifyContentBetween,
+            styles.p4,
+            styles.mb2,
+            StyleUtils.getColorAccentRowStyle(null),
+          ]}>
+          <View style={[styles.flexColumn, styles.flex1]}>
+            <Text style={[styles.textNormal, styles.textStrong]}>
+              {translate('colorPaletteScreen.custom.label')}
+            </Text>
+            <Text style={[styles.textMicroSupporting, styles.mt1]}>
+              {translate('colorPaletteScreen.custom.description')}
+            </Text>
+          </View>
+          <PlusBadge locked />
+        </PressableWithFeedback>
+      );
+    }
+
+    if (customPalette) {
+      // Split the row so the main area selects it (like the presets) and the
+      // trailing button opens the editor.
+      return (
+        <View
+          style={[
+            styles.flexRow,
+            styles.mb2,
+            styles.overflowHidden,
+            StyleUtils.getColorAccentRowStyle(isCustomSelected ? accent : null),
+          ]}>
+          <PressableWithFeedback
+            accessibilityLabel={translate('colorPaletteScreen.custom.select')}
+            accessibilityState={{selected: isCustomSelected}}
+            onPress={onSelectCustom}
+            wrapperStyle={styles.flex1}
+            style={[
+              styles.flex1,
+              styles.flexRow,
+              styles.alignItemsCenter,
+              styles.justifyContentBetween,
+              styles.p4,
+            ]}>
+            <View style={[styles.flexColumn, styles.flex1]}>
+              <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                <Text style={[styles.textNormal, styles.textStrong]}>
+                  {translate('colorPaletteScreen.custom.label')}
+                </Text>
+                <PlusBadge locked={false} />
+              </View>
+              <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                {translate('colorPaletteScreen.custom.description')}
+              </Text>
+              <View style={[styles.flexRow, styles.mt2]}>
+                {PREVIEW_KEYS.map(key => (
+                  <View
+                    key={key}
+                    style={[
+                      styles.palettePreviewSwatch,
+                      StyleUtils.getBackgroundColorStyle(customPalette[key]),
+                      StyleUtils.getDerivedSwatchBorderStyle(
+                        customPalette[key],
+                      ),
+                    ]}
+                  />
+                ))}
+              </View>
+            </View>
+            {isCustomSelected ? (
+              <Icon
+                src={KirokuIcons.Checkmark}
+                fill={accent}
+                width={20}
+                height={20}
+              />
+            ) : null}
+          </PressableWithFeedback>
+          <PressableWithFeedback
+            accessibilityLabel={translate('colorPaletteScreen.custom.edit')}
+            role="button"
+            onPress={onOpenCustom}
+            wrapperStyle={styles.alignSelfStretch}
+            style={[
+              styles.flex1,
+              styles.alignItemsCenter,
+              styles.justifyContentCenter,
+              styles.colorPaletteEditButton,
+            ]}>
+            <Icon
+              src={KirokuIcons.Edit}
+              fill={theme.icon}
+              width={20}
+              height={20}
+            />
+          </PressableWithFeedback>
+        </View>
+      );
+    }
+
+    // First-time users: no palette to select yet, so the whole row navigates to
+    // the editor to create one.
+    return (
+      <PressableWithFeedback
+        accessibilityLabel={translate('colorPaletteScreen.custom.label')}
+        onPress={onOpenCustom}
+        style={[
+          styles.flexRow,
+          styles.alignItemsCenter,
+          styles.justifyContentBetween,
+          styles.p4,
+          styles.mb2,
+          StyleUtils.getColorAccentRowStyle(null),
+        ]}>
+        <View style={[styles.flexColumn, styles.flex1]}>
+          <View style={[styles.flexRow, styles.alignItemsCenter]}>
+            <Text style={[styles.textNormal, styles.textStrong]}>
+              {translate('colorPaletteScreen.custom.label')}
+            </Text>
+            <PlusBadge locked={false} />
+          </View>
+          <Text style={[styles.textMicroSupporting, styles.mt1]}>
+            {translate('colorPaletteScreen.custom.description')}
+          </Text>
+          <Text style={[styles.textMicroSupporting, styles.mt2]}>
+            {translate('colorPaletteScreen.custom.createYourOwn')}
+          </Text>
+        </View>
+        <Icon
+          src={KirokuIcons.ArrowRight}
+          fill={theme.icon}
+          width={20}
+          height={20}
+          additionalStyles={[styles.ml2]}
+        />
+      </PressableWithFeedback>
+    );
   };
 
   return (
@@ -255,126 +418,7 @@ function ColorPaletteScreen() {
                 </PressableWithFeedback>
               );
             })}
-            {customPalette ? (
-              // Saved custom palette: split the row so the main area selects it
-              // (like the presets) and the trailing button opens the editor.
-              <View
-                style={[
-                  styles.flexRow,
-                  styles.mb2,
-                  styles.overflowHidden,
-                  StyleUtils.getColorAccentRowStyle(
-                    isCustomSelected ? accent : null,
-                  ),
-                ]}>
-                <PressableWithFeedback
-                  accessibilityLabel={translate(
-                    'colorPaletteScreen.custom.select',
-                  )}
-                  accessibilityState={{selected: isCustomSelected}}
-                  onPress={onSelectCustom}
-                  wrapperStyle={styles.flex1}
-                  style={[
-                    styles.flex1,
-                    styles.flexRow,
-                    styles.alignItemsCenter,
-                    styles.justifyContentBetween,
-                    styles.p4,
-                  ]}>
-                  <View style={[styles.flexColumn, styles.flex1]}>
-                    <Text style={[styles.textNormal, styles.textStrong]}>
-                      {translate('colorPaletteScreen.custom.label')}
-                    </Text>
-                    <Text style={[styles.textMicroSupporting, styles.mt1]}>
-                      {translate('colorPaletteScreen.custom.description')}
-                    </Text>
-                    <View style={[styles.flexRow, styles.mt2]}>
-                      {PREVIEW_KEYS.map(key => (
-                        <View
-                          key={key}
-                          style={[
-                            styles.palettePreviewSwatch,
-                            StyleUtils.getBackgroundColorStyle(
-                              customPalette[key],
-                            ),
-                            StyleUtils.getDerivedSwatchBorderStyle(
-                              customPalette[key],
-                            ),
-                          ]}
-                        />
-                      ))}
-                    </View>
-                  </View>
-                  {isCustomSelected ? (
-                    <Icon
-                      src={KirokuIcons.Checkmark}
-                      fill={accent}
-                      width={20}
-                      height={20}
-                    />
-                  ) : null}
-                </PressableWithFeedback>
-                <PressableWithFeedback
-                  accessibilityLabel={translate(
-                    'colorPaletteScreen.custom.edit',
-                  )}
-                  role="button"
-                  onPress={() =>
-                    Navigation.navigate(ROUTES.SETTINGS_COLOR_PALETTE_CUSTOM)
-                  }
-                  wrapperStyle={styles.alignSelfStretch}
-                  style={[
-                    styles.flex1,
-                    styles.alignItemsCenter,
-                    styles.justifyContentCenter,
-                    styles.colorPaletteEditButton,
-                  ]}>
-                  <Icon
-                    src={KirokuIcons.Edit}
-                    fill={theme.icon}
-                    width={20}
-                    height={20}
-                  />
-                </PressableWithFeedback>
-              </View>
-            ) : (
-              // First-time users: no palette to select yet, so the whole row
-              // navigates to the editor to create one.
-              <PressableWithFeedback
-                accessibilityLabel={translate(
-                  'colorPaletteScreen.custom.label',
-                )}
-                onPress={() =>
-                  Navigation.navigate(ROUTES.SETTINGS_COLOR_PALETTE_CUSTOM)
-                }
-                style={[
-                  styles.flexRow,
-                  styles.alignItemsCenter,
-                  styles.justifyContentBetween,
-                  styles.p4,
-                  styles.mb2,
-                  StyleUtils.getColorAccentRowStyle(null),
-                ]}>
-                <View style={[styles.flexColumn, styles.flex1]}>
-                  <Text style={[styles.textNormal, styles.textStrong]}>
-                    {translate('colorPaletteScreen.custom.label')}
-                  </Text>
-                  <Text style={[styles.textMicroSupporting, styles.mt1]}>
-                    {translate('colorPaletteScreen.custom.description')}
-                  </Text>
-                  <Text style={[styles.textMicroSupporting, styles.mt2]}>
-                    {translate('colorPaletteScreen.custom.createYourOwn')}
-                  </Text>
-                </View>
-                <Icon
-                  src={KirokuIcons.ArrowRight}
-                  fill={theme.icon}
-                  width={20}
-                  height={20}
-                  additionalStyles={[styles.ml2]}
-                />
-              </PressableWithFeedback>
-            )}
+            {customAccess.isAvailable ? renderCustomRow() : null}
           </View>
         </View>
       </ScrollView>

--- a/src/screens/Settings/Preferences/CustomColorPaletteScreen.tsx
+++ b/src/screens/Settings/Preferences/CustomColorPaletteScreen.tsx
@@ -4,6 +4,8 @@ import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import Navigation from '@libs/Navigation/Navigation';
 import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import useFeatureAccessGuard from '@hooks/useFeatureAccessGuard';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -34,6 +36,10 @@ function CustomColorPaletteScreen() {
   const theme = useTheme();
   const {translate} = useLocalize();
   const preferences = useCurrentUserPreferences();
+
+  // Premium gate: redirects to the palette list once we know the feature is
+  // locked, and lets us avoid flashing the editor to a locked user.
+  const access = useFeatureAccessGuard('CUSTOM_COLOR_PALETTE');
 
   // Seed from the saved custom slot when present, otherwise from the active
   // palette so the user starts from whatever they already see.
@@ -71,6 +77,27 @@ function CustomColorPaletteScreen() {
       })
       .finally(() => setSaving(false));
   }, [draft, translate]);
+
+  // While supporter status hydrates, show a spinner rather than the editor so a
+  // locked user never glimpses the picker before the guard redirects.
+  if (access.isResolving) {
+    return (
+      <ScreenWrapper testID={CustomColorPaletteScreen.displayName}>
+        <HeaderWithBackButton
+          title={translate('colorPaletteScreen.editor.title')}
+          shouldShowBackButton
+          onBackButtonPress={() => Navigation.goBack()}
+          onCloseButtonPress={() => Navigation.dismissModal()}
+        />
+        <FullScreenLoadingIndicator />
+      </ScreenWrapper>
+    );
+  }
+
+  // Locked: the guard's effect is redirecting; render nothing in the meantime.
+  if (access.isLocked) {
+    return null;
+  }
 
   return (
     <ScreenWrapper testID={CustomColorPaletteScreen.displayName}>

--- a/src/types/onyx/FeatureAccessOverrides.ts
+++ b/src/types/onyx/FeatureAccessOverrides.ts
@@ -1,0 +1,19 @@
+/** Dev-only forced lock/unlock for a single premium feature. */
+type FeatureOverride = 'locked' | 'unlocked';
+
+/**
+ * Developer-only entitlement overrides set from the Test Tools panel. NEVER
+ * read or written in production — `CONFIG.IS_IN_PRODUCTION` gates both the
+ * action writes and the hook reads (two layers) — so these only influence
+ * dev/staging/adhoc builds.
+ */
+type FeatureAccessOverrides = {
+  /** Per-feature forced state, keyed by a `CONST.PREMIUM_FEATURES` key. */
+  features?: Partial<Record<string, FeatureOverride>>;
+
+  /** When true, the current user reads as a Kiroku Plus supporter. */
+  simulateSupporter?: boolean;
+};
+
+export default FeatureAccessOverrides;
+export type {FeatureOverride};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -8,6 +8,8 @@ import type DataVisibility from './DataVisibility';
 import type DatabaseProps from './DatabaseProps';
 import type Download from './Download';
 import type DrinkingSession from './DrinkingSession';
+import type FeatureAccessOverrides from './FeatureAccessOverrides';
+import type {FeatureOverride} from './FeatureAccessOverrides';
 import type {
   DrinkingSessionId,
   DrinkingSessionArray,
@@ -102,6 +104,8 @@ export type {
   DrinksList,
   DrinksTimestamp,
   DrinksToUnits,
+  FeatureAccessOverrides,
+  FeatureOverride,
   Feedback,
   FeedbackId,
   FeedbackList,


### PR DESCRIPTION
## What & why

Adds a **reusable premium-feature gating framework** and wires the already-shipped custom session color palette (PR #1327) through it as the **first gated feature**.

The framework is built *ahead* of the paywall so future paid features just register and wrap. It is **inactive in production** (every gated feature ships free at launch → zero App Store risk, matching the v1.1 supporter-tier rollout) yet **active in dev/staging** so the locked/upsell path is exercisable now. Flipping to Plus-gated at v1.1 is a one-line, well-commented switch.

The custom palette continues to **ship free at launch** (prod gates off ⇒ no Plus badge, unlocked).

## Part A — gating framework

- **`CONST.PREMIUM_FEATURES`** registry (`{tier, availabilityFlag?}`), sibling to `CONST.FEATURES`. `CUSTOM_COLOR_PALETTE` is a `plus` feature.
- **`SupporterUtils.arePremiumGatesActive()`** — entitlement-enforcement predicate, deliberately separate from `isSupporterTierVisible()` (visibility) so a staged v1.1 can split the two. Both return `!IS_IN_PRODUCTION` today.
- **`libs/Entitlements.ts`** — pure, fully unit-tested `getFeatureAccess()` resolver (no React/Onyx/CONFIG). Order: availability-flag (beats everything, incl. dev override) → dev override → free → plus+gates-off (unlocked placeholder) → plus+gates-on+loading (`isResolving`, never locked) → plus+gates-on+loaded (locked iff not a supporter).
- **Hooks** `useFeatureAccess` / `useFeatureAccessGuard` (redirects only on `!isResolving && isLocked`).
- **UI** `PlusBadge` (renders `null` when gates inactive — no Plus iconography in prod) + `FeatureGate` (badge/hide/overlay).
- **Dev override** `FEATURE_ACCESS_OVERRIDES` Onyx key + `actions/FeatureAccess.ts` + Test Tools panel ("Simulate Plus" + per-feature lock/unlock). Reads **and** writes both gated behind `!IS_IN_PRODUCTION` (two layers).

### No cold-boot lock flicker
`useOnyx`'s `{status}` metadata is threaded into the resolver as `isSupporterStatusLoading`; while loading the resolver returns `isLocked:false, isResolving:true` (optimistically unlocked). Covered by the resolver matrix test.

## Part B — custom palette wiring

- Gated **"Custom" row** in `ColorPaletteScreen`: locked ⇒ a single upsell row (lock + Plus badge) routing to the Support Kiroku paywall; unlocked ⇒ existing select/edit behavior plus a Plus badge (gates-active only).
- `useFeatureAccessGuard('CUSTOM_COLOR_PALETTE')` in `CustomColorPaletteScreen` with an `isResolving` spinner and an `isLocked` early-return, so the editor never flashes to a locked user.

## Part D — localization & tests

- English keys (`premiumFeatures.*`, `testTools.*`); Czech filled via the `translate` skill (parity test green).
- `__tests__/unit/Entitlements.test.ts` — full resolver matrix (tier × gates × supporter × override × loading × availability-flag).
- Existing `Color.test.ts` already covers the color math.

## Verification

Post-edit checklist (changed files): ✅ prettier · ✅ `lint.sh` (seatbelt) · ✅ `typecheck-tsgo` · ✅ `react-compiler-compliance-check check-changed` · ✅ unit tests (Entitlements 13, Color 19, Translate 10, SupporterUtils, TranslationContext).

Web preview (`npm run web`, dev = gates active), confirmed end-to-end:
1. Custom row renders **locked** with a "Plus" lock badge.
2. Tapping it opens the **Support Kiroku paywall**.
3. With "Simulate Plus" on, the row is **unlocked** (star Plus badge) and opens the **editor** (no redirect).
4. Editor SVG saturation/value square + hue slider render; **dragging recolors the band live** in the week preview.

## Backend (kiroku-api) — already merged & released

Part C is **already done**, not pending: kiroku-api commit `5b23ce1` *feat(preferences): accept custom_session_color_palette with hex validation* adds the field to `OBJECT_PREF_KEYS` and validates both palette fields via `isValidSessionPalette` (all five bands + per-band `#RGB`/`#RRGGBB` hex), with tests. Shipped in kiroku-api `0.8.0` (master is now `0.9.0`). The app persists the active palette via `session_color_palette` and degrades gracefully if any environment hasn't deployed the field yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
