### PR TITLE
perf(home): scope scorecard stats engine to the visible+previous month

### DIFF
--- a/__tests__/unit/libs/Statistics/buildMonthlyStats.test.ts
+++ b/__tests__/unit/libs/Statistics/buildMonthlyStats.test.ts
@@ -184,3 +184,58 @@ describe('buildMonthlyStats — comparisonAvailable', () => {
     expect(laterMonth.comparisonAvailable).toBe(true);
   });
 });
+
+describe('buildMonthlyStats — windowed input is lossless', () => {
+  // Codifies the home-screen optimisation (`useHomeStats` / `useDrinkEvents`'
+  // `window` option): the scorecard reads only the visible + previous month, so
+  // feeding just that window must yield a byte-identical summary to the full
+  // multi-month history — provided the first-activity floor is supplied (which
+  // bypasses the whole-array earliest-event scan). Guards the window bounds
+  // against drift from `buildMonthlyStats`' own internal windows.
+  it('matches the full-history result for the visible + previous month', () => {
+    const now = new Date(2026, 5, 16, 12, 0, 0);
+    const earliest = ms('2026-01-01');
+    const full = [
+      event('2026-01-05', 8), // far history — outside the window
+      event('2026-03-20', 4), // outside the window
+      event('2026-05-03', 6), // previous month — inside the window
+      event('2026-05-14', 2), // previous month — inside the window
+      event('2026-06-02', 7), // current month — inside the window
+      event('2026-06-11', 5), // current month — inside the window
+    ];
+
+    const year = 2026;
+    const month = 6; // 1-based, matching buildMonthlyStats / useHomeStats
+    // Same bounds useHomeStats derives: previous month start → end of the
+    // visible month.
+    const prevStart = new Date(year, month - 2, 1).getTime();
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999).getTime();
+    const windowed = full.filter(
+      e => e.anchorTs >= prevStart && e.anchorTs <= monthEnd,
+    );
+
+    // Sanity: the window actually dropped the Jan/Mar far-history events.
+    expect(windowed).toHaveLength(4);
+
+    const fromFull = buildMonthlyStats(
+      full,
+      year,
+      month,
+      now,
+      THRESHOLDS,
+      earliest,
+    );
+    const fromWindow = buildMonthlyStats(
+      windowed,
+      year,
+      month,
+      now,
+      THRESHOLDS,
+      earliest,
+    );
+
+    // Deep-equals across current, previous, subPeriods, isCurrentMonth and
+    // comparisonAvailable.
+    expect(fromWindow).toEqual(fromFull);
+  });
+});

--- a/__tests__/unit/useDrinkEvents.test.ts
+++ b/__tests__/unit/useDrinkEvents.test.ts
@@ -118,6 +118,34 @@ function makeSessions(): UserDrinkingSessionsList {
   };
 }
 
+// Sessions spanning two calendar months for the `window` option: one inside a
+// May–June window, one in the prior January that the window must exclude.
+const TS_IN_WINDOW = Date.UTC(2025, 5, 12, 15, 0, 0); // 2025-06-12
+const TS_PRE_WINDOW = Date.UTC(2025, 0, 5, 10, 0, 0); // 2025-01-05
+
+function makeWindowSessions(): UserDrinkingSessionsList {
+  return {
+    u1: {
+      jun: {
+        start_time: TS_IN_WINDOW,
+        end_time: TS_IN_WINDOW + 60 * 60_000,
+        timezone: 'Africa/Abidjan',
+        drinks: {[TS_IN_WINDOW]: {beer: 2}},
+      },
+      jan: {
+        start_time: TS_PRE_WINDOW,
+        timezone: 'Africa/Abidjan',
+        drinks: {[TS_PRE_WINDOW]: {wine: 1}},
+      },
+    },
+  };
+}
+
+const WINDOW_MAY_JUNE = {
+  startMs: Date.UTC(2025, 4, 1),
+  endMs: Date.UTC(2025, 5, 30, 23, 59, 59, 999),
+};
+
 describe('useDrinkEvents', () => {
   let runAfterSpy: jest.SpyInstance;
 
@@ -293,5 +321,51 @@ describe('useDrinkEvents', () => {
     expect(passedSessions).toBe(sessions);
     expect(tz).toBe('Africa/Abidjan');
     expect(weekStart).toBe(1);
+  });
+
+  test('window option materialises only sessions whose start_time is in range', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    const {result} = renderHook(() =>
+      useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}),
+    );
+
+    const anchors = new Set(result.current.events.map(e => e.anchorTs));
+    expect(anchors.has(TS_IN_WINDOW)).toBe(true);
+    expect(anchors.has(TS_PRE_WINDOW)).toBe(false);
+    expect(result.current.events.every(e => e.anchorTs === TS_IN_WINDOW)).toBe(
+      true,
+    );
+  });
+
+  test('window option reports earliestStartMs from the full history, not the window', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    const {result} = renderHook(() =>
+      useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}),
+    );
+
+    // The January session is outside the window but is still the user's
+    // earliest — the comparison-baseline fallback must still see it.
+    expect(result.current.earliestStartMs).toBe(TS_PRE_WINDOW);
+  });
+
+  test('window option scopes the time-parts backfill to the windowed sessions', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    renderHook(() => useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}));
+
+    const backfill = jest.mocked(Statistics.backfillSessionTimeParts);
+    expect(backfill).toHaveBeenCalledTimes(1);
+    // Only the in-window session is backfilled — whole-history Intl stays off
+    // the launch path.
+    const passedSessions = backfill.mock.calls[0][1];
+    expect(Object.keys(passedSessions?.u1 ?? {})).toEqual(['jun']);
+  });
+
+  test('omitting the window leaves earliestStartMs undefined (full-stream path)', () => {
+    const {result} = renderHook(() => useDrinkEvents(['u1']));
+
+    expect(result.current.earliestStartMs).toBeUndefined();
   });
 });

