### PR TITLE
fix(stats): keep the home overview in sync after saving a session

### DIFF
--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -30,6 +30,14 @@ const DEFAULT_WEEK_START: WeekStart = 1;
 
 const EMPTY_EVENTS: DrinkEvent[] = [];
 
+// Backstop for the deferred rebuild. `runAfterInteractions` normally fires the
+// moment the navigation transition settles (~300ms), so this only matters when
+// the interaction queue is starved by a leaked handle — then the rebuild runs
+// at the latest this long after the inputs changed, instead of never. Kept
+// comfortably above a typical transition so the happy path always wins the race
+// and the heavy walk never lands mid-transition.
+const REBUILD_BACKSTOP_MS = 1000;
+
 function resolveWeekStart(label: string | undefined): WeekStart {
   if (!label) {
     return DEFAULT_WEEK_START;
@@ -47,7 +55,12 @@ function resolveWeekStart(label: string | undefined): WeekStart {
  * dominant Statistics-tab cost, so we defer the first pass past the
  * navigation transition with `InteractionManager.runAfterInteractions` —
  * the freshly-mounted tab paints skeletons in one frame, then the real
- * events arrive on a later frame.
+ * events arrive on a later frame. A `setTimeout` backstop runs alongside it so
+ * the rebuild always lands even if the interaction queue is starved (otherwise
+ * a post-save recompute can be dropped and the overview stays stale until the
+ * app is reloaded). Per-tap live edits never reach this path — they mutate
+ * `ONGOING_SESSION_DATA`, not the cached snapshot — so this stays off the
+ * drink-logging touch frame.
  *
  * `isLoading` is true until the Onyx subscription has hydrated **and** the
  * deferred compute has produced its first result. During that window
@@ -76,11 +89,25 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
     if (!isHydrated) {
       return;
     }
-    let cancelled = false;
-    const handle = InteractionManager.runAfterInteractions(() => {
-      if (cancelled) {
+    let done = false;
+    let handle: {cancel?: () => void} | undefined;
+    let backstop: ReturnType<typeof setTimeout> | undefined;
+
+    // Whichever of the two timers wins runs the rebuild exactly once; the loser
+    // is cancelled. We prefer `runAfterInteractions` (keeps the heavy walk off
+    // the navigation-transition frame) but can't depend on it alone: a leaked
+    // interaction handle starves its queue indefinitely, which would silently
+    // drop a post-save recompute and leave Home/Stats stale until an app reload.
+    const rebuild = () => {
+      if (done) {
         return;
       }
+      done = true;
+      handle?.cancel?.();
+      if (backstop) {
+        clearTimeout(backstop);
+      }
+
       const next = buildDrinkEvents(
         allSessions,
         drinksToUnits,
@@ -102,10 +129,17 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
         timezone,
         weekStart,
       );
-    });
+    };
+
+    handle = InteractionManager.runAfterInteractions(rebuild);
+    backstop = setTimeout(rebuild, REBUILD_BACKSTOP_MS);
+
     return () => {
-      cancelled = true;
-      handle.cancel?.();
+      done = true;
+      handle?.cancel?.();
+      if (backstop) {
+        clearTimeout(backstop);
+      }
     };
   }, [isHydrated, allSessions, drinksToUnits, timezone, weekStart]);
 


### PR DESCRIPTION
## Problem

Saving (or editing/deleting) a drinking session does not propagate to the **home screen stats overview** card — it keeps showing the old totals and only refreshes after a full app reload. The calendar right below it updates immediately.

## Root cause

The home overview reads `monthlyStats` → `useHomeStats` → `useDrinkEvents`. `useDrinkEvents` does **not** derive its result from Onyx directly; it holds the materialised `DrinkEvent[]` in a `useState` (`allEvents`) whose **only writer** is an `InteractionManager.runAfterInteractions` callback (the heavy `buildDrinkEvents` walk is deferred past the navigation transition for Statistics-tab perf).

`runAfterInteractions` can be **starved indefinitely** when an interaction handle is leaked (a well-known RN footgun, e.g. an interrupted/gestural navigation transition). When that happens, the recompute scheduled after a save is silently dropped, so `allEvents` — and therefore the overview — stays stale. Because the bottom-tab navigator uses `freezeOnBlur: true`, switching tabs freezes Home rather than unmounting it, so nothing re-triggers the compute. Only a full app reload remounts the hook (clean interaction queue) and fixes it.

The calendar, by contrast, reads `CACHED_DRINKING_SESSIONS` directly via `useCurrentUserDrinkingSessions` and re-indexes synchronously, which is why it updates right away — that split is the fingerprint of this bug.

## Fix

Race `runAfterInteractions` against a `setTimeout` backstop (1000ms). Whichever fires first runs the rebuild exactly once and cancels the other:

- **Happy path unchanged:** `runAfterInteractions` fires the moment the transition settles (~300ms) and wins the race, so the heavy walk still stays off the Statistics-tab mount frame — no jank reintroduced.
- **Starved path fixed:** if the interaction queue never drains, the backstop guarantees the rebuild lands within ~1s instead of never.

### Why this doesn't reintroduce the per-tap sluggishness

Per-tap live drink edits never reach this path: they mutate `ONGOING_SESSION_DATA` synchronously and the debounced server echo updates `CACHED_DRINKING_SESSIONS` off the touch frame (see `DrinkingSession.ts` `scheduleLiveSessionPersist`). The deferred compute is preserved, just made starvation-proof, so the drink-logging frame is untouched.

The fix is centralized in `useDrinkEvents`, so it also covers the Statistics tabs, drill-down sheet, Badges, and profile stats.

## Testing

- `npm run typecheck-tsgo` ✅
- `npm run lint-changed` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- Prettier ✅

Behavioural verification (interaction-queue starvation) isn't observable in the web preview; manual on-device check: add a session and confirm the overview totals update without an app reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)