### PR TITLE
perf(stats): defer Statistics content subtree to shrink the pre-skeleton blank

### DIFF
--- a/src/screens/Statistics/StatisticsContent.tsx
+++ b/src/screens/Statistics/StatisticsContent.tsx
@@ -1,0 +1,34 @@
+import StatsContextProvider from '@components/StatsContextProvider';
+import DrillDownProvider from './drilldown/DrillDownContext';
+import StatisticsTabs from './StatisticsTabs';
+import StatsDrillDownSheet from './StatsDrillDownSheet';
+
+/**
+ * The full Statistics subtree — the stats providers, the chart tabs, and the
+ * drill-down sheet — pulled out of `StatisticsScreen` so it can be loaded as a
+ * single dynamic import once the screen has settled.
+ *
+ * Keeping these together (rather than statically imported by the screen) means
+ * the screen's first commit only has to mount the header + skeleton: the
+ * `StatsContextProvider` compute, the Skia/Victory chart bundle, and the
+ * drill-down sheet are all deferred to this module, minimizing the blank
+ * native-tab window before the skeleton paints.
+ *
+ * Provider nesting mirrors what `StatisticsScreen` rendered inline, so every
+ * context consumer (`useStatsContext`, `useStatsDrillDown` in the tabs and the
+ * sheet) keeps working unchanged.
+ */
+function StatisticsContent() {
+  return (
+    <StatsContextProvider>
+      <DrillDownProvider>
+        <StatisticsTabs />
+        <StatsDrillDownSheet />
+      </DrillDownProvider>
+    </StatsContextProvider>
+  );
+}
+
+StatisticsContent.displayName = 'StatisticsContent';
+
+export default StatisticsContent;

--- a/src/screens/Statistics/StatisticsScreen.tsx
+++ b/src/screens/Statistics/StatisticsScreen.tsx
@@ -4,22 +4,22 @@ import {InteractionManager} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import OfflineIndicator from '@components/OfflineIndicator';
 import ScreenWrapper from '@components/ScreenWrapper';
-import StatsContextProvider from '@components/StatsContextProvider';
 import useBottomTabBarHeight from '@hooks/useBottomTabBarHeight';
 import useLocalize from '@hooks/useLocalize';
-import DrillDownProvider from './drilldown/DrillDownContext';
 import StatisticsScreenSkeleton from './StatisticsScreenSkeleton';
