### PR TITLE
fix(social): stop "No friends" flash on cold load before the user record hydrates

### DIFF
--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -923,8 +923,6 @@
 "src/screens/Settings/SettingsScreen.tsx"	"arrow-body-style"	3
 "src/screens/SignUp/AuthScreen.tsx"	"react/jsx-no-leaked-render"	1
 "src/screens/SignUp/SignUpScreenLayout/index.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
-"src/screens/Social/FriendListScreen.tsx"	"react-hooks/set-state-in-effect"	1
-"src/screens/Social/FriendListScreen.tsx"	"rulesdir/prefer-narrow-hook-dependencies"	1
 "src/screens/Social/FriendRequestScreen.tsx"	"@typescript-eslint/switch-exhaustiveness-check"	1
 "src/screens/Social/FriendRequestScreen.tsx"	"react-hooks/set-state-in-effect"	2
 "src/screens/Social/FriendSearchScreen.tsx"	"react-hooks/set-state-in-render"	2

--- a/src/screens/Social/FriendListScreen.tsx
+++ b/src/screens/Social/FriendListScreen.tsx
@@ -2,7 +2,7 @@ import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import SearchWindow from '@components/Social/SearchWindow';
 import type {UserIDToNicknameMapping} from '@src/types/various/Search';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import {objKeys} from '@libs/DataHandling';
 import {getNicknameMapping, searchArrayByText} from '@libs/Search';
 import {filterBlockedUsers} from '@libs/BlockUtils';
@@ -16,6 +16,7 @@ import NoFriendInfo from '@components/Social/NoFriendInfo';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useNetwork from '@hooks/useNetwork';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ERRORS from '@src/ERRORS';
 
