### PR TITLE
feat(ci): dispatch-only Claude self-heal for master failures (Phase 2)

### DIFF
--- a/.claude/commands/fix-ci-failure.md
+++ b/.claude/commands/fix-ci-failure.md
@@ -1,0 +1,62 @@
+---
+allowed-tools: Read,Edit,Write,Glob,Grep,Bash(cat:*),Bash(npm run typecheck:*),Bash(npm run prettier:*),Bash(npx prettier:*),Bash(./scripts/lint.sh:*),Bash(npm run react-compiler-compliance-check:*),Bash(git diff:*),Bash(git status:*),Bash(gh run view:*),Bash(gh pr view:*),Bash(gh pr diff:*)
+description: Reproduce and fix a mechanical master CI failure (typecheck/lint/prettier/imports/react-compiler), then return a structured result. Invoked by .github/workflows/selfHeal.yml.
+---
+
+You are an automated CI-repair agent. The **Process new code merged to master** pipeline failed on
+`master`. Reproduce the failure on the current checkout (this is **master tip**), fix it **only if it
+is a mechanical issue**, verify the fix, and return a structured result.
+
+A separate workflow step opens the PR. You must **NOT** commit, push, or open a PR yourself, and you
+must not run any `*-changed` command (they diff against `origin/master` and are empty here).
+
+You are given in the invocation: **RUN_ID**, **RUN_URL**, and **LOG_FILE** (an absolute path to the
+failed-step logs).
+
+## Scope — mechanical fixes ONLY
+
+You **may** fix:
+
+- **typecheck** — TypeScript type errors (`tsc`/`tsgo`).
+- **lint** — ESLint violations.
+- **prettier** — formatting.
+- **imports** — broken/missing/stale imports and paths.
+- **react-compiler** — React Compiler compliance failures.
+- **merge-conflict** — the simple semantic conflicts the above surface when two green PRs combine on
+  master (a renamed symbol, a moved/renamed file, a stale import, a type that drifted).
+
+You **must NOT** fix: failing unit tests, logic/behavioural bugs, flaky failures, or
+infrastructure/runner failures. Never weaken, skip, or delete a test or assertion. For any of these,
+return the escalation outcome and **STOP without editing any file**.
+
+## Steps
+
+1. **Read** `LOG_FILE` to identify the failing check and the exact file(s), line(s), and error/rule.
+2. **Classify** into a `category`. If it is not in the mechanical set above, STOP and return
+   `outcome: "not_a_code_issue"` (flake/infra) or `"cannot_fix"` (test/logic) with a `summary`. No edits.
+3. **Reproduce** on the current checkout with the **narrowest non-`changed`** command:
+
+   - typecheck → `npm run typecheck`
+   - lint → `./scripts/lint.sh <file>`
+   - prettier → `npx prettier --check <file>`
+   - react-compiler → `npm run react-compiler-compliance-check check <file>`
+
+   If it does **not** reproduce (already fixed upstream, or flaky), return `outcome: "cannot_fix"` and STOP.
+
+4. **Fix** with the smallest change that addresses the root cause. Do not refactor, do not touch
+   unrelated files, do not reformat code you did not change.
+5. **Verify** by re-running the same narrow command. Set `verified` to `true` only if it now passes.
+6. **Return ONLY the JSON object** (no prose, no code fences, nothing before or after) matching this shape:
+
+```json
+{
+  "outcome": "fixed | cannot_fix | not_a_code_issue",
+  "category": "typecheck | lint | prettier | imports | react-compiler | merge-conflict | test | logic | flake | infra | unknown",
+  "verified": true,
+  "summary": "One or two sentences: the root cause and your fix, or why you could not fix it.",
+  "filesChanged": ["repo/relative/path.ts"]
+}
+```
+
+- `filesChanged` lists every file you edited (empty `[]` when you made no edits).
+- Keep the fix minimal and the `summary` concise.

--- a/.claude/schemas/ci-fix-output.json
+++ b/.claude/schemas/ci-fix-output.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "outcome": {
+      "type": "string",
+      "enum": ["fixed", "cannot_fix", "not_a_code_issue"]
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "typecheck",
+        "lint",
+        "prettier",
+        "imports",
+        "react-compiler",
+        "merge-conflict",
+        "test",
+        "logic",
+        "flake",
+        "infra",
+        "unknown"
+      ]
+    },
+    "verified": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "filesChanged": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["outcome", "category", "verified", "summary", "filesChanged"]
+}

