### PR TITLE
test(perf): StatsPerf instrumentation for the post-#1414 regression [diagnostic, do not merge]

### DIFF
--- a/contributingGuides/STATS_PERF_REPRO.md
+++ b/contributingGuides/STATS_PERF_REPRO.md
@@ -1,0 +1,112 @@
+# Stats/calendar perf regression — repro + instrumentation
+
+Diagnostic harness for the post-[#1414](https://github.com/PetrCala/Kiroku/pull/1414)
+device-build regression: the home tap-latency win shipped, but **profile / friends
+got slower** and the **infinite-scroll calendars stall on loading skeletons**.
+
+> ⚠️ This branch is **diagnostic, not for merge.** It widens the Test Tools gate
+> to non-production and adds verbose counters. The real fix lands in a separate
+> PR once the data points at a cause; this branch then gets reverted/trimmed.
+
+## What it measures
+
+A dependency-free profiler (`src/libs/StatsPerf`) accumulates counters on the
+Statistics/calendar hot paths and prints a compact `[StatsPerf]` line every ~2s
+(console **and** a live readout inside Test Tools). Key counters:
+
+| Counter                                              | Meaning                                                 | Points at                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `useDrinkEvents.effectFire`                          | times the deferred-rebuild effect ran                   | **loop** (⚠️LOOP flag when runaway)                                                                    |
+| `useDrinkEvents.via.interaction` / `.via.backstop`   | which timer ran the rebuild                             | **interaction-queue starvation** (backstop-heavy ⇒ queue never settles ⇒ scroll-ready/skeleton stalls) |
+| `backfill.merge` / `.sessions` / `.empty`            | `CACHED_DRINKING_SESSIONS` time-parts writes            | **backfill write loop** (non-converging patch)                                                         |
+| `intl.probe`                                         | real `Intl.formatToParts` calls (~1-3ms each on Hermes) | **lost whole-history backfill** (spikes on profile/calendar)                                           |
+| `bde.storedHit` / `bde.resolveFallback`              | stored-parts vs recompute on the read path              | backfill coverage                                                                                      |
+| `buildDrinkEvents.{call,cacheHit,session,events,ms}` | event-stream walk volume + time                         | compute cost vs cache thrash                                                                           |
+| `groupSessionsByMonth.{sessions,ms,calls}`           | calendar grouping pass                                  | calendar compute cost                                                                                  |
+
+## Web first (fast triage)
+
+A render/backfill **loop** is logic, so it reproduces identically on web — and
+the counters are engine-agnostic, so the per-screen **volumes** (`intl.probe`,
+`bde.resolveFallback`, `effectFire`, `backfill.merge`) are accurate there too. A
+2-minute web pass settles the biggest question for free. What web _cannot_ show:
+the actual Hermes _slowness_ (V8 `Intl` is ~1000× faster), the literal
+stuck-skeleton rendering, and the `via.backstop` starvation signal — those need
+the device build.
+
+1. `npm run web` on this branch, sign into the test account (dev Firebase = the
+   same hundreds of sessions). Instrumentation is on automatically (dev).
+2. Watch the **browser console** for `[StatsPerf]` lines, or drive it from the
+   console (`globalThis.statsPerfDebug`):
+   - `statsPerfDebug.report()` → current readout lines
+   - `statsPerfDebug.clear()` → reset counters between screens
+   - `statsPerfDebug.compute('full' | 'window')`, `statsPerfDebug.backfill('full' | 'window')` → flip the A/B levers
+   - `statsPerfDebug.open()` → pop the Test Tools panel
+3. Or click the **⚡︎ Perf** button (bottom-left, web + non-prod only) to open
+   the panel with the readout + levers.
+
+## Build it (device — confirm timing + stuck behavior)
+
+The _slowness_ is a Hermes/JS-thread effect a web/V8 preview can't reproduce. Use
+a **release ad-hoc** build (instrumentation is gated on `ENVIRONMENT !== prod`,
+so it is on for ad-hoc/staging/dev and off on the store build):
+
+- The PR carries the **`Ready To Build - iOS`** label → CI publishes an ad-hoc
+  IPA. Install it on the device with the test account (hundreds of sessions).
+- On the ad-hoc (release) build, `console.*` is stripped — use the **in-app**
+  Test Tools readout, not Console.app.
+
+## Open the panel
+
+Instrumentation logs by default on the ad-hoc build. To see the readout / flip
+levers on-device (no Xcode needed): **four-finger tap** anywhere → Test Tools →
+scroll to **StatsPerf diagnostics**.
+
+## Procedure (attribution by clearing between screens)
+
+The counters are global, so isolate each screen by clearing first:
+
+1. Open Test Tools, tap **Clear StatsPerf counters**, close.
+2. Cold-launch (or navigate to) **Home**. Reopen Test Tools, screenshot the readout.
+3. Clear → open **Profile** (self) → reopen, screenshot.
+4. Clear → open **Friends**, then a **friend's profile** → reopen, screenshot.
+5. Clear → open the **fullscreen calendar**, scroll back a few months → reopen, screenshot.
+
+Read the screenshots against the table above:
+
+- A line marked **⚠️LOOP**, or `via.backstop` ≫ `via.interaction`, on a screen
+  that stalls ⇒ JS-thread saturation / interaction-queue starvation (the
+  stuck-skeleton mechanism).
+- High `intl.probe` + high `bde.resolveFallback` on profile/calendar ⇒ the
+  lost whole-history backfill (the "slower" mechanism).
+- High `backfill.merge` that never drops to `backfill.empty` ⇒ a non-converging
+  backfill write loop.
+
+## Bisect the fix on the same build (no rebuild)
+
+In Test Tools → StatsPerf diagnostics, two levers (persisted; default `window` =
+current #1414 behaviour, `full` = pre-#1414):
+
+- **Home compute scope** — `full` reverts #1414's event windowing.
+- **Backfill scope** — `full` restores the whole-history time-parts backfill.
+
+Test the four combinations and re-run the procedure for each:
+
+| compute | backfill | expectation                                                        |
+| ------- | -------- | ------------------------------------------------------------------ |
+| window  | window   | current master (Home fast, others regressed)                       |
+| window  | **full** | **leading fix**: Home stays fast, profile/friends/calendar recover |
+| full    | full     | pre-#1414 (all fine, Home slow)                                    |
+| full    | window   | diagnostic corner                                                  |
+
+If `window`+`full` restores the other screens while keeping Home fast, the fix is
+to keep the compute windowed but **deferred-backfill the full history** (off the
+launch frame). That becomes the real PR.
+
+## Where things live
+
+- Profiler core (pure): `src/libs/StatsPerf/index.ts`
+- Onyx/CONFIG wiring + flush + loop flag: `src/libs/StatsPerf/connect.ts` (init in `src/setup/index.ts`)
+- Levers/toggle state: `NVP_STATS_PERF_DEBUG` Onyx key, `src/libs/actions/StatsPerfDebug.ts`
+- Panel: `src/components/TestToolsModal/index.tsx` (gate widened in `src/components/ScreenWrapper.tsx`)
+- Instrumented paths: `events.ts`, `localParts.ts`, `actions/Statistics.ts`, `useStatistics/useDrinkEvents.ts`, `useHomeStats.ts`, `SessionsCalendar/deriveCalendarMonth.ts`

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -781,7 +781,7 @@
 "src/components/Pressable/PressableWithDelayToggle.tsx"	"react/jsx-no-leaked-render"	2
 "src/components/ProfileImage.tsx"	"react/jsx-no-leaked-render"	1
 "src/components/ScreenWrapper.tsx"	"react-hooks/refs"	1
-"src/components/ScreenWrapper.tsx"	"react/jsx-no-leaked-render"	3
+"src/components/ScreenWrapper.tsx"	"react/jsx-no-leaked-render"	2
 "src/components/Search/SendFriendRequestButton/index.tsx"	"arrow-body-style"	2
 "src/components/SelectCircle.tsx"	"react/jsx-no-leaked-render"	1
 "src/components/SelectionList/BaseListItem.tsx"	"react/jsx-no-leaked-render"	2

--- a/src/Kiroku.tsx
+++ b/src/Kiroku.tsx
@@ -35,6 +35,7 @@ import ForceUpdateModal from './components/Modals/ForceUpdateModal';
 import VerifyEmailModal from './components/VerifyEmailModal';
 import AccountSuspendedModal from './components/Modals/AccountSuspendedModal';
 import FullScreenLoadingIndicator from './components/FullscreenLoadingIndicator';
+import StatsPerfDebugButton from './components/StatsPerfDebugButton';
 import useNativeAppearanceSync from './hooks/useNativeAppearanceSync';
 import useCurrentUserData from './hooks/useCurrentUserData';
 import colors from './styles/theme/colors';
@@ -425,6 +426,9 @@ function Kiroku() {
           onHide={onSplashHide}
         />
       )}
+      {/* Web-only, non-prod: one-click opener for the StatsPerf diagnostics
+          panel (diagnostic branch only). No-op on native/production. */}
+      <StatsPerfDebugButton />
     </>
   );
 }

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -137,6 +137,11 @@ const ONYXKEYS = {
    *  read/written outside production — see `@libs/actions/FeatureAccess`. */
   FEATURE_ACCESS_OVERRIDES: 'featureAccessOverrides',
 
+  /** Diagnostic StatsPerf instrumentation: logging toggle, the compute/backfill
+   *  A/B levers, and the rolling profiler readout rendered in Test Tools. Only
+   *  read/written outside production — see `@libs/actions/StatsPerfDebug`. */
+  NVP_STATS_PERF_DEBUG: 'nvp_statsPerfDebug',
+
   /** Whether we should show the compose input or not */
   SHOULD_SHOW_COMPOSE_INPUT: 'shouldShowComposeInput',
 
@@ -323,6 +328,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.IS_LOADING_APP]: boolean;
   [ONYXKEYS.IS_TEST_TOOLS_MODAL_OPEN]: boolean;
   [ONYXKEYS.FEATURE_ACCESS_OVERRIDES]: OnyxTypes.FeatureAccessOverrides;
