### PR TITLE
fix(calendar): cover the restored visible month on the compact home grid

### DIFF
--- a/__tests__/unit/useLazyMarkedDates.test.ts
+++ b/__tests__/unit/useLazyMarkedDates.test.ts
@@ -323,6 +323,55 @@ describe('useLazyMarkedDates compact paging covers the visible month (Rule 1)', 
     expect(result.current.markedDates[sessionDayKey]).toBeDefined();
     expect(result.current.unitsMap.get(sessionDayKey)).toBe(1);
   });
+
+  test('restoring the visible month deeper than the loaded window widens the load target to cover it (+ buffer)', () => {
+    // The last-viewed-restore path PR #1297 left open: on Home the compact
+    // calendar's `visibleDate` is driven by `NVP_LAST_VIEWED_CALENDAR_DATE`
+    // (set when the user scrolled the fullscreen calendar / day-overview, e.g.
+    // logging a back-dated session), NOT by the left-arrow handler. The
+    // orchestrator's visible-month effect must widen the window for that
+    // month exactly as the page-back handler does — otherwise the grid renders
+    // blank for it while the "This month" card (full, unwindowed history) is
+    // correct. Asserted at the same hook/util seam: feed the restored month's
+    // look-ahead target into `loadUpTo` and check the session lands.
+    const restoredStart = startOfMonth(subMonths(new Date(), 7));
+    const restoredYear = restoredStart.getFullYear();
+    const restoredMonth = restoredStart.getMonth(); // 0-based
+    const sessionInstant = Date.UTC(restoredYear, restoredMonth, 12, 12, 0, 0);
+    const restoredMonthKey = `${restoredYear}-${pad(restoredMonth + 1)}`;
+    const sessionDayKey = `${restoredMonthKey}-12` as DateString;
+    const sessions = {
+      s1: {
+        id: 's1',
+        start_time: sessionInstant,
+        timezone: 'UTC',
+        drinks: {[sessionInstant]: {beer: 1}},
+      },
+    } as unknown as DrinkingSessionList;
+
+    const {result} = renderHook(() =>
+      useLazyMarkedDates(TEST_UID, sessions, makePreferences()),
+    );
+
+    // Precondition: the restored month is outside the initial derived window,
+    // so its session is blank — the bug's "blank grid, correct card" state.
+    expect(result.current.markedDates[sessionDayKey]).toBeUndefined();
+
+    // Restoring `visibleDate` to that month feeds its look-ahead target into the
+    // monotonic `loadUpTo` (the orchestrator's visible-month effect), the same
+    // target the page-back handler uses for the same month.
+    act(() => {
+      result.current.loadUpTo(getCompactCalendarLoadTarget(restoredStart, 3));
+    });
+
+    // The window now covers the restored month (at or below its start, plus the
+    // buffer) and its data renders — no in-calendar navigation needed.
+    expect(getLoadedFrom(result).getTime()).toBeLessThanOrEqual(
+      startOfMonth(subMonths(restoredStart, 3)).getTime(),
+    );
+    expect(result.current.markedDates[sessionDayKey]).toBeDefined();
+    expect(result.current.unitsMap.get(sessionDayKey)).toBe(1);
+  });
 });
 
 describe('useLazyMarkedDates ongoing overlay', () => {

--- a/src/components/SessionsCalendar/index.tsx
+++ b/src/components/SessionsCalendar/index.tsx
@@ -362,6 +362,40 @@ function SessionsCalendar({
     }
   }, [mode, loadUpTo, initialMonthYear, initialDay, hasPersistedFloor]);
 
+  // Compact calendar: keep the loaded window covering whatever month is
+  // currently visible, plus the same look-ahead buffer the page-back handler
+  // uses. The visible month can change three ways — left arrow, swipe, or a
+  // last-viewed restore (`NVP_LAST_VIEWED_CALENDAR_DATE`, set when the user
+  // scrolled the fullscreen calendar / day-overview, e.g. while logging a
+  // back-dated session). Only the first two flow through `handleLeftArrowPress`'s
+  // proactive `loadUpTo`; the restore path sets `visibleDate` directly. Without
+  // this effect a restored month deeper than the loaded window derives zero
+  // markedDates and renders blank — even though the "This month" summary card
+  // above reads the FULL (unwindowed) session history and shows the right
+  // numbers (the card-vs-grid window asymmetry). Keying on the visible month
+  // closes that gap so the visible month always renders regardless of HOW it
+  // was selected (Rule 1: data is always rendered — what PR #1297 left open for
+  // the last-viewed-restore path).
+  //
+  // Compact-only: fullscreen derives its whole range up front
+  // (`deriveFullRangeToFloor`). Referenced via the stable primitive
+  // `visibleDate.timestamp` so the effect re-runs only on a real month change.
+  // `loadUpTo` is monotonic and capped at the user's earliest tracked month for
+  // self, so re-requesting once already deep enough is a safe no-op and it never
+  // derives empty pre-tracking months.
+  const visibleTimestamp = visibleDate.timestamp;
+  useEffect(() => {
+    if (mode !== 'compact') {
+      return;
+    }
+    loadUpTo(
+      getCompactCalendarLoadTarget(
+        new Date(visibleTimestamp),
+        COMPACT_LOAD_AHEAD_BUFFER_MONTHS,
+      ),
+    );
+  }, [mode, visibleTimestamp, loadUpTo]);
+
   const onDayPress = useCallback(
     (dateData: DateData) => {
       const date = dateData.dateString as DateString;


### PR DESCRIPTION
## Problem

The compact **home calendar grid renders blank** (no marked day-cells) for any month older than the lazily-loaded scroll window, even though the **"This month" summary card** above it shows the correct numbers for that same month. Reported on released Android 0.3.16-1; also present on current `master`.

## Root cause: card-vs-grid window asymmetry

The summary card and the calendar grid read the **same** Onyx data (`CACHED_DRINKING_SESSIONS`) through two different windows:

- **Card** (`MonthlyOverviewCard` ← `useHomeStats` ← `useDrinkEvents`) builds drink events over the **entire** session history. No window, so it is **always correct**.
- **Grid** (`SessionsCalendar` ← `useLazyMarkedDates`) only derives day-cells for `min(loadedMonths, monthsToEarliest)` months back from today. **Any visible month older than `loadedMonths` gets zero `markedDates` and renders as an empty grid.**

`loadedMonths` was widened in exactly one place: the left-arrow/swipe handler `handleLeftArrowPress`. But on Home the visible month is **also** driven by the per-user last-viewed date (`NVP_LAST_VIEWED_CALENDAR_DATE`), recorded when the user scrolls the fullscreen calendar / day-overview (e.g. while logging a **back-dated session**). That restore sets `visibleDate` directly and never flows through the arrow handler, so the window was never widened to cover it → blank grid + correct card. It clears only on a true cold launch, so on a warm Android app it persists.

[PR #1297](https://github.com/petrcala/kiroku/pull/1297) ("always cover the visible month") made the left arrow proactively `loadUpTo` and fixed the friend windowed-fetch case, but did **not** widen for a *restored* visible month — leaving this self-on-Home path open.

## Fix

Add a **compact-only** effect in `SessionsCalendar` keyed on `visibleDate.timestamp` that drives the existing monotonic `loadUpTo` with the existing pure `getCompactCalendarLoadTarget` helper (the same ones `handleLeftArrowPress` uses, with `COMPACT_LOAD_AHEAD_BUFFER_MONTHS`). This enforces the invariant that **the visible month always renders regardless of HOW it was selected** — arrow, swipe, or last-viewed restore — completing **Rule 1 ("data is always rendered")** for the restore path that #1297 left open.

- `loadUpTo` is monotonic and capped at the user's earliest tracked month for self, so re-requesting on every visible-month change is a safe no-op when already deep enough and never derives empty pre-tracking months.
- Referenced via the stable primitive `visibleDate.timestamp` so the effect re-runs only on a real month change (React-Compiler-friendly).
- **Fullscreen is untouched** (it derives its whole range up front via `deriveFullRangeToFloor`); **friend behavior is untouched**.

Display-only fix — no server data was affected.

## Test

Adds a hook/util-seam unit test in `__tests__/unit/useLazyMarkedDates.test.ts` alongside the existing Rule-1 compact-paging test: restoring the visible month to a month deeper than the currently-loaded window widens the load target so the month's session data renders (asserting the precondition blank state first).

## Checklist

- ✅ `prettier` (no changes)
- ✅ `eslint` on changed files (clean)
- ✅ `typecheck-tsgo` (clean)
- ✅ `react-compiler-compliance-check check-changed` (passed)
- ✅ `jest` — 33/33 pass (`useLazyMarkedDates` + `SessionsCalendarUtils`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipseKqZmT3pkbMvJRjYoW

---
_Generated by [Claude Code](https://claude.ai/code/session_016ipseKqZmT3pkbMvJRjYoW)_