--- a/src/hooks/useHomeStats.ts
+++ b/src/hooks/useHomeStats.ts
@@ -18,7 +18,23 @@ import ONYXKEYS from '@src/ONYXKEYS';
  * friend/profile equivalent.
  */
 function useHomeStats(visibleDate: DateData): MonthlyStats {
-  const {events, isLoading} = useDrinkEvents();
+  const {year, month} = visibleDate;
+
+  // The scorecard reads only the visible month and the previous month (the
+  // current/previous summaries and the per-week sub-period series — see
+  // `buildMonthlyStats`). Scope the event stream to exactly that window so the
+  // launch-path walk stays ~2 months wide instead of materialising the whole
+  // history. Bounds mirror `buildMonthlyStats` (`month` is 1-based): the
+  // previous month's start through the end of the visible month.
+  const eventWindow = useMemo(() => {
+    const prevStart = new Date(year, month - 2, 1);
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+    return {startMs: prevStart.getTime(), endMs: monthEnd.getTime()};
+  }, [year, month]);
+
+  const {events, isLoading, earliestStartMs} = useDrinkEvents(undefined, {
+    window: eventWindow,
+  });
   const preferences = useCurrentUserPreferences();
   const currentUserData = useCurrentUserData();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
@@ -32,8 +48,11 @@ function useHomeStats(visibleDate: DateData): MonthlyStats {
   // Snapshot `now` once per mount so the current/previous clamps agree.
   const now = useMemo(() => new Date(), []);
 
-  const {year, month} = visibleDate;
-  const earliestSessionAt = currentUserData?.earliest_session_at;
+  // Prefer the persisted first-activity floor; fall back to the windowed hook's
+  // cheap all-history minimum so `comparisonAvailable` stays correct even before
+  // `earliest_session_at` has hydrated.
+  const earliestSessionAt =
+    currentUserData?.earliest_session_at ?? earliestStartMs;
   const {current, previous, subPeriods, isCurrentMonth, comparisonAvailable} =
     useMemo(
       () =>

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {InteractionManager} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import {buildDrinkEvents} from '@libs/Statistics';
@@ -9,11 +9,34 @@ import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {
+  DrinkingSessionList,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx/DrinkingSession';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+type UseDrinkEventsOptions = {
+  /**
+   * Restrict the materialised stream to sessions whose `start_time` (ms) falls
+   * inside `[startMs, endMs]`. The home scorecard passes its visible + previous
+   * month so the launch-path walk stays ~2 months wide instead of the whole
+   * history (it only ever reads those two months — see `buildMonthlyStats`).
+   * Full-stream consumers (Statistics tabs, Badges, drill-down) omit it.
+   */
+  window?: {startMs: number; endMs: number};
+};
 
 type UseDrinkEventsResult = {
   events: DrinkEvent[];
   isLoading: boolean;
+  /**
+   * The viewed user's first-ever session `start_time` (ms), computed from the
+   * full session list with a cheap numeric scan (no `Intl`). Only populated
+   * when a `window` is supplied — it lets a windowed caller keep a correct
+   * comparison baseline even though the event stream itself is scoped. Falls
+   * back to `undefined` (no sessions / no window).
+   */
+  earliestStartMs?: number;
 };
 
 const WEEK_START_BY_LABEL: Record<string, WeekStart> = {
@@ -67,7 +90,10 @@ function resolveWeekStart(label: string | undefined): WeekStart {
  * `events` is `[]`. Callers should render a layout-faithful skeleton, not
  * the empty-state.
  */
-function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
+function useDrinkEvents(
+  userIds?: UserID[],
+  options?: UseDrinkEventsOptions,
+): UseDrinkEventsResult {
   const {auth} = useFirebase();
   const preferences = useCurrentUserPreferences();
   const userData = useCurrentUserData();
@@ -81,6 +107,64 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
   const weekStart = resolveWeekStart(preferences?.first_day_of_week);
   const drinksToUnits = preferences?.drinks_to_units;
   const isHydrated = allSessionsMeta.status === 'loaded';
+
+  // Scope the sessions fed to the heavy walk to the requested window, if any.
+  // `buildDrinkEvents` (and `buildMonthlyStats` downstream) window by a
+  // session's `start_time`, so filtering the input by the same numeric bound is
+  // lossless — the windowed input yields a byte-identical monthly summary while
+  // turning the launch-path walk from O(whole history) into O(window). With no
+  // window we return the original `allSessions` reference untouched, so the
+  // full-stream consumers and the `backfillSessionTimeParts` contract are
+  // unchanged. The pass also tracks the current user's all-time earliest
+  // `start_time` (numeric only, no `Intl`) for the comparison-baseline fallback.
+  const windowStartMs = options?.window?.startMs;
+  const windowEndMs = options?.window?.endMs;
+  const {scopedSessions, earliestStartMs} = useMemo<{
+    scopedSessions: UserDrinkingSessionsList | undefined;
+    earliestStartMs: number | undefined;
+  }>(() => {
+    if (
+      windowStartMs === undefined ||
+      windowEndMs === undefined ||
+      !allSessions
+    ) {
+      return {scopedSessions: allSessions, earliestStartMs: undefined};
+    }
+    let earliest = Infinity;
+    const scoped: UserDrinkingSessionsList = {};
+    for (const uid of Object.keys(allSessions)) {
+      const userSessions = allSessions[uid];
+      if (!userSessions) {
+        continue;
+      }
+      const kept: DrinkingSessionList = {};
+      let keptAny = false;
+      for (const sessionId of Object.keys(userSessions)) {
+        const session = userSessions[sessionId];
+        if (!session) {
+          continue;
+        }
+        const startMs = Number(session.start_time);
+        if (!Number.isFinite(startMs)) {
+          continue;
+        }
+        if (uid === currentUserID && startMs < earliest) {
+          earliest = startMs;
+        }
+        if (startMs >= windowStartMs && startMs <= windowEndMs) {
+          kept[sessionId] = session;
+          keptAny = true;
+        }
+      }
+      if (keptAny) {
+        scoped[uid] = kept;
+      }
+    }
+    return {
+      scopedSessions: scoped,
+      earliestStartMs: earliest === Infinity ? undefined : earliest,
+    };
+  }, [allSessions, windowStartMs, windowEndMs, currentUserID]);
 
   const [allEvents, setAllEvents] = useState<DrinkEvent[]>(EMPTY_EVENTS);
   const [isCompiled, setIsCompiled] = useState(false);
@@ -109,7 +193,7 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
       }
 
       const next = buildDrinkEvents(
-        allSessions,
+        scopedSessions,
         drinksToUnits,
         CONST.DRINK_DEFAULTS,
         timezone,
@@ -122,10 +206,13 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
       // the next cold open reads them with zero `Intl`. Reconstructed from the
       // events above (no extra `Intl`); the merge re-fires this effect, which
       // then reads the stored fields and produces an empty patch — so it
-      // converges in one step and never loops.
+      // converges in one step and never loops. Scoped to `scopedSessions`: a
+      // windowed caller only backfills the sessions it walked, keeping
+      // whole-history `Intl` off the launch path (the rest is backfilled when a
+      // full-stream consumer such as the Statistics tab runs).
       Statistics.backfillSessionTimeParts(
         next,
-        allSessions,
+        scopedSessions,
         timezone,
         weekStart,
       );
@@ -141,7 +228,7 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
         clearTimeout(backstop);
       }
     };
-  }, [isHydrated, allSessions, drinksToUnits, timezone, weekStart]);
+  }, [isHydrated, scopedSessions, drinksToUnits, timezone, weekStart]);
 
   const resolvedUserIds = userIds ?? (currentUserID ? [currentUserID] : []);
 