+  [ONYXKEYS.NVP_STATS_PERF_DEBUG]: OnyxTypes.StatsPerfDebug;
   [ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT]: boolean;
   [ONYXKEYS.APP_UPDATE_DISMISSED]: Timestamp;
   [ONYXKEYS.VERIFY_EMAIL_SENT]: Timestamp;

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -158,7 +158,7 @@ function ScreenWrapper(
   const {initialHeight} = useInitialDimensions();
   const styles = useThemeStyles();
   const keyboardState = useKeyboardState();
-  const {isDevelopment} = useEnvironment();
+  const {isDevelopment, isProduction} = useEnvironment();
   const {isOffline} = useNetwork();
   const [didScreenTransitionEnd, setDidScreenTransitionEnd] = useState(false);
   const maxHeight = shouldEnableMaxHeight ? windowHeight : undefined;
@@ -172,12 +172,13 @@ function ScreenWrapper(
 
   const panResponder = useRef(
     PanResponder.create({
-      // Gate the gesture to dev only, matching where `<TestToolsModal />` is
-      // actually rendered (see `isDevelopment &&` below). Outside dev the modal
-      // never mounts, so capturing the multi-touch gesture would only fire a
-      // no-op toggle.
+      // Gate the gesture to non-production, matching where `<TestToolsModal />`
+      // is rendered (see `!isProduction &&` below). On the store build the modal
+      // never mounts, so capturing the gesture would only fire a no-op toggle.
+      // Widened from dev-only so the StatsPerf diagnostics are reachable on the
+      // ad-hoc device build.
       onStartShouldSetPanResponderCapture: (_e, gestureState) =>
-        isDevelopment &&
+        !isProduction &&
         gestureState.numberActiveTouches === CONST.TEST_TOOL.NUMBER_OF_TAPS,
       onPanResponderRelease: toggleTestToolsModal,
     }),
@@ -303,7 +304,7 @@ function ScreenWrapper(
                   }
                   enabled={shouldEnablePickerAvoiding}> */}
                 <HeaderGap styles={headerGapStyles} />
-                {isDevelopment && <TestToolsModal />}
+                {!isProduction && <TestToolsModal />}
                 {isDevelopment && <CustomDevMenu />}
                 <ScreenWrapperStatusContext.Provider value={contextValue}>
                   {

--- a/src/components/SessionsCalendar/deriveCalendarMonth.ts
+++ b/src/components/SessionsCalendar/deriveCalendarMonth.ts
@@ -1,6 +1,7 @@
 import {endOfMonth} from 'date-fns';
 import type {MarkingProps} from 'react-native-calendars/src/calendar/day/marking';
 import {sessionsToDayMarking} from '@libs/DataHandling';
+import StatsPerf from '@libs/StatsPerf';
 import {resolveLocalParts} from '@libs/Statistics/localParts';
 import {resolvePalette} from '@libs/SessionColorPalettes';
 import type {DrinkingSessionList, Preferences} from '@src/types/onyx';
@@ -77,6 +78,8 @@ function groupSessionsByMonth(
   sessions: DrinkingSessionList,
   defaultTimezone: string,
 ): Map<string, Map<DateString, DrinkingSessionKeyValue[]>> {
+  const span = StatsPerf.mark();
+  StatsPerf.inc('groupSessionsByMonth.sessions', Object.keys(sessions).length);
   const byMonth = new Map<string, Map<DateString, DrinkingSessionKeyValue[]>>();
   Object.entries(sessions).forEach(([sessionId, session]) => {
     // Resolve the session's zoned calendar day via the shared cached-offset
@@ -112,6 +115,7 @@ function groupSessionsByMonth(
       dayMap.set(dayKey, [{sessionId, session}]);
     }
   });
+  StatsPerf.measureFrom('groupSessionsByMonth', span);
   return byMonth;
 }
 

--- a/src/components/StatsPerfDebugButton.tsx
+++ b/src/components/StatsPerfDebugButton.tsx
@@ -1,0 +1,54 @@
+import {useCallback} from 'react';
+import {StyleSheet} from 'react-native';
+import {PressableWithFeedback} from '@components/Pressable';
+import Text from '@components/Text';
+import useEnvironment from '@hooks/useEnvironment';
+import getPlatform from '@libs/getPlatform';
+import toggleTestToolsModal from '@userActions/TestTool';
+import CONST from '@src/CONST';
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    bottom: 12,
+    left: 12,
+    zIndex: 100000,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: 'rgba(2, 38, 218, 0.85)',
+  },
+  label: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+});
+
+/**
+ * Web-only, non-production floating button that opens the Test Tools panel
+ * (StatsPerf diagnostics). The four-finger gesture that opens Test Tools on
+ * native is impractical with a mouse, so this gives one-click access during the
+ * web perf investigation. Mounted once at the app root (`Kiroku.tsx`); renders
+ * nothing on native or production. Diagnostic-only — removed with the branch.
+ */
+function StatsPerfDebugButton() {
+  const {isProduction} = useEnvironment();
+  const onPress = useCallback(() => toggleTestToolsModal(), []);
+
+  if (isProduction || getPlatform() !== CONST.PLATFORM.WEB) {
+    return null;
+  }
+
+  return (
+    <PressableWithFeedback
+      accessibilityLabel="Open StatsPerf diagnostics"
+      style={styles.button}
+      onPress={onPress}>
+      <Text style={styles.label}>⚡︎ Perf</Text>
+    </PressableWithFeedback>
+  );
+}
+
+StatsPerfDebugButton.displayName = 'StatsPerfDebugButton';
+export default StatsPerfDebugButton;

