### PR TITLE
Stats Overview redesign v5: wins-forward reorder (no hero curve)

### DIFF
--- a/src/screens/Statistics/tabs/OverviewTab.tsx
+++ b/src/screens/Statistics/tabs/OverviewTab.tsx
@@ -13,7 +13,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOverviewTabData from '@hooks/useStatistics/useOverviewTabData';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type {ChartDatum} from '@libs/Statistics';
 
 type DeltaShape = NonNullable<KpiCardProps['delta']>;
 
@@ -24,10 +23,17 @@ function formatUnits(value: number): string {
 
 /**
  * Total-alcohol scorecard for the selected range. Reads the shared range +
- * comparison from the toolbar and tells a period story top-to-bottom:
- * verdict (units) → wins (restraint) → load (consumption) → risk (threshold
- * days) → texture (shape + intensity mix). Every tile carries a
- * previous-period delta when a comparison is active.
+ * comparison from the toolbar and tells a period story with a wins-forward
+ * arc: verdict (units) → wins (restraint) → reality check (heavy days, then
+ * the day-intensity bar that pictures them) → load detail (consumption) →
+ * shape (units by period).
+ *
+ * The hero's old inline sparkline (an axis-less curve with no labels that
+ * collapsed to a few points at any range) is gone. Instead of leading with a
+ * chart, this version leads with the user's wins right under the headline
+ * number, then pairs the "heavy days" counts with the labeled day-intensity
+ * bar that visualizes them. The consumption detail and the "Units by period"
+ * shape close the tab, so nothing about consumption is lost.
  */
 function OverviewTab() {
   const {translate} = useLocalize();
@@ -85,11 +91,6 @@ function OverviewTab() {
     }
     return {value: diff, direction, label: vsPrevious};
   };
-
-  const sparkline: ChartDatum[] = subPeriods.map(point => ({
-    x: point.label,
-    y: point.units,
-  }));
 
   const winsCards: KpiCardProps[] = [
     {
@@ -234,7 +235,6 @@ function OverviewTab() {
             value={formatUnits(current.totalUnits)}
             unit={translate('statistics.tabs.overview.hero.unit')}
             delta={makeDelta(current.totalUnits, previous?.totalUnits ?? 0)}
-            sparkline={sparkline}
             polarity="lower-is-supportive"
             isLoading={isLoading}
           />
@@ -246,26 +246,9 @@ function OverviewTab() {
         </View>
 
         <View style={styles.mb3}>
-          {sectionLabel('statistics.tabs.overview.sections.consumption')}
-          <KpiCardGroup cards={loadCards} isLoading={isLoading} />
-        </View>
-
-        <View style={styles.mb3}>
           {sectionLabel('statistics.tabs.overview.sections.heavyDays')}
           <KpiCardGroup cards={riskCards} isLoading={isLoading} />
         </View>
-
-        <ChartCard
-          title={translate('statistics.tabs.overview.texture.series.title')}>
-          <PeriodBarList
-            points={subPeriods}
-            granularity={granularity}
-            accessibilityLabel={translate(
-              'statistics.tabs.overview.texture.series.a11y',
-            )}
-            isLoading={isLoading}
-          />
-        </ChartCard>
 
         <ChartCard
           title={translate(
@@ -275,6 +258,23 @@ function OverviewTab() {
             segments={distribution}
             accessibilityLabel={translate(
               'statistics.tabs.overview.texture.distribution.a11y',
+            )}
+            isLoading={isLoading}
+          />
+        </ChartCard>
+
+        <View style={[styles.mb3, styles.mt2]}>
+          {sectionLabel('statistics.tabs.overview.sections.consumption')}
+          <KpiCardGroup cards={loadCards} isLoading={isLoading} />
+        </View>
+
+        <ChartCard
+          title={translate('statistics.tabs.overview.texture.series.title')}>
+          <PeriodBarList
+            points={subPeriods}
+            granularity={granularity}
+            accessibilityLabel={translate(
+              'statistics.tabs.overview.texture.series.a11y',
             )}
             isLoading={isLoading}
           />


### PR DESCRIPTION
## Statistics → Overview redesign — Version 5 of 5

The Overview tab opened with a hero KPI card carrying an **inline sparkline**: an axis-less line with no labels that collapsed to a handful of points at any selected range. This is one of **five alternative redesigns** of the first (Overview) tab, each on its own branch + PR so an ad-hoc iOS build can be compared side by side.

### What this version does
- **Removes the hero curve** (the hero stops passing the `sparkline` prop).
- **Reorders the tab around a wins-forward arc:** after the headline number it leads with **Highlights** (restraint: alcohol-free days, dry streak), then pairs the **Heavy days** counts with the labeled **day-intensity bar** that visualizes exactly those days. **Consumption** detail and the **Units by period** shape close the tab.

### Why
Leading with wins (then a grounded reality-check that pairs the heavy-days numbers with the picture of those days) makes the tab feel encouraging and coherent, while still surfacing everything about consumption further down.

### Scope
Only `src/screens/Statistics/tabs/OverviewTab.tsx` is touched. **No shared chart components changed.**

### The five versions
1. v1 — chart-led: bar chart replaces the curve under the hero.
2. v2 — lean number-first scorecard (drops the per-period chart from Overview).
3. v3 — narrative headline (a computed plain-language sentence under the hero).
4. v4 — day-mix hero (day-intensity distribution bar promoted under the hero).
5. **v5 (this PR)** — wins-forward reorder (Highlights first, heavy-days paired with the intensity bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEywsmE3aMybJNpNaocCkR)_