### PR TITLE
docs: deliver code changes as a PR, not staged-but-uncommitted work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,10 @@ The skill provides guidance on:
 3. **TypeScript**: Run `npm run typecheck-tsgo` after changes that may affect typing (types, interfaces, or function signatures). It is ~10x faster and usually stricter than tsc. CI validates with `npm run typecheck` (tsc), which remains the required merge gate.
 4. **React Compiler**: If you added new React components/hooks or modified existing ones, run `npm run react-compiler-compliance-check check-changed` to verify they compile with React Compiler. This applies the same rules as CI: new components/hooks must compile, and existing compiled files must not regress. See `contributingGuides/REACT_COMPILER.md` for details and common fixes.
 
+### Delivering Changes
+
+When asked to make a code change, deliver it as an open PR, not staged work. As the final step: branch (never `master`), commit, push, `gh pr create` against `master`, report the link. Skip for read-only sessions or when told to hold. Never push `master` directly.
+
 ### Testing
 
 - **Unit Tests**: Jest with React Native Testing Library


### PR DESCRIPTION
## Why

Agents (especially cloud/remote sessions on auto-created `claude/*` branches) tend to end with *"changes are staged on `<branch>` but not committed — I held off since you haven't asked"*. That's Claude Code's built-in git conservatism (*commit/push only when explicitly asked*). Nothing in the repo overrode it, so the default won by forfeit.

## What

Adds a **Delivering Changes** section to `CLAUDE.md` that pre-authorizes the full path for change requests: branch → commit → push → open a PR against `master`, then report the link. Keeps the existing hard rules (never push `master` directly; branch/worktree first) and carves out read-only / "I'll handle git" / hold-off cases.

This is checked into the repo so it reaches **cloud/remote/background agents** (they clone the repo but never see a developer's local `~/.claude/CLAUDE.md`). A mirror of the same instruction was added to the local global `~/.claude/CLAUDE.md` to cover local interactive sessions across all repos.

Instruction-only by design — no enforcement hook — so the model keeps judgment over the exception cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)