@@ -25,24 +26,43 @@ function FriendListScreen() {
   const styles = useThemeStyles();
   const {isOffline} = useNetwork();
   const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
-  const [friends, setFriends] = useState<UserArray>([]);
-  const [friendsToDisplay, setFriendsToDisplay] = useState<UserArray>([]);
-  const [userHasFriends, setUserHasFriends] = useState<boolean>(false);
+
+  // Derive the friend set straight from the signed-in user's own record. Doing
+  // this at render time (rather than copying it into state via a useEffect)
+  // keeps the list, its empty/loading gates, and the record in lockstep: a
+  // useEffect copy lags `userData` by a render, and that one-frame gap is part
+  // of the window where a "No friends" flash slips through on a cold load.
+  // Left unmemoized on purpose — the React Compiler handles it (CLEAN-REACT-0).
+  const friends = filterBlockedUsers(
+    objKeys(userData?.friends),
+    userData?.blocked,
+  );
+  const userHasFriends = friends.length > 0;
+
   const {
     profileList,
     userStatusList,
     isLoading: isLoadingFriends,
   } = useFriendsData(friends);
-  const [isSearching, setIsSearching] = useState<boolean>(false);
 
-  // `friends` is empty until app/open delivers the friend list (or a warm cache
-  // hydrates). `IS_LOADING_APP === false` marks that bootstrap as settled, but it
-  // only flips in app/open's finallyData, which is deferred while offline, so it
-  // stays `true` offline. Online with nothing yet: keep the list loading so the
-  // first-boot "no friends" flash never shows. Offline with nothing cached:
-  // bootstrap can't settle, so show an offline notice rather than spinning
-  // forever or falsely claiming the user has no friends.
-  const isBootstrapPending = isLoadingApp !== false && friends.length === 0;
+  // `null` means no active search; otherwise the narrowed subset to display.
+  const [searchResults, setSearchResults] = useState<UserArray | null>(null);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+  const friendsToDisplay = searchResults ?? friends;
+
+  // Stay in the cold-load state until BOTH the OpenApp bootstrap has settled
+  // (`IS_LOADING_APP === false`, set in app/open's finallyData) AND the
+  // signed-in user's own record has hydrated into `USER_DATA_LIST`. The
+  // bootstrap flag alone is insufficient: it is a tiny merge that can commit a
+  // beat before the large user record lands (the two commit independently
+  // inside one Onyx batch), and in that gap an already-friended user would
+  // momentarily read as having no friends. `IS_LOADING_APP` stays `true` while
+  // offline (its finallyData is deferred), so once nothing is cached and we are
+  // offline, surface an offline notice rather than spinning forever or falsely
+  // claiming the user has no friends.
+  const isUserRecordLoaded = !isEmptyObject(userData);
+  const isBootstrapPending =
+    (isLoadingApp !== false || !isUserRecordLoaded) && !userHasFriends;
   const isInitialFriendsLoad = isBootstrapPending && !isOffline;
   const isFriendsUnavailableOffline = isBootstrapPending && isOffline;
 
@@ -59,7 +79,7 @@ function FriendListScreen() {
           searchText,
           searchMapping,
         );
-        setFriendsToDisplay(relevantResults); // Hide irrelevant
+        setSearchResults(relevantResults); // Hide irrelevant
       } catch (error) {
         ErrorUtils.raiseAppError(ERRORS.DATABASE.SEARCH_FAILED, error);
       } finally {
@@ -70,44 +90,25 @@ function FriendListScreen() {
   );
 
   const resetSearch = () => {
-    setFriendsToDisplay(friends);
+    setSearchResults(null);
   };
 
-  const emptyListComponent = useMemo(() => {
-    if (isFriendsUnavailableOffline) {
-      return (
-        <Text style={styles.noResultsText}>
-          {translate('friendListScreen.offlineNoData')}
-        </Text>
-      );
-    }
-    if (!userHasFriends) {
-      return <NoFriendInfo />;
-    }
-    return (
+  let emptyListComponent: React.JSX.Element;
+  if (isFriendsUnavailableOffline) {
+    emptyListComponent = (
+      <Text style={styles.noResultsText}>
+        {translate('friendListScreen.offlineNoData')}
+      </Text>
+    );
+  } else if (!userHasFriends) {
+    emptyListComponent = <NoFriendInfo />;
+  } else {
+    emptyListComponent = (
       <Text style={styles.noResultsText}>
         {`${translate('userList.noFriendsFound')}\n\n${translate('userList.tryModifyingSearch')}`}
       </Text>
     );
-  }, [
-    isFriendsUnavailableOffline,
-    userHasFriends,
-    styles.noResultsText,
-    translate,
-  ]);
-
-  useEffect(() => {
-    // Consumption filter (#760): a block severs the friendship server-side, so
-    // a blocked user normally won't be in `friends` at all. Filter on the
-    // signed-in user's own block list anyway to cover any cached/edge case.
-    const friendsArray = filterBlockedUsers(
-      objKeys(userData?.friends),
-      userData?.blocked,
-    );
-    setFriends(friendsArray);
-    setFriendsToDisplay(friendsArray);
-    setUserHasFriends(friendsArray.length > 0);
-  }, [userData]);
+  }
 
   return (
     <View style={styles.flex1}>


### PR DESCRIPTION
## Summary

On a cold load with an empty/unhydrated cache (fresh install, or the first paint before `app/open` lands), users who **do** have friends briefly saw the empty **"No friends"** screen until their data arrived. This fixes that flash.

It is the second half of a race the onboarding flow was already hardened against — see the analysis below for why the two reported bugs are the same root cause and why only the friend list was still exposed.

## Root cause

Both the onboarding modal and the friend list make a decision on app start that depends on two Onyx keys committing in order:

- `IS_LOADING_APP` — a **tiny** merge, flipped to `false` in `app/open`'s `finallyData`.
- `USER_DATA_LIST` — the **large** user record (friends, profile, onboarding stamp), merged from the response payload.

These commit **independently** inside one Onyx batch (`Promise.all` over per-key ops, no cross-key ordering), so `IS_LOADING_APP === false` can notify subscribers a beat **before** the record lands.

- **Onboarding** already closes this window: `useOnboardingFlow` gates on `isLoadingApp === false` **AND** `userData !== undefined`, plus a 500&nbsp;ms settle in `OnboardingGuard`, plus selectors that read a not-yet-hydrated record as "completed". So an already-onboarded user is not stranded. *(No change needed here — this is why the onboarding half of the report no longer reproduces on current `master`.)*
- **Friend list** had the weaker gate: `isBootstrapPending = isLoadingApp !== false && friends.length === 0`. Once `IS_LOADING_APP` flips `false` but the record hasn't propagated, `isBootstrapPending` goes false → the spinner stops → `NoFriendInfo` renders for an already-friended user. A `useEffect` that copied `friends` into local state added a second frame of lag on top.

Once the record lands the list self-corrects and never regresses — matching the report that it "disappears and never comes back", and that warm relaunch / sign-out-in / cached sessions are fine (the record is already present, so the gap never opens).

## Fix

`src/screens/Social/FriendListScreen.tsx`:

1. **Derive the friend set from the signed-in user's record at render time** instead of copying it into state via `useEffect`. This removes the one-frame lag and keeps the list, its empty-state choice, and the loading gate in lockstep with the record we actually have. (Left unmemoized; the React Compiler memoizes it — verified by the compliance check — so the array stays referentially stable for `useFriendsData`'s focus effect.)
2. **Require the user's own record to be hydrated before leaving the loading state**: `isBootstrapPending = (isLoadingApp !== false || !isUserRecordLoaded) && !userHasFriends`. This mirrors the readiness gate `useOnboardingFlow` already uses. The offline branch is preserved (`IS_LOADING_APP` stays `true` offline, so an uncached offline user still gets the offline notice rather than a false "no friends").

Search behavior is unchanged: an active search now narrows via a `searchResults` subset (`null` = no search) rather than mutating a copied `friends` state.

## Testing

- `npm run typecheck-tsgo` ✅
- `npm run react-compiler-compliance-check check-changed` ✅ (confirms the derived `friends` array is compiler-memoized / stable)
- `npx eslint` on the changed file ✅
- `npx prettier --write` ✅

No dedicated render test was added — the screen pulls in navigation/Onyx/localize/theme hooks that make a faithful render test heavy and brittle; the sibling onboarding race is already covered by `useOnboardingFlow.test.ts` / `OnboardingGuard.test.tsx`. Happy to add one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5EKsHmaFgtgksnyK1gPqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5EKsHmaFgtgksnyK1gPqB)_