### PR TITLE
Add minimum boot-splash visible duration to prevent flicker

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -760,6 +760,15 @@ const CONST = {
   // a warm listener (typically <500 ms) and shorter than the safety net.
   BOOT_SPLASH_AUTH_DATA_TIMEOUT_MS: 3 * 1000,
 
+  // Minimum time the boot splash stays on screen, measured from app launch.
+  // On a fast boot (warm cache, little data to hydrate) the gates resolve
+  // almost immediately and the splash would otherwise flash for only a few
+  // frames — long enough to register as a flicker, too short to actually see.
+  // If the splash has been up less than this when it's ready to hide, the hide
+  // is deferred for the remainder so the logo reads as an intentional beat
+  // rather than a blink. Tune freely; this is the single source of truth.
+  BOOT_SPLASH_MIN_VISIBLE_DURATION_MS: 500,
+
   // Last-resort safety net (SplashScreenHider): force-hide the splash if the
   // gates never resolve, so a stuck boot can't pin the (untappable) overlay.
   BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS: 15 * 1000,

--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -26,6 +26,16 @@ import type {
 // never flips and the user is left staring at the yellow overlay indefinitely.
 const FORCE_HIDE_TIMEOUT_MS = CONST.BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS;
 
+// Floor for how long the splash stays up, so a fast boot can't flash it for a
+// couple of frames. See CONST for the rationale.
+const MIN_VISIBLE_DURATION_MS = CONST.BOOT_SPLASH_MIN_VISIBLE_DURATION_MS;
+
+// Captured once when this module is first evaluated, which happens during the
+// initial bundle load — the closest JS-side proxy for "splash became visible".
+// It's a slight underestimate (the native splash is already up before JS runs),
+// which only ever makes the enforced minimum more conservative, never less.
+const SPLASH_VISIBLE_SINCE = Date.now();
+
 // Storyboard asset is 108pt (108/216/324 at 1×/2×/3×). The JS overlay
 // renders the logo at the same size so the native → JS handoff is seamless.
 const LOGO_SIZE = 108;
@@ -72,16 +82,12 @@ function SplashScreenHider({
 
   const hideHasBeenCalled = useRef(false);
 
-  const hide = useCallback(() => {
-    if (hideHasBeenCalled.current) {
-      return;
-    }
-
-    hideHasBeenCalled.current = true;
-
-    // The unchanged shrink-out: logo scales to nothing while the overlay fades.
-    // Every non-handoff path lands here, and it never depends on the logo slot,
-    // so it can't be stranded waiting for a target that never arrives.
+  // The actual hide sequence. Split out from hide() so the minimum-visible
+  // gate can defer the whole thing (native dissolve and all) on a fast boot.
+  const runHide = useCallback(() => {
+    // The shrink-out: logo scales to nothing while the overlay fades. Every
+    // non-handoff path lands here, and it never depends on the logo slot, so it
+    // can't be stranded waiting for a target that never arrives.
     const shrinkOut = () => {
       Animated.parallel([
         Animated.timing(scale, {
@@ -200,6 +206,25 @@ function SplashScreenHider({
     logoHandoffTargetRef,
     setIsLogoHandoffActive,
   ]);
+
+  const hide = useCallback(() => {
+    if (hideHasBeenCalled.current) {
+      return;
+    }
+    hideHasBeenCalled.current = true;
+
+    // Enforce a minimum on-screen duration: if the splash has been up for less
+    // than the floor when it's ready to hide, defer the hide for the remainder
+    // so a fast boot reads as an intentional beat rather than a flicker. The
+    // 15s force-hide net sits far above this, so the two never collide.
+    const remainingMs =
+      MIN_VISIBLE_DURATION_MS - (Date.now() - SPLASH_VISIBLE_SINCE);
+    if (remainingMs > 0) {
+      setTimeout(runHide, remainingMs);
+    } else {
+      runHide();
+    }
+  }, [runHide]);
 
   useEffect(() => {
     if (!shouldHideSplash) {

--- a/src/components/SplashScreenHider/index.tsx
+++ b/src/components/SplashScreenHider/index.tsx
@@ -19,6 +19,16 @@ import type {
 // alert), so a trip here always has an accompanying breadcrumb of the offender.
 const FORCE_HIDE_TIMEOUT_MS = CONST.BOOT_SPLASH_FORCE_HIDE_TIMEOUT_MS;
 
+// Floor for how long the splash stays up, so a fast boot can't flash it for a
+// couple of frames. See CONST for the rationale. Mirrors the native hider.
+const MIN_VISIBLE_DURATION_MS = CONST.BOOT_SPLASH_MIN_VISIBLE_DURATION_MS;
+
+// Captured once when this module is first evaluated, during the initial bundle
+// load — the closest JS-side proxy for "splash became visible". A slight
+// underestimate (the #splash div is painted before the bundle runs), which only
+// ever makes the enforced minimum more conservative, never less.
+const SPLASH_VISIBLE_SINCE = Date.now();
+
 function SplashScreenHider({
   onHide = () => {},
   shouldHideSplash,
@@ -30,7 +40,21 @@ function SplashScreenHider({
       return;
     }
     hideHasBeenCalled.current = true;
-    BootSplash.hide().then(() => onHide());
+
+    // Enforce a minimum on-screen duration: if the splash has been up for less
+    // than the floor when it's ready to hide, defer the hide for the remainder
+    // so a fast boot reads as an intentional beat rather than a flicker. The
+    // 15s force-hide net sits far above this, so the two never collide.
+    const runHide = () => {
+      BootSplash.hide().then(() => onHide());
+    };
+    const remainingMs =
+      MIN_VISIBLE_DURATION_MS - (Date.now() - SPLASH_VISIBLE_SINCE);
+    if (remainingMs > 0) {
+      setTimeout(runHide, remainingMs);
+    } else {
+      runHide();
+    }
   }, [onHide]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

When the app opens, the boot splash (logo on the yellow background) can flash on screen only briefly because, on a fast boot, there isn't much data to load. The splash gates resolve almost immediately, so the splash is shown for just a few frames — long enough to register as a flicker, too short for the user to actually see. It feels like the logo was "splashed in front of their eyes" and gone.

## Change

Introduce a configurable **minimum on-screen duration** for the boot splash:

- New constant `CONST.BOOT_SPLASH_MIN_VISIBLE_DURATION_MS` (**500 ms**, easily tweakable — single source of truth).
- A launch reference timestamp is captured once at module load (the earliest JS-side proxy for "splash became visible").
- When the splash is ready to hide, if it has been up for **less** than the floor, the hide is deferred for the remaining time. Otherwise it hides immediately as before.

Applied in **both** `SplashScreenHider` variants:
- **Native** (`index.native.tsx`): the existing hide sequence is split into `runHide`, and the gate defers the whole thing — native cross-dissolve and logo animation included — so the floor covers the entire transition.
- **Web** (`index.tsx`): same gate wraps `BootSplash.hide()`.

### Notes
- The launch timestamp is captured at module evaluation, which is a slight *underestimate* of how long the splash has truly been visible (the native splash / `#splash` div is painted before the JS bundle runs). That only ever makes the enforced minimum more conservative, never less.
- The 15 s force-hide safety net sits far above this 500 ms floor, so the two never collide. Direct `BootSplash.hide()` calls elsewhere (e.g. the force-update path) are intentionally **not** gated.

## Why 500 ms?
Long enough that the logo reads as an intentional beat rather than a blink, short enough not to feel like an artificial delay on a healthy boot. @juke797 — happy to tune this; just change the one constant.

## Testing
- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅
- `eslint` on changed files ✅
- `prettier --write` on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9nAXpnuHgQ5RAdwrwyumx)_