### PR TITLE
feat(stats): frame alcohol-free-days chart against an ideal-pace envelope (option 1 of 3)

### DIFF
--- a/__tests__/unit/Statistics/trends/afCumulative.test.ts
+++ b/__tests__/unit/Statistics/trends/afCumulative.test.ts
@@ -2,7 +2,9 @@
  * @jest-environment node
  */
 
-import buildAfCumulativeSeries from '@libs/Statistics/trends/afCumulative';
+import buildAfCumulativeSeries, {
+  summarizeAfCumulative,
+} from '@libs/Statistics/trends/afCumulative';
 import type {DrinkEvent} from '@libs/Statistics';
 
 function event(localDay: string): DrinkEvent {
@@ -74,5 +76,39 @@ describe('buildAfCumulativeSeries', () => {
       '2026-01-01',
       '2026-01-02',
     ]);
+  });
+});
+
+describe('summarizeAfCumulative', () => {
+  test('reports all zeros for an empty series', () => {
+    expect(summarizeAfCumulative([])).toEqual({
+      afDays: 0,
+      totalDays: 0,
+      ratePct: 0,
+    });
+  });
+
+  test('reads AF-days off the final point and computes the rate', () => {
+    const series = buildAfCumulativeSeries(
+      [event('2026-05-02'), event('2026-05-03')],
+      new Date('2026-05-01T00:00:00.000Z'),
+      new Date('2026-05-04T00:00:00.000Z'),
+    );
+    // 4 days in the window, 2 with drinks -> 2 alcohol-free days (50%).
+    expect(summarizeAfCumulative(series)).toEqual({
+      afDays: 2,
+      totalDays: 4,
+      ratePct: 50,
+    });
+  });
+
+  test('rounds the percentage to a whole number', () => {
+    const series = buildAfCumulativeSeries(
+      [event('2026-05-01')],
+      new Date('2026-05-01T00:00:00.000Z'),
+      new Date('2026-05-03T00:00:00.000Z'),
+    );
+    // 2 alcohol-free of 3 days -> 66.67% -> 67%.
+    expect(summarizeAfCumulative(series).ratePct).toBe(67);
   });
 });

--- a/src/components/Charts/CumulativeLine/CumulativeLine.tsx
+++ b/src/components/Charts/CumulativeLine/CumulativeLine.tsx
@@ -1,6 +1,11 @@
 import {useMemo} from 'react';
 import {DashPathEffect} from '@shopify/react-native-skia';