--- a/src/components/TestToolsModal/index.tsx
+++ b/src/components/TestToolsModal/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
@@ -13,8 +13,11 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getPremiumFeatureKeys} from '@libs/Entitlements';
+import StatsPerf from '@libs/StatsPerf';
 import type {FeatureOverride} from '@src/types/onyx/FeatureAccessOverrides';
+import type {StatsComputeScope} from '@src/types/onyx/StatsPerfDebug';
 import * as FeatureAccess from '@userActions/FeatureAccess';
+import * as StatsPerfDebug from '@userActions/StatsPerfDebug';
 import toggleTestToolsModal from '@userActions/TestTool';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -28,6 +31,12 @@ const OVERRIDE_OPTIONS: Array<{
   {key: 'locked', value: 'locked'},
   {key: 'unlocked', value: 'unlocked'},
 ];
+
+// StatsPerf A/B levers — `window` is the current (#1414) behaviour, `full`
+// reverts to pre-#1414 so each windowing can be bisected on-device.
+const SCOPE_OPTIONS: StatsComputeScope[] = ['window', 'full'];
+// How often the modal re-reads the live profiler readout while open.
+const STATS_PERF_POLL_MS = 1000;
 
 /**
  * Developer-only debug panel. Opened via the CustomDevMenu entry
@@ -46,15 +55,38 @@ function TestToolsModal() {
   const [overrides] = useOnyx(ONYXKEYS.FEATURE_ACCESS_OVERRIDES, {
     canBeMissing: true,
   });
+  const [perfDebug] = useOnyx(ONYXKEYS.NVP_STATS_PERF_DEBUG, {
+    canBeMissing: true,
+  });
 
   const accent = theme.appColor;
   const featureKeys = getPremiumFeatureKeys();
+
+  // Poll the in-memory profiler readout while the panel is open. The lines live
+  // in the StatsPerf module (not Onyx) so this poll never adds Onyx writes that
+  // would skew the very `cachedDrinkingSessions`-write count being measured.
+  const [perfReport, setPerfReport] = useState<string[]>([]);
+  useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
+    // Poll only (no synchronous prime) — the first tick lands within a second,
+    // which is fine for a debug readout and keeps setState out of the effect body.
+    const id = setInterval(
+      () => setPerfReport([...StatsPerf.getReportLines()]),
+      STATS_PERF_POLL_MS,
+    );
+    return () => clearInterval(id);
+  }, [isVisible]);
 
   const handleClose = useCallback(() => {
     if (isVisible) {
       toggleTestToolsModal();
     }
   }, [isVisible]);
+
+  const computeScope = perfDebug?.computeScope ?? 'window';
+  const backfillScope = perfDebug?.backfillScope ?? 'window';
 
   return (
     <Modal
@@ -146,6 +178,123 @@ function TestToolsModal() {
             small
             text={translate('testTools.resetOverrides')}
             onPress={FeatureAccess.clearAllFeatureOverrides}
+          />
+        </View>
+
+        <View style={styles.gap2}>
+          <Text style={[styles.textNormal, styles.textStrong]}>
+            StatsPerf diagnostics
+          </Text>
+
+          <View
+            style={[
+              styles.flexRow,
+              styles.alignItemsCenter,
+              styles.justifyContentBetween,
+              styles.gap3,
+            ]}>
+            <View style={styles.flex1}>
+              <Text style={[styles.textNormal, styles.textStrong]}>
+                Logging
+              </Text>
+              <Text style={[styles.textMicroSupporting, styles.mt1]}>
+                [StatsPerf] counters + the readout below
+              </Text>
+            </View>
+            <Switch
+              accessibilityLabel="StatsPerf logging"
+              isOn={perfDebug?.loggingEnabled ?? true}
+              onToggle={StatsPerfDebug.setLoggingEnabled}
+            />
+          </View>
+
+          <Text style={styles.textMicroSupporting}>
+            Home compute scope (window = #1414, full = pre)
+          </Text>
+          <View style={[styles.flexRow, styles.gap2]}>
+            {SCOPE_OPTIONS.map(scope => {
+              const isActive = computeScope === scope;
+              return (
+                <PressableWithFeedback
+                  key={`compute-${scope}`}
+                  accessibilityLabel={`compute ${scope}`}
+                  accessibilityState={{selected: isActive}}
+                  onPress={() => StatsPerfDebug.setComputeScope(scope)}
+                  style={[
+                    styles.flex1,
+                    styles.alignItemsCenter,
+                    styles.p2,
+                    StyleUtils.getColorAccentRowStyle(isActive ? accent : null),
+                  ]}>
+                  <Text
+                    style={[
+                      styles.textMicro,
+                      isActive
+                        ? StyleUtils.getColorStyle(accent)
+                        : styles.textSupporting,
+                    ]}>
+                    {scope}
+                  </Text>
+                </PressableWithFeedback>
+              );
+            })}
+          </View>
+
+          <Text style={styles.textMicroSupporting}>
+            Backfill scope (window = #1414, full = pre)
+          </Text>
+          <View style={[styles.flexRow, styles.gap2]}>
+            {SCOPE_OPTIONS.map(scope => {
+              const isActive = backfillScope === scope;
+              return (
+                <PressableWithFeedback
+                  key={`backfill-${scope}`}
+                  accessibilityLabel={`backfill ${scope}`}
+                  accessibilityState={{selected: isActive}}
+                  onPress={() => StatsPerfDebug.setBackfillScope(scope)}
+                  style={[
+                    styles.flex1,
+                    styles.alignItemsCenter,
+                    styles.p2,
+                    StyleUtils.getColorAccentRowStyle(isActive ? accent : null),
+                  ]}>
+                  <Text
+                    style={[
+                      styles.textMicro,
+                      isActive
+                        ? StyleUtils.getColorStyle(accent)
+                        : styles.textSupporting,
+                    ]}>
+                    {scope}
+                  </Text>
+                </PressableWithFeedback>
+              );
+            })}
+          </View>
+
+          <Text style={styles.textMicroSupporting}>
+            Readout (newest at bottom; ⚠️LOOP = runaway re-fires)
+          </Text>
+          <View style={[styles.p2, styles.gap1]}>
+            {perfReport.length === 0 ? (
+              <Text style={styles.textMicroSupporting}>
+                No activity yet — navigate the app, then reopen.
+              </Text>
+            ) : (
+              perfReport.slice(-14).map(line => (
+                <Text key={line} style={styles.textMicroSupporting}>
+                  {line}
+                </Text>
+              ))
+            )}
+          </View>
+          <Button
+            small
+            text="Clear StatsPerf counters"
+            onPress={() => {
+              StatsPerfDebug.resetCounters();
+              setPerfReport([]);
+            }}
           />
         </View>
 

--- a/src/hooks/useDrinkingSessionsFetch/index.ts
+++ b/src/hooks/useDrinkingSessionsFetch/index.ts
@@ -7,6 +7,7 @@ import {startOfMonth, subMonths} from 'date-fns';
 import {useEffect, useRef, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
 import useNetwork from '@hooks/useNetwork';
+import StatsPerf from '@libs/StatsPerf';
 
 type UseDrinkingSessionsFetchReturn = {
   /** Last-good snapshot of the windowed session list. Stays populated across
@@ -79,9 +80,15 @@ function useDrinkingSessionsFetch(
     // and Onyx hydration is fast. Wait for the saved depth to hydrate so we
     // don't fetch the default 3 months and then immediately re-fetch wider.
     if (!userID || monthsLoadedMeta.status !== 'loaded') {
+      // DIAGNOSTIC: the fetch is gated. For a friend, a stuck `monthsMeta` here
+      // (never 'loaded') would keep `isLoading` true forever → stuck skeleton.
+      StatsPerf.note(
+        `fetch skip uid=${userID || '(self)'} monthsMeta=${monthsLoadedMeta.status}`,
+      );
       return;
     }
 
+    StatsPerf.note(`fetch run uid=${userID} monthsBack=${sessionsMonthsBack}`);
     const token = ++currentTokenRef.current;
     const prev = prevSessionsMonthsBackRef.current;
     const isWiden = prev !== null && sessionsMonthsBack > prev;
@@ -98,6 +105,9 @@ function useDrinkingSessionsFetch(
     ).getTime();
 
     const finalize = () => {
+      StatsPerf.note(
+        `fetch resolved uid=${userID} stale=${token !== currentTokenRef.current}`,
+      );
       if (token !== currentTokenRef.current) {
         return;
       }

--- a/src/hooks/useHomeStats.ts
+++ b/src/hooks/useHomeStats.ts
@@ -32,9 +32,17 @@ function useHomeStats(visibleDate: DateData): MonthlyStats {
     return {startMs: prevStart.getTime(), endMs: monthEnd.getTime()};
   }, [year, month]);
 
-  const {events, isLoading, earliestStartMs} = useDrinkEvents(undefined, {
-    window: eventWindow,
+  // DIAGNOSTIC A/B lever (StatsPerf): `full` reverts #1414's compute windowing
+  // (passes no window → whole-history walk) so the windowing's contribution can
+  // be isolated on-device. Defaults to the current (`window`) behaviour.
+  const [perfDebug] = useOnyx(ONYXKEYS.NVP_STATS_PERF_DEBUG, {
+    canBeMissing: true,
   });
+  const computeFullHistory = perfDebug?.computeScope === 'full';
+  const {events, isLoading, earliestStartMs} = useDrinkEvents(
+    undefined,
+    computeFullHistory ? undefined : {window: eventWindow},
+  );
   const preferences = useCurrentUserPreferences();
   const currentUserData = useCurrentUserData();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);

--- a/src/hooks/useLazyMarkedDates.ts
+++ b/src/hooks/useLazyMarkedDates.ts
@@ -14,6 +14,7 @@ import type {MarkedDates} from 'react-native-calendars/src/types';
 import {useOnyx} from 'react-native-onyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import * as Calendar from '@userActions/Calendar';
+import StatsPerf from '@libs/StatsPerf';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import {
   getDerivedCalendarMonth,
@@ -391,6 +392,17 @@ function useLazyMarkedDates(
   useEffect(() => {
     loadedFrom.current = loadedFromDate;
   }, [loadedFromDate]);
+
+  // DIAGNOSTIC (StatsPerf): if `months`/`marked` stay 0 while a calendar is
+  // mounted, the week-list has no row to scroll to → `onInitialScrollReady`
+  // never fires → the fullscreen screen hangs on its skeleton.
+  const markedCount = Object.keys(markedDates).length;
+  const monthCount = calendarMonths.length;
+  useEffect(() => {
+    StatsPerf.note(
+      `lazyMarked uid=${userID} months=${monthCount} marked=${markedCount} effMonths=${effectiveMonths} floor=${hasPersistedFloor}`,
+    );
+  }, [userID, monthCount, markedCount, effectiveMonths, hasPersistedFloor]);
 
   // Debounce the Onyx write so a rapid left-arrow scroll fires only one
   // listener-resubscribe / one friend-fetcher refetch at the end of the run.

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -3,6 +3,7 @@ import {InteractionManager} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import {buildDrinkEvents} from '@libs/Statistics';
 import type {DrinkEvent, WeekStart} from '@libs/Statistics';
+import StatsPerf from '@libs/StatsPerf';
 import Statistics from '@libs/actions/Statistics';
 import {useFirebase} from '@context/global/FirebaseContext';
 import useCurrentUserData from '@hooks/useCurrentUserData';
@@ -108,6 +109,15 @@ function useDrinkEvents(
   const drinksToUnits = preferences?.drinks_to_units;
   const isHydrated = allSessionsMeta.status === 'loaded';
 
+  // DIAGNOSTIC A/B lever (StatsPerf): `full` restores the pre-#1414 whole-history
+  // backfill even on a windowed caller, so we can test whether dropping it is
+  // what slowed profile/friends/calendar — without a rebuild. Defaults to the
+  // current (`window`) behaviour.
+  const [perfDebug] = useOnyx(ONYXKEYS.NVP_STATS_PERF_DEBUG, {
+    canBeMissing: true,
+  });
+  const backfillFullHistory = perfDebug?.backfillScope === 'full';
+
   // Scope the sessions fed to the heavy walk to the requested window, if any.
   // `buildDrinkEvents` (and `buildMonthlyStats` downstream) window by a
   // session's `start_time`, so filtering the input by the same numeric bound is
@@ -166,6 +176,11 @@ function useDrinkEvents(
     };
   }, [allSessions, windowStartMs, windowEndMs, currentUserID]);
 
+  // Sessions the launch-time backfill covers. Same ref as `scopedSessions` in
+  // the default (`window`) mode, so behaviour is unchanged; the full set only
+  // when the diagnostic lever is flipped.
+  const backfillSessions = backfillFullHistory ? allSessions : scopedSessions;
+
   const [allEvents, setAllEvents] = useState<DrinkEvent[]>(EMPTY_EVENTS);
   const [isCompiled, setIsCompiled] = useState(false);
 
@@ -173,6 +188,10 @@ function useDrinkEvents(
     if (!isHydrated) {
       return;
     }
+    // Counts every effect run — a runaway here (see the LOOP flag in the
+    // readout) is the JS-thread-saturation signature behind the stuck-skeleton
+    // / slow-screen symptoms.
+    StatsPerf.inc('useDrinkEvents.effectFire');
     let done = false;
     let handle: {cancel?: () => void} | undefined;
     let backstop: ReturnType<typeof setTimeout> | undefined;
@@ -182,7 +201,7 @@ function useDrinkEvents(
     // the navigation-transition frame) but can't depend on it alone: a leaked
     // interaction handle starves its queue indefinitely, which would silently
     // drop a post-save recompute and leave Home/Stats stale until an app reload.
-    const rebuild = () => {
+    const rebuild = (via: 'interaction' | 'backstop') => {
       if (done) {
         return;
       }
@@ -191,6 +210,11 @@ function useDrinkEvents(
       if (backstop) {
         clearTimeout(backstop);
       }
+      // Which timer won: a high `via.backstop` rate means the InteractionManager
+      // queue is starved (interactions never settle) — the deferred-work
+      // starvation that would also strand the calendar's scroll-ready callback.
+      StatsPerf.inc('useDrinkEvents.rebuild');
+      StatsPerf.inc(`useDrinkEvents.via.${via}`);
 
       const next = buildDrinkEvents(
         scopedSessions,
@@ -212,14 +236,16 @@ function useDrinkEvents(
       // full-stream consumer such as the Statistics tab runs).
       Statistics.backfillSessionTimeParts(
         next,
-        scopedSessions,
+        backfillSessions,
         timezone,
         weekStart,
       );
     };
 
-    handle = InteractionManager.runAfterInteractions(rebuild);
-    backstop = setTimeout(rebuild, REBUILD_BACKSTOP_MS);
+    handle = InteractionManager.runAfterInteractions(() =>
+      rebuild('interaction'),
+    );
+    backstop = setTimeout(() => rebuild('backstop'), REBUILD_BACKSTOP_MS);
 
     return () => {
       done = true;
@@ -228,7 +254,14 @@ function useDrinkEvents(
         clearTimeout(backstop);
       }
     };
-  }, [isHydrated, scopedSessions, drinksToUnits, timezone, weekStart]);
+  }, [
+    isHydrated,
+    scopedSessions,
+    backfillSessions,
+    drinksToUnits,
+    timezone,
+    weekStart,
+  ]);
 
   const resolvedUserIds = userIds ?? (currentUserID ? [currentUserID] : []);
 

--- a/src/libs/Statistics/events.ts
+++ b/src/libs/Statistics/events.ts
@@ -1,3 +1,4 @@
+import StatsPerf from '@libs/StatsPerf';
 import CONST from '@src/CONST';
 import type {DrinkKey, DrinksList} from '@src/types/onyx/Drinks';
 import type DrinkingSession from '@src/types/onyx/DrinkingSession';
@@ -94,6 +95,7 @@ function localPartsFor(
   stored: unknown,
 ): LocalParts | null {
   if (isStoredLocalParts(stored)) {
+    StatsPerf.inc('bde.storedHit');
     return {
       localDay: stored.d,
       localMonth: stored.d.slice(0, 7),
@@ -102,6 +104,9 @@ function localPartsFor(
       calendarDow: stored.dow,
     };
   }
+  // Cache miss — recompute (one `Intl` probe per zone-month via resolveLocalParts).
+  // This counter is the proxy for "lost backfill" cost on the cold read path.
+  StatsPerf.inc('bde.resolveFallback');
   return resolveLocalParts(ts, sessionTz);
 }
 
@@ -191,6 +196,7 @@ function buildDrinkEvents(
   timezone: SelectedTimezone,
   weekStart: WeekStart,
 ): DrinkEvent[] {
+  StatsPerf.inc('buildDrinkEvents.call');
   if (
     lastCall &&
     lastCall.sessions === sessions &&
@@ -199,9 +205,11 @@ function buildDrinkEvents(
     lastCall.timezone === timezone &&
     lastCall.weekStart === weekStart
   ) {
+    StatsPerf.inc('buildDrinkEvents.cacheHit');
     return lastCall.result;
   }
 
+  const span = StatsPerf.mark();
   const events: DrinkEvent[] = [];
   if (!sessions) {
     lastCall = {
@@ -245,6 +253,7 @@ function buildDrinkEvents(
       if (!drinks) {
         continue;
       }
+      StatsPerf.inc('buildDrinkEvents.session');
       // Stored fields are trusted only when they were computed under the
       // session's current timezone; on a mismatch every timestamp falls back to
       // recomputing, so a stale tag can never serve a wrong value.
@@ -331,6 +340,8 @@ function buildDrinkEvents(
     weekStart,
     result: events,
   };
+  StatsPerf.inc('buildDrinkEvents.events', events.length);
+  StatsPerf.measureFrom('buildDrinkEvents', span);
   return events;
 }
 

--- a/src/libs/Statistics/localParts.ts
+++ b/src/libs/Statistics/localParts.ts
@@ -26,6 +26,8 @@
  * session and drink regardless of how the timestamps are distributed.
  */
 
