### PR TITLE
perf(home): re-apply scorecard window, loop-free (fixes #1414 regression)

### DIFF
--- a/__tests__/unit/libs/Statistics/buildMonthlyStats.test.ts
+++ b/__tests__/unit/libs/Statistics/buildMonthlyStats.test.ts
@@ -184,3 +184,58 @@ describe('buildMonthlyStats — comparisonAvailable', () => {
     expect(laterMonth.comparisonAvailable).toBe(true);
   });
 });
+
+describe('buildMonthlyStats — windowed input is lossless', () => {
+  // Codifies the home-screen optimisation (`useHomeStats` / `useDrinkEvents`'
+  // `window` option): the scorecard reads only the visible + previous month, so
+  // feeding just that window must yield a byte-identical summary to the full
+  // multi-month history — provided the first-activity floor is supplied (which
+  // bypasses the whole-array earliest-event scan). Guards the window bounds
+  // against drift from `buildMonthlyStats`' own internal windows.
+  it('matches the full-history result for the visible + previous month', () => {
+    const now = new Date(2026, 5, 16, 12, 0, 0);
+    const earliest = ms('2026-01-01');
+    const full = [
+      event('2026-01-05', 8), // far history — outside the window
+      event('2026-03-20', 4), // outside the window
+      event('2026-05-03', 6), // previous month — inside the window
+      event('2026-05-14', 2), // previous month — inside the window
+      event('2026-06-02', 7), // current month — inside the window
+      event('2026-06-11', 5), // current month — inside the window
+    ];
+
+    const year = 2026;
+    const month = 6; // 1-based, matching buildMonthlyStats / useHomeStats
+    // Same bounds useHomeStats derives: previous month start → end of the
+    // visible month.
+    const prevStart = new Date(year, month - 2, 1).getTime();
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999).getTime();
+    const windowed = full.filter(
+      e => e.anchorTs >= prevStart && e.anchorTs <= monthEnd,
+    );
+
+    // Sanity: the window actually dropped the Jan/Mar far-history events.
+    expect(windowed).toHaveLength(4);
+
+    const fromFull = buildMonthlyStats(
+      full,
+      year,
+      month,
+      now,
+      THRESHOLDS,
+      earliest,
+    );
+    const fromWindow = buildMonthlyStats(
+      windowed,
+      year,
+      month,
+      now,
+      THRESHOLDS,
+      earliest,
+    );
+
+    // Deep-equals across current, previous, subPeriods, isCurrentMonth and
+    // comparisonAvailable.
+    expect(fromWindow).toEqual(fromFull);
+  });
+});

--- a/__tests__/unit/useDrinkEvents.test.ts
+++ b/__tests__/unit/useDrinkEvents.test.ts
@@ -118,6 +118,34 @@ function makeSessions(): UserDrinkingSessionsList {
   };
 }
 