--- a/.github/workflows/selfHeal.yml
+++ b/.github/workflows/selfHeal.yml
@@ -1,0 +1,222 @@
+# Manually dispatched self-heal for master CI failures.
+#
+# Given a failed "Process new code merged to master" run id, this spins up a Claude agent to
+# REPRODUCE + FIX a MECHANICAL failure (typecheck / lint / prettier / imports / react-compiler) on
+# master tip, deterministically re-verifies the fix, and opens a human-reviewed PR. It never
+# auto-merges. Test / logic / flake / infra failures are escalated to Discord, not fixed.
+#
+# Dispatch-only by design (cost): the Phase-1 failureNotifier still auto-pings; healing is on demand.
+# Agent contract: .claude/commands/fix-ci-failure.md  +  .claude/schemas/ci-fix-output.json
+name: Self-heal CI failure
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Failed "Process new code merged to master" run id to heal'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+concurrency:
+  group: self-heal-${{ github.event.inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  heal:
+    name: Reproduce, fix, and open a PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out master tip
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          fetch-depth: 0
+          # KirokuAdmin PAT so the later push (and its PR) is authorized.
+          token: ${{ secrets.KIROKU_ADMIN_COMMIT_TOKEN }}
+
+      - name: Set up node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Gather failure context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
+        run: |
+          set -eo pipefail
+
+          LOG_FILE="$RUNNER_TEMP/failed-logs.txt"
+          gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > "$LOG_FILE" 2>/dev/null || true
+          if [[ ! -s "$LOG_FILE" ]]; then
+            gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --log > "$LOG_FILE" 2>/dev/null || echo "(no logs available for run $RUN_ID)" > "$LOG_FILE"
+          fi
+
+          RUN_JSON="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json headSha,headBranch,url,conclusion)"
+          HEAD_SHA="$(echo "$RUN_JSON" | jq -r '.headSha')"
+          RUN_URL="$(echo "$RUN_JSON" | jq -r '.url')"
+
+          # Head branch of the merged PR that introduced this commit (for the heal-of-heal guard).
+          PR_BRANCH="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" -q 'map(select(.merged_at != null)) | .[0].head.ref // ""' 2>/dev/null || echo "")"
+
+          {
+            echo "log_file=$LOG_FILE"
+            echo "head_sha=$HEAD_SHA"
+            echo "short_sha=${HEAD_SHA:0:8}"
+            echo "run_url=$RUN_URL"
+            echo "pr_branch=$PR_BRANCH"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Guard against heal-of-heal
+        id: guard
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_BRANCH: ${{ steps.context.outputs.pr_branch }}
+          RUN_URL: ${{ steps.context.outputs.run_url }}
+        run: |
+          set -eo pipefail
+          if [[ "$PR_BRANCH" == automated-fix/* ]]; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
+              -d "$(jq -n --arg c "🔧 Self-heal skipped for <$RUN_URL>: the failure originates from an automated-fix branch (no heal-of-heal)." '{content: $c}')" >/dev/null || true
+            echo "Refusing to heal a failure caused by an automated-fix branch."
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Load self-heal output schema
+        id: schema
+        if: ${{ steps.guard.outputs.proceed == 'true' }}
+        run: echo "json=$(jq -c . .claude/schemas/ci-fix-output.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Run self-heal agent
+        id: heal
+        if: ${{ steps.guard.outputs.proceed == 'true' }}
+        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1.0.86
+        with:
+          display_report: 'true'
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          prompt: '/fix-ci-failure RUN_ID: ${{ github.event.inputs.run_id }} RUN_URL: ${{ steps.context.outputs.run_url }} LOG_FILE: ${{ steps.context.outputs.log_file }}'
+          claude_args: |
+            --model claude-opus-4-8
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cat:*),Bash(npm run typecheck:*),Bash(npm run prettier:*),Bash(npx prettier:*),Bash(./scripts/lint.sh:*),Bash(npm run react-compiler-compliance-check:*),Bash(git diff:*),Bash(git status:*),Bash(gh run view:*),Bash(gh pr view:*),Bash(gh pr diff:*)" --json-schema '${{ steps.schema.outputs.json }}'
+
+      - name: Open PR or escalate
+        if: ${{ steps.guard.outputs.proceed == 'true' && steps.heal.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.KIROKU_ADMIN_COMMIT_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          STRUCTURED_OUTPUT: ${{ steps.heal.outputs.structured_output }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
+          RUN_URL: ${{ steps.context.outputs.run_url }}
+          SHORT_SHA: ${{ steps.context.outputs.short_sha }}
+        run: |
+          set -eo pipefail
+
+          post_discord() {
+            curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
+              -d "$(jq -n --arg c "$1" '{content: $c}')" >/dev/null || true
+          }
+
+          if [[ -z "$STRUCTURED_OUTPUT" ]]; then
+            echo "::error::agent returned empty structured output"
+            post_discord "🔧 Self-heal for <$RUN_URL> failed: the agent returned no result."
+            exit 1
+          fi
+
+          OUTCOME="$(echo "$STRUCTURED_OUTPUT" | jq -r '.outcome')"
+          CATEGORY="$(echo "$STRUCTURED_OUTPUT" | jq -r '.category')"
+          VERIFIED="$(echo "$STRUCTURED_OUTPUT" | jq -r '.verified')"
+          SUMMARY="$(echo "$STRUCTURED_OUTPUT" | jq -r '.summary')"
+          mapfile -t FILES < <(echo "$STRUCTURED_OUTPUT" | jq -r '.filesChanged[]?')
+
+          MECHANICAL=" typecheck lint prettier imports react-compiler merge-conflict "
+
+          # Escalate anything that is not a verified mechanical fix with real file changes.
+          if [[ "$OUTCOME" != "fixed" || "$VERIFIED" != "true" || ${#FILES[@]} -eq 0 ]] || [[ "$MECHANICAL" != *" $CATEGORY "* ]]; then
+            post_discord "🔧 Self-heal attempted for <$RUN_URL>, no PR opened (outcome: \`$OUTCOME\` / \`$CATEGORY\`). $SUMMARY"
+            echo "No PR. outcome=$OUTCOME category=$CATEGORY verified=$VERIFIED files=${#FILES[@]}"
+            exit 0
+          fi
+
+          # Idempotency: skip if an open auto-fix PR already exists for this commit.
+          EXISTING="$(gh pr list --repo "$REPO" --state open --json headRefName \
+            -q "[.[] | select(.headRefName | startswith(\"automated-fix/ci-$SHORT_SHA\"))] | length")"
+          if [[ "${EXISTING:-0}" -gt 0 ]]; then
+            post_discord "🔧 Self-heal: an open auto-fix PR already exists for commit \`$SHORT_SHA\`; skipping (<$RUN_URL>)."
+            echo "Open auto-fix PR already exists for $SHORT_SHA; skipping."
+            exit 0
+          fi
+
+          # Deterministic re-verify on the agent's changed files (do not trust the self-report).
+          echo "Re-verifying: ${FILES[*]}"
+          VERIFY_OK=true
+          npm run typecheck || VERIFY_OK=false
+          if [[ "$VERIFY_OK" == "true" ]]; then ./scripts/lint.sh "${FILES[@]}" || VERIFY_OK=false; fi
+          if [[ "$VERIFY_OK" == "true" ]]; then npx prettier --check "${FILES[@]}" || VERIFY_OK=false; fi
+          if [[ "$VERIFY_OK" == "true" && "$CATEGORY" == "react-compiler" ]]; then
+            for f in "${FILES[@]}"; do npm run react-compiler-compliance-check check "$f" || VERIFY_OK=false; done
+          fi
+          if [[ "$VERIFY_OK" != "true" ]]; then
+            post_discord "🔧 Self-heal: the agent reported a fix for <$RUN_URL> but workflow re-verification FAILED; no PR opened. $SUMMARY"
+            echo "Workflow re-verify failed; not opening a PR."
+            exit 0
+          fi
+
+          # Open the PR as KirokuAdmin. master is unprotected + the PR is human-reviewed, so commits
+          # are not GPG-signed (keeps this on ubuntu, in line with the check workflows).
+          git config user.name KirokuAdmin
+          git config user.email kiroku.alcohol.tracker@gmail.com
+          BRANCH="automated-fix/ci-${SHORT_SHA}-run-${RUN_ID}"
+          git switch -c "$BRANCH"
+          git add -A
+          git commit \
+            -m "fix(ci): auto-heal $CATEGORY failure on master" \
+            -m "$SUMMARY" \
+            -m "Automated fix for failed run $RUN_URL." \
+            -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+          git push --set-upstream origin "$BRANCH"
+
+          BODY_FILE="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "## Automated CI self-heal"
+            echo ""
+            echo "The **Process new code merged to master** pipeline failed ([run]($RUN_URL)). This PR is an automated **$CATEGORY** fix."
+            echo ""
+            echo "**Root cause / fix:** $SUMMARY"
+            echo ""
+            echo "**Files changed:**"
+            for f in "${FILES[@]}"; do echo "- \`$f\`"; done
+            echo ""
+            echo "### Workflow re-verification (✅ passed before this PR opened)"
+            echo "- \`npm run typecheck\`"
+            echo "- \`./scripts/lint.sh\` on the changed files"
+            echo "- \`npx prettier --check\` on the changed files"
+            if [[ "$CATEGORY" == "react-compiler" ]]; then echo "- react-compiler compliance on the changed files"; fi
+            echo ""
+            echo "> ⚠️ PRs opened by KirokuAdmin skip the standard \`pull_request\` checks, so the re-verification above (run by selfHeal.yml) is the gate. Review the diff before merging. Master's own pipeline re-runs on merge."
+            echo ""
+            echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          } > "$BODY_FILE"
+
+          gh pr create --base master --head "$BRANCH" \
+            --title "fix(ci): auto-heal $CATEGORY failure on master" \
+            --body-file "$BODY_FILE"
+          PR_URL="$(gh pr view "$BRANCH" --json url -q '.url')"
+          post_discord "🔧 Self-heal opened a PR for the \`$CATEGORY\` failure on <$RUN_URL>: $PR_URL — review before merging."
+
+      - name: Report agent error
+        if: ${{ steps.guard.outputs.proceed == 'true' && steps.heal.outcome == 'failure' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ steps.context.outputs.run_url }}
+        run: |
+          set -eo pipefail
+          curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
+            -d "$(jq -n --arg c "🔧 Self-heal for <$RUN_URL> failed: the agent step errored. See the selfHeal run logs." '{content: $c}')" >/dev/null || true


### PR DESCRIPTION
## What

**Phase 2** of the self-healing pipeline. Phase 1 ([#1349](https://github.com/PetrCala/Kiroku/pull/1349)) made master failures *legible* (enriched Discord alert with the failing job + blamed PR + error). This adds the *fix*: a **manually-dispatched** workflow that, given a failed **Process new code merged to master** run id, spins up a Claude agent to **reproduce → fix → verify** a mechanical failure on master tip, then opens a **human-reviewed PR**. It never auto-merges.

Two founder decisions shaped this:
- **Dispatch-only** (no auto-fire on failure) — cost control; the Phase-1 notifier still auto-pings.
- **Mechanical scope only** — typecheck, lint, prettier, imports, react-compiler, and the semantic merge-conflicts these surface. Test/logic/flake/infra are *escalated to Discord, not touched*.

## How (mirrors the review-command pattern)

The agent **doesn't** open the PR — it fixes + verifies in the working tree and returns structured JSON; a **deterministic workflow step** re-verifies and opens the PR (same split as [review-code-pr.md](.claude/commands/review-code-pr.md)).

- **[selfHeal.yml](.github/workflows/selfHeal.yml)** — `workflow_dispatch(run_id)`. Checks out master tip with the `KIROKU_ADMIN_COMMIT_TOKEN` PAT, pulls the failed-run logs, guards against heal-of-heal (`automated-fix/*` branches), runs the agent via `claude-code-action` (`claude-opus-4-8`, `--json-schema`), then re-verifies on the changed files and opens the PR via the proven `createNewVersion` push/PR pattern — or escalates to Discord.
- **[fix-ci-failure.md](.claude/commands/fix-ci-failure.md)** — the agent contract: classify → reproduce (master tip, *narrowest non-`changed` checks*) → mechanical-only fix → verify → return JSON only.
- **[ci-fix-output.json](.claude/schemas/ci-fix-output.json)** — the structured output schema.

## Key correctness decisions

- **Reproduce on master *tip*, not the failing SHA** — branching the fix from tip yields a PR containing *only the fix*. If tip no longer reproduces (already fixed/flaky), the agent returns `cannot_fix` and no PR is opened.
- **Workflow-side re-verify is the real gate.** A PR opened by `KirokuAdmin` *skips* the standard `pull_request` checks (the reusable check workflows guard `if: actor != KirokuAdmin`), so the deterministic step re-runs `typecheck` + targeted `lint`/`prettier` (+ react-compiler) on the changed files before opening, and records the results in the PR body. Master's own pipeline re-runs on merge as the final backstop.
- **Unsigned commits on `ubuntu-latest`** — master isn't a protected branch and human PRs already merge unsigned, so no GPG/macOS needed.
- **Anti-recursion + idempotency** — refuses `automated-fix/*`-origin failures; skips if an open auto-fix PR already exists for the commit.
- **Model `claude-opus-4-8`** — `--model` is resolved server-side, so the latest Opus works with the pinned `claude-code-action@v1.0.86`.

## Verification

- `npm run gh-actions-validate` ✅ (`selfHeal.yml` schema-valid; actionlint/shellcheck clean — only the pre-existing `lint.yml` warning)
- `jq` ✅ `ci-fix-output.json` valid JSON
- Phase-1 files untouched (this is an independent PR off `master`).

## Testing notes

`workflow_dispatch` only, so it's safe to merge dormant. To dry-run: point `DISCORD_WEBHOOK_URL` at a throwaway webhook and `gh workflow run selfHeal.yml -f run_id=<a real past mechanical master failure>`. Verify a fixed run opens a PR with only the fix + re-verify results, and a test-failure run escalates with no PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)