### PR TITLE
fix(api): swallow read-path rejections so non-2xx reads can't escape unhandled

### DIFF
--- a/__tests__/unit/ApiReadRejection.test.ts
+++ b/__tests__/unit/ApiReadRejection.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/no-api-side-effects-method -- this test exercises makeRequestWithSideEffects directly */
+/* eslint-disable rulesdir/no-api-in-views -- this test drives the mocked API layer directly, it is not a view */
+/* eslint-disable rulesdir/no-multiple-api-calls -- each test case intentionally issues its own isolated API call */
+
+import * as API from '@libs/API';
+import {READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS} from '@libs/API/types';
+import HttpsError from '@libs/Errors/HttpsError';
+import Log from '@libs/Log';
+import * as SequentialQueue from '@libs/Network/SequentialQueue';
+import * as Request from '@libs/Request';
+import CONST from '@src/CONST';
+
+// Stub Onyx so importing @libs/API doesn't start real Onyx.connect timers, which
+// otherwise fire after the jest environment is torn down.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+// Log schedules a periodic flush timer at import that fires after teardown.
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    alert: jest.fn(),
+    hmmm: jest.fn(),
+  },
+}));
+
+// The middleware values are only forwarded to the mocked `Request.use`, so their
+// shape is irrelevant — stub them to keep the heavy real middleware out of the run.
+jest.mock('@libs/Middleware', () => ({
+  Logging: 'Logging',
+  RecheckConnection: 'RecheckConnection',
+  Reauthentication: 'Reauthentication',
+  SaveResponseInOnyx: 'SaveResponseInOnyx',
+}));
+
+// `Request.processWithMiddleware` is the seam we drive: it resolves/rejects to
+// simulate the HTTP layer (`HttpUtils` rejects with an `HttpsError` on a non-2xx).
+jest.mock('@libs/Request', () => ({
+  use: jest.fn(),
+  processWithMiddleware: jest.fn(),
+}));
+
+jest.mock('@libs/Network/SequentialQueue', () => ({
+  waitForIdle: jest.fn(() => Promise.resolve()),
+  push: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@libs/Network/NetworkStore', () => ({
+  isOffline: jest.fn(() => false),
+}));
+
+jest.mock('@libs/Pusher/pusher', () => ({
+  getPusherSocketID: jest.fn(() => undefined),
+}));
+
+jest.mock('@userActions/PersistedRequests', () => ({
+  getAll: jest.fn(() => []),
+}));
+
+const mockedProcess = jest.mocked(Request.processWithMiddleware);
+const mockedWaitForIdle = jest.mocked(SequentialQueue.waitForIdle);
+const mockedLogInfo = jest.mocked(Log.info);
+
+const SWALLOW_MESSAGE = '[API] Swallowed rejected read request';
+
+/** Flush the microtask queue so fire-and-forget read chains settle. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- intentional sequential microtask flush
+    await Promise.resolve();
+  }
+}
+
+describe('API read-path rejection handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedWaitForIdle.mockReturnValue(Promise.resolve());
+  });
+
+  it('makeRequestWithSideEffects RESOLVES (never rejects) when a READ-type request fails with a non-2xx', async () => {
+    mockedProcess.mockImplementation(() =>
+      Promise.reject(new HttpsError({message: 'Unauthorized', status: '401'})),
+    );
+
+    // Without the read-path catch this would reject and escape as an unhandled
+    // promise rejection (the web dev-server red overlay seen during #781 QA).
+    await expect(
+      API.makeRequestWithSideEffects(
+        READ_COMMANDS.OPEN_FRIEND_LIST,
+        {userID: 'user-1'},
+        {},
+        CONST.API_REQUEST_TYPE.READ,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Swallowed, but still traced (the Logging middleware logged the details;
+    // this is the "handled, not silent" marker).
+    expect(mockedLogInfo).toHaveBeenCalledWith(
+      SWALLOW_MESSAGE,
+      false,
+      expect.objectContaining({command: READ_COMMANDS.OPEN_FRIEND_LIST}),
+    );
+  });
+
+  it('makeRequestWithSideEffects still REJECTS a non-READ (true side-effect) request so callers can handle errors', async () => {
+    const error = new HttpsError({message: 'Unauthorized', status: '401'});
+    mockedProcess.mockImplementation(() => Promise.reject(error));
+
+    await expect(
+      API.makeRequestWithSideEffects(
+        SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST,
+        {},
+      ),
+    ).rejects.toBe(error);
+
+    expect(mockedLogInfo).not.toHaveBeenCalledWith(
+      SWALLOW_MESSAGE,
+      false,
+      expect.anything(),
+    );
+  });
+
+  it('makeRequestWithSideEffects passes a successful READ response through untouched', async () => {
+    const response = {jsonCode: 200, onyxData: []};
+    mockedProcess.mockImplementation(() => Promise.resolve(response as never));
+
+    await expect(
+      API.makeRequestWithSideEffects(
+        READ_COMMANDS.OPEN_FRIEND_LIST,
+        {userID: 'user-1'},
+        {},
+        CONST.API_REQUEST_TYPE.READ,
+      ),
+    ).resolves.toBe(response);
+
+    expect(mockedLogInfo).not.toHaveBeenCalledWith(
+      SWALLOW_MESSAGE,
+      false,
+      expect.anything(),
+    );
+  });
+
+  it('read() swallows a failed read instead of surfacing an unhandled rejection', async () => {
+    mockedProcess.mockImplementation(() =>
+      Promise.reject(
+        new HttpsError({message: 'Internal Server Error', status: '500'}),
+      ),
+    );
+
+    expect(() =>
+      API.read(READ_COMMANDS.OPEN_FRIEND_LIST, {userID: 'user-1'}),
+    ).not.toThrow();
+
+    await flushMicrotasks();
+
+    expect(mockedLogInfo).toHaveBeenCalledWith(
+      SWALLOW_MESSAGE,
+      false,
+      expect.objectContaining({command: READ_COMMANDS.OPEN_FRIEND_LIST}),
+    );
+  });
+});

--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -181,7 +181,29 @@ function makeRequestWithSideEffects<
   };
 
   // Return a promise containing the response from HTTPS
-  return Request.processWithMiddleware(request);
+  const responsePromise = Request.processWithMiddleware(request);
+
+  // Read-type requests are fire-and-forget reads: their response is merged into
+  // Onyx by the SaveResponseInOnyx middleware, and callers only await them to
+  // settle a loading state (`.finally`) — they don't handle the rejection. A
+  // non-2xx response rejects this promise (`HttpUtils` throws an `HttpsError`),
+  // so an uncaught read rejection escapes as an UNHANDLED promise rejection,
+  // which pops the full-screen react-error-overlay on the web dev server (seen
+  // as "Uncaught HttpsError: Unauthorized" during the #781 revoked-token QA).
+  // Swallow it here: the Logging middleware already logged the failure, the read
+  // carried no optimistic data to roll back, and a 401 already triggered the
+  // central sign-out in `HttpUtils`. Writes and true side-effect requests keep
+  // rejecting so their callers can still handle errors.
+  if (apiRequestType === CONST.API_REQUEST_TYPE.READ) {
+    return responsePromise.catch((error: unknown): void => {
+      Log.info('[API] Swallowed rejected read request', false, {
+        command,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  return responsePromise;
 }
 
 /**
@@ -205,14 +227,25 @@ function read<TCommand extends ReadCommand>(
   // Ensure all write requests on the sequential queue have finished responding before running read requests.
   // Responses from read requests can overwrite the optimistic data inserted by
   // write requests that use the same Onyx keys and haven't responded yet.
-  SequentialQueue.waitForIdle().then(() =>
-    makeRequestWithSideEffects(
-      command,
-      apiCommandParameters,
-      onyxData,
-      CONST.API_REQUEST_TYPE.READ,
-    ),
-  );
+  SequentialQueue.waitForIdle()
+    .then(() =>
+      makeRequestWithSideEffects(
+        command,
+        apiCommandParameters,
+        onyxData,
+        CONST.API_REQUEST_TYPE.READ,
+      ),
+    )
+    // `makeRequestWithSideEffects` already swallows a read's non-2xx rejection
+    // (see above), so this outer catch is a backstop: it guards against a
+    // synchronous throw on the read path (or a future change) ever surfacing as
+    // an unhandled rejection — which would pop the web dev-server error overlay.
+    .catch((error: unknown) => {
+      Log.info('[API] Swallowed rejected read request (queue)', false, {
+        command,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
 }
 
 export {write, makeRequestWithSideEffects, read};


### PR DESCRIPTION
## Problem

Follow-up to [#1334](https://github.com/PetrCala/Kiroku/pull/1334) (issue #781), which added revoked-token (HTTP 401) handling: on a 401 from kiroku-api, `HttpUtils.processHTTPRequest` runs a guarded sign-out and then **re-throws** an `HttpsError` so optimistic data rolls back. That re-throw is intentional and untouched here.

The gap: **read-type side-effect requests don't catch their rejection.** `API.read` and `makeRequestWithSideEffects(..., API_REQUEST_TYPE.READ)` are fire-and-forget reads — their response is merged into Onyx by `SaveResponseInOnyx`, and callers only await them to settle a loading state (`.finally`), never to handle the rejection. So a non-2xx response (the request promise rejects) had nothing catching it and escaped as an **unhandled promise rejection**. On the web dev server (webpack / react-error-overlay) that pops the full-screen red "Uncaught HttpsError" overlay.

Observed during #781 web QA as `HttpsError: Unauthorized` via `fetchUsersData -> fetchUsersBatch` (`src/libs/actions/Profile.ts`), but it is **pre-existing for ANY non-2xx on these reads** (e.g. a 500) — the 401 just makes it common when a token is revoked. Multiple read callers are affected: `useFriendsData`, `useFriendProfile`, `useFriendPreferences`, `FriendRequestScreen`, `FriendsFriendsScreen`, all of which `.finally()` (or `Promise.all(...).finally()`) without a `.catch()`.

## Fix

Handle it once, in the read pipeline (the durable option from the issue) rather than patching each call site:

- `makeRequestWithSideEffects` now catches and **swallows (log-only)** the rejection when `apiRequestType === READ`. This covers both `API.read` and the direct read-type `makeRequestWithSideEffects` callers (`Profile`, `Preferences`, `DrinkingSession`).
- `read()` keeps a backstop `.catch` on its `waitForIdle().then(...)` queue chain.

Writes and true side-effect requests (`MAKE_REQUEST_WITH_SIDE_EFFECTS`) keep rejecting, so their callers can still roll back optimistic data and surface errors — only the read path is changed.

Why swallowing is safe for reads:
- The Logging middleware already logs the failure (the swallow adds a brief `[API] Swallowed rejected read request` trace, so it's handled-not-silent).
- Reads carry no optimistic data to roll back.
- For 401 specifically, the central sign-out already ran in `HttpUtils` (#1334), so the read rejection was purely redundant noise.

A swallowed read resolves to `undefined`, which the existing readers already treat as graceful degradation (`fetchUsersBatch` omits the missing user, etc.), so a failed read settles loading state with empty/partial data instead of crashing the overlay.

**Out of scope (unchanged):** the `HttpUtils` 401 sign-out / re-throw behavior from #1334.

## Tests

New `__tests__/unit/ApiReadRejection.test.ts`:
- a failed READ **resolves** (never rejects) and logs the swallow marker,
- a non-READ side-effect request **still rejects** so callers can handle errors,
- a successful READ passes through untouched,
- `read()` swallows a failed read.

## Gates
- `npx prettier --check` ✓
- `./scripts/lint.sh` (seatbelt) ✓
- `npm run typecheck-tsgo` ✓ (CI `npm run typecheck` is the merge gate)
- `npm run test` ✓ (96 suites / 878 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)