+// Sessions spanning two calendar months for the `window` option: one inside a
+// May–June window, one in the prior January that the window must exclude.
+const TS_IN_WINDOW = Date.UTC(2025, 5, 12, 15, 0, 0); // 2025-06-12
+const TS_PRE_WINDOW = Date.UTC(2025, 0, 5, 10, 0, 0); // 2025-01-05
+
+function makeWindowSessions(): UserDrinkingSessionsList {
+  return {
+    u1: {
+      jun: {
+        start_time: TS_IN_WINDOW,
+        end_time: TS_IN_WINDOW + 60 * 60_000,
+        timezone: 'Africa/Abidjan',
+        drinks: {[TS_IN_WINDOW]: {beer: 2}},
+      },
+      jan: {
+        start_time: TS_PRE_WINDOW,
+        timezone: 'Africa/Abidjan',
+        drinks: {[TS_PRE_WINDOW]: {wine: 1}},
+      },
+    },
+  };
+}
+
+const WINDOW_MAY_JUNE = {
+  startMs: Date.UTC(2025, 4, 1),
+  endMs: Date.UTC(2025, 5, 30, 23, 59, 59, 999),
+};
+
 describe('useDrinkEvents', () => {
   let runAfterSpy: jest.SpyInstance;
 
@@ -293,5 +321,86 @@ describe('useDrinkEvents', () => {
     expect(passedSessions).toBe(sessions);
     expect(tz).toBe('Africa/Abidjan');
     expect(weekStart).toBe(1);
+  });
+
+  test('window option materialises only sessions whose start_time is in range', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    const {result} = renderHook(() =>
+      useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}),
+    );
+
+    const anchors = new Set(result.current.events.map(e => e.anchorTs));
+    expect(anchors.has(TS_IN_WINDOW)).toBe(true);
+    expect(anchors.has(TS_PRE_WINDOW)).toBe(false);
+    expect(result.current.events.every(e => e.anchorTs === TS_IN_WINDOW)).toBe(
+      true,
+    );
+  });
+
+  test('window option reports earliestStartMs from the full history, not the window', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    const {result} = renderHook(() =>
+      useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}),
+    );
+
+    // The January session is outside the window but is still the user's
+    // earliest — the comparison-baseline fallback must still see it.
+    expect(result.current.earliestStartMs).toBe(TS_PRE_WINDOW);
+  });
+
+  test('window option scopes the time-parts backfill to the windowed sessions', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    renderHook(() => useDrinkEvents(['u1'], {window: WINDOW_MAY_JUNE}));
+
+    const backfill = jest.mocked(Statistics.backfillSessionTimeParts);
+    expect(backfill).toHaveBeenCalledTimes(1);
+    // Only the in-window session is backfilled — whole-history Intl stays off
+    // the launch path.
+    const passedSessions = backfill.mock.calls[0][1];
+    expect(Object.keys(passedSessions?.u1 ?? {})).toEqual(['jun']);
+  });
+
+  test('omitting the window leaves earliestStartMs undefined (full-stream path)', () => {
+    const {result} = renderHook(() => useDrinkEvents(['u1']));
+
+    expect(result.current.earliestStartMs).toBeUndefined();
+  });
+
+  test('a fresh-but-equal window object does NOT re-fire the rebuild (loop guard)', () => {
+    setOnyx(makeWindowSessions(), 'loaded');
+
+    // Each render passes a BRAND-NEW window object with identical bounds —
+    // exactly what `useHomeStats` does (`{window: eventWindow}` is fresh each
+    // render). The rebuild must depend on the numeric bounds, not the object
+    // identity; if it re-fires on every render the app loops itself into JS-thread
+    // starvation (the #1414 regression, Kiroku #1417). Asserting the backfill
+    // count stays flat across re-renders pins that invariant.
+    const {rerender} = renderHook(
+      ({win}) => useDrinkEvents(['u1'], {window: win}),
+      {
+        initialProps: {
+          win: {
+            startMs: WINDOW_MAY_JUNE.startMs,
+            endMs: WINDOW_MAY_JUNE.endMs,
+          },
+        },
+      },
+    );
+
+    const backfill = jest.mocked(Statistics.backfillSessionTimeParts);
+    const callsAfterMount = backfill.mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    rerender({
+      win: {startMs: WINDOW_MAY_JUNE.startMs, endMs: WINDOW_MAY_JUNE.endMs},
+    });
+    rerender({
+      win: {startMs: WINDOW_MAY_JUNE.startMs, endMs: WINDOW_MAY_JUNE.endMs},
+    });
+
+    expect(backfill.mock.calls.length).toBe(callsAfterMount);
   });
 });

