### PR TITLE
Stats Overview redesign v1: chart-led (bar chart replaces the hero curve)

### DIFF
--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -24,14 +24,16 @@ function formatUnits(value: number): string {
 /**
  * Total-alcohol scorecard for the selected range. Reads the shared range +
  * comparison from the toolbar and tells a period story top-to-bottom:
- * verdict (units) → shape (units by period) → wins (restraint) → load
- * (consumption) → risk (threshold days) → texture (intensity mix).
+ * verdict + shape (units this period, broken down by sub-period) → wins
+ * (restraint) → load (consumption) → risk (threshold days) → texture
+ * (intensity mix).
  *
- * The headline number is followed immediately by the labeled "Units by
- * period" bar chart: it carries the same trajectory the old inline hero
- * sparkline tried to show, but with readable per-bucket labels and values.
- * The sparkline (an axis-less curve that collapsed to a handful of points
- * at any range) is gone — the bar chart is the readable replacement.
+ * The headline number and the labeled "Units by period" bars live in one
+ * card: the big total sits above a divider, the per-bucket bars below it,
+ * so the number and its breakdown read as a single unit instead of a
+ * lonely full-width value stacked on a separate chart. The old inline hero
+ * sparkline (an axis-less curve that collapsed to a handful of points at
+ * any range) is gone — these readable, labeled bars are its replacement.
  */
 function OverviewTab() {
   const {translate} = useLocalize();
@@ -235,22 +237,27 @@ function OverviewTab() {
             delta={makeDelta(current.totalUnits, previous?.totalUnits ?? 0)}
             polarity="lower-is-supportive"
             isLoading={isLoading}
+            chart={
+              <View
+                style={{
+                  borderTopWidth: 1,
+                  borderTopColor: theme.border,
+                  paddingTop: 12,
+                }}>
+                <PeriodBarList
+                  points={subPeriods}
+                  granularity={granularity}
+                  accessibilityLabel={translate(
+                    'statistics.tabs.overview.texture.series.a11y',
+                  )}
+                  isLoading={isLoading}
+                />
+              </View>
+            }
           />
         </View>
 
-        <ChartCard
-          title={translate('statistics.tabs.overview.texture.series.title')}>
-          <PeriodBarList
-            points={subPeriods}
-            granularity={granularity}
-            accessibilityLabel={translate(
-              'statistics.tabs.overview.texture.series.a11y',
-            )}
-            isLoading={isLoading}
-          />
-        </ChartCard>
-
-        <View style={[styles.mb3, styles.mt2]}>
+        <View style={styles.mb3}>
           {sectionLabel('statistics.tabs.overview.sections.highlights')}
           <KpiCardGroup cards={winsCards} isLoading={isLoading} />
         </View>

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -13,7 +13,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOverviewTabData from '@hooks/useStatistics/useOverviewTabData';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type {ChartDatum} from '@libs/Statistics';
 
 type DeltaShape = NonNullable<KpiCardProps['delta']>;
 
@@ -25,9 +24,14 @@ function formatUnits(value: number): string {
 /**
  * Total-alcohol scorecard for the selected range. Reads the shared range +
  * comparison from the toolbar and tells a period story top-to-bottom:
- * verdict (units) → wins (restraint) → load (consumption) → risk (threshold
- * days) → texture (shape + intensity mix). Every tile carries a
- * previous-period delta when a comparison is active.
+ * verdict (units) → shape (units by period) → wins (restraint) → load
+ * (consumption) → risk (threshold days) → texture (intensity mix).
+ *
+ * The headline number is followed immediately by the labeled "Units by
+ * period" bar chart: it carries the same trajectory the old inline hero
+ * sparkline tried to show, but with readable per-bucket labels and values.
+ * The sparkline (an axis-less curve that collapsed to a handful of points
+ * at any range) is gone — the bar chart is the readable replacement.
  */
 function OverviewTab() {
   const {translate} = useLocalize();
@@ -85,11 +89,6 @@ function OverviewTab() {
     }
     return {value: diff, direction, label: vsPrevious};
   };
-
-  const sparkline: ChartDatum[] = subPeriods.map(point => ({
-    x: point.label,
-    y: point.units,
-  }));
 
   const winsCards: KpiCardProps[] = [
     {
@@ -234,25 +233,9 @@ function OverviewTab() {
             value={formatUnits(current.totalUnits)}
             unit={translate('statistics.tabs.overview.hero.unit')}
             delta={makeDelta(current.totalUnits, previous?.totalUnits ?? 0)}
-            sparkline={sparkline}
             polarity="lower-is-supportive"
             isLoading={isLoading}
           />
-        </View>
-
-        <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.highlights')}
-          <KpiCardGroup cards={winsCards} isLoading={isLoading} />
-        </View>
-
-        <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.consumption')}
-          <KpiCardGroup cards={loadCards} isLoading={isLoading} />
-        </View>
-
-        <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.heavyDays')}
-          <KpiCardGroup cards={riskCards} isLoading={isLoading} />
         </View>
 
         <ChartCard
@@ -266,6 +249,21 @@ function OverviewTab() {
             isLoading={isLoading}
           />
         </ChartCard>
+
+        <View style={[styles.mb3, styles.mt2]}>
+          {sectionLabel('statistics.tabs.overview.sections.highlights')}
+          <KpiCardGroup cards={winsCards} isLoading={isLoading} />
+        </View>
+
+        <View style={styles.mb3}>
+          {sectionLabel('statistics.tabs.overview.sections.consumption')}
+          <KpiCardGroup cards={loadCards} isLoading={isLoading} />
+        </View>
+
+        <View style={styles.mb3}>
+          {sectionLabel('statistics.tabs.overview.sections.heavyDays')}
+          <KpiCardGroup cards={riskCards} isLoading={isLoading} />
+        </View>
 
         <ChartCard
           title={translate(


### PR DESCRIPTION
## Statistics → Overview redesign — Version 1 of 5

The Overview tab opened with a hero KPI card carrying an **inline sparkline**: an axis-less line with no labels that collapsed to a handful of points at any selected range, so it was hard to read and told the user very little. This is one of **five alternative redesigns** of the first (Overview) tab, each on its own branch + PR so an ad-hoc iOS build can be compared side by side.

### What this version does
- **Removes the hero curve** entirely (the hero stops passing the `sparkline` prop).
- **Promotes the labeled "Units by period" bar chart** to sit directly under the headline number. It carries the same trajectory the sparkline tried to show, but with readable per-bucket labels and values.
- Keeps the rest of the scorecard story intact: Highlights → Consumption → Heavy days → day-intensity distribution.

### Why
Consumption shape is already covered well by the Trends tab and this bar chart, so nothing of value is lost by dropping the unreadable curve. Putting a *readable* chart where the curve used to be keeps the "here's your trajectory" beat without the legibility problem.

### Scope
Only `src/screens/Statistics/tabs/OverviewTab.tsx` is touched. **No shared chart components changed**, so the other tabs and the home screen are unaffected.

### The five versions
1. **v1 (this PR)** — chart-led: bar chart replaces the curve under the hero.
2. v2 — lean number-first scorecard (drops the per-period chart from Overview).
3. v3 — narrative headline (a computed plain-language sentence under the hero).
4. v4 — day-mix hero (day-intensity distribution bar promoted under the hero).
5. v5 — wins-forward reorder (Highlights first, heavy-days paired with the intensity bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEywsmE3aMybJNpNaocCkR)_