### PR TITLE
ci(web): verify the deployed build is actually live after deploy

### DIFF
--- a/.github/scripts/verifyWebDeploy.sh
+++ b/.github/scripts/verifyWebDeploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Confirms the live Firebase-hosted web app is serving the build we just deployed,
+# by matching the content-hashed entry bundle referenced in the live index.html
+# against the one in the local dist/ (the build that was just uploaded).
+#
+# Usage: verifyWebDeploy.sh <host-url> [dist-index-path]
+#   <host-url>        e.g. https://app.kiroku.cz
+#   [dist-index-path] defaults to dist/index.html
+set -euo pipefail
+
+HOST="${1:?usage: verifyWebDeploy.sh <host-url> [dist-index-path]}"
+DIST_INDEX="${2:-dist/index.html}"
+
+# Entry bundle name, e.g. main-13d0a5b11e3669b71d70.bundle.js (contenthash, hex).
+EXPECTED_BUNDLE="$(grep -oE 'main-[0-9a-f]+\.bundle\.js' "$DIST_INDEX" | head -1 || true)"
+if [[ -z "$EXPECTED_BUNDLE" ]]; then
+  echo "::error::No main-<hash>.bundle.js found in $DIST_INDEX"
+  exit 1
+fi
+echo "Expecting $HOST to serve: $EXPECTED_BUNDLE"
+
+readonly MAX_ATTEMPTS=12
+readonly SLEEP_SECONDS=5
+sleep "$SLEEP_SECONDS" # give Firebase's CDN a moment to propagate
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  # Cache-bust so we read the freshly deployed shell, not an edge-cached copy.
+  LIVE_INDEX="$(curl -fsSL -H 'Cache-Control: no-cache' "$HOST/?cacheBust=$RANDOM$attempt" 2>/dev/null || true)"
+  LIVE_BUNDLE="$(printf '%s' "$LIVE_INDEX" | grep -oE 'main-[0-9a-f]+\.bundle\.js' | head -1 || true)"
+
+  if [[ "$LIVE_BUNDLE" == "$EXPECTED_BUNDLE" ]] && curl -fsSL -o /dev/null "$HOST/$EXPECTED_BUNDLE"; then
+    echo "✅ Verified: $HOST is serving $EXPECTED_BUNDLE"
+    exit 0
+  fi
+  echo "attempt $attempt/$MAX_ATTEMPTS: live='${LIVE_BUNDLE:-<none>}' expected='$EXPECTED_BUNDLE'"
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "::error::Deploy verification failed: $HOST never served $EXPECTED_BUNDLE after $MAX_ATTEMPTS attempts (~$((MAX_ATTEMPTS * SLEEP_SECONDS))s)"
+exit 1

--- a/.github/workflows/deployWeb.yml
+++ b/.github/workflows/deployWeb.yml
@@ -60,11 +60,13 @@ jobs:
             {
               echo "PROJECT=prod"
               echo "BUILD_SCRIPT=build-web"
+              echo "HOST=https://app.kiroku.cz"
             } >> "$GITHUB_OUTPUT"
           else
             {
               echo "PROJECT=dev"
               echo "BUILD_SCRIPT=build-web-adhoc"
+              echo "HOST=https://app-dev.kiroku.cz"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -101,6 +103,9 @@ jobs:
             --project ${{ steps.target.outputs.PROJECT }} \
             --non-interactive \
             --message "Deploy ${{ github.sha }} (${{ github.ref_name }})"
+
+      - name: Verify the new build is live
+        run: bash ./.github/scripts/verifyWebDeploy.sh "${{ steps.target.outputs.HOST }}"
 
   deployPreview:
     name: Build and deploy web preview channel


### PR DESCRIPTION
## Why

`deployWeb.yml` has no post-deploy check — once `firebase deploy` exits 0, CI assumes success and never confirms the live site is serving the build it just uploaded. That's exactly how a stale, broken build sat unnoticed on app.kiroku.cz (the 2026-06-16 infinite-reload incident). Upstream Expensify guards this with a `verifyDeploy.sh` step at the end of its web deploy.

## What

An Expensify-style post-deploy verify, adapted to Kiroku's content-hashed bundles (no `/version.json` needed):

- **New `.github/scripts/verifyWebDeploy.sh <host>`** — reads the expected `main-<contenthash>.bundle.js` from the local `dist/index.html` (the build just uploaded), then polls the live host (cache-busted, ~12×5s) until its `index.html` references the same bundle **and** that bundle returns HTTP 200.
- **`deployWeb.yml`** — the `Resolve deploy target` step now emits a `HOST` output (prod → app.kiroku.cz, staging → app-dev.kiroku.cz), and a new final step in `deployLive` runs the script.

Runs for **both** live targets; the PR-preview / Playwright path is untouched. A mismatch **fails the `deployLive` job**, so the existing Discord failure alert fires instead of a green check hiding a stale/partial deploy.

## Scope

- **Purely additive** — the deploy step itself is untouched, and the web build is unchanged (the entry bundle is already content-hashed).
- Confirms the right build is **live**, not that it **boots** — a runtime crash with a matching hash would still pass. A boot smoke-test (dev Playwright against the live URL; unauthenticated prod boot check) is a noted follow-up.

## Verification

- `actionlint` + `shellcheck` + `prettier --check`: all pass.
- Tested against **live prod**:
  - **Pass:** the currently-deployed `dist/` (`main-13d0a5b…`) → `✅ Verified … exit 0`.
  - **Fail:** a bogus hash → logs each attempt, `❌ … exit 1` with a `::error::` annotation.
- True end-to-end: the next push to `staging` runs it against app-dev.kiroku.cz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)