### PR TITLE
fix(terms): open Terms/Privacy links in the system browser

### DIFF
--- a/src/components/TermsScreenContent.tsx
+++ b/src/components/TermsScreenContent.tsx
@@ -76,10 +76,10 @@ function TermsScreenContent({
       <Text style={[styles.mv4, styles.textNormal]}>
         {description ?? translate('agreeToTerms.description')}
       </Text>
-      <TextLink style={linkStyles} href={CONST.TERMS_URL}>
+      <TextLink style={linkStyles} href={CONST.TERMS_URL} forceExternal>
         {translate('common.termsOfService')}
       </TextLink>
-      <TextLink style={linkStyles} href={CONST.PRIVACY_URL}>
+      <TextLink style={linkStyles} href={CONST.PRIVACY_URL} forceExternal>
         {translate('common.privacyPolicy')}
       </TextLink>
     </>

--- a/src/components/TextLink.tsx
+++ b/src/components/TextLink.tsx
@@ -14,7 +14,7 @@ import type {
 } from 'react-native';
 import useEnvironment from '@hooks/useEnvironment';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {openLink as openLinkUtil} from '@userActions/Link';
+import {openExternalLink, openLink as openLinkUtil} from '@userActions/Link';
 import CONST from '@src/CONST';
 import type {TextProps} from './Text';
 import Text from './Text';
@@ -40,6 +40,15 @@ type TextLinkProps = (LinkProps | PressProps) &
 
     /** Callback that is called when mousedown is triggered */
     onMouseDown?: MouseEventHandler;
+
+    /**
+     * Always open `href` in the system browser (or a new tab on web), skipping
+     * the same-origin internal-navigation heuristic in {@link openLinkUtil}.
+     * Use for public pages (e.g. the terms/privacy marketing pages) that live
+     * on the app's own origin but have no matching in-app route, which would
+     * otherwise resolve to the Not Found screen.
+     */
+    forceExternal?: boolean;
   };
 
 function TextLink(
@@ -49,6 +58,7 @@ function TextLink(
     children,
     style,
     onMouseDown = event => event.preventDefault(),
+    forceExternal = false,
     ...rest
   }: TextLinkProps,
   ref: ForwardedRef<RNText>,
@@ -59,6 +69,8 @@ function TextLink(
   const openLink = (event: GestureResponderEvent | KeyboardEvent) => {
     if (onPress) {
       onPress(event);
+    } else if (forceExternal) {
+      openExternalLink(href);
     } else {
       openLinkUtil(href, environmentURL);
     }


### PR DESCRIPTION
## Problem

A user who updated from `0.3.10` to `0.3.16` was shown the **"We've updated our terms of service"** re-consent modal (expected, since the published terms post-dated their last acceptance). The actual bug: tapping the **Terms of Service** or **Privacy Policy** links inside that modal sent them to the in-app **Not Found** screen instead of opening the legal pages in a browser.

## Root cause

`openLink` (`src/libs/actions/Link.ts`) treats any URL that shares the app's production origin as an **internal deep link** and hands it to `Navigation.navigate(path)`.

The legal pages live on the app's own origin:

- `CONST.TERMS_URL` → `https://kiroku.cz/terms`
- `CONST.PRIVACY_URL` → `https://kiroku.cz/privacy`

The production environment URL is also `https://kiroku.cz`, so the same-origin check passes and the app navigates to `/terms` / `/privacy`. Those are **not** registered in-app routes (the real screens are `settings/terms-of-service` and `settings/privacy-policy`), so navigation resolves to the **Not Found** screen. These are genuinely external static pages, so they should open in the system browser.

## Fix

- Add an opt-in `forceExternal` prop to `TextLink`. When set, the link always opens its `href` in the system browser (new tab on web) via `openExternalLink`, bypassing the same-origin heuristic, while keeping the web anchor `href` for accessibility and open-in-new-tab.
- Use `forceExternal` for the two legal links in `TermsScreenContent`, which powers **both** the terms re-consent modal and the onboarding terms step, so both are fixed.

## Testing

- `npm run typecheck-tsgo` — passes
- `eslint` on the changed files — passes (only a pre-existing grandfathered warning, untouched)
- `npm run react-compiler-compliance-check check-changed` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si4KKeY2LfPfZ4xK6SuRjV)_