### PR TITLE
fix(ios): distribute existing TestFlight build in production lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -310,8 +310,15 @@ platform :ios do
 
   desc "Move app to App Store Review"
   lane :production do
+    # The binary was already built and uploaded to TestFlight by the staging
+    # `beta` lane, so this lane must NOT rebuild/re-upload — it only distributes
+    # that existing build externally. `distribute_only: true` tells pilot to
+    # skip the upload and act on the build identified by app_version/build_number;
+    # without it pilot looks for an IPA to upload and fails with
+    # "No ipa or pkg file given" (see `deliver(skip_binary_upload: true)` below).
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
+        distribute_only: true,
         distribute_external: true,
         notify_external_testers: true,
         changelog: ENV.fetch("TESTFLIGHT_CHANGELOG", "Improvements and bug fixes."),


### PR DESCRIPTION
## What

Adds `distribute_only: true` to `upload_to_testflight` in the iOS `production` lane (`fastlane/Fastfile`, the "Move app to App Store Review" lane).

## Why

The **first-ever** staging → production promotion (`0.3.16-44`, deploy run [27824066598](https://github.com/PetrCala/Kiroku/actions/runs/27824066598)) **failed on the iOS step** with:

```
[!] No ipa or pkg file given
💥 upload_to_testflight
```

The promotion mechanism itself worked end to end (closing the `StagingDeployCash` checklist [#262](https://github.com/PetrCala/Kiroku/issues/262) with `:shipit:` promoted `staging` → `production`); Android's production deploy succeeded. Only the iOS lane failed, deterministically across all three retries.

### Root cause

iOS uses a two-phase deploy:

| Lane | When | Does |
|---|---|---|
| `beta` | staging deploy | `build_app` + `upload_to_testflight(distribute_external: false)` → internal TestFlight |
| `production` | production deploy | redistribute that **same** build externally + submit for review |

The `production` lane has **no `build_app`** and never downloads an IPA — by design it reuses the binary the `beta` lane already uploaded (its `deliver` call uses `skip_binary_upload: true`, "already in TestFlight"). But `upload_to_testflight` was missing `distribute_only: true`, so pilot looked for a fresh IPA to upload, found none, and died.

This is a latent bug that could only surface on the first production promotion, which just happened.

## Fix

`distribute_only: true` tells pilot to skip the upload and distribute the build identified by the already-passed `app_version` / `build_number`. (Contrast Expensify upstream, whose `upload_testflight_hybrid` passes an explicit `ipa:` and re-uploads — Kiroku deliberately reuses the staging binary instead.)

## Note on the stuck `0.3.16-44` iOS build

The `0.3.16.44` binary is already on TestFlight (the staging `beta` job succeeded), but `production` is at the pre-fix commit, so this fix reaches it only on the **next** promotion. Getting `0.3.16-44`'s iOS build out externally + submitted is a separate manual step — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)