### PR TITLE
fix(security): clear-by-default on sign-out (pre-launch audit 1.1)

### DIFF
--- a/__tests__/unit/sessionCleanupClearsOnyx.test.ts
+++ b/__tests__/unit/sessionCleanupClearsOnyx.test.ts
@@ -1,0 +1,204 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/unbound-method -- references to mocked methods are read-only assertions, not actual call sites */
+
+/**
+ * Pre-launch security audit, Finding 1.1: sign-out must purge the previous
+ * user's data from the on-device Onyx store instead of leaking it across an
+ * account switch on the same device (and account deletion, which runs this same
+ * `cleanupSession` path via CloseAccount). The fix inverts the model:
+ * `cleanupSession()` calls `Onyx.clear(KEYS_TO_PRESERVE)`, so every per-user key
+ * is cleared BY DEFAULT and only a minimal device-/build-level allowlist
+ * survives. A key added later is therefore cleared-by-default, not
+ * leaked-by-default.
+ *
+ * These tests pin:
+ *  - the wiring: `cleanupSession` purges through a single
+ *    `Onyx.clear(KEYS_TO_PRESERVE)` and never falls back to a per-key denylist
+ *    (no stray `Onyx.set(piiKey, null)`), while still tearing down the realtime
+ *    socket, the request queue, and timing data;
+ *  - the allowlist: `KEYS_TO_PRESERVE` keeps the device/UI keys and EXCLUDES
+ *    every sensitive key the audit flagged — which, under `Onyx.clear`'s
+ *    "clear everything except the preserved keys" contract, is exactly what
+ *    guarantees those keys are wiped.
+ */
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {KEYS_TO_PRESERVE} from '@userActions/App';
+import * as Session from '@userActions/Session';
+import * as PersistedRequests from '@userActions/PersistedRequests';
+import * as Pusher from '@libs/Pusher/pusher';
+import Timing from '@userActions/Timing';
+
+// This project's jest.config overrides `setupFiles`, which drops the RN preset's
+// AppState mock, so importing the real App.ts (for the real KEYS_TO_PRESERVE)
+// hits `AppState.addEventListener` at module load. Shim only AppState via a Proxy
+// and pass every other react-native export through untouched (CONST etc. read
+// Platform/Dimensions from the real jest-expo mock).
+jest.mock('react-native', () => {
+  const ReactNative =
+    jest.requireActual<Record<PropertyKey, unknown>>('react-native');
+  return new Proxy(ReactNative, {
+    get: (target, prop) =>
+      prop === 'AppState'
+        ? {addEventListener: jest.fn(() => ({remove: jest.fn()}))}
+        : target[prop],
+  });
+});
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    clear: jest.fn(() => Promise.resolve()),
+    set: jest.fn(() => Promise.resolve()),
+    merge: jest.fn(() => Promise.resolve()),
+    METHOD: {MERGE: 'merge', SET: 'set'},
+  },
+  useOnyx: jest.fn(),
+}));
+
+// App.ts (imported for KEYS_TO_PRESERVE) pulls the API/navigation graph; stub the
+// heavy edges so importing it stays inert under jest.
+jest.mock('@libs/API', () => ({
+  write: jest.fn(),
+  read: jest.fn(),
+  makeRequestWithSideEffects: jest.fn(),
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+  __esModule: true,
+  default: {
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+    setParams: jest.fn(),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    waitForProtectedRoutes: jest.fn(() => Promise.resolve()),
+  },
+}));
+jest.mock('@libs/Navigation/navigationRef', () => ({
+  __esModule: true,
+  default: {current: null},
+}));
+jest.mock('@libs/Navigation/currentUrl', () => ({
+  __esModule: true,
+  default: jest.fn(() => ''),
+}));
+jest.mock('@libs/setCalendarLocale', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// Session.ts side-effect collaborators — assert on `Pusher.disconnect` and
+// `PersistedRequests.clear`; the rest just need to exist.
+jest.mock('@libs/Pusher/pusher', () => ({disconnect: jest.fn()}));
+jest.mock('@libs/Timers', () => ({
+  __esModule: true,
+  default: {clearAll: jest.fn()},
+}));
+jest.mock('@userActions/PersistedRequests', () => ({clear: jest.fn()}));
+jest.mock('@userActions/Subscriptions', () => ({
+  forget: jest.fn(),
+  identify: jest.fn(),
+  initialize: jest.fn(),
+}));
+jest.mock('@userActions/Timing', () => ({
+  __esModule: true,
+  default: {clearData: jest.fn(), start: jest.fn(), end: jest.fn()},
+}));
+jest.mock('@libs/ErrorUtils', () => ({
+  raiseAppError: jest.fn(),
+  getMicroSecondOnyxError: jest.fn(),
+}));
+jest.mock('@libs/Log', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    hmmm: jest.fn(),
+    alert: jest.fn(),
+  },
+}));
+jest.mock('@userActions/Session/clearCache', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('firebase/auth', () => ({signOut: jest.fn(() => Promise.resolve())}));
+
+describe('Session.cleanupSession – Onyx purge wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('purges the store with a single Onyx.clear(KEYS_TO_PRESERVE)', () => {
+    Session.cleanupSession();
+
+    expect(Onyx.clear).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(Onyx.clear).mock.calls[0][0]).toEqual(KEYS_TO_PRESERVE);
+  });
+
+  it('does NOT fall back to a per-key denylist (no stray Onyx.set)', () => {
+    // The whole point of the inversion: clearing is by-default, so there must be
+    // no hand-maintained `Onyx.set(key, null)` calls that a future key could slip
+    // past.
+    Session.cleanupSession();
+
+    // eslint-disable-next-line rulesdir/prefer-actions-set-data -- asserting the action does NOT touch Onyx.set; this is a negative assertion, not a write site
+    expect(Onyx.set).not.toHaveBeenCalled();
+  });
+
+  it('still tears down the socket, request queue, and timing data', () => {
+    Session.cleanupSession();
+
+    expect(Pusher.disconnect).toHaveBeenCalledTimes(1);
+    expect(PersistedRequests.clear).toHaveBeenCalledTimes(1);
+    expect(Timing.clearData).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('KEYS_TO_PRESERVE allowlist', () => {
+  it('keeps only the non-sensitive device/build/UI keys', () => {
+    expect(KEYS_TO_PRESERVE).toEqual(
+      expect.arrayContaining([
+        ONYXKEYS.DEVICE_ID,
+        ONYXKEYS.NETWORK,
+        ONYXKEYS.PREFERRED_THEME,
+        ONYXKEYS.NVP_PREFERRED_LOCALE,
+        ONYXKEYS.IS_BETA,
+      ]),
+    );
+  });
+
+  it('excludes every sensitive / per-user key so they are cleared by default', () => {
+    // Single-value PII + per-user state flagged by the audit, plus the auth keys
+    // (Kiroku auth is Firebase-gated, so SESSION/CREDENTIALS are pure leak
+    // surface) and the bootstrap flag that must reset between accounts.
+    const mustBeCleared = [
+      ONYXKEYS.USER_LOCATION,
+      ONYXKEYS.USER_PRIVATE_DATA,
+      ONYXKEYS.DATA_VISIBILITY,
+      ONYXKEYS.PREFERENCES,
+      ONYXKEYS.USER,
+      ONYXKEYS.USER_DATA_LIST,
+      ONYXKEYS.CACHED_DRINKING_SESSIONS,
+      ONYXKEYS.FEEDBACK_LIST,
+      ONYXKEYS.BUG_LIST,
+      ONYXKEYS.SESSION,
+      ONYXKEYS.CREDENTIALS,
+      ONYXKEYS.IS_LOADING_APP,
+      // app/open's "user record delivered" proof (#1435): must not survive a
+      // sign-out, or a returning user could be dropped into onboarding.
+      ONYXKEYS.USER_DATA_HYDRATED,
+      ONYXKEYS.NVP_ONBOARDING,
+      ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION,
+      ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT,
+      // Collection prefixes — Onyx.clear wipes their member keys too.
+      ONYXKEYS.COLLECTION.DRINKING_SESSION,
+      ONYXKEYS.COLLECTION.DRINKS,
+      ONYXKEYS.COLLECTION.SESSION_LOCATIONS,
+    ];
+
+    mustBeCleared.forEach(key => {
+      expect(KEYS_TO_PRESERVE).not.toContain(key);
+    });
+  });
+});

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -67,17 +67,37 @@ Onyx.connect({
   callback: val => (preferredLocale = val),
 });
 
+/**
+ * The allowlist of Onyx keys that survive a sign-out. `Session.cleanupSession()`
+ * calls `Onyx.clear(KEYS_TO_PRESERVE)`, which wipes EVERYTHING else — the model
+ * is inverted on purpose: a newly added key is cleared-by-default, and only the
+ * device-/build-level, non-sensitive keys below are kept. Anything carrying user
+ * PII (location, private data incl. DOB, data-visibility, preferences, drinking
+ * sessions/drinks/locations, admin feedback/bug lists, …) must NOT be added here.
+ *
+ * Deliberately NOT preserved — diverges from upstream Expensify, whose
+ * `KEYS_TO_PRESERVE` keeps `SESSION`/`CREDENTIALS` because its auth gate reads
+ * `SESSION.authToken`. Kiroku authenticates against Firebase
+ * (`onAuthStateChanged` for the gate, `getIdToken()` for the API Bearer), so the
+ * Onyx `SESSION`/`CREDENTIALS` keys are NOT the source of truth for auth — they
+ * only hold the previous user's email/token, which is exactly the cross-account
+ * leak we want gone. The next sign-in's `openApp` response repopulates `SESSION`.
+ * `IS_LOADING_APP` is likewise cleared (not preserved) so a stale `false` can't
+ * open the onboarding/terms readiness gates before the next bootstrap runs.
+ */
 const KEYS_TO_PRESERVE: OnyxKey[] = [
-  // ONYXKEYS.ACCOUNT,
-  ONYXKEYS.IS_LOADING_APP,
-  ONYXKEYS.IS_SIDEBAR_LOADED,
-  ONYXKEYS.MODAL,
+  // Device identity — documented to survive logout (see Device/generateDeviceID).
+  ONYXKEYS.DEVICE_ID,
+  // Connectivity drives the offline request queue + OfflineIndicator; its sole
+  // writer (UserConnectionProvider) sits above AuthScreens and doesn't re-emit on
+  // sign-out, so clearing it could strand the queue mid-transition.
   ONYXKEYS.NETWORK,
-  ONYXKEYS.SESSION,
-  ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT,
+  // Visual/locale preferences are device-level: keep the login screen on the
+  // user's theme and language instead of flashing back to the defaults.
   ONYXKEYS.PREFERRED_THEME,
   ONYXKEYS.NVP_PREFERRED_LOCALE,
-  ONYXKEYS.CREDENTIALS,
+  // Build-channel flag derived from the installed binary, not the account.
+  ONYXKEYS.IS_BETA,
 ];
 
 let resolveIsReadyPromise: () => void;

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -8,6 +8,7 @@ import Onyx from 'react-native-onyx';
 // import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 // import type {ValueOf} from 'type-fest';
 import * as ErrorUtils from '@libs/ErrorUtils';
+import {KEYS_TO_PRESERVE} from '@userActions/App';
 import * as PersistedRequests from '@userActions/PersistedRequests';
 import * as Subscriptions from '@userActions/Subscriptions';
 // import * as API from '@libs/API';
@@ -669,47 +670,39 @@ function cleanupSession() {
   Timers.clearAll();
   // PriorityMode.resetHasReadRequiredDataFromStorage();
   // HttpUtils.cancelPendingRequests();
+  // Drop any queued/in-flight writes so the previous user's pending requests are
+  // never replayed under the next account that signs in on this device.
   PersistedRequests.clear();
   // NetworkConnection.clearReconnectionCallbacks();
   // SessionUtils.resetDidUserLogInDuringSession();
   resetHomeRouteParams();
-  // Drop any in-flight OAuth-link state so credentials don't leak across users.
-  Onyx.set(ONYXKEYS.PENDING_OAUTH_CREDENTIAL, null);
-  // Clear verification-email cooldown so the next user on this device can
-  // immediately receive a fresh verification email without hitting the
-  // previous user's send timestamp.
-  Onyx.set(ONYXKEYS.VERIFY_EMAIL_SENT, null);
-  // Drop the cached drinking sessions snapshot so the next account on this
-  // device can't briefly render the previous user's data on cold launch.
-  Onyx.set(ONYXKEYS.CACHED_DRINKING_SESSIONS, null);
-  // Reset the last visited path so re-login always starts at Home, not wherever
-  // the user happened to be when they signed out.
-  Onyx.set(ONYXKEYS.LAST_VISITED_PATH, null);
-  // Reset the OpenApp bootstrap signals: the onboarding/terms readiness gates
-  // read these as "this auth session's bootstrap completed / delivered the user
-  // record", so a leftover value must not carry into the next sign-in on this
-  // device.
-  Onyx.set(ONYXKEYS.IS_LOADING_APP, null);
-  Onyx.set(ONYXKEYS.USER_DATA_HYDRATED, false);
-  // Drop ALL user records on sign-out, same rationale as the cached-sessions
-  // clear above but more critical: the onboarding/terms gates read
-  // `USER_DATA_LIST[uid]` the moment the next session's bootstrap completes,
-  // and a stale entry from a previous session (e.g. a poisoned or
-  // mid-onboarding record) re-routes an already-onboarded user back into the
-  // one-way onboarding flow (2026-06-11 field repro). Friends' records are
-  // refetched by the next session's app/open + friend reads.
-  Onyx.set(ONYXKEYS.USER_DATA_LIST, null);
-  // The server's update sequence (lastUpdateID) is PER USER, but this client
-  // key is global: after switching from a high-counter account to a
-  // low-counter one, every update for the new account compares as "older than
-  // current state" and its onyxData is silently skipped (only OpenApp
-  // survives, via its explicit exemption in OnyxUpdates.apply). Reset on
-  // sign-out so the next account starts from its own baseline.
-  Onyx.set(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, null);
-  // Per-account onboarding/terms mirrors written by app/open — must not leak
-  // into the next account's session on this device.
-  Onyx.set(ONYXKEYS.NVP_ONBOARDING, null);
-  Onyx.set(ONYXKEYS.NVP_TERMS_ACCEPTED_VERSION, null);
+  // Wipe the entire Onyx store except the device-/build-level allowlist
+  // (`KEYS_TO_PRESERVE`). This is the security-critical step of sign-out and of
+  // account deletion (CloseAccount routes through this same path): every per-user
+  // key is cleared by DEFAULT rather than by a hand-maintained denylist, so a key
+  // added later can't silently leak across an account switch. This subsumes the
+  // keys we used to null out by hand and adds the ones that previously survived —
+  // USER_LOCATION, USER_PRIVATE_DATA (incl. DOB), DATA_VISIBILITY, PREFERENCES,
+  // USER, the drinking-session/drinks/session-location collections, and the
+  // admin-only feedback/bug lists — plus the SESSION token + email and the
+  // CREDENTIALS key. Notable knock-on effects that the old explicit clears
+  // covered and `Onyx.clear` keeps covering:
+  //  - IS_LOADING_APP is removed, so a stale `false` can't open the
+  //    onboarding/terms readiness gates before the next bootstrap finishes.
+  //  - USER_DATA_HYDRATED is removed: the onboarding gate reads it as `=== true`,
+  //    so a removed key and an explicit `false` are equivalent — this session's
+  //    "app/open delivered the user record" proof can't carry into the next
+  //    sign-in (the returning-user fix, #1435).
+  //  - USER_DATA_LIST is removed, so a poisoned/mid-onboarding record can't
+  //    re-route an already-onboarded user back into onboarding (2026-06-11 repro).
+  //  - ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT is removed, so the next
+  //    (per-user) update sequence isn't compared against the prior account's
+  //    counter and silently skipped.
+  // `Onyx.clear` re-applies the preserved keys' initial states, so the next
+  // sign-in's `openApp` rehydrates a clean store. On native this complements the
+  // `clearCache()` below, which wipes the on-disk image cache Onyx doesn't own;
+  // on web `Onyx.clear` is what actually purges the store (clearCache is a no-op).
+  Onyx.clear(KEYS_TO_PRESERVE);
   clearCache().then(() => {
     Log.info('Cleared all cache data', true, {}, true);
   });


### PR DESCRIPTION
## Summary

Pre-launch security audit **Finding 1.1 (Medium)**: `cleanupSession()` cleared only a hand-curated allowlist of Onyx keys, so several global single-value keys retained the **previous user's PII after sign-out** and persisted across account switches on the same device (and across account deletion, which routes through the same path via `CloseAccount`). On web the exposure was worse because `clearCache` is a no-op.

This inverts the model: `cleanupSession()` now calls **`Onyx.clear(KEYS_TO_PRESERVE)`** with an explicit minimal allowlist of non-sensitive device/build/UI keys, so a newly added sensitive key is **cleared-by-default instead of leaked-by-default**.

## What changed

- **`src/libs/actions/Session/index.ts`** — `cleanupSession()` replaces the per-key `Onyx.set(<key>, null)` denylist with a single `Onyx.clear(KEYS_TO_PRESERVE)`. This now also wipes the keys the audit flagged that previously survived: `USER_LOCATION`, `USER_PRIVATE_DATA` (incl. DOB), `DATA_VISIBILITY`, `PREFERENCES`, `USER`, the `drinkingSession_*` / `drinks_*` / `sessionLocations_*` collections, the admin-only `feedbackList`/`bugList`, plus the `SESSION` token + email and `credentials`. The socket teardown, request-queue clear, and timing reset are unchanged. On native, the existing `clearCache()` (image-cache `unlink`) still runs alongside; **on web `Onyx.clear` is what actually purges the store.**
- **`src/libs/actions/App.ts`** — reconciles the dead, Expensify-derived `KEYS_TO_PRESERVE` (never wired into the Firebase sign-out path) into the canonical sign-out allowlist: `DEVICE_ID`, `NETWORK`, `PREFERRED_THEME`, `NVP_PREFERRED_LOCALE`, `IS_BETA`. It is imported by `cleanupSession` (matching upstream's `Session`-imports-`App` direction).
- **`__tests__/unit/sessionCleanupClearsOnyx.test.ts`** — pins the wiring (single `Onyx.clear(KEYS_TO_PRESERVE)`, no per-key `Onyx.set` fallback, socket/queue/timing torn down) and the real allowlist (keeps device/UI keys; excludes every sensitive/per-user key, the auth keys, and the collection prefixes).

## Why it's safe to clear `SESSION`/`CREDENTIALS` (deliberate divergence from upstream)

Upstream Expensify preserves `SESSION`/`CREDENTIALS` because **its** auth gate reads `SESSION.authToken`. Kiroku does not:

- The auth gate is **Firebase `onAuthStateChanged`** (`Kiroku.tsx`), not the Onyx `SESSION` key.
- API requests authenticate with the **Firebase ID token** via `getIdToken()` (`HttpUtils.kirokuXhr`), not `SESSION.authToken`.
- `SESSION` (userID/email/`encryptedAuthToken`) is repopulated by the next sign-in's `openApp` response — the same merge that already overwrites it today (covered by `openAppFlushReplay.test.ts`, which replays the real server envelope). `CREDENTIALS` is never written in Kiroku.

So after clear, the store is in the well-tested fresh-install state and the next `openApp` rehydrates it cleanly. `IS_LOADING_APP` is intentionally **not** preserved (a stale `false` must not open the onboarding/terms readiness gates early) — `Onyx.clear` removes it, preserving the old explicit behavior.

## Testing

- `npm run test` — **919 passed, 0 failed** (new suite + the existing sign-out/openApp suites).
- `typecheck-tsgo`, `lint-changed`, `react-compiler-compliance-check check-changed`, `prettier` — all clean.

### Residual manual QA (needs real accounts; not runnable here)
The audit asks for an on-device **sign-out → sign-in-as-different-user** check on iOS, Android, and web confirming no stale data leaks and that re-hydration still works. That requires two real Firebase accounts/credentials I can't exercise in this environment. The automated coverage proves the clear behavior and the re-hydration path (= cold-launch path); a human pass on device/web before release is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Rebase note (sync onto master)

Rebased onto current `master`, which now includes #1435 (returning-Apple-user onboarding fix). That PR added a new bootstrap key `USER_DATA_HYDRATED` to the old `cleanupSession` denylist. The conflict was resolved in favor of this PR's `Onyx.clear(KEYS_TO_PRESERVE)`, which **subsumes** that key: the onboarding gate reads `userDataHydrated === true`, so a key removed by `Onyx.clear` is equivalent to the explicit `false` #1435 set — the returning-user fix is preserved, and `USER_DATA_HYDRATED` is now cleared-by-default like every other per-user key. Added it to the test's "must be cleared" assertions.