--- a/src/hooks/useHomeStats.ts
+++ b/src/hooks/useHomeStats.ts
@@ -18,7 +18,23 @@ import ONYXKEYS from '@src/ONYXKEYS';
  * friend/profile equivalent.
  */
 function useHomeStats(visibleDate: DateData): MonthlyStats {
-  const {events, isLoading} = useDrinkEvents();
+  const {year, month} = visibleDate;
+
+  // The scorecard reads only the visible month and the previous month (the
+  // current/previous summaries and the per-week sub-period series — see
+  // `buildMonthlyStats`). Scope the event stream to exactly that window so the
+  // launch-path walk stays ~2 months wide instead of materialising the whole
+  // history. Bounds mirror `buildMonthlyStats` (`month` is 1-based): the
+  // previous month's start through the end of the visible month.
+  const eventWindow = useMemo(() => {
+    const prevStart = new Date(year, month - 2, 1);
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+    return {startMs: prevStart.getTime(), endMs: monthEnd.getTime()};
+  }, [year, month]);
+
+  const {events, isLoading, earliestStartMs} = useDrinkEvents(undefined, {
+    window: eventWindow,
+  });
   const preferences = useCurrentUserPreferences();
   const currentUserData = useCurrentUserData();
   const [ongoingSessionData] = useOnyx(ONYXKEYS.ONGOING_SESSION_DATA);
@@ -32,8 +48,11 @@ function useHomeStats(visibleDate: DateData): MonthlyStats {
   // Snapshot `now` once per mount so the current/previous clamps agree.
   const now = useMemo(() => new Date(), []);
 
-  const {year, month} = visibleDate;
-  const earliestSessionAt = currentUserData?.earliest_session_at;
+  // Prefer the persisted first-activity floor; fall back to the windowed hook's
+  // cheap all-history minimum so `comparisonAvailable` stays correct even before
+  // `earliest_session_at` has hydrated.
+  const earliestSessionAt =
+    currentUserData?.earliest_session_at ?? earliestStartMs;
   const {current, previous, subPeriods, isCurrentMonth, comparisonAvailable} =
     useMemo(
       () =>

--- a/src/hooks/useStatistics/useDrinkEvents.ts
+++ b/src/hooks/useStatistics/useDrinkEvents.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {InteractionManager} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import {buildDrinkEvents} from '@libs/Statistics';
@@ -9,11 +9,42 @@ import useCurrentUserData from '@hooks/useCurrentUserData';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {
+  DrinkingSessionList,
+  UserDrinkingSessionsList,
+} from '@src/types/onyx/DrinkingSession';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
+
+type UseDrinkEventsOptions = {
+  /**
+   * Restrict the materialised stream to sessions whose `start_time` (ms) is in
+   * `[startMs, endMs]`. The home scorecard passes its visible + previous month
+   * so the launch-path walk stays ~2 months wide instead of the whole history
+   * (it only ever reads those two months — see `buildMonthlyStats`). Full-stream
+   * consumers (Statistics tabs, Badges, drill-down) omit it.
+   *
+   * IMPORTANT — why the bounds are primitives and the filtering happens inside
+   * the rebuild effect (not via a `useMemo` object fed into the effect deps):
+   * a render-derived object in the dependency array churns identity every
+   * render (under React Compiler it keys on the fresh `{window}` object the
+   * caller passes), which re-fires the effect → `setState` → re-render → re-fire
+   * into an infinite rebuild loop. That loop saturated the JS interaction queue
+   * and starved every async-gated screen (the #1414 regression reverted in
+   * Kiroku #1417). Depending only on the stable numeric bounds keeps it stable.
+   */
+  window?: {startMs: number; endMs: number};
+};
 
 type UseDrinkEventsResult = {
   events: DrinkEvent[];
   isLoading: boolean;
+  /**
+   * The viewed user's first-ever session `start_time` (ms), from a cheap numeric
+   * scan (no `Intl`). Populated only when a `window` is supplied — it lets a
+   * windowed caller keep a correct comparison baseline even though the event
+   * stream is scoped. `undefined` with no window / no sessions.
+   */
+  earliestStartMs?: number;
 };
 
 const WEEK_START_BY_LABEL: Record<string, WeekStart> = {
@@ -46,6 +77,48 @@ function resolveWeekStart(label: string | undefined): WeekStart {
 }
 
 /**
+ * Keep only sessions whose `start_time` falls in `[startMs, endMs]`. Pure, and
+ * deliberately called *inside* the rebuild (never in render) so its fresh-object
+ * output never reaches the effect's dependency array — see `UseDrinkEventsOptions`.
+ * `buildDrinkEvents` / `buildMonthlyStats` window by `start_time`, so filtering
+ * by the same numeric bound is lossless for the monthly summary.
+ */
+function filterSessionsToWindow(
+  sessions: UserDrinkingSessionsList,
+  startMs: number,
+  endMs: number,
+): UserDrinkingSessionsList {
+  const scoped: UserDrinkingSessionsList = {};
+  for (const uid of Object.keys(sessions)) {
+    const userSessions = sessions[uid];
+    if (!userSessions) {
+      continue;
+    }
+    const kept: DrinkingSessionList = {};
+    let keptAny = false;
+    for (const sessionId of Object.keys(userSessions)) {
+      const session = userSessions[sessionId];
+      if (!session) {
+        continue;
+      }
+      const startTime = Number(session.start_time);
+      if (
+        Number.isFinite(startTime) &&
+        startTime >= startMs &&
+        startTime <= endMs
+      ) {
+        kept[sessionId] = session;
+        keptAny = true;
+      }
+    }
+    if (keptAny) {
+      scoped[uid] = kept;
+    }
+  }
+  return scoped;
+}
+
+/**
  * Subscribe to the inputs of the Statistics v2 event stream and return the
  * materialised `DrinkEvent[]` for the requested users.
  *
@@ -62,12 +135,18 @@ function resolveWeekStart(label: string | undefined): WeekStart {
  * `ONGOING_SESSION_DATA`, not the cached snapshot — so this stays off the
  * drink-logging touch frame.
  *
+ * Pass `options.window` to scope the walk to a date range (the home scorecard
+ * does; everyone else omits it and gets the full stream).
+ *
  * `isLoading` is true until the Onyx subscription has hydrated **and** the
  * deferred compute has produced its first result. During that window
  * `events` is `[]`. Callers should render a layout-faithful skeleton, not
  * the empty-state.
  */
-function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
+function useDrinkEvents(
+  userIds?: UserID[],
+  options?: UseDrinkEventsOptions,
+): UseDrinkEventsResult {
   const {auth} = useFirebase();
   const preferences = useCurrentUserPreferences();
   const userData = useCurrentUserData();
@@ -81,6 +160,33 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
   const weekStart = resolveWeekStart(preferences?.first_day_of_week);
   const drinksToUnits = preferences?.drinks_to_units;
   const isHydrated = allSessionsMeta.status === 'loaded';
+
+  // Read the window as primitives — these (not a derived object) drive the
+  // effect below; see `UseDrinkEventsOptions` for why.
+  const windowStartMs = options?.window?.startMs;
+  const windowEndMs = options?.window?.endMs;
+
+  // Current user's all-time earliest `start_time` (numeric, no `Intl`) — the
+  // windowed scorecard's comparison-baseline fallback. Its own memo: returns a
+  // number, is never in the effect deps, so it can't drive a rebuild loop even
+  // if it recomputes.
+  const earliestStartMs = useMemo<number | undefined>(() => {
+    if (windowStartMs === undefined || !allSessions || !currentUserID) {
+      return undefined;
+    }
+    const userSessions = allSessions[currentUserID];
+    if (!userSessions) {
+      return undefined;
+    }
+    let earliest = Infinity;
+    for (const sessionId of Object.keys(userSessions)) {
+      const startTime = Number(userSessions[sessionId]?.start_time);
+      if (Number.isFinite(startTime) && startTime < earliest) {
+        earliest = startTime;
+      }
+    }
+    return earliest === Infinity ? undefined : earliest;
+  }, [allSessions, windowStartMs, currentUserID]);
 
   const [allEvents, setAllEvents] = useState<DrinkEvent[]>(EMPTY_EVENTS);
   const [isCompiled, setIsCompiled] = useState(false);
@@ -108,8 +214,17 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
         clearTimeout(backstop);
       }
 
+      // Apply the window HERE, not via a memo feeding the effect deps (see
+      // `UseDrinkEventsOptions`). With no window we pass `allSessions` untouched,
+      // so the full-stream consumers and the `backfillSessionTimeParts` contract
+      // stay byte-identical.
+      const scopedSessions =
+        windowStartMs !== undefined && windowEndMs !== undefined && allSessions
+          ? filterSessionsToWindow(allSessions, windowStartMs, windowEndMs)
+          : allSessions;
+
       const next = buildDrinkEvents(
-        allSessions,
+        scopedSessions,
         drinksToUnits,
         CONST.DRINK_DEFAULTS,
         timezone,
@@ -122,10 +237,13 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
       // the next cold open reads them with zero `Intl`. Reconstructed from the
       // events above (no extra `Intl`); the merge re-fires this effect, which
       // then reads the stored fields and produces an empty patch — so it
-      // converges in one step and never loops.
+      // converges in one step and never loops. Scoped to the same windowed set,
+      // so a windowed caller keeps whole-history `Intl` off the launch path (the
+      // rest is backfilled when a full-stream consumer such as the Statistics
+      // tab runs).
       Statistics.backfillSessionTimeParts(
         next,
-        allSessions,
+        scopedSessions,
         timezone,
         weekStart,
       );
@@ -141,7 +259,15 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
         clearTimeout(backstop);
       }
     };
-  }, [isHydrated, allSessions, drinksToUnits, timezone, weekStart]);
+  }, [
+    isHydrated,
+    allSessions,
+    windowStartMs,
+    windowEndMs,
+    drinksToUnits,
+    timezone,
+    weekStart,
+  ]);
 
   const resolvedUserIds = userIds ?? (currentUserID ? [currentUserID] : []);
 
