### PR TITLE
fix(iap): hide subscription terms link in production builds

### DIFF
--- a/src/screens/Settings/AboutScreen.tsx
+++ b/src/screens/Settings/AboutScreen.tsx
@@ -15,6 +15,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as Environment from '@libs/Environment/Environment';
 import Navigation from '@libs/Navigation/Navigation';
+import SupporterUtils from '@libs/SupporterUtils';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ROUTES from '@src/ROUTES';
@@ -47,6 +48,12 @@ function AboutScreen() {
   const styles = useThemeStyles();
   const popoverAnchor = useRef<View | RNText | null>(null);
   const {shouldUseNarrowLayout} = useResponsiveLayout();
+
+  // The Supporter tier (and its subscription terms) is hidden in production
+  // until the v1.1 launch attaches the IAP. Gate the subscription-terms link on
+  // the same visibility predicate as the Support Kiroku menu so production
+  // builds never reference a subscription they can't actually purchase.
+  const shouldShowSubscriptionTerms = SupporterUtils.isSupporterTierVisible();
 
   const menuItems = useMemo(() => {
     const baseMenuItems: MenuItem[] = [
@@ -89,11 +96,16 @@ function AboutScreen() {
         icon: KirokuIcons.FileDocument,
         onPress: () => Navigation.navigate(ROUTES.SETTINGS_PRIVACY_POLICY),
       },
-      {
-        translationKey: 'common.subscriptionTerms',
-        icon: KirokuIcons.FileDocument,
-        onPress: () => Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_TERMS),
-      },
+      ...(shouldShowSubscriptionTerms
+        ? [
+            {
+              translationKey: 'common.subscriptionTerms',
+              icon: KirokuIcons.FileDocument,
+              onPress: () =>
+                Navigation.navigate(ROUTES.SETTINGS_SUBSCRIPTION_TERMS),
+            } as MenuItem,
+          ]
+        : []),
     ];
 
     return baseMenuItems.map(
@@ -109,7 +121,7 @@ function AboutScreen() {
         wrapperStyle: [styles.sectionMenuItemTopDescription],
       }),
     );
-  }, [styles, translate]);
+  }, [shouldShowSubscriptionTerms, styles, translate]);
 
   const versionInfoContainer = useCallback(
     () => (

--- a/src/screens/Settings/SubscriptionTermsScreen.tsx
+++ b/src/screens/Settings/SubscriptionTermsScreen.tsx
@@ -1,10 +1,11 @@
 import {Linking, View} from 'react-native';
 import {WebView} from 'react-native-webview';
 import Navigation from '@libs/Navigation/Navigation';
+import SupporterUtils from '@libs/SupporterUtils';
 import ScreenWrapper from '@components/ScreenWrapper';
 import CONST from '@src/CONST';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import useThemeStyles from '@hooks/useThemeStyles';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import {useUserConnection} from '@context/global/UserConnectionContext';
@@ -20,6 +21,17 @@ function SubscriptionTermsScreen() {
     'settingsScreen.subscriptionTermsScreen.loading',
   );
   const [isLoading, setIsLoading] = useState(false);
+  const isSupporterTierVisible = SupporterUtils.isSupporterTierVisible();
+
+  // The Supporter tier is hidden in production, so this page has no in-app entry
+  // point there. Bounce back if it is somehow reached (e.g. via deep link) to
+  // keep parity with the gated About menu item.
+  useEffect(() => {
+    if (isSupporterTierVisible) {
+      return;
+    }
+    Navigation.goBack();
+  }, [isSupporterTierVisible]);
 
   const handleStartLoadWithRequest = (request: WebViewRequest) => {
     if (request.url.startsWith('mailto:')) {
@@ -28,6 +40,10 @@ function SubscriptionTermsScreen() {
     }
     return true;
   };
+
+  if (!isSupporterTierVisible) {
+    return null;
+  }
 
   return (
     <ScreenWrapper testID={SubscriptionTermsScreen.displayName}>


### PR DESCRIPTION
## Why

The **Settings → About** menu renders a **"Subscription Terms"** link ([`AboutScreen.tsx`](src/screens/Settings/AboutScreen.tsx)) that opens a page describing auto-renewing **"Monthly / Annual Supporter"** subscriptions (via Apple / RevenueCat). But the Supporter tier ships **hidden in production** until v1.1 (`SupporterUtils.isSupporterTierVisible()` → `!IS_IN_PRODUCTION`), so production builds have **no purchasable subscription**.

An App Store reviewer who taps that link reads subscription terms for an IAP that doesn't exist in the build — the same **Guideline 2.1(b)** pattern that caused a prior rejection. This link is present in the build currently in App Store review (`0.3.16-1`).

## What

- **`AboutScreen`** — gate the `common.subscriptionTerms` menu item on `SupporterUtils.isSupporterTierVisible()`, the **same predicate** that already hides the *Support Kiroku* button in `SettingsScreen`. In production the About menu now shows only *Terms of Service* and *Privacy Policy*.
- **`SubscriptionTermsScreen`** — defense-in-depth: bounce back (`Navigation.goBack()`) and render nothing when the tier isn't visible, so the route can't be reached via deep link in production.

No behavior change in dev / staging / adhoc builds, where the Supporter tier is intentionally visible and exercisable end-to-end.

## Verification

- `npx prettier --check` — clean
- `npm run typecheck-tsgo` — clean
- `npm run react-compiler-compliance-check check-changed` — passed (2 files)
- `./scripts/lint.sh <files>` — exit 0

Not browser-verifiable: the gate keys off the build-time `IS_IN_PRODUCTION` constant, which the dev/web preview can't toggle (the link stays visible in non-production, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)