-import {BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
+import {
+  Area,
+  BaseChart,
+  Line,
+  useChartFont,
+} from '@components/Charts/BaseChart';
 import {
   roundTick,
   valueTicks,
@@ -13,6 +18,13 @@ type CumulativeLineProps = {
   points: CumulativeLinePoint[];
   /** Parallel-indexed comparison series; omit to hide. */
   comparisonPoints?: CumulativeLinePoint[];
+  /**
+   * Draw the "ideal pace" envelope — the count the line would hit if every
+   * elapsed day were alcohol-free (i.e. `index + 1`). It rises as a straight
+   * ramp to the top-right; the actual line rides below it, so the gap between
+   * the two reads directly as "days you drank". Off by default.
+   */
+  showIdeal?: boolean;
   accessibilityLabel: string;
   emptyLabel?: string;
   height?: number;
@@ -20,7 +32,7 @@ type CumulativeLineProps = {
   isLoading?: boolean;
 };
 
-type CumulativeRow = {x: number; y: number; cmp: number};
+type CumulativeRow = {x: number; y: number; cmp: number; ideal: number};
 
 const COMPARISON_DASH: number[] = [4, 4];
 
@@ -29,10 +41,17 @@ const COMPARISON_DASH: number[] = [4, 4];
  * whole selected range without resetting at year boundaries, so the series
  * handed in is monotonically non-decreasing and the line only ever climbs
  * from the bottom-left to the top-right.
+ *
+ * On its own that line is hard to read — a perfect period and a heavy-drinking
+ * period both slope up, just at different angles. With `showIdeal` the chart
+ * also fills the "if every day were alcohol-free" envelope behind the line, so
+ * the empty wedge above the actual line is exactly the drinking days and the
+ * picture finally moves with behaviour instead of only ever climbing.
  */
 function CumulativeLine({
   points,
   comparisonPoints,
+  showIdeal = false,
   accessibilityLabel,
   emptyLabel,
   height,
@@ -47,15 +66,19 @@ function CumulativeLine({
       points.map((p, i) => ({
         x: i,
         y: p.count,
-        cmp: showComparison ? comparisonPoints?.[i]?.count ?? 0 : 0,
+        cmp: showComparison ? (comparisonPoints?.[i]?.count ?? 0) : 0,
+        // The most AF-days reachable by day `i` is `i + 1` (every day counts).
+        ideal: i + 1,
       })),
     [points, comparisonPoints, showComparison],
   );
 
-  const yKeys = useMemo<ReadonlyArray<'y' | 'cmp'>>(
-    () => (showComparison ? ['y', 'cmp'] : ['y']),
-    [showComparison],
-  );
+  const yKeys = useMemo<ReadonlyArray<'y' | 'cmp' | 'ideal'>>(() => {
+    const keys: Array<'y' | 'cmp' | 'ideal'> = ['y'];
+    if (showIdeal) keys.push('ideal');
+    if (showComparison) keys.push('cmp');
+    return keys;
+  }, [showIdeal, showComparison]);
 
   const maxCount = useMemo(() => {
     let max = 1;
@@ -66,9 +89,13 @@ function CumulativeLine({
       if (showComparison && row.cmp > max) {
         max = row.cmp;
       }
+      // The ideal ramp tops out at the day count, so it sets the ceiling.
+      if (showIdeal && row.ideal > max) {
+        max = row.ideal;
+      }
     }
     return max;
-  }, [data, showComparison]);
+  }, [data, showComparison, showIdeal]);
 
   const dateTicks = useMemo(
     () =>
@@ -97,8 +124,16 @@ function CumulativeLine({
         formatYLabel: roundTick,
       }}
       loading={isLoading}>
-      {({points: linePoints, theme}) => (
+      {({points: linePoints, chartBounds, theme}) => (
         <>
+          {showIdeal ? (
+            <Area
+              points={linePoints.ideal}
+              y0={chartBounds.bottom}
+              color={theme.bandFill}
+              animate={{type: 'timing', duration: 200}}
+            />
+          ) : null}
           <Line
             points={linePoints.y}
             color={theme.primaryStroke}

--- a/src/hooks/useStatistics/useTrendsTabData.ts
+++ b/src/hooks/useStatistics/useTrendsTabData.ts
@@ -6,8 +6,12 @@ import {
   buildWeeklyStackedSeries,
   buildWeeklyUnits,
   shiftRange,
+  summarizeAfCumulative,
 } from '@libs/Statistics/trends';
-import type {AfCumulativePoint} from '@libs/Statistics/trends';
+import type {
+  AfCumulativePoint,
+  AfCumulativeSummary,
+} from '@libs/Statistics/trends';
 import useStatsContext from '@hooks/useStatsContext';
 import CONST from '@src/CONST';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
@@ -36,6 +40,7 @@ type TrendsTabData = {
   afCumulative: {
     points: AfCumulativePoint[];
     comparisonPoints?: AfCumulativePoint[];
+    summary: AfCumulativeSummary;
     hidden: boolean;
   };
   stack: Stack;
@@ -125,9 +130,14 @@ function useTrendsTabData(): TrendsTabData {
   const afCumulative = useMemo(() => {
     const hidden = range.preset === 'W';
     if (hidden) {
-      return {points: [] as AfCumulativePoint[], hidden};
+      return {
+        points: [] as AfCumulativePoint[],
+        summary: {afDays: 0, totalDays: 0, ratePct: 0},
+        hidden,
+      };
     }
     const points = buildAfCumulativeSeries(events, range.start, range.end);
+    const summary = summarizeAfCumulative(points);
     let comparisonPoints: AfCumulativePoint[] | undefined;
     if (comparisonRange) {
       const raw = buildAfCumulativeSeries(
@@ -152,7 +162,7 @@ function useTrendsTabData(): TrendsTabData {
         comparisonPoints = [...pad, ...raw];
       }
     }
-    return {points, comparisonPoints, hidden};
+    return {points, comparisonPoints, summary, hidden};
   }, [events, range.start, range.end, range.preset, comparisonRange]);
 
   // Drink-type stacked area.

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -36,6 +36,7 @@ import type {
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
   WeekOfParams,
+  AfCumulativeSummaryParams,
 } from './params';
 
 export default {
@@ -1186,6 +1187,9 @@ export default {
         cumulativeAf: {
           title: 'Dny bez alkoholu v čase',
           emptyLabel: 'Každý den bez alkoholu se počítá.',
+          idealLegend: 'Kdyby byl každý den bez alkoholu',
+          summary: ({afDays, totalDays, ratePct}: AfCumulativeSummaryParams) =>
+            `Bez alkoholu ${afDays} z ${totalDays} dní (${ratePct} %).`,
         },
         drinkTypeStack: {
           title: 'Mix drinků v čase',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -36,6 +36,7 @@ import type {
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
   WeekOfParams,
+  AfCumulativeSummaryParams,
 } from './params';
 
 export default {
@@ -1180,6 +1181,9 @@ export default {
         cumulativeAf: {
           title: 'Alcohol-free days over time',
           emptyLabel: 'Every alcohol-free day adds up.',
+          idealLegend: 'If every day were alcohol-free',
+          summary: ({afDays, totalDays, ratePct}: AfCumulativeSummaryParams) =>
+            `Alcohol-free ${afDays} of ${totalDays} days (${ratePct}%).`,
         },
         drinkTypeStack: {
           title: 'Drink mix over time',

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -71,6 +71,12 @@ type WeekOfParams = {
   date: string;
 };
 
+type AfCumulativeSummaryParams = {
+  afDays: number;
+  totalDays: number;
+  ratePct: number;
+};
+
 type UnitCountParams = {
   unitCount: number;
 };
@@ -148,6 +154,7 @@ export type {
   StatsDrillDownTitleParams,
   StatsThresholdParams,
   WeekOfParams,
+  AfCumulativeSummaryParams,
   SupporterCancelledStatusParams,
   SupporterPriceParams,
   SupporterPurchaseCtaParams,

--- a/src/libs/Statistics/trends/afCumulative.ts
+++ b/src/libs/Statistics/trends/afCumulative.ts
@@ -6,6 +6,15 @@ type AfCumulativePoint = {
   count: number;
 };
 
+type AfCumulativeSummary = {
+  /** Alcohol-free days in the window (the final cumulative count). */
+  afDays: number;
+  /** Total elapsed days in the window. */
+  totalDays: number;
+  /** Alcohol-free share of the window, 0–100, rounded to a whole percent. */
+  ratePct: number;
+};
+
 /**
  * Cumulative alcohol-free-days series over the inclusive window
  * `[start, end]`. The counter accumulates across the entire window and never
@@ -51,5 +60,21 @@ function buildAfCumulativeSeries(
   return out;
 }
 
+/**
+ * Collapse a cumulative AF-days series into headline numbers for the chart
+ * caption: how many of the window's days were alcohol-free, and what share
+ * that is. The final point already holds the running total, so this is an O(1)
+ * read of the tail rather than a re-scan. An empty series reports all zeros.
+ */
+function summarizeAfCumulative(
+  points: AfCumulativePoint[],
+): AfCumulativeSummary {
+  const totalDays = points.length;
+  const afDays = totalDays > 0 ? points[totalDays - 1].count : 0;
+  const ratePct = totalDays > 0 ? Math.round((afDays / totalDays) * 100) : 0;
+  return {afDays, totalDays, ratePct};
+}
+
 export default buildAfCumulativeSeries;
-export type {AfCumulativePoint};
+export {summarizeAfCumulative};
+export type {AfCumulativePoint, AfCumulativeSummary};

--- a/src/libs/Statistics/trends/index.ts
+++ b/src/libs/Statistics/trends/index.ts
@@ -1,5 +1,8 @@
-export {default as buildAfCumulativeSeries} from './afCumulative';
-export type {AfCumulativePoint} from './afCumulative';
+export {
+  default as buildAfCumulativeSeries,
+  summarizeAfCumulative,
+} from './afCumulative';
+export type {AfCumulativePoint, AfCumulativeSummary} from './afCumulative';
 export {default as buildWeeklyUnits} from './weeklyUnits';
 export type {WeeklyUnitsPoint} from './weeklyUnits';
 export {default as buildWeeklyStackedSeries} from './weeklyStacked';

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -85,15 +85,29 @@ function TrendsTab() {
           <ChartCard
             title={translate('statistics.tabs.trends.cumulativeAf.title')}
             footer={
-              afCumulative.comparisonPoints ? (
+              <View style={{rowGap: 4}}>
+                {afCumulative.summary.totalDays > 0 ? (
+                  <Text style={themeStyles.textMicroSupporting}>
+                    {translate(
+                      'statistics.tabs.trends.cumulativeAf.summary',
+                      afCumulative.summary,
+                    )}
+                  </Text>
+                ) : null}
                 <Text style={themeStyles.textMicroSupporting}>
-                  {comparisonLegend}
+                  {translate('statistics.tabs.trends.cumulativeAf.idealLegend')}
                 </Text>
-              ) : undefined
+                {afCumulative.comparisonPoints ? (
+                  <Text style={themeStyles.textMicroSupporting}>
+                    {comparisonLegend}
+                  </Text>
+                ) : null}
+              </View>
             }>
             <CumulativeLine
               points={afCumulative.points}
               comparisonPoints={afCumulative.comparisonPoints}
+              showIdeal
               emptyLabel={translate(
                 'statistics.tabs.trends.cumulativeAf.emptyLabel',
               )}


### PR DESCRIPTION
## Why

In **Statistics → Trends**, the *"Alcohol-free days over time"* chart is a bare cumulative line. Because the counter never resets, the line **only ever climbs**: a perfect period and a heavy-drinking period both slope up, just at different angles. In practice the picture barely moves with behaviour, and the *only* thing that visibly bends the line is drinking (it flattens). That's a perverse read of a sobriety chart.

This is **option 1 of 3** the user asked for: *improve the current chart in place*, rather than replace it. The two replacements are separate PRs:
- Weekly alcohol-free days bars
- Rolling 30-day alcohol-free rate (%)

## What this PR does

Keeps the cumulative line but gives it a frame of reference:

- **Ideal-pace envelope.** Fills the "if every day were alcohol-free" curve (`index + 1`) behind the actual line. The empty wedge between the line and the top of the envelope is *exactly* the drinking days, so the gap **widens when you drink and closes when you abstain** — the chart finally responds to abstinence, not only to drinking.
- **Headline caption.** "Alcohol-free N of M days (P%)" via a small pure `summarizeAfCumulative` helper, plus an ideal-pace legend line.

## Implementation notes

- `summarizeAfCumulative` is an O(1) tail read (the last point already holds the running total) with unit-test coverage.
- `CumulativeLine` gains an opt-in `showIdeal` prop; the comparison-period line still works alongside it.
- English keys added to `en.ts`; `cs_cz` filled via the `translate` skill against its glossary. Translation parity test passes.

## Checks run locally

- `npm run typecheck-tsgo` ✅
- `npx jest __tests__/unit/Statistics/trends/afCumulative.test.ts` ✅ (incl. new summary tests)
- `npx jest __tests__/unit/Translate.test.ts` ✅ (key parity)
- React Compiler compliance check ✅
- Prettier + ESLint on changed files ✅

`Ready To Build - iOS` label applied so an ad-hoc build spins up for comparison against the other two options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWmB2fxUwJQUZ1wPwCb4o9)_