@@ -158,9 +284,9 @@ function useDrinkEvents(userIds?: UserID[]): UseDrinkEventsResult {
 
   const isLoading = !isHydrated || !isCompiled;
 
-  return {events, isLoading};
+  return {events, isLoading, earliestStartMs};
 }
 
 export default useDrinkEvents;
 export {resolveWeekStart};
-export type {UseDrinkEventsResult};
+export type {UseDrinkEventsResult, UseDrinkEventsOptions};


### PR DESCRIPTION
Re-applies [#1414](https://github.com/PetrCala/Kiroku/pull/1414)'s home-scorecard windowing **without the infinite-loop regression** that forced its revert in [#1417](https://github.com/PetrCala/Kiroku/pull/1417).

## What #1414 got wrong

#1414 windowed the scorecard's stats compute to the visible + previous month (a real launch-latency win on top of #1409). But its windowed `useDrinkEvents` built the scoped session set in a `useMemo` and put **that derived object in the rebuild effect's dependency array**. Under React Compiler the object's identity churns every render (it keys on the fresh `{window}` object the caller passes each render), so the effect re-fired → `setState` → re-render → re-fired — **~69k rebuilds**, all via `runAfterInteractions`.

That runaway **saturated the JS interaction queue**, starving every async-gated screen:
- **Profile / Friends list / friend profiles** → fetches never resolved (endless spinners).
- **Fullscreen calendar** → it *had* its data (`calendarMonths` populated), but `onInitialScrollReady` never got a turn → stuck on the skeleton.
- Home only looked fine because its content had already painted.

Diagnosed on-device with the StatsPerf harness ([#1416](https://github.com/PetrCala/Kiroku/pull/1416)): `⚠️LOOP`, `useDrinkEvents.rebuild ≈ 69547`, 14.8 s of `buildDrinkEvents` in one flush — vs `rebuild:3` in the non-windowed path.

## The fix

Re-apply the windowing so the effect can't churn:
- The window filter runs **inside the rebuild** (`filterSessionsToWindow`), and the effect depends only on the **stable numeric bounds** (`windowStartMs` / `windowEndMs`) plus the stable `allSessions` ref — **never a render-derived object**. A fresh `{window}` with unchanged bounds no longer re-fires it.
- `earliestStartMs` moves to its own memo (a number, never in the effect deps → can't drive a loop).
- **No-window callers are byte-identical** (`scoped === allSessions`), so Statistics tabs / Badges / drill-down and the `backfillSessionTimeParts` contract are unchanged.

Net: Home keeps the #1414 launch win **and** profile/friends/calendar work.

## Tests
- Window filtering, scoped backfill, `earliestStartMs`, and the `buildMonthlyStats` windowed-vs-full **equivalence** guard (windowing is lossless).
- A new **loop guard**: a fresh-but-equal `{window}` object across re-renders must not re-fire the rebuild (asserts the effect depends on bounds, not object identity).
- `typecheck-tsgo`, `lint-changed`, `react-compiler check-changed`, prettier — all clean; 84 Statistics/calendar jest tests pass.

## Verification
Carries **`Ready To Build - iOS`** for an ad-hoc build. On-device with the heavy test account, confirm: Home is fast on launch **and** Friends list / profiles / fullscreen calendar all load (no stuck spinners/skeletons). The loop's gone, so the screens that #1414 starved should work. The StatsPerf branch (#1416) remains available if we want counter-level confirmation (`useDrinkEvents.rebuild` bounded, no `⚠️LOOP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)