### PR TITLE
fix(feedback): admin reads no longer escape as unhandled rejections

### DIFF
--- a/__tests__/unit/FeedbackReadRejection.test.ts
+++ b/__tests__/unit/FeedbackReadRejection.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this test asserts on the mocked Onyx.set, not app code */
+
+import Onyx from 'react-native-onyx';
+import {getBugList, getFeedbackList} from '@libs/actions/Feedback';
+import HttpsError from '@libs/Errors/HttpsError';
+import Log from '@libs/Log';
+import * as Request from '@libs/Request';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+// Stub Onyx so importing the action (via @libs/API) doesn't start real
+// Onyx.connect timers, and so we can assert whether the list key was written.
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    update: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+// Log schedules a periodic flush timer at import that fires after teardown.
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    alert: jest.fn(),
+    hmmm: jest.fn(),
+  },
+}));
+
+// The middleware values are only forwarded to the mocked `Request.use`, so their
+// shape is irrelevant — stub them to keep the heavy real middleware out of the run.
+jest.mock('@libs/Middleware', () => ({
+  Logging: 'Logging',
+  RecheckConnection: 'RecheckConnection',
+  Reauthentication: 'Reauthentication',
+  SaveResponseInOnyx: 'SaveResponseInOnyx',
+}));
+
+// `Request.processWithMiddleware` is the seam we drive: it resolves/rejects to
+// simulate the HTTP layer (`HttpUtils` rejects with an `HttpsError` on a non-2xx).
+jest.mock('@libs/Request', () => ({
+  use: jest.fn(),
+  processWithMiddleware: jest.fn(),
+}));
+
+jest.mock('@libs/Network/SequentialQueue', () => ({
+  waitForIdle: jest.fn(() => Promise.resolve()),
+  push: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@libs/Network/NetworkStore', () => ({
+  isOffline: jest.fn(() => false),
+}));
+
+jest.mock('@libs/Pusher/pusher', () => ({
+  getPusherSocketID: jest.fn(() => undefined),
+}));
+
+jest.mock('@userActions/PersistedRequests', () => ({
+  getAll: jest.fn(() => []),
+}));
+
+const mockedProcess = jest.mocked(Request.processWithMiddleware);
+const mockedSet = jest.mocked(Onyx.set);
+const mockedLogWarn = jest.mocked(Log.warn);
+
+describe('Feedback admin read rejection handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getFeedbackList', () => {
+    it('RESOLVES (never rejects) and leaves FEEDBACK_LIST untouched when the read fails with a non-2xx', async () => {
+      const error = new HttpsError({message: 'Unauthorized', status: '401'});
+      mockedProcess.mockImplementation(() => Promise.reject(error));
+
+      // Without the action-level catch this would reject and escape as an
+      // unhandled rejection (the screen calls it with `.finally`, no `.catch`).
+      await expect(getFeedbackList()).resolves.toBeUndefined();
+
+      // The cached list must survive a transient failure, never clobbered with {}.
+      expect(mockedSet).not.toHaveBeenCalled();
+      expect(mockedLogWarn).toHaveBeenCalledWith(
+        '[Feedback] getFeedbackList failed',
+        {error},
+      );
+    });
+
+    it('writes the fetched list to FEEDBACK_LIST on a successful response', async () => {
+      const list = {abc: {user_id: 'user-1', text: 'hi', submit_time: 1}};
+      mockedProcess.mockImplementation(() => Promise.resolve(list as never));
+
+      await expect(getFeedbackList()).resolves.toBeUndefined();
+
+      expect(mockedSet).toHaveBeenCalledWith(ONYXKEYS.FEEDBACK_LIST, list);
+      expect(mockedLogWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getBugList', () => {
+    it('RESOLVES (never rejects) and leaves BUG_LIST untouched when the read fails with a non-2xx', async () => {
+      const error = new HttpsError({
+        message: 'Internal Server Error',
+        status: '500',
+      });
+      mockedProcess.mockImplementation(() => Promise.reject(error));
+
+      await expect(getBugList()).resolves.toBeUndefined();
+
+      expect(mockedSet).not.toHaveBeenCalled();
+      expect(mockedLogWarn).toHaveBeenCalledWith(
+        '[Feedback] getBugList failed',
+        {
+          error,
+        },
+      );
+    });
+
+    it('writes the fetched list to BUG_LIST on a successful response', async () => {
+      const list = {xyz: {user_id: 'user-2', text: 'broken', submit_time: 2}};
+      mockedProcess.mockImplementation(() => Promise.resolve(list as never));
+
+      await expect(getBugList()).resolves.toBeUndefined();
+
+      expect(mockedSet).toHaveBeenCalledWith(ONYXKEYS.BUG_LIST, list);
+      expect(mockedLogWarn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/libs/actions/Feedback.ts
+++ b/src/libs/actions/Feedback.ts
@@ -2,6 +2,7 @@ import Onyx from 'react-native-onyx';
 import type {OnyxUpdate} from 'react-native-onyx';
 import * as API from '@libs/API';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
+import Log from '@libs/Log';
 import type {Bug, BugList, Feedback, FeedbackList} from '@src/types/onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 
@@ -27,6 +28,15 @@ import ONYXKEYS from '@src/ONYXKEYS';
  * via `useOnyx`. Storing it in Onyx (rather than transient component state) means
  * a slow response still lands safely after the screen has unmounted, and a
  * re-visit renders the cached list instantly while a fresh fetch refreshes it.
+ *
+ * These reads go through `makeRequestWithSideEffects` (the default
+ * `MAKE_REQUEST_WITH_SIDE_EFFECTS` request type, not `READ`), so a non-2xx response
+ * (e.g. a 500 or a 401) rejects out of the call — `HttpUtils` throws an `HttpsError`.
+ * The screens fire these without a `.catch` (only `.finally`), so that rejection
+ * would escape as an unhandled promise rejection and pop the web dev-server red
+ * overlay. Each read therefore catches its own failure: it logs and resolves WITHOUT
+ * touching the Onyx key, so a transient failure leaves the cached list intact rather
+ * than clearing it (which is why we don't simply resolve-undefined-on-error).
  * Part of the #809 realtime cutover.
  */
 
@@ -83,10 +93,17 @@ function getFeedbackList(): Promise<void> {
   return API.makeRequestWithSideEffects(
     SIDE_EFFECT_REQUEST_COMMANDS.GET_FEEDBACK_LIST,
     {},
-  ).then(response => {
-    const list = (response as unknown as FeedbackList | undefined) ?? {};
-    return Onyx.set(ONYXKEYS.FEEDBACK_LIST, list);
-  });
+  )
+    .then(response => {
+      const list = (response as unknown as FeedbackList | undefined) ?? {};
+      return Onyx.set(ONYXKEYS.FEEDBACK_LIST, list);
+    })
+    .catch((error: unknown) => {
+      // Swallow the rejection so it doesn't escape as an unhandled promise
+      // rejection, and leave FEEDBACK_LIST untouched so a transient failure keeps
+      // the cached list instead of clearing it.
+      Log.warn('[Feedback] getFeedbackList failed', {error});
+    });
 }
 
 function getBugList(): Promise<void> {
@@ -94,10 +111,17 @@ function getBugList(): Promise<void> {
   return API.makeRequestWithSideEffects(
     SIDE_EFFECT_REQUEST_COMMANDS.GET_BUG_LIST,
     {},
-  ).then(response => {
-    const list = (response as unknown as BugList | undefined) ?? {};
-    return Onyx.set(ONYXKEYS.BUG_LIST, list);
-  });
+  )
+    .then(response => {
+      const list = (response as unknown as BugList | undefined) ?? {};
+      return Onyx.set(ONYXKEYS.BUG_LIST, list);
+    })
+    .catch((error: unknown) => {
+      // Swallow the rejection so it doesn't escape as an unhandled promise
+      // rejection, and leave BUG_LIST untouched so a transient failure keeps the
+      // cached list instead of clearing it.
+      Log.warn('[Feedback] getBugList failed', {error});
+    });
 }
 
 export {


### PR DESCRIPTION
## Problem

The admin **See Feedback** and **See Bugs** screens fetch their data through `getFeedbackList()` / `getBugList()` in `src/libs/actions/Feedback.ts`. Those call `API.makeRequestWithSideEffects(...)` with the **default** `MAKE_REQUEST_WITH_SIDE_EFFECTS` request type (not `CONST.API_REQUEST_TYPE.READ`), and the callers (`SeeFeedbackScreen.tsx` / `SeeBugsScreen.tsx`) invoke them with only `.finally()` — **no `.catch()`**.

On any non-2xx response (e.g. a 500 or a 401), `makeRequestWithSideEffects` rejects (HttpUtils throws an `HttpsError`) and `.finally()` re-throws it, so it escapes as an **unhandled promise rejection** and pops the full-screen react-error-overlay on the web dev server.

This is the same class of bug fixed for `READ`-type requests in the central read-path swallow, which does **not** cover these two because they're side-effect-typed, not `READ`. They were intentionally left out because their `.then()` chains write the fetched list into Onyx — naively resolving undefined-on-error would clear the admin list on a transient failure.

## Fix

Add a per-action `.catch` in `getFeedbackList` / `getBugList` that:
- logs the failure via `@libs/Log` (`Log.warn`, matching the existing `Subscriptions.ts` pattern), and
- resolves **without** overwriting `ONYXKEYS.FEEDBACK_LIST` / `ONYXKEYS.BUG_LIST`.

Only the success `.then` does `Onyx.set(...)`, so a transient failure leaves the cached list intact (the screens already render from Onyx via `useOnyx`, with the reconnect re-fetch in place).

## Tests

New `__tests__/unit/FeedbackReadRejection.test.ts` (mirrors the read-rejection test pattern, driving the mocked `@libs/Request.processWithMiddleware` seam):
- on reject → the read **resolves** (never throws), does **not** call `Onyx.set`, and logs a warning;
- on success → the read writes the fetched list to the Onyx key.

## Verification

- `npx prettier --check` — clean
- `./scripts/lint.sh` on changed files — clean
- `npm run typecheck-tsgo` — clean
- `npm run test` (full suite) — 882 passed, 6 skipped, 97 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)