### PR TITLE
fix(auth): back from reset password slides forward instead of going back

### DIFF
--- a/src/screens/SignUp/ForgotPasswordScreen.tsx
+++ b/src/screens/SignUp/ForgotPasswordScreen.tsx
@@ -20,7 +20,6 @@ import InputWrapper from '@components/Form/InputWrapper';
 import variables from '@src/styles/variables';
 import TextInput from '@components/TextInput';
 import {useFirebase} from '@context/global/FirebaseContext';
-import ROUTES from '@src/ROUTES';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 
 function ForgotPasswordScreen() {
@@ -94,7 +93,7 @@ function ForgotPasswordScreen() {
       <HeaderWithBackButton
         title={translate('forgotPasswordScreen.title')}
         shouldShowBackButton
-        onBackButtonPress={() => Navigation.navigate(ROUTES.AUTH)}
+        onBackButtonPress={() => Navigation.goBack()}
       />
       {isLoading ? (
         <FullscreenLoadingIndicator


### PR DESCRIPTION
## Problem

Pressing **Back** from the **reset password** (Forgot Password) screen plays a *forward* slide — it pushes the Auth (sign up / log in) screen in from the right instead of dismissing back to it.

## Root cause

The back button forward-navigates instead of going back:

```tsx
onBackButtonPress={() => Navigation.navigate(ROUTES.AUTH)}
```

ForgotPassword is reached by pushing onto AuthScreen in the public stack (`Initial → navigate(AUTH) → navigate(FORGOT_PASSWORD)`), so it sits **on top of** Auth. Calling `Navigation.navigate(...)` on the back button is a forward navigation, so React Navigation plays a forward slide and pushes a fresh Auth on top — the "goes forward" effect.

This is the same class of bug as the Settings back buttons fixed in #1330 ("back slides forward instead of dismissing"). There the trigger was a `goBack(ROUTES.SETTINGS)` fallback route degrading to a forward `PUSH`; here the cause is even more direct — a literal `navigate()` on the back button.

## Fix

Use plain `Navigation.goBack()`, matching #1330's conclusion:

```diff
-        onBackButtonPress={() => Navigation.navigate(ROUTES.AUTH)}
+        onBackButtonPress={() => Navigation.goBack()}
```

- **Normal flow** — ForgotPassword sits above Auth, so `goBack()` pops to the *existing* Auth screen with a backward slide. Bonus: it preserves Auth's `?mode=signUp|logIn` param, which the old `navigate(ROUTES.AUTH)` silently dropped.
- **No fallback route** — `goBack`'s fallback branch only fires on `isFirstRouteInNavigator`, which doesn't apply to this flat public stack, so a fallback would be inert and only risks re-introducing the #1330 forward-slide branch. Plain `goBack()` is the cleaner, lower-risk choice.

Also drops the now-unused `ROUTES` import.

## Testing

- `npx prettier --write` — clean (unchanged)
- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed
- `npm run lint-changed` — passed

Behavior to verify: open **sign up / log in → Forgot password?**, press **Back** → the screen should slide back to the auth screen, not slide a new one in from the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)