### PR TITLE
ci(web): add manual workflow_dispatch trigger for live web deploys

### DIFF
--- a/.github/workflows/deployWeb.yml
+++ b/.github/workflows/deployWeb.yml
@@ -14,8 +14,16 @@ name: Deploy web
 #                                                build on the dev backend, so the
 #                                                dev-only test account can sign in.
 # - PR labeled `Ready To Build - Web`         -> build-web-dev -> preview channel
-#   (or manual dispatch with a PR number)        `pr-<number>` on the dev site,
+#                                                `pr-<number>` on the dev site,
 #                                                URL commented on the PR
+# - manual dispatch (Actions tab / `gh workflow run`), `ENVIRONMENT` input:
+#     * `production` -> build-web       -> live deploy to app.kiroku.cz
+#     * `staging`    -> build-web-adhoc -> live deploy to app-dev.kiroku.cz
+#     * `preview`    -> build-web-dev   -> PR preview channel (needs PULL_REQUEST_NUMBER)
+#   Break-glass: a `production` dispatch ships the web to prod WITHOUT pushing the
+#   `production` branch (which would also fire the native iOS/Android store deploy
+#   via deploy.yml). It builds whatever ref the run is dispatched from, so dispatch
+#   from `master`/`staging` (or a vetted hotfix branch) only.
 #
 # Auth: a single Google service-account JSON in the FIREBASE_SERVICE_ACCOUNT
 # secret, granted Firebase Hosting Admin on BOTH Firebase projects
@@ -32,9 +40,18 @@ on:
     types: [labeled]
   workflow_dispatch:
     inputs:
-      PULL_REQUEST_NUMBER:
-        description: Pull request number to build a preview channel for
+      ENVIRONMENT:
+        description: What to deploy (preview = temporary PR channel)
         required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - staging
+          - production
+      PULL_REQUEST_NUMBER:
+        description: PR number to build a preview channel for (only when ENVIRONMENT=preview)
+        required: false
 
 permissions:
   contents: read
@@ -47,7 +64,7 @@ concurrency:
 jobs:
   deployLive:
     name: Build and deploy web (live)
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.ENVIRONMENT != 'preview') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,14 +72,26 @@ jobs:
 
       - name: Resolve deploy target
         id: target
+        env:
+          # On a branch push the environment is the branch name; on a manual
+          # workflow_dispatch it is the chosen ENVIRONMENT input.
+          DISPATCH_ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
         run: |
-          if [[ "$GITHUB_REF_NAME" == "production" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            ENVIRONMENT="$DISPATCH_ENVIRONMENT"
+          else
+            ENVIRONMENT="$GITHUB_REF_NAME"
+          fi
+
+          if [[ "$ENVIRONMENT" == "production" ]]; then
             {
+              echo "ENVIRONMENT=production"
               echo "PROJECT=prod"
               echo "BUILD_SCRIPT=build-web"
             } >> "$GITHUB_OUTPUT"
           else
             {
+              echo "ENVIRONMENT=staging"
               echo "PROJECT=dev"
               echo "BUILD_SCRIPT=build-web-adhoc"
             } >> "$GITHUB_OUTPUT"
@@ -74,11 +103,11 @@ jobs:
       # (not prod, as STAGING_ENV_FILE did) — a production-grade build on the dev
       # backend.
       - name: Stage .env.production from secret
-        if: ${{ github.ref_name == 'production' }}
+        if: ${{ steps.target.outputs.ENVIRONMENT == 'production' }}
         run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env.production
 
       - name: Stage .env.adhoc from secret
-        if: ${{ github.ref_name == 'staging' }}
+        if: ${{ steps.target.outputs.ENVIRONMENT == 'staging' }}
         run: echo "${{ secrets.ADHOC_ENV_FILE }}" > .env.adhoc
 
       - name: Setup Node
@@ -100,17 +129,23 @@ jobs:
             --only hosting:app \
             --project ${{ steps.target.outputs.PROJECT }} \
             --non-interactive \
-            --message "Deploy ${{ github.sha }} (${{ github.ref_name }})"
+            --message "Deploy ${{ github.sha }} (${{ steps.target.outputs.ENVIRONMENT }})"
 
   deployPreview:
     name: Build and deploy web preview channel
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'Ready To Build - Web') }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.ENVIRONMENT == 'preview') || (github.event_name == 'pull_request' && github.event.label.name == 'Ready To Build - Web') }}
     runs-on: ubuntu-latest
     outputs:
       preview-url: ${{ steps.preview.outputs.URL }}
     env:
       PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.inputs.PULL_REQUEST_NUMBER }}
     steps:
+      - name: Require PULL_REQUEST_NUMBER for a preview dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && env.PULL_REQUEST_NUMBER == '' }}
+        run: |
+          echo "::error::ENVIRONMENT=preview requires the PULL_REQUEST_NUMBER input." >&2
+          exit 1
+
       - name: Resolve PR head ref
         id: ref
         if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Why

`deployWeb.yml` could only deploy **prod** web on a push to the `production` branch — but [`deploy.yml`](.github/workflows/deploy.yml) shares that trigger, so a `production` push also fires a full **native iOS/Android store release** via `platformDeploy.yml`. There was no way to ship a web-only fix through CI, which is why app.kiroku.cz had to be repaired with a manual local `firebase deploy` (the drift-prone path that shipped a broken bundle on 2026-06-10).

## What

Adds an `ENVIRONMENT` choice input (`preview` | `staging` | `production`) to the existing `workflow_dispatch` so `deployLive` can run a clean `npm ci` CI deploy on demand:

| ENVIRONMENT | build script | target |
|---|---|---|
| `production` | `build-web` | app.kiroku.cz (kiroku-app-prod) |
| `staging` | `build-web-adhoc` | app-dev.kiroku.cz (kiroku-app-dev) |
| `preview` | `build-web-dev` | PR preview channel (needs `PULL_REQUEST_NUMBER`) |

- Target/env is resolved from the **branch** (push) or the **input** (dispatch); **push behavior is unchanged**.
- `deployPreview` / `playwright` are scoped to the preview path only.
- `PULL_REQUEST_NUMBER` is now optional, with a guard that fails a `preview` dispatch if it's missing.

This is **break-glass** for web-only hotfixes — it does **not** touch the native store deploy. The full `production`-branch promotion (web + native together via `finishReleaseCycle.yml`) is unchanged.

## Caveats

- A `production` dispatch builds **whatever ref the run is dispatched from** — dispatch from `master`/`staging` (or a vetted hotfix branch).
- The CI prod build uses the `PRODUCTION_ENV_FILE` secret (not a local `.env.production`); confirm it is current before relying on it.

## Verification

- `actionlint` passes; `prettier --check` clean.
- Logic traced: push→staging/prod unchanged; dispatch `production`→`deployLive` (prod) only; dispatch `staging`→`deployLive` (dev) only; dispatch `preview` / PR label→`deployPreview`+`playwright` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)