### PR TITLE
fix(social): show hidden-data friends as "Private" (list row + profile)

### DIFF
--- a/__tests__/unit/DisplayPriority.test.ts
+++ b/__tests__/unit/DisplayPriority.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  calculateAllUsersPriority,
+  calculateUserPriority,
+  orderUsersByPriority,
+} from '@libs/algorithms/DisplayPriority';
+import type {UserStatus, UserStatusList} from '@src/types/onyx';
+
+// A recent, non-expired ongoing session (expiry boundary is now - 12h, see
+// `DrinkingSessionUtils.sessionIsExpired`). One minute ago keeps the time
+// coefficient finite and the session active.
+const ACTIVE_STATUS: UserStatus = {
+  last_online: Date.now(),
+  latest_session: {start_time: Date.now() - 60_000, ongoing: true},
+};
+
+// A visible friend with presence but no session at all → floored priority.
+const IDLE_STATUS: UserStatus = {last_online: Date.now()};
+
+describe('libs/algorithms/DisplayPriority.calculateAllUsersPriority', () => {
+  it('floors a user absent from the status list to the same priority as an idle visible friend', () => {
+    // The regression guard: a hidden friend (the server evicts their
+    // `user_status`, so they're absent here) used to default to `0` and float
+    // ABOVE idle visible friends (`-1e10`). They must now share the bottom band.
+    const statusList: UserStatusList = {idle: IDLE_STATUS};
+    const priorities = calculateAllUsersPriority(
+      ['hidden', 'idle'],
+      statusList,
+    );
+
+    expect(priorities.hidden).toBe(priorities.idle);
+  });
+
+  it('ranks an active-session friend above a hidden (absent) friend', () => {
+    const statusList: UserStatusList = {active: ACTIVE_STATUS};
+    const priorities = calculateAllUsersPriority(
+      ['hidden', 'active'],
+      statusList,
+    );
+
+    expect(priorities.active).toBeGreaterThan(priorities.hidden);
+  });
+});
+
+describe('libs/algorithms/DisplayPriority.calculateUserPriority', () => {
+  it('returns the same floor whether latest_session is null or undefined', () => {
+    const nullSession: UserStatus = {
+      last_online: Date.now(),
+      latest_session: null,
+    };
+    const noSession: UserStatus = {last_online: Date.now()};
+
+    expect(calculateUserPriority(nullSession)).toBe(
+      calculateUserPriority(noSession),
+    );
+  });
+
+  it('scores an active session well above an idle one', () => {
+    expect(calculateUserPriority(ACTIVE_STATUS)).toBeGreaterThan(
+      calculateUserPriority(IDLE_STATUS),
+    );
+  });
+});
+
+describe('libs/algorithms/DisplayPriority.orderUsersByPriority', () => {
+  it('sorts active friends first and never places a hidden friend above an active one', () => {
+    const statusList: UserStatusList = {
+      active: ACTIVE_STATUS,
+      idle: IDLE_STATUS,
+      // `hidden` is intentionally absent — the hidden-data case.
+    };
+    const userIDs = ['hidden', 'idle', 'active'];
+    const priorities = calculateAllUsersPriority(userIDs, statusList);
+
+    const ordered = orderUsersByPriority(userIDs, priorities);
+
+    expect(ordered[0]).toBe('active');
+    expect(ordered.indexOf('hidden')).toBeGreaterThan(
+      ordered.indexOf('active'),
+    );
+  });
+
+  it('does not mutate the input array', () => {
+    const userIDs = ['a', 'b'];
+    orderUsersByPriority(userIDs, {a: 1, b: 2});
+
+    expect(userIDs).toEqual(['a', 'b']);
+  });
+});

