### PR TITLE
fix(home): stop the compact calendar painting while Home is blurred

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -12,7 +12,7 @@ import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import Navigation from '@navigation/Navigation';
 import type {StackScreenProps} from '@react-navigation/stack';
-import {useFocusEffect} from '@react-navigation/native';
+import {useFocusEffect, useIsFocused} from '@react-navigation/native';
 import type {BottomTabNavigatorParamList} from '@libs/Navigation/types';
 import type SCREENS from '@src/SCREENS';
 import MonthlyOverviewCard, {
@@ -84,6 +84,11 @@ function HomeScreen({route}: HomeScreenProps) {
   const preferences = useCurrentUserPreferences();
   const drinkingSessionData = useCurrentUserDrinkingSessions();
   const {isOffline} = useNetwork();
+  // Whether Home is the focused screen. Used to stop the (heavy, colored)
+  // compact calendar from PAINTING while Home sits blurred underneath an RHP
+  // (e.g. a friend's profile) or another tab — see the calendar's visibility
+  // gate in `renderMainContent`.
+  const isFocused = useIsFocused();
   const [localVisibleDate, setLocalVisibleDate] = useState<DateData>(
     dateToDateData(new Date()),
   );
@@ -220,13 +225,24 @@ function HomeScreen({route}: HomeScreenProps) {
           showWeeklyUnits={false}
           showMonthComparison
         />
-        <SessionsCalendar
-          userID={user.uid}
-          visibleDate={visibleDate}
-          onDateChange={onDateChange}
-          drinkingSessionData={drinkingSessionData}
-          preferences={preferences}
-        />
+        {/* Keep the compact calendar mounted across blur (preserving its heavy
+            `useLazyMarkedDates` index — see the loadingText overlay note below)
+            but stop it PAINTING while Home isn't the focused screen. When an RHP
+            such as a friend's profile opens over Home, the tab briefly
+            re-renders / unfreezes during the transition; without this gate the
+            viewer's own day tiles flash at unsettled positions before they're
+            clipped offscreen — the stray "orphan tiles" on the profile's entry.
+            Gating visibility (not mounting) avoids both that flash and a
+            skeleton swap when Home regains focus. */}
+        <View style={isFocused ? undefined : styles.opacity0}>
+          <SessionsCalendar
+            userID={user.uid}
+            visibleDate={visibleDate}
+            onDateChange={onDateChange}
+            drinkingSessionData={drinkingSessionData}
+            preferences={preferences}
+          />
+        </View>
       </>
     );
   };


### PR DESCRIPTION
## Problem

On the friend **Profile screen** ("Friend Overview"), rounded session-tile squares colored like the **viewing user's own** palette flashed in (one over the avatar, one bottom-left) and shrank/faded on entry. Distinct from the iOS tab-switch zoom (#1389).

## Root cause

The stray tiles are the **viewer's own Home-tab calendar**, not the profile's. Opening a friend profile re-renders/unfreezes the Home tab during the transition, and `HomeScreen` painted its compact `<SessionsCalendar>` immediately (no transition-ready gate, unlike `ProfileScreen`), so the viewer's day tiles painted at unsettled positions before being clipped offscreen.

## Fix

Gate the Home calendar's visibility on `useIsFocused()` — keep it mounted (preserving its heavy `useLazyMarkedDates` index, no skeleton swap on return) but render at `opacity: 0` whenever Home isn't the focused screen, so it can't paint during the entry transition.

## Verification

- Verified on web: opacity 1 focused, opacity 0 blurred, instant restore on return; no console errors.
- All gates pass: prettier, `lint-changed`, `typecheck-tsgo`, React Compiler compliance.
- **Confirmed on device:** the over-the-avatar colored tile is gone.

> A separate, residual artifact (a thin sliver of the screen *behind* the profile visible at the left edge during the push transition) is still under investigation and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