-import StatsDrillDownSheet from './StatsDrillDownSheet';
 
 /**
- * As a bottom tab, this screen has no entry slide to protect, but the chart-tab
- * tree (StatisticsTabs → 4 tabs → Skia/Victory imports) plus the
- * `StatsContextProvider` compute is still heavy enough to block the JS thread
- * for 1–3 s on first mount.
+ * As a bottom tab, this screen has no entry slide to protect, but the content
+ * subtree (`StatisticsContent` → stats providers + chart tabs → Skia/Victory
+ * imports + drill-down sheet) plus the `StatsContextProvider` compute is heavy
+ * enough to block the JS thread for 1–3 s on first mount.
  *
- * Gate the heavy subtree on `InteractionManager.runAfterInteractions` so the
- * layout-faithful skeleton paints first, then mount the providers and the
- * dynamically-imported tabs. The tab is lazily mounted on first visit and then
+ * Keep the screen's *static* import graph to just the header + skeleton, and
+ * defer the whole content subtree behind a dynamic import gated on
+ * `InteractionManager.runAfterInteractions`. That way the first commit (the
+ * layout-faithful skeleton) lands as early as possible — minimizing the blank
+ * native-tab window — and the providers, tabs, and sheet are mounted only once
+ * the screen has settled. The tab is lazily mounted on first visit and then
  * stays mounted (frozen while blurred), so this cost is paid once.
  *
  * `useDrinkEvents` / `useAggregate` further defer the *data* compute, so the
@@ -29,7 +29,7 @@ function StatisticsScreen() {
   const {translate} = useLocalize();
   const bottomTabBarHeight = useBottomTabBarHeight();
   const [isReady, setIsReady] = useState(false);
-  const [Tabs, setTabs] = useState<ComponentType | null>(null);
+  const [Content, setContent] = useState<ComponentType | null>(null);
 
   useEffect(() => {
     const handle = InteractionManager.runAfterInteractions(() =>
@@ -38,19 +38,19 @@ function StatisticsScreen() {
     return () => handle.cancel();
   }, []);
 
-  // Only kick off the chart-bundle import once the screen has settled, so its
+  // Only kick off the content-bundle import once the screen has settled, so its
   // parse and the subsequent heavy mount never compete with the first paint.
   useEffect(() => {
     if (!isReady) {
       return undefined;
     }
     let cancelled = false;
-    import('./StatisticsTabs')
+    import('./StatisticsContent')
       .then(mod => {
         if (cancelled) {
           return;
         }
-        setTabs(() => mod.default);
+        setContent(() => mod.default);
       })
       .catch(() => {
         // Dynamic import only fails when the underlying module itself throws —
@@ -70,16 +70,7 @@ function StatisticsScreen() {
         title={translate('statistics.title')}
         shouldShowBackButton={false}
       />
-      {Tabs ? (
-        <StatsContextProvider>
-          <DrillDownProvider>
-            <Tabs />
-            <StatsDrillDownSheet />
-          </DrillDownProvider>
-        </StatsContextProvider>
-      ) : (
-        <StatisticsScreenSkeleton />
-      )}
+      {Content ? <Content /> : <StatisticsScreenSkeleton />}
       <OfflineIndicator style={{marginBottom: bottomTabBarHeight}} />
     </ScreenWrapper>
   );


### PR DESCRIPTION
## Problem

On iOS (release build), tapping the **Statistics** bottom tab for the first time shows a **blank screen** for a moment before content appears, instead of the loading skeleton.

The bottom tabs are native (`react-native-bottom-tabs` → `UITabBarController`) and the Statistics tab is lazily mounted on first visit. There are two loading windows:

- **Window A — blank:** from the tap until React commits `StatisticsScreen`'s *first frame*. The native tab fills it with its opaque `sceneStyle` background (`theme.appBG`) → the "blank".
- **Window B — skeleton:** from that first frame until the charts/aggregates are ready. Already covered by `StatisticsScreenSkeleton` + per-card `ChartSkeleton`s.

The skeleton lives *inside* the React subtree that hasn't mounted yet during Window A, so it can't paint over the blank. Window A's length is dominated by JS-thread availability, but it was inflated because `StatisticsScreen` **statically imported** `StatsContextProvider`, `DrillDownProvider`, and `StatsDrillDownSheet` — none of which are needed for the skeleton-only first frame, yet they were evaluated/mounted as part of it.

## Change

- **New `src/screens/Statistics/StatisticsContent.tsx`** — a thin wrapper that holds the full provider tree (`StatsContextProvider` → `DrillDownProvider` → `StatisticsTabs` + `StatsDrillDownSheet`). It statically imports the heavy pieces, so they load together with the (already-deferred) chart bundle rather than before it.
- **`src/screens/Statistics/StatisticsScreen.tsx`** — drops the three static provider/sheet imports and dynamically imports `./StatisticsContent` (instead of `./StatisticsTabs`). The screen's static graph is now just `ScreenWrapper` + header + skeleton, so the **first commit mounts only the header + skeleton** and the skeleton paints as early as possible.

Provider nesting is preserved exactly, so every context consumer (`useStatsContext`, `useStatsDrillDown` in the tabs and the sheet) keeps working unchanged. The existing `InteractionManager.runAfterInteractions` gate and dynamic-import pattern are kept as-is — this only widens what they defer.

## Notes / scope

- This **minimizes** Window A; it doesn't fully eliminate the native-tab → first-commit gap. Pre-warming the tab is a possible follow-up if the gap is still perceptible on device.
- No change to data loading, `StatsContextProvider` internals, the skeleton, or any tab.
- The improvement is **iOS-native-specific** (web uses a custom JS tab bar, with no native-tab blank).

## Verification

- `npx prettier --write` — clean
- `npm run react-compiler-compliance-check check-changed` — passed
- `npm run typecheck-tsgo` — clean (resolves the new module + its provider/tabs/sheet imports)
- `./scripts/lint.sh` on both files — clean

Behavioral check (for a reviewer with a build): cold-start iOS, tap **Statistics** as the first tab visit → the skeleton should appear noticeably sooner (less/no flat-`appBG` blank), then charts replace it. Confirm the Overview tab, tab switching, and the drill-down sheet still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)