### PR TITLE
feat(dev): floating button to open the Test Tools modal

### DIFF
--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -35,6 +35,7 @@ import ForceUpdateModal from './components/Modals/ForceUpdateModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import AccountSuspendedModal from './components/Modals/AccountSuspendedModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import DevMenuButton from './components/DevMenuButton';
 import useNativeAppearanceSync from './hooks/useNativeAppearanceSync';
 import useCurrentUserData from './hooks/useCurrentUserData';
 import colors from './styles/theme/colors';
@@ -406,6 +407,13 @@ function Kiroku() {
             lastVisitedPath={lastVisitedPath as Route}
             initialUrl={initialUrl}
           />
+          {/*
+            Dev-only floating button that opens the Test Tools modal. Painted
+            over NavigationRoot but declared before the splash guard/hider
+            below, so the splash still covers it during boot. Renders null in
+            production via its own `isDevelopment` gate.
+          */}
+          <DevMenuButton />
         </>
       )}
       {/*

--- a/src/components/DevMenuButton/index.tsx
+++ b/src/components/DevMenuButton/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {View} from 'react-native';
+import Icon from '@components/Icon';
+import * as KirokuIcons from '@components/Icon/KirokuIcons';
+import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
+import useEnvironment from '@hooks/useEnvironment';
+import useLocalize from '@hooks/useLocalize';
+import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+import toggleTestToolsModal from '@userActions/TestTool';
+import CONST from '@src/CONST';
+
+/**
+ * A small floating button pinned to the top-right corner that opens the Test
+ * Tools modal — the tappable equivalent of the existing 4-finger-tap gesture
+ * and the native shake-menu "Open Test Preferences" item.
+ *
+ * Gated to non-production builds: in production `isDevelopment` is false and the
+ * component renders nothing, so the button never reaches users. It toggles the
+ * same `IS_TEST_TOOLS_MODAL_OPEN` Onyx flag the other triggers use, so the
+ * `<TestToolsModal />` mounted in ScreenWrapper picks it up regardless of which
+ * screen is on top.
+ */
+function DevMenuButton() {
+  const {isDevelopment} = useEnvironment();
+  const insets = useSafeAreaInsets();
+  const theme = useTheme();
+  const styles = useThemeStyles();
+  const {translate} = useLocalize();
+
+  if (!isDevelopment) {
+    return null;
+  }
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[
+        styles.devMenuButtonContainer,
+        {top: insets.top + variables.spacing2},
+      ]}>
+      <PressableWithFeedback
+        accessibilityLabel={translate('testTools.title')}
+        role={CONST.ROLE.BUTTON}
+        onPress={toggleTestToolsModal}
+        style={styles.devMenuButton}>
+        <Icon
+          src={KirokuIcons.Settings}
+          width={variables.iconSizeNormal}
+          height={variables.iconSizeNormal}
+          fill={theme.icon}
+        />
+      </PressableWithFeedback>
+    </View>
+  );
+}
+
+DevMenuButton.displayName = 'DevMenuButton';
+
+export default DevMenuButton;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1190,6 +1190,29 @@ const styles = (theme: ThemeColors) =>
       right: 20,
     },
 
+    // Dev-only floating button (top-right) that toggles the Test Tools modal.
+    // The `top` offset is applied by the caller to clear the safe-area inset.
+    // Rendered only by <DevMenuButton />, which is gated to non-production
+    // builds, so these styles never reach users.
+    devMenuButtonContainer: {
+      position: 'absolute',
+      right: variables.spacing2,
+      zIndex: 10,
+    },
+
+    devMenuButton: {
+      height: variables.componentSizeNormal,
+      width: variables.componentSizeNormal,
+      borderRadius: variables.componentSizeNormal / 2,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.cardBG,
+      borderWidth: 1,
+      borderColor: theme.border,
+      opacity: 0.9,
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)',
+    },
+
     highlightBG: {
       backgroundColor: theme.highlightBG,
     },


### PR DESCRIPTION
## What

Adds a small **dev-only floating button** pinned to the top-right corner that opens the **Test Tools** modal — the tappable equivalent of the affordances we already have (the 4-finger-tap gesture in `ScreenWrapper` and the native shake-menu "Open Test Preferences" item in `CustomDevMenu`).

Inspired by the convenience of Expo's dev-client launcher button in a sister project; here it's implemented natively since Kiroku is a bare RN app and doesn't ship `expo-dev-client`.

## How

- **`src/components/DevMenuButton/index.tsx`** — a `PressableWithFeedback` with the `Settings`/gear icon that calls the existing `toggleTestToolsModal()` action. It reuses the `IS_TEST_TOOLS_MODAL_OPEN` Onyx flag the `<TestToolsModal />` (mounted in `ScreenWrapper`) already reads, so **no new dev-menu infrastructure** — just a new trigger.
- **Gated on `useEnvironment().isDevelopment`** → renders `null` in production. The button never reaches users.
- **Mounted once** in `Kiroku.tsx`, above `NavigationRoot` but declared before the splash guard/hider, so the splash still covers it during boot.
- **Styles** added to the central styles index next to `floatingActionButton` (`devMenuButtonContainer` / `devMenuButton`); the safe-area `top` offset is applied by the component.

## Why a single global mount (not in `ScreenWrapper`)

`ScreenWrapper` wraps every screen, so mounting there would render N stacked buttons. A single root mount gives one floating control over all screens — matching the "floating bubble" feel — while toggling the same Onyx flag, so the per-screen modal still picks it up.

## Testing

- `npm run typecheck` → passes (0 errors)
- `eslint` on changed files → 0 errors
- Behavior: in a dev build, the gear appears top-right and opens/closes Test Tools; the existing 4-finger gesture and shake-menu item still work. In a production build the button is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)