### PR TITLE
ci(deploy): tidy the Android production promote and clarify the deploy announcement

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -354,11 +354,12 @@ jobs:
           # so drop the build suffix (e.g. 0.3.16-14 -> 0.3.16).
           CLI_VERSION="${APP_VERSION%-*}"
           DESCRIPTION="Successfully deployed Kiroku [${{ inputs.RELEASE_TAG }}](https://github.com/PetrCala/Kiroku/releases/tag/${{ inputs.RELEASE_TAG }}) to ${{ inputs.DEPLOY_ENVIRONMENT }}"
-          # Production builds are NOT live for users yet: iOS sits in 'Pending Developer
-          # Release' (automatic_release: false) and Android promotes to the beta track.
-          # Remind a human to bump the in-app version gate once the build actually ships.
+          # Production builds are deployed but not public yet: iOS is submitted to
+          # App Store review and held as Pending Developer Release (automatic_release:
+          # false); Android is promoted to the open-testing track (held by Managed
+          # publishing). Remind a human of the manual steps to go fully public.
           if [[ "${{ inputs.SHOULD_DEPLOY_PRODUCTION }}" == "true" ]]; then
-            DESCRIPTION="${DESCRIPTION}\n\n📌 Production build is not live yet. It's awaiting manual release:\n• App Store: release it from 'Pending Developer Release'\n• Google Play: promote it from the beta track to production\n\nOnce v${CLI_VERSION} is downloadable on both, bump the in-app update prompt:\n\`kiroku-cli app-version set --latest ${CLI_VERSION}\`"
+            DESCRIPTION="${DESCRIPTION}\n\n📌 v${CLI_VERSION} is deployed but not public yet. Manual steps to go live:\n• App Store: release it from 'Pending Developer Release' once Apple approves\n• Google Play: publish the open-testing release (Managed publishing), then promote it to production\n\nOnce v${CLI_VERSION} is public on both, bump the in-app update prompt:\n\`kiroku-cli app-version set --latest ${CLI_VERSION}\`"
           fi
           curl -s -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -134,18 +134,16 @@ platform :android do
   lane :production do
     # Google is very unreliable, so we retry a few times
     ENV["SUPPLY_UPLOAD_MAX_RETRIES"]="5"
-    google_play_track_version_codes(
-      package_name: "com.alcohol_tracker",
-      json_key: './android/app/android-fastlane-json-key.json',
-      track: 'beta' # modify to 'production' when ready
-    )
-
     upload_to_play_store(
       package_name: "com.alcohol_tracker",
       json_key: './android/app/android-fastlane-json-key.json',
       version_code: ENV["VERSION"].to_i,
       track: 'internal',
       track_promote_to: 'beta', # Modify to production when ready
+      # 'completed' auto-submits the promoted open-testing release for Google
+      # review. The go-live to testers is held by Play Console "Managed
+      # publishing", so releasing to open testing stays a manual click.
+      track_promote_release_status: 'completed',
       rollout: '1.0',
       skip_upload_apk: true,
       skip_upload_aab: true,


### PR DESCRIPTION
### Details

Scope note: this PR originally removed the iOS `production` lane's `deliver` step (open-beta-only). We decided to **keep `deliver`** — iOS is launching on the App Store imminently, and `deliver` (with `automatic_release: false`) submits to App Store review while holding the build as Pending Developer Release for a manual public launch. So **iOS is unchanged**. What's left is a small Android cleanup + a clearer production announcement, with **no behavior change**.

- **`fastlane/Fastfile` Android `production`**: drop the vestigial `google_play_track_version_codes` call (its result was never used; the version code comes from `ENV`). Make `track_promote_release_status: 'completed'` explicit with a comment noting the go-live to open testing is gated by Play Console **Managed Publishing**. `completed` is already supply's default for a promote, so this documents intent without changing behavior. (A *promote* is governed by `track_promote_release_status`, not `release_status`, which is for uploads.)
- **`.github/workflows/platformDeploy.yml`**: reword the production success Discord announcement to accurately list the post-deploy manual steps — iOS: release from Pending Developer Release once Apple approves; Android: publish the open-testing release (Managed Publishing), then promote to production.

### Tests

1. `ruby -c fastlane/Fastfile` → Syntax OK.
2. `bundle exec fastlane lanes` → loads cleanly; `ios production` = "Move app to App Store Review" (unchanged), `android production` = "Deploy app to Google Play open beta", `upload_metadata` intact.
3. `grep -n 'deliver(' fastlane/Fastfile` → 2 occurrences (iOS `production` + `upload_metadata`) — the iOS App Store submission is untouched.
4. `.github/workflows/platformDeploy.yml` parses as YAML.

- [x] No app / JS / UI changes — JS-console, device runs, localization, and offline behavior are N/A.

### QA Steps

On the next real `staging → production` promotion, verify the production deploy behaves as before (iOS → TestFlight Beta + App Store review, held as Pending Developer Release; Android → open testing, held by Managed Publishing) and that the Discord announcement reads correctly.

**Readiness check before the next production run** (so the automated `deliver` doesn't fail): `node scripts/asc.mjs status` → target version `PREPARE_FOR_SUBMISSION`, build `VALID`. `deliver` uses `skip_screenshots: true`, so screenshots / App Privacy / age rating must already be in ASC.

### Notes for reviewer

- Supersedes the original "open-beta-only" scope; the iOS `deliver` removal and the README/submission-kit doc edits from the first commit were reverted.
- `deliver` auto-*submits to App Store review* on every production cut; the manual gate is only the public go-live (Pending Developer Release). `reject_if_possible: true` will reject any build currently in review when the lane runs.