--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -100,11 +100,16 @@ function UserListComponent({
     const profileData = profileList[userID] ?? {};
     const userStatusData = userStatusList[userID] ?? {};
 
-    // A friend whose status the viewer may not see is hidden (the server evicts
-    // status for hidden/denied friends), matching the pre-existing behaviour.
-    if (isEmptyObject(profileData) || isEmptyObject(userStatusData)) {
+    // No profile means the server evicted everything (block, ban, or a deleted
+    // account) — there's nothing to show, so keep the row hidden.
+    if (isEmptyObject(profileData)) {
       return null;
     }
+    // Profile present but status evicted → the friend hid their drinking data
+    // (`hide_from_all` / `hidden_from`). Still list them by name + avatar; the
+    // `isPrivate` branch in UserOverview shows a neutral marker instead of any
+    // activity info.
+    const isPrivate = isEmptyObject(userStatusData);
 
     return (
       <FriendOfflineFeedback key={`${index}-user-feedback`} userID={userID}>
@@ -117,6 +122,7 @@ function UserListComponent({
             profileData={profileData}
             userStatusData={userStatusData}
             timezone={userData?.timezone}
+            isPrivate={isPrivate}
           />
         </PressableWithFeedback>
       </FriendOfflineFeedback>

--- a/src/components/Social/UserOverview.tsx
+++ b/src/components/Social/UserOverview.tsx
@@ -11,6 +11,7 @@ import DateUtils from '@libs/DateUtils';
 import type {Timezone} from '@src/types/onyx/UserData';
 import Text from '@components/Text';
 import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
 import useTheme from '@hooks/useTheme';
 import useLocalize from '@hooks/useLocalize';
 
@@ -19,6 +20,10 @@ type UserOverviewProps = {
   profileData: Profile;
   userStatusData: UserStatus;
   timezone?: Timezone;
+  /** The friend hid their drinking data, so `userStatusData` is empty and
+   *  carries no session/presence info. Show a neutral "Private" marker instead
+   *  of any activity status. */
+  isPrivate?: boolean;
 };
 
 function UserOverview({
@@ -26,6 +31,7 @@ function UserOverview({
   profileData,
   userStatusData,
   timezone,
+  isPrivate = false,
 }: UserOverviewProps) {
   const styles = useThemeStyles();
   const theme = useTheme();
@@ -61,6 +67,64 @@ function UserOverview({
     return translate('userOverview.noSessionsYet');
   }
 
+  // Right-hand status content, three mutually exclusive states. A hidden friend
+  // (`isPrivate`) has no `user_status`, so render a neutral "Private" marker —
+  // never `getSessionStatus()`'s "no sessions yet", which would misrepresent a
+  // hidden history as an empty one.
+  function renderRightContent() {
+    if (isPrivate) {
+      return (
+        <>
+          <Icon small src={KirokuIcons.Lock} fill={theme.textSupporting} />
+          <Text
+            style={[
+              styles.textLabelSupporting,
+              styles.textAlignCenter,
+              styles.ml1,
+            ]}>
+            {translate('userOverview.private')}
+          </Text>
+        </>
+      );
+    }
+    if (inSession && shouldDisplaySessionInfo) {
+      return (
+        <View style={styles.flexColumn}>
+          <View style={commonStyles.flexRow}>
+            <Text
+              key={`${userID}-status-info`}
+              style={[styles.textLabelSupporting, styles.textAlignCenter]}>
+              {`${translate('userOverview.inSession')}${mostCommonDrinkIcon ? ':' : ''}`}
+            </Text>
+            {mostCommonDrinkIcon && (
+              <Icon
+                small
+                src={mostCommonDrinkIcon}
+                fill={theme.textSupporting}
+              />
+            )}
+          </View>
+          <Text
+            key={`${userID}-status-time`}
+            style={[
+              styles.textLabelSupporting,
+              styles.textAlignCenter,
+              styles.mt1,
+            ]}>
+            {`${translate('userOverview.from')}: ${sessionStartTime}`}
+          </Text>
+        </View>
+      );
+    }
+    return (
+      <Text
+        key={`${userID}-status`}
+        style={[styles.textLabelSupporting, styles.textAlignCenter]}>
+        {getSessionStatus()}
+      </Text>
+    );
+  }
+
   return (
     <View key={`${userID}-container`} style={styles.userOverviewContainer}>
       <View
@@ -85,40 +149,7 @@ function UserOverview({
       <View
         key={`${userID}-right-container`}
         style={[styles.flexRow, styles.alignItemsCenter]}>
-        {/* ? `In session:\n${drinksThisSession} ${mostCommonDrink}` */}
-        {inSession && shouldDisplaySessionInfo ? (
-          <View style={styles.flexColumn}>
-            <View style={commonStyles.flexRow}>
-              <Text
-                key={`${userID}-status-info`}
-                style={[styles.textLabelSupporting, styles.textAlignCenter]}>
-                {`${translate('userOverview.inSession')}${mostCommonDrinkIcon ? ':' : ''}`}
-              </Text>
-              {mostCommonDrinkIcon && (
-                <Icon
-                  small
-                  src={mostCommonDrinkIcon}
-                  fill={theme.textSupporting}
-                />
-              )}
-            </View>
-            <Text
-              key={`${userID}-status-time`}
-              style={[
-                styles.textLabelSupporting,
-                styles.textAlignCenter,
-                styles.mt1,
-              ]}>
-              {`${translate('userOverview.from')}: ${sessionStartTime}`}
-            </Text>
-          </View>
-        ) : (
-          <Text
-            key={`${userID}-status`}
-            style={[styles.textLabelSupporting, styles.textAlignCenter]}>
-            {getSessionStatus()}
-          </Text>
-        )}
+        {renderRightContent()}
       </View>
     </View>
   );

--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -74,6 +74,7 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 | session intensity: light    | **mírná** (relace)                                | lehká          |
 | session intensity: moderate | **střední** (relace)                              |                |
 | session intensity: heavy    | **náročná** (relace)                              | silná, těžká   |
+| private (data status label) | **Soukromé** (neuter, of implied data/údaje)      | Skryté         |
 | report (verb)               | **nahlásit**                                      |                |
 | report (noun)               | **hlášení**                                       |                |
 | inappropriate               | **nevhodné / nevhodný / nevhodná**                |                |

--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -74,7 +74,7 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 | session intensity: light    | **mírná** (relace)                                | lehká          |
 | session intensity: moderate | **střední** (relace)                              |                |
 | session intensity: heavy    | **náročná** (relace)                              | silná, těžká   |
-| private (data status label) | **Soukromé** (neuter, of implied data/údaje)      | Skryté         |
+| private (status / profile)  | **Soukromé / Soukromý** (agree w/ noun gender)    | Skryté         |
 | report (verb)               | **nahlásit**                                      |                |
 | report (noun)               | **hlášení**                                       |                |
 | inappropriate               | **nevhodné / nevhodný / nevhodná**                |                |

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1095,7 +1095,7 @@ export default {
     offlineUnavailableMessage:
       'Tento profil se nepodařilo načíst v režimu offline. Pro zobrazení se znovu připojte.',
     privateTitle: 'Soukromý profil',
-    privateMessage: 'Tento uživatel nesdílí své alkoholové relace.',
+    privateMessage: 'Relace tohoto uživatele jsou soukromé.',
   },
   statistics: {
     title: 'Statistiky',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1511,6 +1511,7 @@ export default {
     sober: 'Bez pití',
     sessionStarted: 'Relace zahájena',
     noSessionsYet: 'Zatím žádné relace',
+    private: 'Soukromé',
   },
   yearPickerScreen: {
     year: 'Rok',

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -1094,6 +1094,8 @@ export default {
     offlineUnavailableTitle: 'Profil se nepodařilo načíst',
     offlineUnavailableMessage:
       'Tento profil se nepodařilo načíst v režimu offline. Pro zobrazení se znovu připojte.',
+    privateTitle: 'Soukromý profil',
+    privateMessage: 'Tento uživatel nesdílí své alkoholové relace.',
   },
   statistics: {
     title: 'Statistiky',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1510,6 +1510,7 @@ export default {
     sober: 'Sober',
     sessionStarted: 'Session started',
     noSessionsYet: 'No sessions yet',
+    private: 'Private',
   },
   yearPickerScreen: {
     year: 'Year',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1088,6 +1088,8 @@ export default {
     offlineUnavailableTitle: "Couldn't load this profile",
     offlineUnavailableMessage:
       "We couldn't load this profile while offline. Reconnect to view it.",
+    privateTitle: 'Private profile',
+    privateMessage: 'This person keeps their drinking sessions private.',
   },
   statistics: {
     title: 'Statistics',

--- a/src/libs/algorithms/DisplayPriority.ts
+++ b/src/libs/algorithms/DisplayPriority.ts
@@ -8,6 +8,15 @@ import {sumAllDrinks} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 
 /**
+ * Floor priority for users with no usable session signal: those whose latest
+ * session is missing/expired and those absent from `userStatusList` entirely (a
+ * friend who hid their drinking data, whose `user_status` the server evicts).
+ * Keeps both in the bottom band instead of letting a hidden friend — which used
+ * to default to `0` — float above genuinely idle friends.
+ */
+const LOWEST_PRIORITY = -1e10;
+
+/**
  * Based on the user status data, calculate the display priority of the users.
  * Return the user IDs in the order they should be displayed.
  *
@@ -29,7 +38,10 @@ function calculateAllUsersPriority(
 ): UserPriorityList {
   const usersPriority: UserPriorityList = {};
   userIDs.forEach(userID => {
-    let userPriority: UserPriority = 0;
+    // Absent from `userStatusList` → no readable status (e.g. a friend who hid
+    // their data; the server evicts their `user_status`). Floor them into the
+    // bottom band rather than the old `0`, which floated them above idle friends.
+    let userPriority: UserPriority = LOWEST_PRIORITY;
     const userStatusData: UserStatus = userStatusList[userID];
     if (userStatusData) {
       userPriority = calculateUserPriority(userStatusData);
@@ -40,11 +52,9 @@ function calculateAllUsersPriority(
 }
 
 function calculateUserPriority(userStatusData: UserStatus): number {
-  const lowestPrio = -1e10;
-
   const latestSession = userStatusData.latest_session;
   if (!latestSession) {
-    return lowestPrio;
+    return LOWEST_PRIORITY;
   }
 
   const latestSessionTime = latestSession ? latestSession.start_time : null;

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -17,6 +17,7 @@ import {getCommonFriendsCount} from '@libs/FriendUtils';
 import {isBlocked} from '@libs/BlockUtils';
 import * as FeatureFlags from '@libs/FeatureFlags';
 import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import Icon from '@components/Icon';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {ProfileNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
@@ -38,6 +39,7 @@ import ManageFriendPopover from '@components/ManageFriendPopover';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
+import useNetwork from '@hooks/useNetwork';
 
 type ProfileScreenProps = StackScreenProps<
   ProfileNavigatorParamList,
@@ -56,6 +58,7 @@ function ProfileScreen({route}: ProfileScreenProps) {
   const {translate} = useLocalize();
   const styles = useThemeStyles();
   const StyleUtils = useStyleUtils();
+  const {isOffline} = useNetwork();
   const {userData, isLoading: isProfileFetchLoading} = useFriendProfile(userID);
   const {preferences, isLoading: isPrefsLoading} = useFriendPreferences(userID);
   // Own sessions come straight off the app/open snapshot in Onyx; the windowed
@@ -130,6 +133,19 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // data (the server denies block-gated reads, but a cached entry may linger).
   const myBlocked = user ? userDataList?.[user.uid]?.blocked : undefined;
   const isViewingBlockedUser = !isSelf && isBlocked(myBlocked, userID);
+  // A friend who hid their drinking data (`hide_from_all` / `hidden_from`)
+  // returns a readable profile, but the server evicts their preferences,
+  // sessions, and status (#786). That is NOT an unreachable profile: render it
+  // with a "private" notice in place of the sessions overview + calendar.
+  // Online-gated so an offline read that simply hasn't landed still falls
+  // through to the "couldn't load / reconnect" state below.
+  const isPrivateProfile =
+    !isSelf &&
+    !isViewingBlockedUser &&
+    !isOffline &&
+    !!profileData &&
+    !!userData &&
+    !preferences;
 
   const friendCountLabel = useMemo((): string => {
     return `${translate('profileScreen.commonFriendsLabel', {
@@ -211,10 +227,15 @@ function ProfileScreen({route}: ProfileScreenProps) {
       </ScreenWrapper>
     );
   }
-  // A blocked/blocking user resolves with no profile (we blocked them, or they
-  // blocked us and the server denied/evicted the read), so this is a clean empty
-  // state with no sessions and no common-friends count — never a surfaced error.
-  if (!profileData || !preferences || !userData || isViewingBlockedUser) {
+  // Full-screen "couldn't load" only when the profile is genuinely unreachable:
+  // no profile (deleted, or they blocked us), we blocked them, or we're offline
+  // without cached preferences to render. A friend who merely hid their data
+  // (`isPrivateProfile`) is reachable and online, so it's excluded here and
+  // renders below with a private notice instead of a surfaced error.
+  if (
+    !isPrivateProfile &&
+    (!profileData || !preferences || !userData || isViewingBlockedUser)
+  ) {
     return (
       <ScreenWrapper
         testID={ProfileScreen.displayName}
@@ -287,28 +308,63 @@ function ProfileScreen({route}: ProfileScreenProps) {
           />
         </View>
         <View style={styles.ph2}>
-          {didScreenTransitionEnd ? (
-            <MonthlyOverviewCard
-              stats={profileStats}
-              showWeeklyUnits={false}
-              showMonthComparison
-              interactive={isSelf}
-              showArrow={isSelf}
-            />
+          {preferences ? (
+            <>
+              {didScreenTransitionEnd ? (
+                <MonthlyOverviewCard
+                  stats={profileStats}
+                  showWeeklyUnits={false}
+                  showMonthComparison
+                  interactive={isSelf}
+                  showArrow={isSelf}
+                />
+              ) : (
+                <MonthlyOverviewCardSkeleton />
+              )}
+              {didScreenTransitionEnd ? (
+                <SessionsCalendar
+                  userID={userID}
+                  visibleDate={visibleDateData}
+                  onDateChange={onDateChange}
+                  drinkingSessionData={drinkingSessionData}
+                  preferences={preferences}
+                  isFetchingOlderMonths={isFetchingOlderMonths}
+                />
+              ) : (
+                <SessionsCalendarCompactSkeleton />
+              )}
+            </>
           ) : (
-            <MonthlyOverviewCardSkeleton />
-          )}
-          {didScreenTransitionEnd ? (
-            <SessionsCalendar
-              userID={userID}
-              visibleDate={visibleDateData}
-              onDateChange={onDateChange}
-              drinkingSessionData={drinkingSessionData}
-              preferences={preferences}
-              isFetchingOlderMonths={isFetchingOlderMonths}
-            />
-          ) : (
-            <SessionsCalendarCompactSkeleton />
+            <View
+              style={[
+                styles.alignItemsCenter,
+                styles.justifyContentCenter,
+                styles.ph5,
+                styles.mt5,
+              ]}>
+              <Icon
+                src={KirokuIcons.Lock}
+                fill={StyleUtils.getIconFillColor()}
+                medium
+              />
+              <Text
+                style={[
+                  styles.textHeadlineH1,
+                  styles.textAlignCenter,
+                  styles.mt2,
+                ]}>
+                {translate('profileScreen.privateTitle')}
+              </Text>
+              <Text
+                style={[
+                  styles.textNormal,
+                  styles.textSupporting,
+                  styles.textAlignCenter,
+                  styles.mt2,
+                ]}>
+                {translate('profileScreen.privateMessage')}
+              </Text>
+            </View>
           )}
         </View>
         <View style={[styles.flexRow, styles.justifyContentEnd]}>


### PR DESCRIPTION
Handles a friend who turned on **"Hide my data from all friends"** (`hide_from_all` / `hidden_from`) across two surfaces. The server returns their **`profile`** but evicts the whole **`user_status`** + **preferences** + **sessions** (#786); both surfaces mistook that eviction for "unavailable" and hid/blanked the friend.

Product decision: "Hide my data" = **total invisibility of activity, including presence** — so `last_online` stays hidden and this is **client-only, no API change**.

## 1. Friends list — keep them in the list as "Private"

`UserListComponent` dropped any row whose status was empty, so a hidden friend **vanished entirely**, indistinguishable from a blocked/deleted user.

- **`UserListComponent`** — gate the drop on **profile** only (block/ban/deleted null the profile too → stay hidden). Profile present + status empty → derive `isPrivate`, still render.
- **`UserOverview`** — new `isPrivate` prop → muted **Lock + "Private"** in the right slot instead of session status (never "No sessions yet", which would misrepresent a hidden history).
- **`DisplayPriority`** — a user absent from the status list floored to `LOWEST_PRIORITY` (was `0`, which floated them above idle friends) → they sort to the bottom band.

## 2. Profile screen — "private" notice instead of "couldn't load"

`ProfileScreen`'s empty-state gate required `preferences`, so a private friend hit the full-screen **"Couldn't load this profile / reconnect"** state — an offline-framed error for someone who's online and just private.

- Narrow the gate to fire only when genuinely unreachable: no profile (deleted / they blocked us), we blocked them, or **offline** without cached prefs.
- `isPrivateProfile` = profile present, not blocked, **online**, but preferences evicted. When private, render the rest of the profile (avatar, name, friend count, Manage) and replace **only** the monthly-stats overview + calendar with a **"Private profile"** notice (Lock + message). `preferences ?` doubles as the type-narrowing guard for the calendar.

## i18n
`userOverview.private` and `profileScreen.private{Title,Message}` in en + cs_cz (`Soukromé` / `Soukromý profil`), via the `translate` skill; terms recorded in the cs_cz glossary.

## Tests / gates
- New `__tests__/unit/DisplayPriority.test.ts` covers the bottom-band ordering.
- `Translate` / `TranslationContext` parity green; `typecheck-tsgo`, `lint.sh`, `react-compiler-compliance-check` all pass.

> Visual verification of both "Private" states needs a friend with `hide_from_all` set — best validated on a device build (apply **Ready To Build - iOS**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)