### PR TITLE
refactor(i18n): tone pass on 23 Czech UI strings

### DIFF
--- a/__tests__/unit/Translate.test.ts
+++ b/__tests__/unit/Translate.test.ts
@@ -126,6 +126,11 @@ const UNTRANSLATED_ALLOWLIST = new Set<string>([
   'common.role',
   'statistics.tabs.trends.weeklyTrend.legend.trend',
   'errors.auth.networkRequestFailed.title',
+  // "Blackout" kept as a loanword in Czech (casual register, used as a
+  // severity-band label); see src/languages/context/cs_cz.md glossary.
+  'common.blackout',
+  'liveSessionScreen.blackout',
+  'colorPaletteScreen.bands.black',
 ]);
 
 describe('Translation Keys', () => {

--- a/src/languages/context/cs_cz.md
+++ b/src/languages/context/cs_cz.md
@@ -69,7 +69,7 @@ zde`, `Přidejte si je zde`, `Zkuste hledat zde`.
 | sober                       | **bez pití**                                      |                |
 | alcohol-free day(s)         | **dny bez alkoholu**                              |                |
 | quiet day(s)                | **klidné dny**                                    |                |
-| blackout                    | **výpadek paměti**                                |                |
+| blackout                    | **Blackout** (loanword)                           | výpadek paměti |
 | streak (alcohol-free)       | **série** (dnů bez alkoholu)                      |                |
 | session intensity: light    | **mírná** (relace)                                | lehká          |
 | session intensity: moderate | **střední** (relace)                              |                |

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -265,7 +265,7 @@ export default {
     member: 'Člen',
     role: 'Role',
     note: 'Poznámka',
-    blackout: 'Výpadek paměti',
+    blackout: 'Blackout',
     timezone: 'Časové pásmo',
   },
   modal: {
@@ -687,7 +687,7 @@ export default {
       yellow: 'Mírná',
       orange: 'Střední',
       red: 'Náročná',
-      black: 'Výpadek paměti',
+      black: 'Blackout',
     },
     hex: {
       label: 'Hex barva',
@@ -756,9 +756,9 @@ export default {
   },
   appShareScreen: {
     title: 'Sdílet aplikaci',
-    sectionTitle: 'Všichni sem!',
+    sectionTitle: 'Sezvěte své přátele!',
     prompt:
-      'Pomozte nám růst tím, že budete Kiroku sdílet se svými přáteli! Můžete tak učinit pomocí odkazu nebo naskenováním QR kódu.',
+      'Líbí se vám Kiroku? Sdílejte ho s přáteli! Stačí poslat odkaz nebo naskenovat QR kód.',
     link: 'Zkopírovat odkaz ke sdílení do schránky',
     linkCopied: 'Odkaz ke sdílení byl zkopírován do schránky!',
     qrCode: 'Zobrazit QR kód',
@@ -820,7 +820,7 @@ export default {
       heroPill: 'Odznak podporovatele',
       heroTitle: 'Staňte se Kiroku Supporter',
       heroSubtitle:
-        'Vyjádřete svou podporu a noste na profilu exkluzivní odznak podporovatele.',
+        'Vyjádřete svou podporu a získejte exkluzivní odznak podporovatele.',
       featureBadgeTitle: 'Odznak podporovatele',
       featureBadgeDescription:
         'Exkluzivní odznak zobrazený na vašem veřejném profilu',
@@ -909,7 +909,7 @@ export default {
     },
     live: {
       title: 'Živá',
-      description: 'Přidávejte drinky v reálném čase',
+      description: 'Přidávejte drinky průběžně',
     },
     edit: {
       title: 'Zpětná',
@@ -1049,7 +1049,7 @@ export default {
   manageAccountScreen: {
     title: 'Správa účtu',
     dangerZone: {
-      title: 'Nebezpečná zóna',
+      title: 'Nevratné akce',
       subtitle: 'Tyto akce jsou trvalé a nelze je vrátit zpět.',
     },
     deleteAccount: {
@@ -1076,7 +1076,7 @@ export default {
   },
   profileScreen: {
     title: 'Profil',
-    titleNotSelf: 'Přehled uživatele',
+    titleNotSelf: 'Profil uživatele',
     seeAllFriends: 'Zobrazit všechny přátele',
     drinkingSessions: ({sessionsCount}: DrinkingSessionsParams) =>
       `${Str.pluralize('Alkoholová relace', 'Alkoholových relací', sessionsCount)}`,
@@ -1123,7 +1123,7 @@ export default {
           afDays: {label: 'Dny bez alkoholu'},
           dryStreak: {label: 'Nejdelší série bez alkoholu', unit: 'dní'},
           sessions: {label: 'Relace'},
-          heaviestDay: {label: 'Nejtěžší den', unit: 'jednotek'},
+          heaviestDay: {label: 'Nejnáročnější den', unit: 'jednotek'},
           avgPerDrinkingDay: {label: 'Průměr / den pití', unit: 'jednotek'},
           monthlyAvg: {label: 'Průměr / měsíc', unit: 'jednotek'},
           daysOverYellow: {
@@ -1155,14 +1155,14 @@ export default {
         },
         empty: {
           neverLogged: {
-            title: 'Zatím není co zaznamenat',
-            body: 'Až zaznamenáte relaci, objeví se zde váš přehled za období.',
+            title: 'Zatím žádné záznamy',
+            body: 'Až zaznamenáte první relaci, objeví se zde váš přehled za období.',
           },
           noDataInRange:
             'Žádné relace v tomto období. Každý uplynulý den byl bez alkoholu.',
         },
         sparseFooter:
-          'Zatím jen málo historie. Tato čísla se zpřesní, jak budete přidávat další záznamy.',
+          'Zatím máte jen málo záznamů. Postupně, jak budete přidávat další, se čísla zpřesní.',
       },
       trends: {
         label: 'Trendy',
@@ -1174,9 +1174,9 @@ export default {
             trend: 'Trend',
           },
           captions: {
-            trendingDown: 'Vaše týdenní jednotky mají sestupný trend.',
-            trendingUp: 'Vaše týdenní jednotky mají vzestupný trend.',
-            neutral: 'Vaše týdny se mění obvyklým způsobem.',
+            trendingDown: 'Vaše týdenní konzumace klesá.',
+            trendingUp: 'Vaše týdenní konzumace roste.',
+            neutral: 'Vaše týdenní hodnoty se pohybují v obvyklém rozmezí.',
             notEnoughData:
               'Pokračujte v zaznamenávání. Trend se ukáže, až bude víc dat.',
           },
@@ -1195,7 +1195,8 @@ export default {
       },
       patterns: {
         label: 'Návyky',
-        placeholder: 'Kdy a jak (hodina dne a den v týdnu) uvidíte tady.',
+        placeholder:
+          'Zde se objeví, kdy a jak pijete (hodina dne a den v týdnu).',
       },
       breakdown: {
         label: 'Rozpis',
@@ -1222,9 +1223,9 @@ export default {
         },
         concentration: {
           moreVaried: ({period}: BreakdownPeriodParams) =>
-            `Tento ${period} jste pil/a pestřeji než minulý.`,
+            `Tento ${period} jste pil/a více druhů než minulý.`,
           moreFocused: ({period}: BreakdownPeriodParams) =>
-            `Tento ${period} jste se zaměřil/a víc než minulý.`,
+            `Tento ${period} jste pil/a méně druhů než minulý.`,
           aboutTheSame: ({period}: BreakdownPeriodParams) =>
             `Skladba drinků je zhruba stejná jako minulý ${period}.`,
           period: {
@@ -1335,8 +1336,7 @@ export default {
   badgesScreen: {
     title: 'Odznaky',
     badgesTitle: 'Odznaky',
-    empty:
-      'Zaznamenejte svou první alkoholovou relaci, abyste začali získávat odznaky a sledovat svou sérii dnů bez alkoholu.',
+    empty: 'Zaznamenejte svou první relaci a začněte sbírat odznaky.',
     dayUnit: ({count}: BadgesDayCountParams) => (count === 1 ? 'den' : 'dní'),
     streak: {
       label: 'Aktuální série dnů bez alkoholu',
@@ -1376,7 +1376,7 @@ export default {
         description: 'Nasbírejte 50 dní bez alkoholu.',
       },
       sessions25: {
-        title: 'Pečlivé zaznamenávání',
+        title: 'Mistr zápisů',
         description: 'Zaznamenejte 25 alkoholových relací.',
       },
     },
@@ -1399,7 +1399,7 @@ export default {
     startingSession: 'Spouštím novou relaci…',
     welcomeToKiroku: 'Vítejte v Kiroku!',
     startNewSessionByClickingPlus:
-      'Spusťte novou relaci kliknutím na tlačítko plus v dolní části obrazovky',
+      'Klepnutím na tlačítko plus dole na obrazovce spustíte novou relaci',
     offlineNoData: {
       title: 'Jste offline',
       message:
@@ -1434,7 +1434,7 @@ export default {
       statistics: 'Statistiky',
       viewStatistics: 'Zobrazit statistiky',
       vsLastMonth: 'vs minulý měsíc',
-      monthToDate: 'zatím',
+      monthToDate: 'k dnešku',
       unitsByWeek: 'Jednotky podle týdne',
       unitsPerWeekA11y: 'Zkonzumované jednotky za týden v tomto měsíci',
     },
@@ -1450,8 +1450,8 @@ export default {
     drinksConsumed: 'Zkonzumované drinky',
     sessionFrom: 'Relace od',
     sessionOn: 'Relace dne',
-    blackout: 'Výpadek paměti',
-    blackoutSwitchLabel: 'Označuje, zda vaše relace skončila výpadkem paměti.',
+    blackout: 'Blackout',
+    blackoutSwitchLabel: 'Označuje, zda vaše relace skončila blackoutem.',
     note: 'Poznámka',
     discardSessionWarning: (discardWord: string) =>
       `Opravdu chcete tuto relaci ${discardWord}?`,
@@ -1534,7 +1534,7 @@ export default {
   forceUpdate: {
     heading: 'Je vyžadována aktualizace aplikace',
     text: ({platform}: ForceUpdateTextParams) =>
-      `Tato verze aplikace je nyní ukončena. Aktualizujte prosím na nejnovější verzi pomocí odkazu níže${
+      `Podpora této verze aplikace skončila. Aktualizujte prosím na nejnovější verzi pomocí odkazu níže${
         platform === CONST.PLATFORM.IOS
           ? ' nebo z prostředí aplikace TestFlight'
           : ''
@@ -1544,7 +1544,7 @@ export default {
   login: {
     hero: {
       header: 'Mějte přehled o svých alkoholových dobrodružstvích',
-      body: 'Vítejte v Kiroku, kde můžete sledovat, monitorovat a sdílet svou konzumaci alkoholu',
+      body: 'Vítejte v Kiroku, kde můžete sledovat svou konzumaci alkoholu a sdílet ji s přáteli',
     },
     email: 'E-mail',
     existingAccount: 'Už máte účet?',


### PR DESCRIPTION
## Summary

A founder-reviewed tone/nuance pass over **23 Czech UI strings**, chosen for being **high-impact** (first impressions, emotionally loaded moments, motivational surfaces) and **nuance-sensitive** (where small wording shifts change how the copy lands). Each string was revised one-by-one from a menu of alternatives. All changes keep **vykání** and stay **em-dash-free** per `src/languages/context/cs_cz.md`.

## Changes by theme

**Voice / first impression**
- `login.hero.body` — dropped the redundant "monitorovat" anglicism; added "sdílet ji s přáteli"
- `appShareScreen.sectionTitle` → "Sezvěte své přátele!"
- `appShareScreen.prompt` — warmer, less corporate; fixed stiff "Můžete tak učinit"
- `supporter.paywallScreen.heroSubtitle` — "noste odznak" calque → "získejte"

**Emotionally loaded**
- `manageAccountScreen.dangerZone.title` — "Nebezpečná zóna" → "Nevratné akce" (de-calque, matches subtitle)
- `forceUpdate.text` — "je nyní ukončena" → "Podpora této verze aplikace skončila."

**Motivational / empty states** (tone matters most here)
- `statistics…sparseFooter`, `empty.neverLogged.title`/`.body`
- trend captions `trendingDown` / `trendingUp` (mirrored for consistency) / `neutral` — "sestupný trend" → natural, encouraging phrasing
- `badgesScreen.empty` — shorter, punchier
- `homeScreen.startNewSessionByClickingPlus` — "kliknutím" (desktop) → "klepnutím" (mobile, matches rest of app)

**Word choice / connotation**
- `statistics.tabs.patterns.placeholder` — fixed awkward "uvidíte tady" word order
- `kpi.heaviestDay.label` — "Nejtěžší den" → "Nejnáročnější den" (consistent with the "náročná" intensity scale)
- `badges.sessions25.title` — "Pečlivé zaznamenávání" → "Mistr zápisů" (persona badge name)
- `drinkingSession.live.description` — dropped "v reálném čase" jargon → "průběžně"
- `profileScreen.titleNotSelf` — "Přehled uživatele" → "Profil uživatele"
- `concentration.moreVaried` / `moreFocused` — recast as a clear antonym pair ("více druhů" / "méně druhů"); fixes the confusing "zaměřil/a"
- `homeScreen.stats.monthToDate` — "zatím" → "k dnešku"

**`blackout` → "Blackout" loanword** (casual register; works as a severity-band label)
- Applied across all 3 surfaces (`common.blackout`, `liveSessionScreen.blackout`, `colorPaletteScreen.bands.black`) + the switch label
- Updated the glossary in `src/languages/context/cs_cz.md`
- Added the 3 keys to `UNTRANSLATED_ALLOWLIST` in `Translate.test.ts` (value is intentionally identical to EN)

## Verification
- `jest __tests__/unit/Translate.test.ts` — 10/10 pass (parity, value-shape, untranslated-equality)
- `npm run typecheck-tsgo` — clean
- Prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)