### PR TITLE
fix(web): dim, don't hide, the app behind centered modals in the desktop phone frame

### DIFF
--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -18,6 +18,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import ComposerFocusManager from '@libs/ComposerFocusManager';
+import getIsInPhoneFrame from '@libs/getIsInPhoneFrame';
 import Overlay from '@libs/Navigation/AppNavigator/Navigators/Overlay';
 import variables from '@styles/variables';
 import * as Modal from '@userActions/Modal';
@@ -111,7 +112,18 @@ function BaseModal(
   const {windowWidth, windowHeight} = useWindowDimensions();
   // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to apply correct modal width
   // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-  const {isSmallScreenWidth} = useResponsiveLayout();
+  const {isSmallScreenWidth: isSmallScreenWidthFromLayout} =
+    useResponsiveLayout();
+  // On desktop web the app renders inside a clamped ~480px "phone frame", which
+  // reports a small-screen width even though the modal is portaled to the real
+  // (wide) browser window. Treat the frame as the wide screen it really is, so
+  // `getModalStyles` keeps the desktop "inset card" layout (and the backdrop
+  // dims the app) instead of the full-bleed mobile branch that hides it. This
+  // restores the upstream invariant that a modal's `isSmallScreenWidth` tracks
+  // its real container. No-op on native and genuinely narrow web, where
+  // `getIsInPhoneFrame()` is false.
+  const isSmallScreenWidth =
+    isSmallScreenWidthFromLayout && !getIsInPhoneFrame();
   const keyboardStateContextValue = useKeyboardState();
 
   const safeAreaInsets = useSafeAreaInsets();

--- a/src/libs/getIsInPhoneFrame/index.ts
+++ b/src/libs/getIsInPhoneFrame/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether the app is rendering inside the desktop-web "phone frame" (issue
+ * #1219). The phone frame is a web-only concept, so on native this is always
+ * false. See the `.web.ts` variant for the real implementation.
+ */
+export default function getIsInPhoneFrame(): boolean {
+  return false;
+}

--- a/src/libs/getIsInPhoneFrame/index.web.ts
+++ b/src/libs/getIsInPhoneFrame/index.web.ts
@@ -1,0 +1,23 @@
+import variables from '@styles/variables';
+
+/**
+ * Whether the app is rendering inside the desktop-web "phone frame" (issue
+ * #1219).
+ *
+ * On web above the responsive breakpoint the app renders inside a centered
+ * ~480px "phone frame" (web/index.html + index.web.js), which clamps the
+ * reported window width to the frame so the existing mobile layout is reused.
+ * That clamp makes the app permanently report a small-screen width, so
+ * `isSmallScreenWidth` can no longer tell a genuinely narrow browser apart from
+ * the desktop phone frame (both report ~480px).
+ *
+ * Read the *real* (unclamped) viewport width straight from `window.innerWidth`
+ * to recover that distinction. Keep the breakpoint in sync with the `BREAKPOINT`
+ * constant in index.web.js and `variables.mobileResponsiveWidthBreakpoint`.
+ */
+export default function getIsInPhoneFrame(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.innerWidth > variables.mobileResponsiveWidthBreakpoint
+  );
+}


### PR DESCRIPTION
## Problem

On the **web** build, centered modals (e.g. the verify-email gate) don't dim the app behind them — they fully cover it with an opaque card, so you can't tell there's an app underneath.

### Root cause

Desktop web renders inside a clamped ~480px "phone frame" (`index.web.js`, #1219), which forces `isSmallScreenWidth = true` regardless of the real viewport. The `CENTERED` / `CENTERED_UNSWIPEABLE` modal types are *designed* to take over the whole viewport on small screens (intended mobile behavior): they drop their margins, rounded corners, and width inset and render full-bleed with an opaque `appBG`. That opaque full-bleed card sits on top of the (correctly 72%-transparent) backdrop, so the app is hidden rather than dimmed.

The backdrop was never the problem — it composes to a single `theme.overlay` layer at `variables.overlayOpacity` (0.72). The opaqueness comes entirely from the modal's content card going full-bleed.

## Fix — mirror upstream

This **mirrors Expensify** instead of special-casing the shared style util. Our `ModalStyleUtils.ts` is a fork of Expensify's and makes the full-bleed-vs-inset-card decision the same way (off `isSmallScreenWidth`). Expensify gets the dimmed inset card "for free" on desktop because, with no phone frame, `isSmallScreenWidth` reflects the real viewport. Our global `Dimensions` clamp just feeds it the wrong input.

A modal is portaled to `document.body`, **outside** the 480px `#root` frame, so its real container is the wide browser window. So we restore that invariant: `BaseModal` now computes the modal's `isSmallScreenWidth` from the **real, unclamped** viewport.

- **`ModalStyleUtils.ts` is left byte-identical to upstream** — no new field, no new branch. The only change is the value `BaseModal` feeds it.
- `getIsInPhoneFrame()` (web reads the unclamped `window.innerWidth` vs the responsive breakpoint; native always `false`) is the one small, well-named platform fact.
- `BaseModal`: `const isSmallScreenWidth = isSmallScreenWidthFromLayout && !getIsInPhoneFrame();`

## Scope / safety

- **Native:** `getIsInPhoneFrame()` is `false` → identical to before.
- **Genuinely narrow web** (real viewport ≤ breakpoint): `false` → unchanged full-screen mobile modals.
- In the pristine util, `isSmallScreenWidth` only drives `CENTERED`, `CENTERED_UNSWIPEABLE`, and `RIGHT_DOCKED`. RIGHT_DOCKED is never instantiated as a modal (the RHP uses navigation), so the **effective change is the two centered types only**.
- The Terms of Service / onboarding flow is a separate full-screen navigator (`OnboardingModalNavigator` + `ScreenWrapper`), **not** a `BaseModal`, so it is intentionally out of scope.

## Verification

Ran the live web app, signed in with the dev account (verify-email gate = `CENTERED_UNSWIPEABLE`). DOM inspection of the modal card:

| Viewport | `marginTop/Bottom` | `borderRadius` | result |
|---|---|---|---|
| Desktop, `innerWidth 1280` (frame active) | `20px` | `16px` | inset card centered in the 480 frame, app dimmed around it ✓ |
| Narrow, `innerWidth 375` | `0` | `0` | full-bleed (no regression) ✓ |

Gates: `prettier`, `typecheck` (tsgo), `lint-changed`, and `react-compiler-compliance-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