+import StatsPerf from '@libs/StatsPerf';
+
 /**
  * One `Intl.DateTimeFormat` per timezone. Constructing the formatter is the
  * expensive part, so we build it once and reuse it for every offset probe in
@@ -61,6 +63,10 @@ function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
  * the caller skips that timestamp.
  */
 function probeOffsetMs(ts: number, timeZone: string): number {
+  // The single most diagnostic counter: every increment is one real
+  // `Intl.formatToParts` call (~1-3ms on Hermes). A spike here on profile /
+  // calendar is the signature of the lost whole-history time-parts backfill.
+  StatsPerf.inc('intl.probe');
   const fields: Record<string, string> = {};
   for (const part of getOffsetFormatter(timeZone).formatToParts(ts)) {
     fields[part.type] = part.value;
@@ -152,6 +158,7 @@ type LocalParts = {
  * invalid timezone (the caller skips).
  */
 function resolveLocalParts(ts: number, timeZone: string): LocalParts | null {
+  StatsPerf.inc('resolveLocalParts.call');
   const wall = new Date(ts + getTzOffsetMs(ts, timeZone));
   const year = wall.getUTCFullYear();
   const month = wall.getUTCMonth() + 1;

--- a/src/libs/StatsPerf/connect.ts
+++ b/src/libs/StatsPerf/connect.ts
@@ -1,0 +1,122 @@
+/**
+ * Wires the dependency-free {@link StatsPerf} core to the app: the
+ * build-environment gate, the Onyx logging toggle, and the periodic flush that
+ * turns accumulated counters into a readable `[StatsPerf]` line (console + the
+ * Test Tools readout). Imported once at app setup so the heavy Onyx / CONFIG
+ * deps never reach the instrumented pure utilities.
+ */
+import Onyx from 'react-native-onyx';
+import CONFIG from '@src/CONFIG';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import toggleTestToolsModal from '@userActions/TestTool';
+import {
+  resetCounters,
+  setBackfillScope,
+  setComputeScope,
+  setLoggingEnabled,
+} from '@userActions/StatsPerfDebug';
+import StatsPerf from '.';
+
+// Env-file driven (NOT NODE_ENV/`__DEV__`), so it is unambiguously true on the
+// ad-hoc release build used for device testing and false on the store build.
+const IS_BUILD_ALLOWED = CONFIG.ENVIRONMENT !== CONST.ENVIRONMENT.PROD;
+
+const FLUSH_INTERVAL_MS = 2000;
+// A flush window seeing this many `useDrinkEvents` effect re-fires (or backfill
+// merges) is almost certainly a render/backfill loop rather than honest work —
+// flag the line so it stands out in the readout.
+const LOOP_FIRE_THRESHOLD = 30;
+
+// Console driver exposed on `globalThis.statsPerfDebug` for the web dev console
+// (the 4-finger Test Tools gesture is impractical with a mouse).
+type StatsPerfConsole = {
+  /** Returns the current readout lines (shows expandable in the console). */
+  report: () => string[];
+  /** Clear counters + readout. */
+  clear: () => void;
+  /** Master logging switch. */
+  logging: (on: boolean) => void;
+  /** A/B lever: home compute scope. */
+  compute: (scope: 'window' | 'full') => void;
+  /** A/B lever: backfill scope. */
+  backfill: (scope: 'window' | 'full') => void;
+  /** Pop the Test Tools panel. */
+  open: () => void;
+};
+
+let initialized = false;
+let loggingToggle = true;
+let sequence = 0;
+
+function applyEnabled(): void {
+  StatsPerf.setEnabled(IS_BUILD_ALLOWED && loggingToggle);
+}
+
+/** Compact `key:value` rendering of the changed counters this window. */
+function formatDelta(delta: Record<string, number>): string {
+  return Object.keys(delta)
+    .sort()
+    .map(key => `${key}:${delta[key]}`)
+    .join(' ');
+}
+
+function flush(): void {
+  if (!StatsPerf.isEnabled()) {
+    return;
+  }
+  const delta = StatsPerf.snapshotDelta();
+  if (Object.keys(delta).length === 0) {
+    return;
+  }
+  sequence += 1;
+  const looped =
+    (delta['useDrinkEvents.effectFire'] ?? 0) >= LOOP_FIRE_THRESHOLD ||
+    (delta['backfill.merge'] ?? 0) >= LOOP_FIRE_THRESHOLD;
+  const line = `#${sequence}${looped ? ' ⚠️LOOP' : ''} ${formatDelta(delta)}`;
+  StatsPerf.pushReportLine(line);
+  // eslint-disable-next-line no-console
+  console.debug(`[StatsPerf] ${line}`);
+}
+
+/**
+ * Start instrumentation. No-op on the production build. Defaults logging on for
+ * every non-prod build; the Test Tools toggle (persisted in
+ * `NVP_STATS_PERF_DEBUG.loggingEnabled`) can turn it off without a rebuild.
+ */
+function init(): void {
+  if (initialized || !IS_BUILD_ALLOWED) {
+    return;
+  }
+  initialized = true;
+  // This is a plain module (no React), so it can't use `useOnyx`; a module-level
+  // `Onyx.connect` is the established pattern for reacting to a toggle key here
+  // (cf. `@userActions/TestTool`). Diagnostic-only and gated to non-production.
+  // eslint-disable-next-line rulesdir/no-onyx-connect
+  Onyx.connect({
+    key: ONYXKEYS.NVP_STATS_PERF_DEBUG,
+    callback: value => {
+      loggingToggle = value?.loggingEnabled ?? true;
+      applyEnabled();
+    },
+  });
+  applyEnabled();
+  setInterval(flush, FLUSH_INTERVAL_MS);
+
+  // Drive everything from the web dev console, e.g. `statsPerfDebug.report()`,
+  // `statsPerfDebug.compute('full')`, `statsPerfDebug.backfill('full')`,
+  // `statsPerfDebug.open()`. Set only on the non-prod build (this whole init is
+  // gated above).
+  const consoleApi: StatsPerfConsole = {
+    report: () => [...StatsPerf.getReportLines()],
+    clear: resetCounters,
+    logging: setLoggingEnabled,
+    compute: setComputeScope,
+    backfill: setBackfillScope,
+    open: toggleTestToolsModal,
+  };
+  (globalThis as {statsPerfDebug?: StatsPerfConsole}).statsPerfDebug =
+    consoleApi;
+}
+
+export default {init};

--- a/src/libs/StatsPerf/index.ts
+++ b/src/libs/StatsPerf/index.ts
@@ -1,0 +1,140 @@
+/**
+ * Dependency-free performance counters for the Statistics / calendar stack.
+ *
+ * This is a DIAGNOSTIC instrument (not a shipped feature) for chasing the
+ * post-#1414 device-build regression: profile/friends getting slower and the
+ * infinite-scroll calendars stalling on skeletons. It counts the two things the
+ * competing hypotheses hinge on:
+ *   - runaway re-fires / Onyx writes (a render or backfill loop saturating the
+ *     JS thread → everything downstream starves), and
+ *   - `Intl` probe volume on the read path (the lost whole-history time-parts
+ *     backfill forcing `resolveLocalParts` recomputes off the cold path).
+ *
+ * Kept intentionally free of Onyx / CONFIG / React imports so it can be dropped
+ * into low-level pure utilities (`localParts`, `events`) without dragging those
+ * heavy deps into their unit tests. The Onyx toggle, the build-environment gate
+ * and the periodic flush live in `./connect`, which is imported only at app
+ * setup. Until `setEnabled(true)` runs, every call here is a cheap no-op, so
+ * tests and production are unaffected.
+ */
+
+/** High-resolution clock when available (RN polyfills `performance`), else 0. */
+function nowMs(): number {
+  const perf = (globalThis as {performance?: {now?: () => number}}).performance;
+  return typeof perf?.now === 'function' ? perf.now() : 0;
+}
+
+let enabled = false;
+
+/** Monotonic integer/float counters, keyed by a dotted metric name. */
+const counters: Record<string, number> = {};
+/** Snapshot taken at the last `snapshotDelta()` so the flusher can log deltas. */
+const lastFlushed: Record<string, number> = {};
+
+/**
+ * Rolling formatted readout, oldest first. Held here (not in Onyx) so the Test
+ * Tools panel can poll it while open without our own Onyx writes perturbing the
+ * `cachedDrinkingSessions`-write count we are trying to measure.
+ */
+const reportLines: string[] = [];
+const REPORT_MAX_LINES = 60;
+
+/** Toggle instrumentation. Driven by `./connect` from the Onyx debug key. */
+function setEnabled(next: boolean): void {
+  enabled = next;
+}
+
+function isEnabled(): boolean {
+  return enabled;
+}
+
+/** Add `n` to a counter (no-op when disabled). */
+function inc(key: string, n = 1): void {
+  if (!enabled) {
+    return;
+  }
+  counters[key] = (counters[key] ?? 0) + n;
+}
+
+/** Time a synchronous call, accumulating `<key>.ms` and `<key>.calls`. */
+function time<T>(key: string, fn: () => T): T {
+  if (!enabled) {
+    return fn();
+  }
+  const start = nowMs();
+  const result = fn();
+  counters[`${key}.ms`] = (counters[`${key}.ms`] ?? 0) + (nowMs() - start);
+  counters[`${key}.calls`] = (counters[`${key}.calls`] ?? 0) + 1;
+  return result;
+}
+
+/**
+ * Open a timing span. Returns a start mark to pass to {@link measureFrom}, or 0
+ * when disabled. Use across early returns where {@link time} can't wrap cleanly.
+ */
+function mark(): number {
+  return enabled ? nowMs() : 0;
+}
+
+/** Close a span opened by {@link mark}, accumulating `<key>.ms` and `.calls`. */
+function measureFrom(key: string, start: number): void {
+  if (!enabled || start === 0) {
+    return;
+  }
+  counters[`${key}.ms`] = (counters[`${key}.ms`] ?? 0) + (nowMs() - start);
+  counters[`${key}.calls`] = (counters[`${key}.calls`] ?? 0) + 1;
+}
+
+/**
+ * Counters that changed since the previous call, and advance the baseline.
+ * `.ms` accumulators are rounded so the readout stays compact. Returns an empty
+ * object when nothing moved (the flusher skips emitting an idle line).
+ */
+function snapshotDelta(): Record<string, number> {
+  const delta: Record<string, number> = {};
+  for (const key of Object.keys(counters)) {
+    const diff = counters[key] - (lastFlushed[key] ?? 0);
+    if (diff !== 0) {
+      delta[key] = key.endsWith('.ms') ? Math.round(diff) : diff;
+      lastFlushed[key] = counters[key];
+    }
+  }
+  return delta;
+}
+
+/** Append a formatted readout line (called by the flusher in `./connect`). */
+function pushReportLine(line: string): void {
+  reportLines.push(line);
+  if (reportLines.length > REPORT_MAX_LINES) {
+    reportLines.splice(0, reportLines.length - REPORT_MAX_LINES);
+  }
+}
+
+/** Current readout, oldest first (polled by the Test Tools panel). */
+function getReportLines(): string[] {
+  return reportLines;
+}
+
+/** Wipe all counters, the delta baseline, and the readout (Test Tools reset). */
+function reset(): void {
+  for (const key of Object.keys(counters)) {
+    delete counters[key];
+  }
+  for (const key of Object.keys(lastFlushed)) {
+    delete lastFlushed[key];
+  }
+  reportLines.length = 0;
+}
+
+export default {
+  setEnabled,
+  isEnabled,
+  inc,
+  time,
+  mark,
+  measureFrom,
+  snapshotDelta,
+  pushReportLine,
+  getReportLines,
+  reset,
+};

--- a/src/libs/StatsPerf/index.ts
+++ b/src/libs/StatsPerf/index.ts
@@ -110,6 +110,19 @@ function pushReportLine(line: string): void {
   }
 }
 
+/**
+ * Emit an ad-hoc event line immediately (prefixed `~`), independent of the
+ * periodic counter flush. Used to trace loading-gate / fetch state transitions
+ * — the things that gate a screen *before* any instrumented compute runs, which
+ * the counters can't see. No-op when disabled.
+ */
+function note(message: string): void {
+  if (!enabled) {
+    return;
+  }
+  pushReportLine(`~ ${message}`);
+}
+
 /** Current readout, oldest first (polled by the Test Tools panel). */
 function getReportLines(): string[] {
   return reportLines;
@@ -135,6 +148,7 @@ export default {
   measureFrom,
   snapshotDelta,
   pushReportLine,
+  note,
   getReportLines,
   reset,
 };

--- a/src/libs/actions/Statistics.ts
+++ b/src/libs/actions/Statistics.ts
@@ -1,4 +1,5 @@
 import Onyx from 'react-native-onyx';
+import StatsPerf from '@libs/StatsPerf';
 import {buildTimePartsPatchFromEvents} from '@libs/Statistics/sessionTimeParts';
 import type {DrinkEvent, WeekStart} from '@libs/Statistics';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -36,7 +37,18 @@ function backfillSessionTimeParts(
     weekStart,
   );
   if (patch) {
+    // Each merge bumps CACHED_DRINKING_SESSIONS identity → re-renders/re-derives
+    // every subscriber. A high merge rate here is the signature of a backfill
+    // write loop (non-converging patch). `sessions` = the per-merge session count.
+    StatsPerf.inc('backfill.merge');
+    let sessionCount = 0;
+    for (const userId of Object.keys(patch)) {
+      sessionCount += Object.keys(patch[userId] ?? {}).length;
+    }
+    StatsPerf.inc('backfill.sessions', sessionCount);
     Onyx.merge(ONYXKEYS.CACHED_DRINKING_SESSIONS, patch);
+  } else {
+    StatsPerf.inc('backfill.empty');
   }
 }
 

--- a/src/libs/actions/StatsPerfDebug.ts
+++ b/src/libs/actions/StatsPerfDebug.ts
@@ -1,0 +1,52 @@
+import Onyx from 'react-native-onyx';
+import StatsPerf from '@libs/StatsPerf';
+import CONFIG from '@src/CONFIG';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {
+  StatsBackfillScope,
+  StatsComputeScope,
+} from '@src/types/onyx/StatsPerfDebug';
+
+/**
+ * Developer-only writes for the diagnostic StatsPerf panel (Test Tools). Gated
+ * on the build environment (never production) rather than `IS_IN_PRODUCTION`, so
+ * the gate is unambiguous on the ad-hoc release build used for device testing.
+ */
+function isWriteAllowed(): boolean {
+  return CONFIG.ENVIRONMENT !== CONST.ENVIRONMENT.PROD;
+}
+
+/** Master switch for the `[StatsPerf]` instrumentation. */
+function setLoggingEnabled(enabled: boolean): void {
+  if (!isWriteAllowed()) {
+    return;
+  }
+  Onyx.merge(ONYXKEYS.NVP_STATS_PERF_DEBUG, {loggingEnabled: enabled});
+}
+
+/** A/B lever: home scorecard event-compute scope (`window` = #1414, `full` = pre). */
+function setComputeScope(scope: StatsComputeScope): void {
+  if (!isWriteAllowed()) {
+    return;
+  }
+  Onyx.merge(ONYXKEYS.NVP_STATS_PERF_DEBUG, {computeScope: scope});
+}
+
+/** A/B lever: launch-time backfill scope (`window` = #1414, `full` = pre). */
+function setBackfillScope(scope: StatsBackfillScope): void {
+  if (!isWriteAllowed()) {
+    return;
+  }
+  Onyx.merge(ONYXKEYS.NVP_STATS_PERF_DEBUG, {backfillScope: scope});
+}
+
+/** Clear the in-memory counters and the readout (does not touch the toggles). */
+function resetCounters(): void {
+  if (!isWriteAllowed()) {
+    return;
+  }
+  StatsPerf.reset();
+}
+
+export {setLoggingEnabled, setComputeScope, setBackfillScope, resetCounters};

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -33,6 +33,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import useLocalize from '@hooks/useLocalize';
 import useReadyAfterScreenTransition from '@hooks/useReadyAfterScreenTransition';
+import StatsPerf from '@libs/StatsPerf';
 import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Button from '@components/Button';
@@ -85,6 +86,21 @@ function ProfileScreen({route}: ProfileScreenProps) {
   // indexing on first render, which otherwise blocks the push slide-in.
   const {isReady: didScreenTransitionEnd, onEntryTransitionEnd} =
     useReadyAfterScreenTransition();
+
+  // DIAGNOSTIC (StatsPerf): trace the profile loading gate. The last line while
+  // stuck names the holdout (profileFetch / prefs / sessions).
+  useEffect(() => {
+    StatsPerf.note(
+      `profile self=${isSelf} txEnd=${didScreenTransitionEnd} profileFetch=${isProfileFetchLoading} prefs=${isPrefsLoading} sessions=${isSessionsLoading} isLoading=${isLoading}`,
+    );
+  }, [
+    isSelf,
+    didScreenTransitionEnd,
+    isProfileFetchLoading,
+    isPrefsLoading,
+    isSessionsLoading,
+    isLoading,
+  ]);
   const [userDataList] = useOnyx(ONYXKEYS.USER_DATA_LIST);
   const [friendCount, setFriendCount] = useState(0);
   const [commonFriendCount, setCommonFriendCount] = useState(0);

--- a/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
+++ b/src/screens/SessionsCalendar/SessionsCalendarScreen.tsx
@@ -1,5 +1,6 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
+import StatsPerf from '@libs/StatsPerf';
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {DateData} from 'react-native-calendars';
 import SessionsCalendar from '@components/SessionsCalendar';
@@ -100,6 +101,26 @@ function SessionsCalendarScreen({route}: SessionsCalendarScreenProps) {
 
   const showLoader =
     !didScreenTransitionEnd || isLoading || !preferences || !isScrollReady;
+
+  // DIAGNOSTIC (StatsPerf): trace the gate inputs. The last line while stuck on
+  // the skeleton names the holdout (e.g. scrollReady=false). hasData/hasPrefs
+  // are booleans so the effect only fires on a real gate transition.
+  const hasData = drinkingSessionData !== undefined;
+  const hasPrefs = !!preferences;
+  useEffect(() => {
+    StatsPerf.note(
+      `calScreen self=${isSelf} txEnd=${didScreenTransitionEnd} loading=${isLoading} prefs=${hasPrefs} data=${hasData} scrollReady=${isScrollReady} fetchingOlder=${isFetchingOlderMonths} showLoader=${showLoader}`,
+    );
+  }, [
+    isSelf,
+    didScreenTransitionEnd,
+    isLoading,
+    hasPrefs,
+    hasData,
+    isScrollReady,
+    isFetchingOlderMonths,
+    showLoader,
+  ]);
 
   return (
     <ScreenWrapper

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -9,6 +9,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import intlPolyfill from '@libs/IntlPolyfill';
 import {initFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import StartupMetrics from '@libs/StartupMetrics';
+import StatsPerfConnect from '@libs/StatsPerf/connect';
 import initializeLastVisitedPath from './initializeLastVisitedPath';
 import platformSetup from './platformSetup';
 import suppressSkiaPathDeprecationWarnings from './suppressSkiaPathDeprecationWarnings';
@@ -97,4 +98,8 @@ export default function () {
   // and log them in the same `Timing:` format as Timing.ts so Grafana picks
   // them up.
   StartupMetrics.init();
+
+  // Diagnostic Statistics/calendar profiler. No-op on the production build;
+  // defaults on for ad-hoc/staging/dev. See `@libs/StatsPerf`.
+  StatsPerfConnect.init();
 }

--- a/src/types/onyx/StatsPerfDebug.ts
+++ b/src/types/onyx/StatsPerfDebug.ts
@@ -1,0 +1,33 @@
+/** Which session window the home scorecard's event compute uses (A/B lever). */
+type StatsComputeScope = 'window' | 'full';
+
+/** Which session set the launch-time time-parts backfill covers (A/B lever). */
+type StatsBackfillScope = 'window' | 'full';
+
+/**
+ * Diagnostic StatsPerf debug state (Test Tools panel). Lets the
+ * post-#1414 regression be measured and bisected on a single ad-hoc device
+ * build. Never present in production — writes are gated in
+ * `@libs/actions/StatsPerfDebug`.
+ */
+type StatsPerfDebug = {
+  /** Master switch for the `[StatsPerf]` instrumentation. */
+  loggingEnabled?: boolean;
+  /**
+   * Home scorecard event-compute scope. `window` = #1414's optimisation (visible
+   * + previous month); `full` = pre-#1414 whole-history compute. Bisects whether
+   * the compute windowing is responsible for a symptom.
+   */
+  computeScope?: StatsComputeScope;
+  /**
+   * Launch-time time-parts backfill scope. `window` = #1414 (only the windowed
+   * sessions); `full` = pre-#1414 (whole history). Bisects whether dropping the
+   * full backfill is what slowed the other screens.
+   */
+  backfillScope?: StatsBackfillScope;
+  /** Rolling profiler readout, oldest first, rendered live in Test Tools. */
+  report?: string[];
+};
+
+export default StatsPerfDebug;
+export type {StatsComputeScope, StatsBackfillScope};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -10,6 +10,8 @@ import type Download from './Download';
 import type DrinkingSession from './DrinkingSession';
 import type FeatureAccessOverrides from './FeatureAccessOverrides';
 import type {FeatureOverride} from './FeatureAccessOverrides';
+import type StatsPerfDebug from './StatsPerfDebug';
+import type {StatsComputeScope, StatsBackfillScope} from './StatsPerfDebug';
 import type {
   DrinkingSessionId,
   DrinkingSessionArray,
@@ -148,6 +150,9 @@ export type {
   RangePreset,
   StartSession,
   StatisticsFilters,
+  StatsPerfDebug,
+  StatsComputeScope,
+  StatsBackfillScope,
   Theme,
   UnconfirmedDayKey,
   UnconfirmedDays,


### PR DESCRIPTION
## ⚠️ Diagnostic — do not merge

Instrumentation to root-cause the post-[#1414](https://github.com/PetrCala/Kiroku/pull/1414) device regression: home tap-latency is fixed, but **profile/friends got slower** and the **infinite-scroll calendars stall on skeletons**. The real fix ships in a separate PR once the data points at a cause; this branch is then reverted/trimmed. It widens the Test Tools gate to non-production and adds verbose counters — both unacceptable for the store build, hence draft.

## How to use it

Full procedure in [`contributingGuides/STATS_PERF_REPRO.md`](contributingGuides/STATS_PERF_REPRO.md). In short:

1. Build the ad-hoc IPA (this PR carries **Ready To Build - iOS**), install on the device with the test account (hundreds of sessions).
2. **Four-finger tap** → Test Tools → **StatsPerf diagnostics** (gate widened from dev-only so it's reachable on ad-hoc).
3. **Clear counters**, open one screen (Home / Profile / Friends / fullscreen calendar), reopen Test Tools, screenshot the readout. Repeat per screen (clearing between gives per-screen attribution).

## What it separates

A dependency-free profiler (`src/libs/StatsPerf`, wired via a thin `connect` at setup) prints a `[StatsPerf]` line every ~2s (console + the live Test Tools readout). Counters target the two competing hypotheses:

- **Loop / JS-thread saturation** (would strand every deferred load → stuck skeletons + slow screens): `useDrinkEvents.effectFire` (with a ⚠️LOOP flag), `via.interaction` vs `via.backstop` (interaction-queue starvation), `backfill.merge` vs `backfill.empty` (non-converging backfill write loop).
- **Lost whole-history backfill** (would slow the full-history screens): `intl.probe` (real `Intl` calls, ~1-3ms each on Hermes), `bde.storedHit` vs `bde.resolveFallback`, plus `buildDrinkEvents.*` / `groupSessionsByMonth.*` volume + time.

## Bisect the fix on one build (no rebuild)

Two persisted A/B levers in the panel (`NVP_STATS_PERF_DEBUG`), each `window` (#1414) | `full` (pre-#1414):
- **Home compute scope** — reverts #1414's event windowing.
- **Backfill scope** — restores the whole-history time-parts backfill.

Leading fix hypothesis: `compute=window` + `backfill=full` keeps Home fast while restoring the other screens → the fix is windowed compute + deferred full-history backfill.

## Safety
- All instrumentation gated on `ENVIRONMENT !== prod` (env-file driven, so unambiguously on for ad-hoc, off on the store build). Profiler is a no-op until `setEnabled` runs.
- Verified: `typecheck-tsgo`, `lint-changed`, `react-compiler check-changed`, prettier, and the Statistics/calendar jest suites (124 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)