### PR TITLE
test(e2e): cover launch-critical flows on web + native harness proposal

### DIFF
--- a/e2e/native/README.md
+++ b/e2e/native/README.md
@@ -1,0 +1,122 @@
+# Native E2E — proposal (not yet wired)
+
+> **Status: proposal + starter flow, not a running harness.** The flow in
+> [`flows/`](./flows) is a concrete starting point written against the real app,
+> but it has **not** been executed against a simulator/emulator or in CI yet.
+> Standing the runner up needs a device/simulator and a built app, which the
+> authoring environment didn't have — so this is deliberately delivered as a
+> documented path to expand rather than a half-working harness. Everything below
+> is what's needed to make it real.
+
+## Why native E2E (what the web suite can't catch)
+
+The Playwright web suite ([`../web`](../web)) covers the launch-critical flows
+that render on react-native-web. But Kiroku's most painful recurring bugs are
+**native boot/navigation races** that only exist on device:
+
+- splash-screen / auth-gate deadlock on cold boot,
+- the iOS tab-switch "fly to top-left" zoom on root tabs,
+- first-run empty-state flashes (friends list, onboarding),
+- native modal/RHP transition freezes.
+
+None of these reproduce on web, so native coverage has unique value for the App
+Store launch. A single green smoke flow on a real iOS simulator + Android
+emulator would guard the boot → sign-in → core-loop path that a store reviewer
+(and every new user) hits first.
+
+## Tool choice: Maestro
+
+| Tool        | Verdict        | Why                                                                                                                                                                                     |
+| ----------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Maestro** | ✅ recommended | YAML flows, zero app instrumentation, built-in waits/retries (less flake), trivial local install, one CLI for iOS + Android, [Maestro Cloud] option. Lowest lift for a solo maintainer. |
+| Detox       | ❌             | Gray-box; needs native build integration, a JS test runner, and per-RN-version upkeep. Heavy for one smoke flow.                                                                        |
+| Appium      | ❌             | Powerful but verbose (WebDriver), heavier setup, more flake to manage.                                                                                                                  |
+
+Maestro matches elements by `text:` (the on-screen / accessibility label) or
+`id:` (RN `testID` → `resource-id` on Android, `accessibilityIdentifier` on
+iOS). **The `testID`s this PR added for the web suite are reused verbatim as
+Maestro `id:` matchers** — `add-drink-<key>`, `session-total-units`,
+`summary-edit-session`, `calendar-day-<date>` — so the two suites share one set
+of stable selectors.
+
+[Maestro Cloud]: https://docs.maestro.dev/cloud/run-maestro-tests-in-the-cloud
+
+## First flow
+
+[`flows/sign_in_log_session.yaml`](./flows/sign_in_log_session.yaml) drives
+launch → email/password sign-in → start a live session → log a drink → save,
+asserting the saved unit count — the native mirror of the web lifecycle test.
+
+### Auth in automation — keep it email/password
+
+Use the **dev** Firebase project and a dev test account (the same
+`E2E_TEST_*` credentials the web suite uses). Avoid scripting Google / Apple
+sign-in:
+
+- Google SSO throws `DEVELOPER_ERROR` on ad-hoc builds when the signing SHA
+  isn't registered for the variant's Firebase app.
+- Apple-on-Android is a web OAuth popup (not a native sheet), which Maestro
+  can't drive reliably.
+
+The email/password form is fully native and deterministic. Like the web build,
+dev/ad-hoc builds re-show the **email-verification gate** ("Skip verification
+(dev only)") and may show the **terms** sheet — the flow clears both, mirroring
+`e2e/web/fixtures/devGates.ts`.
+
+## Local setup
+
+```bash
+# 1. Install Maestro (https://docs.maestro.dev/getting-started/installing-maestro)
+curl -fsSL "https://get.maestro.mobile.dev" | bash
+
+# 2. Build & install a debug/dev app onto a booted simulator/emulator.
+#    Android dev variant applicationId: com.alcohol_tracker.dev
+npm run android            # or: npm run ios
+#    (or install a CI ad-hoc APK — see the android-test-apk notes)
+
+# 3. Provide the dev test account (same values as e2e/web/.env.e2e)
+export MAESTRO_APP_ID=com.alcohol_tracker.dev      # iOS: confirm the dev bundle id
+export E2E_TEST_EMAIL=...                            # dev-backend account
+export E2E_TEST_PASSWORD=...
+
+# 4. Run the flow
+maestro test e2e/native/flows/sign_in_log_session.yaml
+```
+
+`maestro studio` is the fastest way to discover/verify selectors against the
+running app while expanding flows.
+
+## CI plan
+
+Add a manually-/label-gated workflow (mirror `deployWeb.yml`'s
+`Ready To Build - Web` gating — **not** every PR; device runners are slow/costly):
+
+- **Android** — `ubuntu-latest` + `reactivecircus/android-emulator-runner` (KVM
+  acceleration). Build the dev/ad-hoc APK (or pull the CI ad-hoc APK from S3),
+  `maestro test`, upload the Maestro report + a recording artifact.
+- **iOS** — `macos-14`, boot an iOS simulator, build the dev scheme, `maestro
+test`. macOS minutes are expensive, so gate this tightly (label or
+  `workflow_dispatch`).
+- Inject `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD` from repo secrets (already exist
+  for the web job). Point the build at the **dev** Firebase env so the dev test
+  account authenticates (same constraint as the web preview job).
+- [Maestro Cloud] is the lower-maintenance alternative to self-hosted device
+  runners if budget allows.
+
+## Effort estimate
+
+| Step                                                                            | Estimate      |
+| ------------------------------------------------------------------------------- | ------------- |
+| Validate `sign_in_log_session.yaml` locally on a sim/emulator (selector fixups) | 0.5 day       |
+| Add 2–3 more flows (onboarding/first-run, tab tour, calendar→day-overview)      | 0.5–1 day     |
+| Android CI job (emulator-runner)                                                | 0.5–1 day     |
+| iOS CI job (macOS runner) + tighten gating/artifacts                            | 1 day         |
+| **Total to a gated, green native smoke suite**                                  | **~3–4 days** |
+
+## Why this wasn't built here
+
+Building it requires a booted simulator/emulator and a compiled app — neither
+was available in the authoring environment, and `maestro test` can't be
+verified without them. Per the brief's guidance, a native harness that can't be
+run is worse than an honest proposal, so the web suite (Path A) was completed
+and verified instead, and this is left as a scoped follow-up.

--- a/e2e/native/flows/sign_in_log_session.yaml
+++ b/e2e/native/flows/sign_in_log_session.yaml
@@ -1,0 +1,74 @@
+# UNVERIFIED STARTER FLOW — see ../README.md.
+#
+# This is the native mirror of the web `session-lifecycle` test: launch ->
+# email/password sign-in -> clear dev gates -> start a live session -> log a
+# drink -> save, asserting the saved unit count. It is written against the real
+# app (reusing the same testIDs the web suite uses as Maestro `id:` matchers),
+# but it has NOT yet been run on a simulator/emulator. Validate and adjust
+# selectors with `maestro studio` before wiring it into CI.
+#
+# Run:
+#   export MAESTRO_APP_ID=com.alcohol_tracker.dev   # confirm iOS bundle id
+#   export E2E_TEST_EMAIL=... E2E_TEST_PASSWORD=...
+#   maestro test e2e/native/flows/sign_in_log_session.yaml
+
+appId: ${MAESTRO_APP_ID}
+env:
+  EMAIL: ${E2E_TEST_EMAIL}
+  PASSWORD: ${E2E_TEST_PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# --- Sign in (email / password) ---------------------------------------------
+# The welcome screen defaults to sign-up; switch to log-in mode first.
+- tapOn:
+    text: 'Log in'
+- tapOn:
+    text: 'Email'
+- inputText: ${EMAIL}
+- tapOn:
+    text: 'Password'
+- inputText: ${PASSWORD}
+- tapOn:
+    text: 'Log in'
+
+# --- Clear dev-build gates (mirror e2e/web/fixtures/devGates.ts) --------------
+# Best-effort: an already-verified account that has accepted the current terms
+# goes straight to Home, so these are optional.
+- runFlow:
+    when:
+      visible: 'Skip verification (dev only)'
+    commands:
+      - tapOn: 'Skip verification (dev only)'
+- runFlow:
+    when:
+      visible: 'Confirm'
+    commands:
+      - tapOn: 'Confirm'
+
+- assertVisible:
+    id: 'Home Screen'
+
+# --- Start a live session, log a drink, save ---------------------------------
+- tapOn:
+    text: 'Start a session (Floating action)' # the FAB's accessibility label
+- tapOn:
+    text: 'Live' # popover: start a live session
+- assertVisible:
+    id: 'Live Session Screen'
+
+# Unit count starts at 0; logging a drink moves it off 0 and enables Save.
+- assertVisible:
+    id: 'session-total-units'
+    text: '0'
+- tapOn:
+    id: 'add-drink-beer' # any add-drink-<key> stepper; adjust per DrinkData
+- assertNotVisible:
+    id: 'session-total-units'
+    text: '0'
+
+- tapOn:
+    text: 'Save Session'
+- assertVisible:
+    id: 'Session Summary Screen'

--- a/e2e/web/README.md
+++ b/e2e/web/README.md
@@ -1,7 +1,39 @@
 # Web E2E (Playwright)
 
-Smoke suite for the react-native-web build: email/password sign-in plus
-navigation across the four bottom tabs (Home, Friends, Statistics, Settings).
+End-to-end suite for the react-native-web build, covering the launch-critical
+flows the web surface can exercise:
+
+- **Sign-in & boot** (`smoke.spec.ts`) — email/password sign-in, booting an
+  authenticated session straight to Home, and navigating the four bottom tabs
+  (Home, Friends, Statistics, Settings) console-clean.
+- **Drinking session lifecycle** (`session-lifecycle.spec.ts`) — the core flow:
+  start a live session, log a drink, save it, re-open it through its summary to
+  confirm the drink persisted across the save round-trip, then delete it; plus a
+  start → log → discard path. Both self-clean, so the shared dev account never
+  accumulates sessions.
+- **Calendar navigation** (`calendar.spec.ts`) — tapping a day on the Home
+  calendar opens that day's overview (a known nav-freeze transition) and backs
+  out to Home.
+- **Friends tab** (`friends.spec.ts`) — the friend list tab settles into a
+  determinate, console-clean state and the Friend List / Friend Requests inner
+  tabs are switchable (guards the first-run empty-state races).
+- **Offline resilience** (`offline.spec.ts`) — the app stays navigable across
+  the cached tab roots while offline and after reconnecting. See the note on the
+  offline indicator below.
+- **Desktop phone frame** (`desktop-frame.spec.ts`) — the wide-window centered
+  phone-frame layout (#1219 / #1224).
+
+Several flows rely on `testID`s added to app components (the drink steppers, the
+session unit headline, the summary edit button, and calendar day cells), which
+surface as `data-testid` on web and double as Maestro `id:` matchers for the
+proposed native suite (see [`../native/README.md`](../native/README.md)).
+
+> **Offline indicator caveat.** `offline.spec.ts` asserts navigability, not the
+> `OfflineIndicator` banner. Under Playwright's simulated offline (which flips
+> `navigator.onLine` and fires the offline events), the banner did **not**
+> appear within 30s on the web dev build — the NetInfo → NETWORK bridge does not
+> seem to react to browser offline state on web. Whether the deployed web app
+> behaves the same is unconfirmed; flagged as a follow-up rather than asserted.
 
 - **Run locally:** copy `.env.e2e.example` to `.env.e2e`, fill in a dev-backend
   account, then `npm run test:e2e:web` from the repo root. With no

--- a/e2e/web/pages/DayOverviewPage.ts
+++ b/e2e/web/pages/DayOverviewPage.ts
@@ -1,0 +1,66 @@
+import type {Locator, Page} from '@playwright/test';
+
+/** Local calendar day (`YYYY-MM-DD`) for the machine running the test. */
+export function localDateString(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Page Object for the Day Overview screen (`DayOverviewScreen.displayName`),
+ * reached by tapping a day cell in the Home compact calendar. Lists that day's
+ * drinking sessions and, in edit mode, exposes a per-tile edit affordance.
+ *
+ * Actions and locators only -- assertions live in the specs.
+ */
+export class DayOverviewPage {
+  constructor(private readonly page: Page) {}
+
+  // A calendar day cell on Home. testID `calendar-day-<YYYY-MM-DD>` was added to
+  // `DayComponent` so a specific (e.g. today's) cell can be tapped without
+  // relying on the bare day-number text, which is ambiguous across the grid.
+  dayCell(dateString: string): Locator {
+    return this.page.getByTestId(`calendar-day-${dateString}`);
+  }
+
+  screen(): Locator {
+    return this.page.getByTestId('Day Overview Screen');
+  }
+
+  // The header Edit/Done toggle (self only): accessibility label flips between
+  // `common.edit` and `common.done`.
+  editModeToggle(): Locator {
+    return this.page.getByRole('button', {name: 'Edit', exact: true});
+  }
+
+  doneModeToggle(): Locator {
+    return this.page.getByRole('button', {name: 'Done', exact: true});
+  }
+
+  // A session tile, identified by its `dayOverviewScreen.sessionWindow`
+  // accessibility label which embeds the session id.
+  sessionTile(sessionId: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Drinking session: ${sessionId}`,
+    });
+  }
+
+  // The empty-day message (`dayOverviewScreen.noDrinkingSessions`).
+  emptyState(): Locator {
+    return this.page.getByText('No drinking sessions', {exact: true});
+  }
+
+  /** Tap a Home calendar day cell; resolve on the Day Overview screen. */
+  async openDay(dateString: string): Promise<void> {
+    await this.dayCell(dateString).click();
+    await this.screen().waitFor({state: 'visible'});
+  }
+
+  /** Turn the per-tile edit affordances on. */
+  async enableEditMode(): Promise<void> {
+    await this.editModeToggle().click();
+    await this.doneModeToggle().waitFor({state: 'visible'});
+  }
+}

--- a/e2e/web/pages/FriendsPage.ts
+++ b/e2e/web/pages/FriendsPage.ts
@@ -1,0 +1,49 @@
+import type {Locator, Page} from '@playwright/test';
+
+/**
+ * Page Object for the Friends (Social) tab. The screen hosts two inner tabs --
+ * "Friend List" and "Friend Requests" -- in a `react-native-tab-view` pager.
+ *
+ * Actions and locators only -- assertions live in the specs.
+ */
+export class FriendsPage {
+  constructor(private readonly page: Page) {}
+
+  // The Social tab root (`SocialScreen.displayName`).
+  screen(): Locator {
+    return this.page.getByTestId('SocialScreen');
+  }
+
+  // Inner tab labels (`socialScreen.friendList` / `.friendRequests`). The pager
+  // renders each label as a tab button; matching by accessible name keeps the
+  // selector independent of the underlying tab-view DOM.
+  friendListTab(): Locator {
+    return this.page.getByRole('tab', {name: 'Friend List'});
+  }
+
+  friendRequestsTab(): Locator {
+    return this.page.getByRole('tab', {name: 'Friend Requests'});
+  }
+
+  // The friend-list search field is always present on the Friend List tab
+  // (placeholder = `friendListScreen.searchYourFriendList`), so it is a stable
+  // signal that the tab's content rendered, regardless of how many friends the
+  // account has.
+  searchInput(): Locator {
+    return this.page.getByPlaceholder('Search your friend list');
+  }
+
+  // Empty-state copy when the account has no friends
+  // (`socialScreen.noFriendsYet`). One of this or a populated list is always the
+  // resolved Friend List state.
+  noFriendsInfo(): Locator {
+    return this.page.getByText('You do not have any friends yet', {
+      exact: true,
+    });
+  }
+
+  /** Switch to the Friend Requests inner tab. */
+  async openFriendRequestsTab(): Promise<void> {
+    await this.friendRequestsTab().click();
+  }
+}

--- a/e2e/web/pages/SessionPage.ts
+++ b/e2e/web/pages/SessionPage.ts
@@ -1,0 +1,126 @@
+import type {Locator, Page} from '@playwright/test';
+
+/**
+ * Page Object for the drinking-session lifecycle: the Home start-session FAB,
+ * the live/edit session window (`DrinkingSessionWindow`), and the post-save
+ * session summary.
+ *
+ * Actions and locators only -- assertions live in the specs.
+ */
+export class SessionPage {
+  constructor(private readonly page: Page) {}
+
+  // The floating action button on Home that opens the start-session popover
+  // (`StartSessionButtonAndPopover`). Its accessibility label is the
+  // `startSession.newSessionExplained` string.
+  fab(): Locator {
+    return this.page.getByRole('button', {
+      name: 'Start a session (Floating action)',
+    });
+  }
+
+  // Popover items render as `MenuItem`s whose accessible name is the session
+  // type title (`drinkingSession.live.title` / `.edit.title`). "Live" starts a
+  // live session immediately; "Edit" creates a back-dated (past) session.
+  liveSessionMenuItem(): Locator {
+    return this.page.getByRole('menuitem', {name: 'Live', exact: true});
+  }
+
+  // The live drinking-session screen (`LiveSessionScreen.displayName`).
+  liveScreen(): Locator {
+    return this.page.getByTestId('Live Session Screen');
+  }
+
+  // The edit drinking-session screen (`EditSessionScreen.displayName`), reached
+  // from a saved session's summary via the header edit button.
+  editScreen(): Locator {
+    return this.page.getByTestId('Edit Session Screen');
+  }
+
+  // The post-save read-only summary (`SessionSummaryScreen.displayName`).
+  summaryScreen(): Locator {
+    return this.page.getByTestId('Session Summary Screen');
+  }
+
+  // The headline unit count on the session window (testID added in
+  // `DrinkingSessionWindow`). Reads "0" until a drink is logged.
+  totalUnits(): Locator {
+    return this.page.getByTestId('session-total-units');
+  }
+
+  // The per-drink-type "+"/"-" steppers carry `add-drink-<key>` /
+  // `remove-drink-<key>` testIDs (one row per drink type). Any "+" adds units,
+  // so the smoke flow targets the first.
+  firstAddDrinkButton(): Locator {
+    return this.page.getByTestId(/^add-drink-/).first();
+  }
+
+  saveButton(): Locator {
+    return this.page.getByRole('button', {name: 'Save Session', exact: true});
+  }
+
+  // Same button for both wordings: "Discard Session" (live) / "Delete Session"
+  // (a saved session being edited).
+  discardButton(): Locator {
+    return this.page.getByRole('button', {
+      name: /^(Discard|Delete) Session$/,
+    });
+  }
+
+  // The destructive-confirm modal's affirmative action.
+  confirmYesButton(): Locator {
+    return this.page.getByRole('button', {name: 'Yes', exact: true});
+  }
+
+  // The edit affordance in the summary header (icon-only `Button`, testID
+  // `summary-edit-session`). Loads the session into the edit buffer and opens
+  // the edit screen.
+  summaryEditButton(): Locator {
+    return this.page.getByTestId('summary-edit-session');
+  }
+
+  /** Open the FAB popover and start a live session; resolve on the live screen. */
+  async startLiveSession(): Promise<void> {
+    await this.fab().click();
+    await this.liveSessionMenuItem().click();
+    await this.liveScreen().waitFor({state: 'visible'});
+  }
+
+  /**
+   * The session id is carried in the session-screen URL
+   * (`/drinking-session/<id>/live` and, after save, `/.../summary`). The saved
+   * session keeps the same id, so specs use it to assert on the exact session.
+   */
+  currentSessionId(): string {
+    const match = /drinking-session\/([^/]+)\//.exec(this.page.url());
+    if (!match) {
+      throw new Error(
+        `Could not parse a session id from URL: ${this.page.url()}`,
+      );
+    }
+    return match[1];
+  }
+
+  /** Tap the first drink's "+" once. */
+  async logOneDrink(): Promise<void> {
+    await this.firstAddDrinkButton().click();
+  }
+
+  /** Save the session; resolve on the summary screen. */
+  async save(): Promise<void> {
+    await this.saveButton().click();
+    await this.summaryScreen().waitFor({state: 'visible'});
+  }
+
+  /** From the summary, open the edit screen for the saved session. */
+  async openEditFromSummary(): Promise<void> {
+    await this.summaryEditButton().click();
+    await this.editScreen().waitFor({state: 'visible'});
+  }
+
+  /** Discard/delete the open session and confirm the warning modal. */
+  async discardAndConfirm(): Promise<void> {
+    await this.discardButton().click();
+    await this.confirmYesButton().click();
+  }
+}

--- a/e2e/web/tests/calendar.spec.ts
+++ b/e2e/web/tests/calendar.spec.ts
@@ -1,0 +1,38 @@
+import {test, expect} from '../fixtures/auth';
+import {HomePage} from '../pages/HomePage';
+import {DayOverviewPage, localDateString} from '../pages/DayOverviewPage';
+import {trackErrors} from '../fixtures/consoleErrors';
+
+/**
+ * Calendar navigation: tapping a day on the Home compact calendar opens that
+ * day's overview. This is one of the synchronous-mount transitions that has
+ * regressed into a "nav freeze" before (see the nav-freeze notes), so the value
+ * is in asserting the destination screen actually mounts -- not just that the
+ * source highlighted.
+ */
+test.describe('calendar navigation', () => {
+  test("opens today's day overview from the Home calendar and returns", async ({
+    authedPage,
+  }) => {
+    const errors = trackErrors(authedPage);
+    const homePage = new HomePage(authedPage);
+    const dayOverview = new DayOverviewPage(authedPage);
+
+    await homePage.goto();
+    await expect(homePage.screen()).toBeVisible();
+
+    // Today's cell is always present in the current month and (being the max
+    // selectable day) is enabled.
+    const today = localDateString();
+    await dayOverview.openDay(today);
+    await expect(dayOverview.screen()).toBeVisible();
+
+    // Back out to Home via browser history (the day overview is a pushed route).
+    await authedPage.goBack();
+    await expect(homePage.screen()).toBeVisible();
+
+    expect(errors, `Unexpected console errors:\n${errors.join('\n')}`).toEqual(
+      [],
+    );
+  });
+});

--- a/e2e/web/tests/friends.spec.ts
+++ b/e2e/web/tests/friends.spec.ts
@@ -1,0 +1,53 @@
+import {test, expect} from '../fixtures/auth';
+import {HomePage} from '../pages/HomePage';
+import {TabNav} from '../pages/TabNav';
+import {FriendsPage} from '../pages/FriendsPage';
+import {trackErrors} from '../fixtures/consoleErrors';
+
+/**
+ * The Friends tab is a recurring source of first-run/empty-state races (the
+ * friends list once flashed "no friends" on a cold boot). These specs assert
+ * the tab settles into a determinate, console-clean state and that its two
+ * inner tabs are switchable -- independent of how many friends the dev test
+ * account happens to have.
+ */
+test.describe('friends tab', () => {
+  test('renders the friend list tab content', async ({authedPage}) => {
+    const errors = trackErrors(authedPage);
+    const homePage = new HomePage(authedPage);
+    const tabNav = new TabNav(authedPage);
+    const friends = new FriendsPage(authedPage);
+
+    await homePage.goto();
+    await expect(homePage.screen()).toBeVisible();
+
+    await tabNav.open('Friends');
+    await expect(friends.screen()).toBeVisible();
+
+    // The search field is always rendered on the Friend List tab, so it is a
+    // stable signal the tab's content mounted (vs. spinning forever or flashing
+    // an empty state) regardless of the account's friend count.
+    await expect(friends.searchInput()).toBeVisible();
+
+    expect(errors, `Unexpected console errors:\n${errors.join('\n')}`).toEqual(
+      [],
+    );
+  });
+
+  test('switches to the Friend Requests tab', async ({authedPage}) => {
+    const homePage = new HomePage(authedPage);
+    const tabNav = new TabNav(authedPage);
+    const friends = new FriendsPage(authedPage);
+
+    await homePage.goto();
+    await tabNav.open('Friends');
+    await expect(friends.screen()).toBeVisible();
+    await expect(friends.friendListTab()).toBeVisible();
+
+    await friends.openFriendRequestsTab();
+    await expect(friends.friendRequestsTab()).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+});

--- a/e2e/web/tests/offline.spec.ts
+++ b/e2e/web/tests/offline.spec.ts
@@ -1,0 +1,50 @@
+import {test, expect} from '../fixtures/auth';
+import {HomePage} from '../pages/HomePage';
+import {TabNav, type TabName} from '../pages/TabNav';
+
+/**
+ * Offline-first resilience: losing the network must not break the app. With a
+ * warm (already-loaded) session, the user should still be able to move between
+ * the cached tab roots while offline, and everything should keep working once
+ * the connection returns. We drive the browser context's offline state, which
+ * flips `navigator.onLine` and blocks the network the way a real drop would.
+ *
+ * Note: this intentionally does NOT assert the OfflineIndicator banner. On the
+ * web dev build it does not surface under simulated offline (the NetInfo ->
+ * NETWORK bridge does not flip from `navigator.onLine`); see the PR description
+ * for that finding. This test covers the behavior that IS deterministic and
+ * matters most for launch -- the app stays usable offline and recovers.
+ */
+test.describe('offline resilience', () => {
+  test('stays navigable while offline and after reconnecting', async ({
+    authedPage,
+  }) => {
+    const homePage = new HomePage(authedPage);
+    const tabNav = new TabNav(authedPage);
+
+    await homePage.goto();
+    await expect(homePage.screen()).toBeVisible();
+
+    // Drop the connection, then walk the cached tab roots: each destination
+    // must still mount (no freeze, no crash, no forced sign-out).
+    await authedPage.context().setOffline(true);
+
+    const offlineTour: TabName[] = [
+      'Friends',
+      'Statistics',
+      'Settings',
+      'Home',
+    ];
+    for (const tabName of offlineTour) {
+      await tabNav.open(tabName);
+      await expect(tabNav.tabScreen(tabName)).toBeVisible();
+    }
+
+    // Reconnect: the app keeps working.
+    await authedPage.context().setOffline(false);
+    await tabNav.open('Friends');
+    await expect(tabNav.tabScreen('Friends')).toBeVisible();
+    await tabNav.open('Home');
+    await expect(homePage.screen()).toBeVisible();
+  });
+});

--- a/e2e/web/tests/session-lifecycle.spec.ts
+++ b/e2e/web/tests/session-lifecycle.spec.ts
@@ -1,0 +1,89 @@
+import {test, expect} from '../fixtures/auth';
+import {HomePage} from '../pages/HomePage';
+import {SessionPage} from '../pages/SessionPage';
+import {trackErrors} from '../fixtures/consoleErrors';
+
+/**
+ * The drinking-session lifecycle is Kiroku's core flow: start a session, log a
+ * drink, save it, and later edit/delete it. These specs drive it end to end
+ * against the dev backend and assert observable outcomes (the unit count, the
+ * screen the app lands on, and that the saved session round-trips with the
+ * logged units) rather than just that a screen mounted.
+ *
+ * Both tests are self-cleaning: the lifecycle test deletes the session it
+ * creates, and the discard test never persists one. That keeps the shared dev
+ * test account from accumulating sessions across CI runs.
+ */
+test.describe('drinking session lifecycle', () => {
+  test('creates a live session, logs a drink, saves it, then deletes it', async ({
+    authedPage,
+  }) => {
+    const errors = trackErrors(authedPage);
+    const homePage = new HomePage(authedPage);
+    const session = new SessionPage(authedPage);
+
+    await homePage.goto();
+    await expect(homePage.screen()).toBeVisible();
+
+    // Start a live session and log one drink.
+    await session.startLiveSession();
+    const sessionId = session.currentSessionId();
+
+    // Capture the starting count rather than assuming zero, so the test is
+    // robust if a prior ongoing session is resumed on the shared dev account.
+    const unitsBefore = Number(await session.totalUnits().innerText());
+
+    await session.logOneDrink();
+    // Logging a drink increments the unit count and enables Save.
+    await expect
+      .poll(async () => Number(await session.totalUnits().innerText()))
+      .toBeGreaterThan(unitsBefore);
+    await expect(session.saveButton()).toBeEnabled();
+
+    const loggedUnits = await session.totalUnits().innerText();
+
+    // Save -> the read-only summary for this exact session.
+    await session.save();
+    await expect(authedPage).toHaveURL(
+      new RegExp(`drinking-session/${sessionId}/summary`),
+    );
+
+    // Re-open the saved session through the summary's edit button: it loads the
+    // persisted session into the edit buffer, so the unit count surviving the
+    // save round-trip proves the drink actually persisted.
+    await session.openEditFromSummary();
+    await expect(session.totalUnits()).toHaveText(loggedUnits);
+
+    // Delete it and confirm. The edit screen pops back out of the session modal
+    // flow, landing on Home.
+    await session.discardAndConfirm();
+    await expect(homePage.screen()).toBeVisible();
+    await expect(session.editScreen()).toBeHidden();
+
+    expect(errors, `Unexpected console errors:\n${errors.join('\n')}`).toEqual(
+      [],
+    );
+  });
+
+  test('discards an in-progress session without persisting it', async ({
+    authedPage,
+  }) => {
+    const homePage = new HomePage(authedPage);
+    const session = new SessionPage(authedPage);
+
+    await homePage.goto();
+    await expect(homePage.screen()).toBeVisible();
+
+    await session.startLiveSession();
+    const unitsBefore = Number(await session.totalUnits().innerText());
+    await session.logOneDrink();
+    await expect
+      .poll(async () => Number(await session.totalUnits().innerText()))
+      .toBeGreaterThan(unitsBefore);
+
+    // Discard -> warning modal -> confirm. Returns to Home with nothing saved.
+    await session.discardAndConfirm();
+    await expect(homePage.screen()).toBeVisible();
+    await expect(session.liveScreen()).toBeHidden();
+  });
+});

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -127,6 +127,9 @@ type ButtonProps = Partial<ChildrenProps> & {
   /** Accessibility label for the component */
   accessibilityLabel?: string;
 
+  /** Test identifier, surfaced as `data-testid` on web for E2E selectors */
+  testID?: string;
+
   /** The icon asset to display to the left of the text */
   icon?: IconAsset | null;
 
@@ -252,6 +255,7 @@ function Button(
 
     id = '',
     accessibilityLabel = '',
+    testID,
     isSplitButton = false,
     link = false,
     isContentCentered = false,
@@ -463,6 +467,7 @@ function Button(
         ]}
         id={id}
         accessibilityLabel={accessibilityLabel}
+        testID={testID}
         role={CONST.ROLE.BUTTON}
         hoverDimmingValue={1}
         onHoverIn={() => setIsHovered(true)}

--- a/src/components/DrinkTypesView.tsx
+++ b/src/components/DrinkTypesView.tsx
@@ -102,6 +102,7 @@ function DrinkTypesView({session}: DrinkTypesViewProps) {
                 onPress={() => handleRemoveDrinks(drinkKey, 1)}
                 icon={KirokuIcons.Minus}
                 iconFill={theme.text}
+                testID={`remove-drink-${drinkKey}`}
               />
               <SessionDrinksInputWindow
                 drinks={session?.drinks}
@@ -113,6 +114,7 @@ function DrinkTypesView({session}: DrinkTypesViewProps) {
                 onPress={() => handleAddDrinks(drinkKey, 1)}
                 icon={KirokuIcons.Plus}
                 iconFill={theme.text}
+                testID={`add-drink-${drinkKey}`}
               />
             </View>
           );

--- a/src/components/DrinkingSessionWindow/index.tsx
+++ b/src/components/DrinkingSessionWindow/index.tsx
@@ -213,6 +213,7 @@ function DrinkingSessionWindow({
             styles.justifyContentCenter,
           ]}>
           <Text
+            testID="session-total-units"
             style={[
               styles.sessionUnitCountText(sessionColor),
               styles.shadowStrong,

--- a/src/components/SessionsCalendar/DayComponent/index.tsx
+++ b/src/components/SessionsCalendar/DayComponent/index.tsx
@@ -32,6 +32,9 @@ function DayComponent({
     <View>
       <PressableWithFeedback
         accessibilityLabel=""
+        testID={
+          date?.dateString ? `calendar-day-${date.dateString}` : undefined
+        }
         disabled={isDisabled}
         onPress={() => onPress && date && onPress(date)}
         onLongPress={onLongPress ? () => date && onLongPress(date) : undefined}>

--- a/src/screens/DrinkingSession/SessionSummaryScreen.tsx
+++ b/src/screens/DrinkingSession/SessionSummaryScreen.tsx
@@ -327,6 +327,7 @@ function SessionSummaryScreen({route}: SessionSummaryScreenProps) {
               style={styles.bgTransparent}
               icon={KirokuIcons.Edit}
               onPress={onEditSessionPress}
+              testID="summary-edit-session"
             />
           )
         }


### PR DESCRIPTION
## Goal

Improve E2E coverage of Kiroku's launch-critical flows before the App Store launch. I started by inventorying what scaffolding already exists, then invested where the payoff was highest and verifiable.

## 1. Current-state inventory

**Web E2E (exists):** `e2e/web/` — Playwright + Page Object Model.
- Page objects: `LoginPage`, `HomePage`, `TabNav`. Fixtures: `auth` (signs in once per worker, caches `.auth/user.json` incl. IndexedDB), `consoleErrors` (benign-pattern filter), `devGates` (clears the email-verification + terms gates).
- Coverage before this PR: email/password sign-in, boot-to-Home, bottom-tab navigation (Friends/Statistics/Settings), a console-clean tab tour, and the desktop phone-frame layout (#1219/#1224).
- Auth: dev Firebase account via `e2e/web/.env.e2e` (`E2E_TEST_EMAIL/PASSWORD`); mobile viewport 393×852; serial (1 worker) on a shared account.
- CI: the `playwright` job in `.github/workflows/deployWeb.yml` runs it against the PR preview channel when a PR is labeled `Ready To Build - Web`. npm scripts: `test:e2e:web`, `test:e2e:web:ui`.

**Native E2E (does NOT exist):** verified no Detox (`.detoxrc*`, no `detox` dep), no Maestro (`.maestro/`, no flow YAML), no Appium. Nothing in `package.json`.

**Gaps in launch-critical flows:** the existing suite covered sign-in + tab nav but **not** the core drinking-session lifecycle (create → log → save → edit → delete), calendar→day-overview navigation, friends-tab content/empty-state, or offline behavior. And no web suite can catch Kiroku's native boot/nav races (splash deadlock, iOS tab-switch zoom, first-run empty states).

## 2. Decision — Path A (done, verified) + Path B (concrete proposal)

**Path A — extend the existing web suite to close the gaps it can exercise. Done and verified** against a live `npm run web` dev server (each spec run green, the full suite 14/14, lifecycle re-run across invocations).

**Path B — native harness: proposed, not built.** Standing up Maestro requires a booted simulator/emulator and a compiled app, neither of which the authoring environment had, so `maestro test` couldn't be verified. Per the brief's guidance ("do NOT rush a half-working native harness"), I delivered a **concrete written proposal + a starter flow** instead of half-working scaffolding: [`e2e/native/README.md`](../blob/claude/confident-gauss-6e69cc/e2e/native/README.md) (tool choice, setup, CI plan, auth strategy, ~3–4 day effort estimate) and [`e2e/native/flows/sign_in_log_session.yaml`](../blob/claude/confident-gauss-6e69cc/e2e/native/flows/sign_in_log_session.yaml) (the native mirror of the web lifecycle test, reusing the same testIDs as Maestro `id:` matchers).

## 3. What I implemented (Path A)

New page objects (following existing POM conventions): `SessionPage`, `DayOverviewPage`, `FriendsPage`. New specs:

- **`session-lifecycle.spec.ts`** (the crown jewel) — start a live session → log a drink (asserts the unit count increments) → **Save** → lands on the summary for that exact session id → re-open via the summary's edit button and assert the unit count survived the **save round-trip** (proves persistence) → **delete**. Plus a start → log → **discard** path. Both self-clean (one deletes its session, the other never persists), so the shared dev account doesn't accumulate sessions.
- **`calendar.spec.ts`** — tap today's cell on the Home calendar → day overview mounts → back to Home (guards the synchronous-mount "nav freeze" transitions).
- **`friends.spec.ts`** — the friend-list tab settles into a determinate, console-clean state (asserts the always-present search field, not a friend-count-dependent state) and the Friend List / Friend Requests inner tabs switch.
- **`offline.spec.ts`** — the app stays navigable across an offline → reconnect round-trip (offline-first resilience).

**Minimal app-code testIDs** to drive these deterministically (no arbitrary sleeps; all assertions are observable outcomes):
- `Button` gains a `testID` passthrough (reusable; it only forwarded `accessibilityLabel` before).
- `add-drink-<key>` / `remove-drink-<key>` on the drink steppers, `session-total-units` on the unit headline, `summary-edit-session` on the summary edit button, `calendar-day-<YYYY-MM-DD>` on calendar day cells.

These surface as `data-testid` on web and double as Maestro `id:` matchers for the native suite.

### Finding (documented, not papered over): web offline indicator

While writing the offline test I found that under Playwright's simulated offline (which flips `navigator.onLine` and fires the offline events), the `OfflineIndicator` banner does **not** appear within 30s on the web dev build — the NetInfo → NETWORK bridge doesn't seem to react to browser offline state on web (a manually dispatched `offline` event didn't trigger it either). So the offline spec asserts navigability, **not** the banner. Whether the deployed web app behaves the same is unconfirmed — flagged here as a follow-up rather than asserted on a signal that doesn't fire.

## 4. How to run locally

```bash
# one-time: copy e2e/web/.env.e2e.example -> e2e/web/.env.e2e, fill a dev account
npm run test:e2e:web                     # full suite (auto-starts npm run web)
# iterate fast against a warm dev server:
PLAYWRIGHT_BASE_URL=http://localhost:8083 \
  npx playwright test --config=e2e/web/playwright.config.ts session-lifecycle
```
Iterate against the live dev server (~5s targeted runs), not the ~30-min deployWeb CI loop. From a worktree, symlink `node_modules`, `.env.development`, and `e2e/web/.env.e2e` first.

> Local note: a long `--repeat-each` stress run can trip webpack's react-refresh HMR error overlay (an empty `react-refresh-overlay` iframe that intercepts clicks). That's a **dev-server-only** artifact — CI runs against a built preview channel with no HMR — so it doesn't affect CI. Restart the dev server if it appears locally.

## 5. Verification

- Full web suite: **14/14 green** against a local dev server; new specs re-run green across separate invocations.
- `npx prettier --write` (clean), `./scripts/lint.sh` (exit 0), `npm run typecheck-tsgo` + e2e `tsc` (clean), `npm run react-compiler-compliance-check check-changed` (pass).
- The deployWeb `playwright` CI job authenticates against the staging env (prod Firebase), where the dev-only test account doesn't exist, so that job can't pass with prod auth regardless — these were verified locally against the dev backend (consistent with the existing suite).

## 6. Follow-ups

- **Build the native Maestro harness** per `e2e/native/README.md` (~3–4 days: validate the starter flow on a sim/emulator, add onboarding/tab/calendar flows, gate Android + iOS CI jobs). This is where the unique value is (boot/nav races web can't catch).
- **Confirm the web offline-indicator behavior** on the deployed build and fix the NetInfo→NETWORK bridge if real.
- Optional: explicit calendar month-arrow navigation (the Home calendar is a compact week-list; month arrows live in the flagged fullscreen calendar and lack stable selectors today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)