### PR TITLE
perf(calendar): fix ~5s launch tap-freeze (per-session Intl in calendar grouping)

### DIFF
--- a/src/components/SessionsCalendar/deriveCalendarMonth.ts
+++ b/src/components/SessionsCalendar/deriveCalendarMonth.ts
@@ -1,7 +1,7 @@
 import {endOfMonth} from 'date-fns';
-import {toZonedTime} from 'date-fns-tz';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import {sessionsToDayMarking} from '@libs/DataHandling';
+import {resolveLocalParts} from '@libs/Statistics/localParts';
 import {resolvePalette} from '@libs/SessionColorPalettes';
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
@@ -79,12 +79,27 @@ function groupSessionsByMonth(
 ): Map<string, Map<DateString, DrinkingSessionKeyValue[]>> {
   const byMonth = new Map<string, Map<DateString, DrinkingSessionKeyValue[]>>();
   Object.entries(sessions).forEach(([sessionId, session]) => {
-    const zonedDate = toZonedTime(
-      session.start_time,
+    // Resolve the session's zoned calendar day via the shared cached-offset
+    // resolver (one `Intl` probe per timezone-month, then pure `Date.UTC`
+    // arithmetic) instead of `toZonedTime`, which calls `Intl.formatToParts`
+    // once *per session*. On Hermes each such call is ~1-3 ms; across a
+    // multi-year history this O(N) pass re-runs on every `CACHED_DRINKING_SESSIONS`
+    // identity change at launch (disk hydrate → time-parts backfill → app/open
+    // merge), so the per-session `Intl` blocked the JS thread for seconds right
+    // after the home screen painted — the calendar scrolled (UI thread) but taps
+    // were dead (JS thread). `resolveLocalParts` is the same resolver
+    // `buildDrinkEvents` and the session write-path use, so the calendar's day
+    // bucketing now matches the stats engine exactly. Returns null only on an
+    // invalid timezone — skip that session rather than bucket it under "NaN".
+    const parts = resolveLocalParts(
+      Number(session.start_time),
       session.timezone ?? defaultTimezone,
     );
-    const dayKey = toDateKey(zonedDate);
-    const monthKey = dayKey.slice(0, 7);
+    if (!parts) {
+      return;
+    }
+    const dayKey = parts.localDay as DateString;
+    const monthKey = parts.localMonth;
     let dayMap = byMonth.get(monthKey);
     if (!dayMap) {
       dayMap = new Map();


### PR DESCRIPTION
## Symptom

On every app launch there's a ~5s window where the home screen renders and **scrolls** but **taps are dead** (FAB, calendar days, banners). The app isn't fully frozen — scrolling works — which is the classic signature of a **blocked JS thread**: native scroll runs on the UI thread, but `onPress` handlers need the JS thread to dispatch.

## Root cause

The home calendar's `groupSessionsByMonth` (`src/components/SessionsCalendar/deriveCalendarMonth.ts`) called `toZonedTime(session.start_time, tz)` **once per session across the entire history**, synchronously during render. `toZonedTime` does an `Intl.formatToParts` per call, and **on Hermes each one is ~1-3 ms** (the trap noted in our perf guidance: V8/web benchmarks make this look free).

Worse, this O(N) pass re-runs on **every `CACHED_DRINKING_SESSIONS` identity change** during boot:
1. disk hydrate, 2. the one-time time-parts backfill write, 3. the `app/open` network merge.

So a heavy user pays *hundreds of sessions × ~3 passes* of `Intl` calls = several seconds of JS-thread blocking right after paint. It happens on *every* launch because, unlike the stats engine, the calendar's `toZonedTime` path never benefited from the stored-time-parts backfill.

For contrast, `buildDrinkEvents` (the stats engine) was already optimized — it uses stored parts or a cached per-(zone,month) offset probe, so it's near-zero `Intl`. `groupSessionsByMonth` was the one remaining per-session `Intl` straggler on the launch path.

## Fix

Route the day/month bucketing through `resolveLocalParts` — the shared cached-offset resolver already used by `buildDrinkEvents` and the session write-path. It does **one `Intl` probe per (timezone, month)**, then pure `Date.UTC` arithmetic. The per-session `Intl` cost is eliminated.

Bonus: the calendar's day assignment now matches the stats engine byte-for-byte, and at DST boundaries it's strictly *more* correct than date-fns-tz (which our `localParts` docstring notes is off-by-one-hour at the spring-forward instant).

## Verification

- Existing timezone test matrix passes: `deriveCalendarMonth`, `timezoneDeviceVsSession`, `localParts`, `buildWeekListItems` (37 tests — UTC / Tokyo / LA / Pacific-Auckland / device-tz independence), confirming day/month bucketing is unchanged.
- `typecheck-tsgo`, prettier, eslint (seatbelt) all clean.
- Not verified in the web preview **on purpose**: the win is a Hermes-specific `Intl` cost that V8/JSC doesn't reproduce, so a browser run can't demonstrate it. To confirm on-device, launch a release/Hermes build with a large session history and check that the FAB/calendar are tappable immediately after paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)