### PR TITLE
Stats Overview redesign v4: day-mix distribution bar as the hero visual

### DIFF
--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -13,7 +13,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOverviewTabData from '@hooks/useStatistics/useOverviewTabData';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type {ChartDatum} from '@libs/Statistics';
 
 type DeltaShape = NonNullable<KpiCardProps['delta']>;
 
@@ -25,9 +24,16 @@ function formatUnits(value: number): string {
 /**
  * Total-alcohol scorecard for the selected range. Reads the shared range +
  * comparison from the toolbar and tells a period story top-to-bottom:
- * verdict (units) → wins (restraint) → load (consumption) → risk (threshold
- * days) → texture (shape + intensity mix). Every tile carries a
- * previous-period delta when a comparison is active.
+ * verdict (units) → day mix (how the days split) → wins (restraint) → load
+ * (consumption) → risk (threshold days) → shape (units by period).
+ *
+ * The hero's old inline sparkline (an axis-less curve with no labels that
+ * collapsed to a few points at any range) is replaced as the at-a-glance
+ * visual by the day-intensity distribution bar, promoted to sit right under
+ * the headline number. The segmented bar is labeled and readable: it answers
+ * "how were my days?" instantly — alcohol-free vs light vs moderate vs heavy.
+ * The labeled "Units by period" bar chart still closes the tab with the
+ * consumption shape.
  */
 function OverviewTab() {
   const {translate} = useLocalize();
@@ -85,11 +91,6 @@ function OverviewTab() {
     }
     return {value: diff, direction, label: vsPrevious};
   };
-
-  const sparkline: ChartDatum[] = subPeriods.map(point => ({
-    x: point.label,
-    y: point.units,
-  }));
 
   const winsCards: KpiCardProps[] = [
     {
@@ -234,13 +235,25 @@ function OverviewTab() {
             value={formatUnits(current.totalUnits)}
             unit={translate('statistics.tabs.overview.hero.unit')}
             delta={makeDelta(current.totalUnits, previous?.totalUnits ?? 0)}
-            sparkline={sparkline}
             polarity="lower-is-supportive"
             isLoading={isLoading}
           />
         </View>
 
-        <View style={styles.mb3}>
+        <ChartCard
+          title={translate(
+            'statistics.tabs.overview.texture.distribution.title',
+          )}>
+          <DistributionBar
+            segments={distribution}
+            accessibilityLabel={translate(
+              'statistics.tabs.overview.texture.distribution.a11y',
+            )}
+            isLoading={isLoading}
+          />
+        </ChartCard>
+
+        <View style={[styles.mb3, styles.mt2]}>
           {sectionLabel('statistics.tabs.overview.sections.highlights')}
           <KpiCardGroup cards={winsCards} isLoading={isLoading} />
         </View>
@@ -262,19 +275,6 @@ function OverviewTab() {
             granularity={granularity}
             accessibilityLabel={translate(
               'statistics.tabs.overview.texture.series.a11y',
-            )}
-            isLoading={isLoading}
-          />
-        </ChartCard>
-
-        <ChartCard
-          title={translate(
-            'statistics.tabs.overview.texture.distribution.title',
-          )}>
-          <DistributionBar
-            segments={distribution}
-            accessibilityLabel={translate(
-              'statistics.tabs.overview.texture.distribution.a11y',
             )}
             isLoading={isLoading}
           />


### PR DESCRIPTION
## Statistics → Overview redesign — Version 4 of 5

The Overview tab opened with a hero KPI card carrying an **inline sparkline**: an axis-less line with no labels that collapsed to a handful of points at any selected range. This is one of **five alternative redesigns** of the first (Overview) tab, each on its own branch + PR so an ad-hoc iOS build can be compared side by side.

### What this version does
- **Removes the hero curve** (the hero stops passing the `sparkline` prop).
- **Promotes the day-intensity distribution bar** to sit directly under the headline number, as the tab's at-a-glance visual. The segmented, labeled bar answers "how were my days?" instantly: alcohol-free vs light vs moderate vs heavy.
- Keeps the labeled "Units by period" bar chart at the bottom for trajectory.

### Why
The distribution bar is already labeled and readable — unlike the curve — and it tells the most human version of the consumption story (what kind of days you had), making it a strong lead visual.

### Scope
Only `src/screens/Statistics/tabs/OverviewTab.tsx` is touched. **No shared chart components changed.**

### The five versions
1. v1 — chart-led: bar chart replaces the curve under the hero.
2. v2 — lean number-first scorecard (drops the per-period chart from Overview).
3. v3 — narrative headline (a computed plain-language sentence under the hero).
4. **v4 (this PR)** — day-mix hero (day-intensity distribution bar promoted under the hero).
5. v5 — wins-forward reorder (Highlights first, heavy-days paired with the intensity bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEywsmE3aMybJNpNaocCkR)_