### PR TITLE
chore(logging): gate debug logs behind __DEV__, stop logging device ID

### DIFF
--- a/src/components/MenuItemList.tsx
+++ b/src/components/MenuItemList.tsx
@@ -36,7 +36,9 @@ function MenuItemList({
     link: MenuItemLink | undefined,
     event: GestureResponderEvent | MouseEvent,
   ) => {
-    console.debug('Secondary interaction', link, event);
+    if (__DEV__) {
+      console.debug('Secondary interaction', link, event);
+    }
     // if (typeof link === 'function') {
     //   link().then(url =>
     //     ReportActionContextMenu.showContextMenu(

--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -149,9 +149,14 @@ function NavigationRoot({
       return;
     }
     const currentRoute = navigationRef.getCurrentRoute();
-    console.debug(
-      `[NAVIGATION] screen: ${currentRoute?.name}, params: ${JSON.stringify(currentRoute?.params ?? {})}`,
-    ); // TODO change this to Firebase.log
+    if (__DEV__) {
+      // Dev-only: route params can include userID/sessionId, so we must not log
+      // them to the device console in production builds.
+      // TODO change this to Firebase.log
+      console.debug(
+        `[NAVIGATION] screen: ${currentRoute?.name}, params: ${JSON.stringify(currentRoute?.params ?? {})}`,
+      );
+    }
 
     // const activeWorkspaceID = getPolicyIDFromState(state as NavigationState<RootStackParamList>);
     // // Performance optimization to avoid context consumers to delay first render

--- a/src/libs/actions/Device/index.ts
+++ b/src/libs/actions/Device/index.ts
@@ -40,7 +40,8 @@ function setDeviceID() {
     })
     .then(generateDeviceID)
     .then((uniqueID: string) => {
-      Log.info('Got new deviceID', false, uniqueID);
+      // Avoid persisting the deviceID (a per-install identifier) into the in-app log store.
+      Log.info('Got new deviceID');
       Onyx.set(ONYXKEYS.DEVICE_ID, uniqueID);
     })
     .catch((error: Error) =>


### PR DESCRIPTION
Small logging-hygiene cleanup so debug output and a per-install identifier don't end up in production logs.

### Changes
- **`NavigationRoot.tsx`** — the `[NAVIGATION]` route log now only runs in development builds (it previously printed screen params to the production device console on every screen change).
- **`Device/index.ts`** — dropped the device-ID argument from `Log.info('Got new deviceID')`, so the per-install identifier isn't written to the in-app log store.
- **`MenuItemList.tsx`** — gated a stray secondary-interaction `console.debug` behind `__DEV__`.

No behavioral change in development; these only quiet/sanitize logs in production builds.

### Verification
- `npx prettier --write` (changed files) ✓
- `npm run lint-changed` ✓
- `npm run typecheck-tsgo` ✓
- `npm run react-compiler-compliance-check check-changed` ✓
- `npm run test` ✓ (914 passed, 6 skipped)