### PR TITLE
fix(ios): set app_platform in production lane to avoid CI prompt

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -318,6 +318,7 @@ platform :ios do
     # "No ipa or pkg file given" (see `deliver(skip_binary_upload: true)` below).
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
+        app_platform: "ios",
         distribute_only: true,
         distribute_external: true,
         notify_external_testers: true,


### PR DESCRIPTION
## What

Adds `app_platform: "ios"` to `upload_to_testflight` in the iOS `production` lane (`fastlane/Fastfile`).

## Why

The `0.3.18-2` production deploy's iOS job ([run 27838371807](https://github.com/PetrCala/Kiroku/actions/runs/27838371807)) failed at `upload_to_testflight` with:

```
[!] Could not retrieve response as fastlane runs in non-interactive mode
  from pilot/build_manager.rb:119 in 'wait_for_build_processing_to_be_complete'
```

The raw log shows the exact prompt that crashes it:

```
Creating authorization token for App Store Connect API
Please enter the app's platform (appletvos, ios, osx, xros):
```

Pilot needs `app_platform` to resolve the build to distribute, it was `nil`, so it fell back to an interactive prompt — and CI has no stdin, so it hard-crashed (3 retries, identical failure).

### Why only the production lane

| Lane | `build_app`? | Platform source |
|---|---|---|
| `beta` (staging) | ✅ yes | pilot infers `ios` from the freshly-built IPA |
| `production` | ❌ no (`distribute_only`) | nothing to infer from → `app_platform` nil → **prompt** |

The production lane deliberately skips building (it redistributes the staging binary via `distribute_only`), so there's no build context for pilot to derive the platform from.

### Where this sits

This was the third and final layer of the production-deploy iOS path, only reachable once a real build existed for pilot to act on:
1. Missing `distribute_only` → "No ipa or pkg file given" — fixed earlier.
2. Version supersede → build not on TestFlight — fixed by shipping a cleanly-built version.
3. **Missing `app_platform` → interactive platform prompt → crash** ← this PR.

## Fix

`app_platform: "ios"` directly answers the prompt. It's safe for the external-distribution flow, unlike `skip_waiting_for_build_processing: true`, which fastlane documents as disabling `distribute_external` (the whole purpose of this lane).

## Note on the stuck `0.3.18-2` iOS build

Build `0.3.18.2` is already on TestFlight (Android promoted the same release successfully). This fix reaches `production` on the next promotion; getting `0.3.18-2`'s iOS out can be done then or manually (`pilot distribute` + `scripts/asc.mjs submit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)