### PR TITLE
fix(nav): back from NotFoundScreen forward-slides instead of going back

### DIFF
--- a/src/screens/ErrorScreen/NotFoundScreen.tsx
+++ b/src/screens/ErrorScreen/NotFoundScreen.tsx
@@ -20,7 +20,7 @@ function NotFoundScreen() {
       style={styles.appContent}>
       <HeaderWithBackButton
         title={translate('notFoundScreen.title')}
-        onBackButtonPress={() => Navigation.navigate(ROUTES.HOME)}
+        onBackButtonPress={() => Navigation.goBack(ROUTES.HOME)}
       />
       <View style={{backgroundColor: theme.appBG}} />
       {/* // TODO  */}

--- a/src/screens/SignUp/ForgotPasswordScreen.tsx
+++ b/src/screens/SignUp/ForgotPasswordScreen.tsx
@@ -20,7 +20,6 @@ import InputWrapper from '@components/Form/InputWrapper';
 import variables from '@src/styles/variables';
 import TextInput from '@components/TextInput';
 import {useFirebase} from '@context/global/FirebaseContext';
-import ROUTES from '@src/ROUTES';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 
 function ForgotPasswordScreen() {
@@ -94,7 +93,7 @@ function ForgotPasswordScreen() {
       <HeaderWithBackButton
         title={translate('forgotPasswordScreen.title')}
         shouldShowBackButton
-        onBackButtonPress={() => Navigation.navigate(ROUTES.AUTH)}
+        onBackButtonPress={() => Navigation.goBack()}
       />
       {isLoading ? (
         <FullscreenLoadingIndicator


### PR DESCRIPTION
## Problem

Pressing **Back** on the 404 / Not Found screen plays a *forward* slide — the Home screen slides in from the right — instead of going back.

## Root cause

```tsx
onBackButtonPress={() => Navigation.navigate(ROUTES.HOME)}
```

`Navigation.navigate(...)` is a forward navigation, so React Navigation plays a forward slide. Same class of bug as the Settings screens fixed in [#1330](https://github.com/PetrCala/Kiroku/pull/1330) and ForgotPasswordScreen fixed in [#1353](https://github.com/PetrCala/Kiroku/pull/1353).

## Fix

```diff
-        onBackButtonPress={() => Navigation.navigate(ROUTES.HOME)}
+        onBackButtonPress={() => Navigation.goBack(ROUTES.HOME)}
```

`goBack(ROUTES.HOME)` handles both cases:
- **Normal navigation** (user tapped into a broken link) — goes back to the previous screen with a backward slide.
- **Deep link with no back stack** — `isFirstRouteInNavigator` fires the `ROUTES.HOME` fallback, landing on the home tab. HOME is the main central-pane tab so its fallback path resolves correctly (no forward-push degradation like the Settings tab in #1330).

## Testing

- `npx prettier --write` — clean (unchanged)
- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed
- `npm run lint-changed` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)