### PR TITLE
feat(stats): weekly alcohol-free-days bars (option 2 of 3)

### DIFF
--- a/__tests__/unit/Statistics/trends/weeklyAfDays.test.ts
+++ b/__tests__/unit/Statistics/trends/weeklyAfDays.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import buildWeeklyAfDays, {
+  summarizeWeeklyAfDays,
+} from '@libs/Statistics/trends/weeklyAfDays';
+import type {DrinkEvent} from '@libs/Statistics';
+
+function event(localDay: string): DrinkEvent {
+  const ts = new Date(`${localDay}T12:00:00.000Z`).getTime();
+  return {
+    userId: 'u1',
+    sessionId: 's1',
+    ts,
+    anchorTs: ts,
+    localDay,
+    localIsoWeek: '2026-W01',
+    localMonth: localDay.slice(0, 7),
+    localHour: 12,
+    localDow: 0,
+    isWeekend: false,
+    drinkKey: 'beer',
+    count: 1,
+    units: 1,
+    blackoutSession: false,
+  };
+}
+
+// 2026-05-04 is a Monday, so 05-04..05-10 and 05-11..05-17 are two whole ISO
+// weeks — convenient for asserting per-week buckets without boundary effects.
+describe('buildWeeklyAfDays', () => {
+  test('returns empty array when end is before start', () => {
+    expect(
+      buildWeeklyAfDays([], new Date('2026-05-05'), new Date('2026-05-04')),
+    ).toEqual([]);
+  });
+
+  test('buckets alcohol-free days into their ISO week (out of 7)', () => {
+    const out = buildWeeklyAfDays(
+      [event('2026-05-05'), event('2026-05-06'), event('2026-05-12')],
+      new Date('2026-05-04T00:00:00.000Z'),
+      new Date('2026-05-17T00:00:00.000Z'),
+    );
+    expect(out).toHaveLength(2);
+    // Week A: 2 drinking days -> 5 AF; week B: 1 drinking day -> 6 AF.
+    expect(out.map(p => p.afDays)).toEqual([5, 6]);
+    expect(out.map(p => p.daysInRange)).toEqual([7, 7]);
+  });
+
+  test('boundary weeks report only the days inside the window', () => {
+    const out = buildWeeklyAfDays(
+      [],
+      new Date('2026-05-06T00:00:00.000Z'),
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
+    // Week A keeps Wed..Sun (5 days), week B keeps Mon..Tue (2 days).
+    expect(out.map(p => p.daysInRange)).toEqual([5, 2]);
+    expect(out.map(p => p.afDays)).toEqual([5, 2]);
+  });
+});
+
+describe('summarizeWeeklyAfDays', () => {
+  test('reports all zeros for an empty series', () => {
+    expect(summarizeWeeklyAfDays([])).toEqual({
+      afDays: 0,
+      totalDays: 0,
+      ratePct: 0,
+    });
+  });
+
+  test('sums across weeks and rounds the rate', () => {
+    const series = buildWeeklyAfDays(
+      [event('2026-05-05'), event('2026-05-06'), event('2026-05-12')],
+      new Date('2026-05-04T00:00:00.000Z'),
+      new Date('2026-05-17T00:00:00.000Z'),
+    );
+    // 11 alcohol-free of 14 days -> 78.57% -> 79%.
+    expect(summarizeWeeklyAfDays(series)).toEqual({
+      afDays: 11,
+      totalDays: 14,
+      ratePct: 79,
+    });
+  });
+});

--- a/src/components/Charts/BaseChart/BaseChart.tsx
+++ b/src/components/Charts/BaseChart/BaseChart.tsx
@@ -42,6 +42,7 @@ function BaseChart<TYKey extends string = 'y'>({
   height = DEFAULT_HEIGHT,
   hideAxes = false,
   axis,
+  domainY,
   loading = false,
   children,
 }: BaseChartProps<TYKey>) {
@@ -132,7 +133,8 @@ function BaseChart<TYKey extends string = 'y'>({
           xKey="x"
           yKeys={castedYKeys as never}
           axisOptions={axisOptions}
-          domainPadding={domainPadding}>
+          domainPadding={domainPadding}
+          domain={domainY ? {y: domainY} : undefined}>
           {ctx =>
             children?.({...ctx, theme} as unknown as ChartRenderCtx<TYKey>)
           }

--- a/src/components/Charts/BaseChart/types.ts
+++ b/src/components/Charts/BaseChart/types.ts
@@ -82,6 +82,13 @@ type BaseChartProps<TYKey extends string = 'y'> = {
   /** Optional axis customization. When omitted, axis behavior is unchanged. */
   axis?: ChartAxisOptions;
   /**
+   * Pin the y-axis to a fixed `[min, max]` instead of letting victory derive
+   * `[0, dataMax]` from the data. Use for charts whose axis carries meaning
+   * independent of the data range (e.g. days out of 7). When omitted, the
+   * domain auto-fits the data as before.
+   */
+  domainY?: [number, number];
+  /**
    * When true, short-circuits to a layout-faithful skeleton matching
    * `height` instead of rendering the Skia canvas. Used during the
    * Statistics first-paint window so the tab transition stays on a single

--- a/src/components/Charts/WeeklyAfBars/WeeklyAfBars.tsx
+++ b/src/components/Charts/WeeklyAfBars/WeeklyAfBars.tsx
@@ -85,6 +85,7 @@ function WeeklyAfBars({
       accessibilityLabel={accessibilityLabel}
       emptyLabel={emptyLabel}
       height={height}
+      domainY={[0, DAYS_PER_WEEK]}
       axis={{
         font: axisFont,
         tickValues: {x: dateTicks.indices, y: yTicks},

--- a/src/components/Charts/WeeklyAfBars/WeeklyAfBars.tsx
+++ b/src/components/Charts/WeeklyAfBars/WeeklyAfBars.tsx
@@ -1,0 +1,118 @@
+import {useMemo} from 'react';
+import {DashPathEffect} from '@shopify/react-native-skia';
+import {Bar, BaseChart, Line, useChartFont} from '@components/Charts/BaseChart';
+import {
+  roundTick,
+  valueTicks,
+} from '@components/Charts/BaseChart/axisFormatters';
+import buildDateTicks from '@components/Charts/BaseChart/dateTicks';
+
+type WeeklyAfBarsProps = {
+  /** ISO-week labels, one per bar. Drives the x-axis order. */
+  weeks: string[];
+  /** Alcohol-free days per week (0–7), length === weeks.length. */
+  afDays: number[];
+  /** Comparison-period AF-days, parallel-indexed; omit to hide. */
+  comparison?: number[];
+  accessibilityLabel: string;
+  emptyLabel?: string;
+  height?: number;
+  /** When true, shows the BaseChart skeleton instead of the bars. */
+  isLoading?: boolean;
+};
+
+type WeeklyAfRow = {x: number; y: number; cmp: number};
+
+const COMPARISON_DASH: number[] = [4, 4];
+/** A week has at most 7 days; pin the axis there so a full week is a full bar. */
+const DAYS_PER_WEEK = 7;
+
+/**
+ * Alcohol-free days per week. Where the cumulative line only ever climbs, these
+ * bars stand on their own: a drinking week is a short bar, an abstinent week is
+ * a tall (up to 7) one, so the chart responds to both relapse and recovery. The
+ * y-axis is pinned to 7 so bar height reads as "days out of the week".
+ *
+ * An optional dashed comparison line traces the previous period's weekly
+ * AF-days. Callers zero-fill missing series upstream so the chart never ingests
+ * NaN.
+ */
+function WeeklyAfBars({
+  weeks,
+  afDays,
+  comparison,
+  accessibilityLabel,
+  emptyLabel,
+  height,
+  isLoading,
+}: WeeklyAfBarsProps) {
+  const axisFont = useChartFont();
+  const showComparison =
+    !!comparison && comparison.length === weeks.length && weeks.length > 0;
+
+  const data = useMemo<WeeklyAfRow[]>(
+    () =>
+      weeks.map((w, i) => ({
+        x: i,
+        y: afDays[i] ?? 0,
+        cmp: showComparison ? comparison?.[i] ?? 0 : 0,
+      })),
+    [weeks, afDays, comparison, showComparison],
+  );
+
+  const yKeys = useMemo<ReadonlyArray<'y' | 'cmp'>>(
+    () => (showComparison ? ['y', 'cmp'] : ['y']),
+    [showComparison],
+  );
+
+  const dateTicks = useMemo(
+    () =>
+      buildDateTicks({
+        firstKey: weeks[0] ?? '',
+        lastKey: weeks[weeks.length - 1] ?? '',
+        length: weeks.length,
+        unit: 'week',
+      }),
+    [weeks],
+  );
+  const yTicks = useMemo(() => valueTicks(DAYS_PER_WEEK), []);
+
+  return (
+    <BaseChart
+      data={data}
+      yKeys={yKeys}
+      range="rolling8w"
+      accessibilityLabel={accessibilityLabel}
+      emptyLabel={emptyLabel}
+      height={height}
+      axis={{
+        font: axisFont,
+        tickValues: {x: dateTicks.indices, y: yTicks},
+        formatXLabel: dateTicks.labelFor,
+        formatYLabel: roundTick,
+      }}
+      loading={isLoading}>
+      {({points, chartBounds, theme}) => (
+        <>
+          <Bar
+            points={points.y}
+            chartBounds={chartBounds}
+            color={theme.primaryFill}
+            roundedCorners={{topLeft: 3, topRight: 3}}
+          />
+          {showComparison ? (
+            <Line
+              points={points.cmp}
+              color={theme.comparisonStroke}
+              strokeWidth={1.5}>
+              <DashPathEffect intervals={COMPARISON_DASH} />
+            </Line>
+          ) : null}
+        </>
+      )}
+    </BaseChart>
+  );
+}
+
+export default WeeklyAfBars;
+export type {WeeklyAfBarsProps};

--- a/src/components/Charts/WeeklyAfBars/index.ts
+++ b/src/components/Charts/WeeklyAfBars/index.ts
@@ -1,0 +1,2 @@
+export {default as WeeklyAfBars} from './WeeklyAfBars';
+export type {WeeklyAfBarsProps} from './WeeklyAfBars';

--- a/src/hooks/useStatistics/useTrendsTabData.ts
+++ b/src/hooks/useStatistics/useTrendsTabData.ts
@@ -2,12 +2,13 @@ import {useMemo} from 'react';
 import {DRINK_KEY_COLORS} from '@libs/Statistics/drinkKeyMeta';
 import {ewma, mannKendall} from '@libs/Statistics/stats';
 import {
-  buildAfCumulativeSeries,
+  buildWeeklyAfDays,
   buildWeeklyStackedSeries,
   buildWeeklyUnits,
   shiftRange,
+  summarizeWeeklyAfDays,
 } from '@libs/Statistics/trends';
-import type {AfCumulativePoint} from '@libs/Statistics/trends';
+import type {WeeklyAfDaysSummary} from '@libs/Statistics/trends';
 import useStatsContext from '@hooks/useStatsContext';
 import CONST from '@src/CONST';
 import type {DrinkKey} from '@src/types/onyx/Drinks';
@@ -31,13 +32,17 @@ type Stack = {
   comparisonTotal?: number[];
 };
 
+type WeeklyAf = {
+  weeks: string[];
+  afDays: number[];
+  comparison?: number[];
+  summary: WeeklyAfDaysSummary;
+  hidden: boolean;
+};
+
 type TrendsTabData = {
   hero: Hero;
-  afCumulative: {
-    points: AfCumulativePoint[];
-    comparisonPoints?: AfCumulativePoint[];
-    hidden: boolean;
-  };
+  weeklyAf: WeeklyAf;
   stack: Stack;
   isLoading: boolean;
 };
@@ -52,8 +57,8 @@ const ALL_DRINK_KEYS: readonly DrinkKey[] = Object.values(CONST.DRINKS.KEYS);
  * once, then derives:
  *
  *   - Hero weekly-units series (raw + EWMA + band + Mann–Kendall caption).
- *   - Cumulative AF-days series over the range (and its comparison twin when
- *     enabled).
+ *   - Weekly alcohol-free-days series over the range (and its comparison twin
+ *     when enabled).
  *   - Per-DrinkKey weekly stack (respecting the active `drinkTypeFilter`).
  *
  * All series are zero-filled and index-aligned with their comparison
@@ -121,38 +126,46 @@ function useTrendsTabData(): TrendsTabData {
     };
   }, [events, range.start, range.end, comparisonRange]);
 
-  // Cumulative AF-days.
-  const afCumulative = useMemo(() => {
+  // Weekly alcohol-free days.
+  const weeklyAf = useMemo<WeeklyAf>(() => {
+    // A single week of bars is trivial; keep this chart for the longer presets.
     const hidden = range.preset === 'W';
     if (hidden) {
-      return {points: [] as AfCumulativePoint[], hidden};
+      return {
+        weeks: [],
+        afDays: [],
+        summary: {afDays: 0, totalDays: 0, ratePct: 0},
+        hidden,
+      };
     }
-    const points = buildAfCumulativeSeries(events, range.start, range.end);
-    let comparisonPoints: AfCumulativePoint[] | undefined;
+
+    const points = buildWeeklyAfDays(events, range.start, range.end);
+    const weeks = points.map(p => p.isoWeek);
+    const afDays = points.map(p => p.afDays);
+    const summary = summarizeWeeklyAfDays(points);
+
+    let comparisonAf: number[] | undefined;
     if (comparisonRange) {
-      const raw = buildAfCumulativeSeries(
+      const raw = buildWeeklyAfDays(
         events,
         comparisonRange.start,
         comparisonRange.end,
-      );
-      // Pad to match `points.length` so the chart layer can index in lock-
-      // step. Drop oldest or pad with the leading count, mirroring the hero
-      // alignment policy.
-      if (raw.length === points.length) {
-        comparisonPoints = raw;
-      } else if (raw.length > points.length) {
-        comparisonPoints = raw.slice(raw.length - points.length);
-      } else if (raw.length > 0) {
-        const padCount = points.length - raw.length;
-        const head = raw[0];
-        const pad: AfCumulativePoint[] = Array.from(
-          {length: padCount},
-          () => head,
-        );
-        comparisonPoints = [...pad, ...raw];
+      ).map(p => p.afDays);
+      // Pad / trim to match weeks.length so the chart can index by position,
+      // mirroring the hero alignment policy.
+      if (raw.length === weeks.length) {
+        comparisonAf = raw;
+      } else if (raw.length > weeks.length) {
+        comparisonAf = raw.slice(raw.length - weeks.length);
+      } else {
+        comparisonAf = [
+          ...new Array<number>(weeks.length - raw.length).fill(0),
+          ...raw,
+        ];
       }
     }
-    return {points, comparisonPoints, hidden};
+
+    return {weeks, afDays, comparison: comparisonAf, summary, hidden};
   }, [events, range.start, range.end, range.preset, comparisonRange]);
 
   // Drink-type stacked area.
@@ -217,8 +230,8 @@ function useTrendsTabData(): TrendsTabData {
     };
   }, [events, range.start, range.end, drinkTypeFilter, comparisonRange]);
 
-  return {hero, afCumulative, stack, isLoading};
+  return {hero, weeklyAf, stack, isLoading};
 }
 
 export default useTrendsTabData;
-export type {CaptionKey, Hero, Stack, TrendsTabData};
+export type {CaptionKey, Hero, Stack, TrendsTabData, WeeklyAf};

--- a/src/languages/cs_cz.ts
+++ b/src/languages/cs_cz.ts
@@ -36,6 +36,7 @@ import type {
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
   WeekOfParams,
+  WeeklyAfDaysSummaryParams,
 } from './params';
 
 export default {
@@ -1183,9 +1184,12 @@ export default {
               'Pokračujte v zaznamenávání. Trend se ukáže, až bude víc dat.',
           },
         },
-        cumulativeAf: {
-          title: 'Dny bez alkoholu v čase',
-          emptyLabel: 'Každý den bez alkoholu se počítá.',
+        weeklyAf: {
+          title: 'Dny bez alkoholu každý týden',
+          emptyLabel:
+            'Vaše týdny bez alkoholu se ukážou, jak budou přibývat data.',
+          summary: ({afDays, totalDays, ratePct}: WeeklyAfDaysSummaryParams) =>
+            `Bez alkoholu ${afDays} z ${totalDays} dní (${ratePct} %).`,
         },
         drinkTypeStack: {
           title: 'Mix drinků v čase',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -36,6 +36,7 @@ import type {
   UpdateEmailSentEmailParams,
   VerifyEmailScreenEmailParmas,
   WeekOfParams,
+  WeeklyAfDaysSummaryParams,
 } from './params';
 
 export default {
@@ -1177,9 +1178,11 @@ export default {
               'Keep logging. Your trend will surface as data builds.',
           },
         },
-        cumulativeAf: {
-          title: 'Alcohol-free days over time',
-          emptyLabel: 'Every alcohol-free day adds up.',
+        weeklyAf: {
+          title: 'Alcohol-free days each week',
+          emptyLabel: 'Your alcohol-free weeks will show as data builds.',
+          summary: ({afDays, totalDays, ratePct}: WeeklyAfDaysSummaryParams) =>
+            `Alcohol-free ${afDays} of ${totalDays} days (${ratePct}%).`,
         },
         drinkTypeStack: {
           title: 'Drink mix over time',

--- a/src/languages/params.ts
+++ b/src/languages/params.ts
@@ -71,6 +71,12 @@ type WeekOfParams = {
   date: string;
 };
 
+type WeeklyAfDaysSummaryParams = {
+  afDays: number;
+  totalDays: number;
+  ratePct: number;
+};
+
 type UnitCountParams = {
   unitCount: number;
 };
@@ -148,6 +154,7 @@ export type {
   StatsDrillDownTitleParams,
   StatsThresholdParams,
   WeekOfParams,
+  WeeklyAfDaysSummaryParams,
   SupporterCancelledStatusParams,
   SupporterPriceParams,
   SupporterPurchaseCtaParams,

--- a/src/libs/Statistics/trends/index.ts
+++ b/src/libs/Statistics/trends/index.ts
@@ -2,6 +2,11 @@ export {default as buildAfCumulativeSeries} from './afCumulative';
 export type {AfCumulativePoint} from './afCumulative';
 export {default as buildWeeklyUnits} from './weeklyUnits';
 export type {WeeklyUnitsPoint} from './weeklyUnits';
+export {
+  default as buildWeeklyAfDays,
+  summarizeWeeklyAfDays,
+} from './weeklyAfDays';
+export type {WeeklyAfDaysPoint, WeeklyAfDaysSummary} from './weeklyAfDays';
 export {default as buildWeeklyStackedSeries} from './weeklyStacked';
 export type {StackedWeek} from './weeklyStacked';
 export {default as percentileBand} from './percentileBand';

--- a/src/libs/Statistics/trends/weeklyAfDays.ts
+++ b/src/libs/Statistics/trends/weeklyAfDays.ts
@@ -1,0 +1,93 @@
+import {addDays, format, startOfDay} from 'date-fns';
+import type {DrinkEvent} from '@libs/Statistics/types';
+import {formatIsoWeek, weekKeysInRange} from './weeks';
+
+type WeeklyAfDaysPoint = {
+  isoWeek: string;
+  /** Alcohol-free days in this ISO week that fall inside the window. 0–7. */
+  afDays: number;
+  /** Days of this ISO week that fall inside the window. 1–7. */
+  daysInRange: number;
+};
+
+type WeeklyAfDaysSummary = {
+  /** Alcohol-free days across the whole window. */
+  afDays: number;
+  /** Total elapsed days across the whole window. */
+  totalDays: number;
+  /** Alcohol-free share of the window, 0–100, rounded to a whole percent. */
+  ratePct: number;
+};
+
+/**
+ * Alcohol-free days bucketed per ISO week over the inclusive window
+ * `[start, end]`. Unlike the cumulative series (which only ever climbs), each
+ * week stands on its own: a heavy week is a short bar, an abstinent week is a
+ * tall one, so the chart moves in both directions and a relapse is as visible
+ * as a streak.
+ *
+ * Every ISO week the window touches is emitted exactly once (gap-filled and
+ * index-aligned with {@link weekKeysInRange}), so the "vs previous period"
+ * comparison series lines up row-by-row. Boundary weeks that only partly
+ * overlap the window report `daysInRange < 7`; the chart caps the axis at 7 so
+ * a full alcohol-free week always reads as a full bar.
+ *
+ * Reads `localDay` directly to avoid re-deriving the session timezone here.
+ */
+function buildWeeklyAfDays(
+  events: DrinkEvent[],
+  start: Date,
+  end: Date,
+): WeeklyAfDaysPoint[] {
+  const startDay = startOfDay(start);
+  const endDay = startOfDay(end);
+  if (endDay.getTime() < startDay.getTime()) {
+    return [];
+  }
+
+  const eventDays = new Set<string>();
+  for (const event of events) {
+    eventDays.add(event.localDay);
+  }
+
+  const afByWeek = new Map<string, number>();
+  const daysByWeek = new Map<string, number>();
+  let cursor = startDay;
+  while (cursor.getTime() <= endDay.getTime()) {
+    const dayKey = format(cursor, 'yyyy-MM-dd');
+    const weekKey = formatIsoWeek(cursor);
+    daysByWeek.set(weekKey, (daysByWeek.get(weekKey) ?? 0) + 1);
+    if (!eventDays.has(dayKey)) {
+      afByWeek.set(weekKey, (afByWeek.get(weekKey) ?? 0) + 1);
+    }
+    cursor = addDays(cursor, 1);
+  }
+
+  return weekKeysInRange(start, end).map(isoWeek => ({
+    isoWeek,
+    afDays: afByWeek.get(isoWeek) ?? 0,
+    daysInRange: daysByWeek.get(isoWeek) ?? 0,
+  }));
+}
+
+/**
+ * Collapse the weekly AF-days series into headline numbers for the chart
+ * caption: how many of the window's days were alcohol-free, and what share
+ * that is. An empty series reports all zeros.
+ */
+function summarizeWeeklyAfDays(
+  points: WeeklyAfDaysPoint[],
+): WeeklyAfDaysSummary {
+  let afDays = 0;
+  let totalDays = 0;
+  for (const point of points) {
+    afDays += point.afDays;
+    totalDays += point.daysInRange;
+  }
+  const ratePct = totalDays > 0 ? Math.round((afDays / totalDays) * 100) : 0;
+  return {afDays, totalDays, ratePct};
+}
+
+export default buildWeeklyAfDays;
+export {summarizeWeeklyAfDays};
+export type {WeeklyAfDaysPoint, WeeklyAfDaysSummary};

--- a/src/screens/Statistics/tabs/TrendsTab.tsx
+++ b/src/screens/Statistics/tabs/TrendsTab.tsx
@@ -1,9 +1,9 @@
 import React, {useMemo} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {ChartCard} from '@components/Charts/ChartCard';
-import {CumulativeLine} from '@components/Charts/CumulativeLine';
 import {StackedArea} from '@components/Charts/StackedArea';
 import {TrendLine, WeeklyTrendLegend} from '@components/Charts/TrendLine';
+import {WeeklyAfBars} from '@components/Charts/WeeklyAfBars';
 import ScrollView from '@components/ScrollView';
 import StatsFilterToolbar from '@components/Statistics/StatsFilterToolbar';
 import Text from '@components/Text';
@@ -33,7 +33,7 @@ const CAPTION_KEYS: Record<string, TranslationPaths> = {
 function TrendsTab() {
   const {translate} = useLocalize();
   const themeStyles = useThemeStyles();
-  const {hero, afCumulative, stack, isLoading} = useTrendsTabData();
+  const {hero, weeklyAf, stack, isLoading} = useTrendsTabData();
   const {openDrillDown} = useStatsDrillDown();
 
   const heroComparisonShown = !!hero.comparison;
@@ -81,24 +81,35 @@ function TrendsTab() {
           />
         </ChartCard>
 
-        {afCumulative.hidden ? null : (
+        {weeklyAf.hidden ? null : (
           <ChartCard
-            title={translate('statistics.tabs.trends.cumulativeAf.title')}
+            title={translate('statistics.tabs.trends.weeklyAf.title')}
             footer={
-              afCumulative.comparisonPoints ? (
-                <Text style={themeStyles.textMicroSupporting}>
-                  {comparisonLegend}
-                </Text>
-              ) : undefined
+              <View style={{rowGap: 4}}>
+                {weeklyAf.summary.totalDays > 0 ? (
+                  <Text style={themeStyles.textMicroSupporting}>
+                    {translate(
+                      'statistics.tabs.trends.weeklyAf.summary',
+                      weeklyAf.summary,
+                    )}
+                  </Text>
+                ) : null}
+                {weeklyAf.comparison ? (
+                  <Text style={themeStyles.textMicroSupporting}>
+                    {comparisonLegend}
+                  </Text>
+                ) : null}
+              </View>
             }>
-            <CumulativeLine
-              points={afCumulative.points}
-              comparisonPoints={afCumulative.comparisonPoints}
+            <WeeklyAfBars
+              weeks={weeklyAf.weeks}
+              afDays={weeklyAf.afDays}
+              comparison={weeklyAf.comparison}
               emptyLabel={translate(
-                'statistics.tabs.trends.cumulativeAf.emptyLabel',
+                'statistics.tabs.trends.weeklyAf.emptyLabel',
               )}
               accessibilityLabel={translate(
-                'statistics.tabs.trends.cumulativeAf.title',
+                'statistics.tabs.trends.weeklyAf.title',
               )}
               isLoading={isLoading}
             />


### PR DESCRIPTION
## Why

In **Statistics → Trends**, the *"Alcohol-free days over time"* chart is a cumulative line. Because the counter never resets it **only ever climbs**, so the picture barely moves with behaviour and the *only* thing that visibly bends it is drinking (it flattens). That's a perverse read of a sobriety chart.

This is **option 2 of 3** the user asked for, and the **first of two replacements**. It swaps the cumulative line for a per-week bar chart.

Companion PRs:
- Option 1 (improve in place): ideal-pace envelope on the existing line — #1431
- Option 3 (second replacement): rolling 30-day alcohol-free rate (%)

## What this PR does

**Alcohol-free days each week** — one bar per ISO week, 0–7, with the axis pinned to 7:

- A drinking week is a short bar; an abstinent week is a full bar. The chart now responds to **both relapse and recovery** — a streak is as legible as a slip, and abstinence finally moves the picture.
- Optional dashed comparison line (previous period), consistent with the other Trends charts.
- Headline caption reports the period total: "Alcohol-free N of M days (P%)".

## Implementation notes

- New `buildWeeklyAfDays` / `summarizeWeeklyAfDays` builders — gap-filled and index-aligned with `weekKeysInRange` so the comparison series lines up row-by-row. Boundary weeks report `daysInRange < 7` honestly. Unit-tested.
- New `WeeklyAfBars` component built on the shared `BaseChart` (Victory/Skia), mirroring the existing `TrendLine` bar pattern.
- `useTrendsTabData` now exposes `weeklyAf` in place of `afCumulative`; `TrendsTab` renders the new card in the same slot.
- English keys in `en.ts`; `cs_cz` filled via the `translate` skill. Parity test passes.
- The old `CumulativeLine` component is left in the tree (unused here) so the three option PRs stay independent; whichever option wins, cleanup is trivial.

## Checks run locally

- `npm run typecheck-tsgo` ✅
- `npx jest __tests__/unit/Statistics/trends/weeklyAfDays.test.ts __tests__/unit/Translate.test.ts` ✅
- React Compiler compliance check ✅
- Prettier + ESLint on changed files ✅ (incl. no-shadow fix)

`Ready To Build - iOS` label applied so an ad-hoc build spins up for comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWmB2fxUwJQUZ1wPwCb4o9)_