@@ -158,7 +245,7 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
 
   const isLoading = !isHydrated || !isCompiled;
 
-  return {events, isLoading};
+  return {events, isLoading, earliestStartMs};
 }
 
 export default useDrinkEvents;


### PR DESCRIPTION
## Context

[#1409](https://github.com/PetrCala/Kiroku/pull/1409) removed the calendar's per-session `Intl` freeze that caused the ~5s "scrolls but taps are dead" window on launch. Testing confirmed it's much better but **not fully gone** — a smaller residual stall remains.

## Root cause (the residual stall)

The home screen also mounts the Statistics v2 event engine to feed the Units scorecard:
`useHomeStats` → `useDrinkEvents` → `buildDrinkEvents`. That engine walks the **entire drink history** (one `DrinkEvent` per drink × type), deferred via `InteractionManager.runAfterInteractions`, so the heavy synchronous JS walk lands ~300 ms **after paint** (the early-tap window) and re-fires on every `CACHED_DRINKING_SESSIONS` identity change at boot (disk hydrate → time-parts backfill write → `app/open` network merge).

`Intl` is now mostly cached (stored parts / cached per-month offset), so what's left is the pure-JS array build + the downstream `buildMonthlyStats` pass — hence "a fraction of what it was."

## Key insight

The scorecard only reads the **visible month + previous month**. `buildMonthlyStats` windows events by `anchorTs` (= session `start_time` ms), and its only whole-array scan (`earliestMs`) is **skipped when `earliestSessionAt` is supplied** — which `useHomeStats` already does. So the home path was materialising multi-year, all-user history just to render two months.

## Fix

- **`useDrinkEvents`** gains an optional `window: {startMs, endMs}`. When set, it pre-filters the sessions fed to `buildDrinkEvents` (and the launch-time backfill) to that window. Because the filter uses the same `start_time` bound `buildMonthlyStats` windows by, the result is **byte-identical** — it just turns the launch-path walk from `O(whole history)` into `O(~2 months)`. It also returns the current user's cheap all-history min `start_time` (`earliestStartMs`, numeric only, no `Intl`) as a comparison-baseline fallback.
- **`useHomeStats`** computes `[prevStart, monthEnd]` from `visibleDate` and passes it, using `earliest_session_at ?? earliestStartMs` so `comparisonAvailable` stays correct even before the floor hydrates.
- **No-window callers are untouched** (Statistics tabs, Badges, drill-down): the sessions object keeps its identity, so the full-stream and `backfillSessionTimeParts` contracts are unchanged. The full-history time-parts backfill now happens when the Statistics tab opens (behind its skeletons) instead of on the home launch path — deliberate.

### Why not the alternatives
- **Reuse the calendar's per-day `unitsMap`**: the compact calendar starts at the current month only, so the previous month isn't loaded at cold launch and the month-over-month delta would break.
- **Chunk `buildDrinkEvents` to yield**: keeps the whole-history walk and forces an async rewrite across all callers. Windowing is strictly less work.

## Tests
- `useDrinkEvents`: window filters out-of-window sessions, `earliestStartMs` reflects full history (not the window), backfill is scoped to the windowed object, and the no-window path still reports `earliestStartMs` undefined (the existing `backfill === sessions` identity test still guards the default path).
- `buildMonthlyStats`: a windowed-vs-full **equivalence guard** — feeding only `[prevStart, monthEnd]` yields a deep-equal summary to the full multi-month history (with the floor supplied).

## Verification
- `TZ=utc jest` for `useDrinkEvents`, `events`, `buildMonthlyStats`, `overview`, `localParts` — 106 passed.
- `typecheck-tsgo`, prettier, `lint-changed`, `react-compiler-compliance-check check-changed` — all clean.
- **Not verifiable in a web/V8 preview on purpose** (consistent with #1409): the win is Hermes-specific JS-thread cost. Confirm on a release/Hermes build with a large session history — the FAB / calendar / banners should be tappable immediately after the home screen paints, and the scorecard numbers must match the pre-change values for the visible and previous months.

## Follow-ups (out of scope)
- Apply the same window pre-filter to `useUserMonthlyStats` (profile/friend scorecard) — a one-line input filter.
- Coalesce the boot-time re-fires of the deferred rebuild (lower leverage now each walk is ~2 months).

🤖 Generated with [Claude Code](https://claude.com/claude-code)