### PR TITLE
Stats Overview redesign v3: narrative headline replaces the hero curve

### DIFF
--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -21,6 +21,7 @@ import type {
   FriendRequestsCountParams,
   LastSessionSummaryParams,
   OnboardingStepCounterParams,
+  OverviewNarrativeParams,
   RelativeTimeAgoParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
@@ -1116,6 +1117,10 @@ export default {
         delta: {
           vsPrevious: 'vs předchozí',
         },
+        narrative: ({units, sessions, afDays, days}: OverviewNarrativeParams) =>
+          `${units} jednotek v ${sessions} ${
+            sessions === 1 ? 'relaci' : 'relacích'
+          }, z toho ${afDays} z ${days} dní bez alkoholu.`,
         sections: {
           highlights: 'Hlavní body',
           consumption: 'Konzumace',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -21,6 +21,7 @@ import type {
   FriendRequestsCountParams,
   LastSessionSummaryParams,
   OnboardingStepCounterParams,
+  OverviewNarrativeParams,
   RelativeTimeAgoParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,
@@ -1110,6 +1111,10 @@ export default {
         delta: {
           vsPrevious: 'vs previous',
         },
+        narrative: ({units, sessions, afDays, days}: OverviewNarrativeParams) =>
+          `${units} units across ${sessions} ${
+            sessions === 1 ? 'session' : 'sessions'
+          }, with ${afDays} of ${days} days alcohol-free.`,
         sections: {
           highlights: 'Highlights',
           consumption: 'Consumption',

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -63,6 +63,14 @@ type StatsThresholdParams = {
   threshold: number;
 };
 
+type OverviewNarrativeParams = {
+  /** Pre-formatted total units for the range (e.g. "12.5"). */
+  units: string;
+  sessions: number;
+  afDays: number;
+  days: number;
+};
+
 type StatsDrillDownTitleParams = {
   label: string;
 };
@@ -141,6 +149,7 @@ export type {
   FriendRequestsCountParams,
   LastSessionSummaryParams,
   OnboardingStepCounterParams,
+  OverviewNarrativeParams,
   RelativeTimeAgoParams,
   SessionConfirmTimezoneChangeParams,
   SessionStartTimeParams,

--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -13,7 +13,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOverviewTabData from '@hooks/useStatistics/useOverviewTabData';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type {ChartDatum} from '@libs/Statistics';
 
 type DeltaShape = NonNullable<KpiCardProps['delta']>;
 
@@ -25,9 +24,15 @@ function formatUnits(value: number): string {
 /**
  * Total-alcohol scorecard for the selected range. Reads the shared range +
  * comparison from the toolbar and tells a period story top-to-bottom:
- * verdict (units) → wins (restraint) → load (consumption) → risk (threshold
- * days) → texture (shape + intensity mix). Every tile carries a
- * previous-period delta when a comparison is active.
+ * verdict (units) → narrative (one plain-language line) → wins (restraint) →
+ * load (consumption) → risk (threshold days) → texture (shape + intensity).
+ *
+ * The hero's old inline sparkline (an axis-less curve with no labels that
+ * collapsed to a few points at any range) is replaced by a single computed
+ * sentence under the headline number. It names the things a curve never
+ * could — units, sessions, and alcohol-free days — so the period reads as a
+ * story before the tiles break it down. The labeled "Units by period" bar
+ * chart lower in the tab still carries the consumption shape.
  */
 function OverviewTab() {
   const {translate} = useLocalize();
@@ -85,11 +90,6 @@ function OverviewTab() {
     }
     return {value: diff, direction, label: vsPrevious};
   };
-
-  const sparkline: ChartDatum[] = subPeriods.map(point => ({
-    x: point.label,
-    y: point.units,
-  }));
 
   const winsCards: KpiCardProps[] = [
     {
@@ -221,6 +221,11 @@ function OverviewTab() {
     </Text>
   );
 
+  // One plain-language line that frames the period before the tiles break it
+  // down. Only shown when there's something to narrate; the all-AF case is
+  // covered by the dedicated footer below.
+  const showNarrative = !isLoading && current.sessions > 0;
+
   return (
     <View style={styles.flex1}>
       <StatsFilterToolbar showDrinkTypeFilter={false} />
@@ -234,10 +239,24 @@ function OverviewTab() {
             value={formatUnits(current.totalUnits)}
             unit={translate('statistics.tabs.overview.hero.unit')}
             delta={makeDelta(current.totalUnits, previous?.totalUnits ?? 0)}
-            sparkline={sparkline}
             polarity="lower-is-supportive"
             isLoading={isLoading}
           />
+          {showNarrative ? (
+            <Text
+              style={[
+                styles.textNormal,
+                styles.mt2,
+                {color: theme.textSupporting},
+              ]}>
+              {translate('statistics.tabs.overview.narrative', {
+                units: formatUnits(current.totalUnits),
+                sessions: current.sessions,
+                afDays: current.afDays,
+                days: current.elapsedDays,
+              })}
+            </Text>
+          ) : null}
         </View>
 
         <View style={styles.mb3}>


### PR DESCRIPTION
## Statistics → Overview redesign — Version 3 of 5

The Overview tab opened with a hero KPI card carrying an **inline sparkline**: an axis-less line with no labels that collapsed to a handful of points at any selected range. This is one of **five alternative redesigns** of the first (Overview) tab, each on its own branch + PR so an ad-hoc iOS build can be compared side by side.

### What this version does
- **Removes the hero curve** (the hero stops passing the `sparkline` prop).
- **Adds a single computed sentence** under the headline number that narrates the period: total units, sessions, and alcohol-free days out of the elapsed window. The period now reads as a *story* before the tiles break it down.
- Keeps the labeled "Units by period" bar chart and the day-intensity distribution where they were, so consumption shape is still covered.

### Why
A curve can't name *units*, *sessions*, or *alcohol-free days* — a sentence can. This trades an illegible visual for a plain-language hook that sets up the scorecard below it.

### i18n note
Adds one English string (`statistics.tabs.overview.narrative`) plus its param type. Non-English locales fall back to English at runtime until filled via the `translate` skill (no key-parity test or typecheck gate is affected). Czech can be filled in a follow-up.

### Scope
`src/screens/Statistics/tabs/OverviewTab.tsx`, plus the new English key in `src/languages/en.ts` and `src/languages/params.ts`. **No shared chart components changed.**

### The five versions
1. v1 — chart-led: bar chart replaces the curve under the hero.
2. v2 — lean number-first scorecard (drops the per-period chart from Overview).
3. **v3 (this PR)** — narrative headline (a computed plain-language sentence under the hero).
4. v4 — day-mix hero (day-intensity distribution bar promoted under the hero).
5. v5 — wins-forward reorder (Highlights first, heavy-days paired with the intensity bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEywsmE3aMybJNpNaocCkR)_