### PR TITLE
docs(watch): Apple Watch MVP scope + Phase 0 data-path spike

### DIFF
--- a/docs/apple-watch-mvp.md
+++ b/docs/apple-watch-mvp.md
@@ -1,0 +1,206 @@
+# Apple Watch app — MVP scope & task list
+
+> Status: **planning / Phase 0 spike in progress.** This doc is the canonical
+> reference for the watchOS companion effort. Each phase below is spun off into
+> its own session/worktree; this doc is the shared contract between them.
+
+## Verdict
+
+Feasible, and the backend side is **easier now than when the watch was first
+scaffolded** — the client long since migrated off direct Firebase RTDB writes to
+a clean kiroku-api REST contract. The existing watch code
+([`ios/Kiroku Watch App/`](../ios/Kiroku%20Watch%20App/)) is a **UI mock-up
+disconnected from everything** (in-memory `SessionModel`, every Firebase/Auth
+line commented out, no WatchConnectivity, orphaned from the build). Realistic
+shape: **keep the SwiftUI views as a visual starting point, rebuild the target
+wiring from scratch, and add a small native networking + credential-bridge
+layer.**
+
+T-shirt size: **M** for a "remote control while the phone is nearby" MVP; **L**
+for a phone-free standalone logger (adds backend token-minting + on-watch
+Firebase).
+
+## What exists today (audit)
+
+- ~674 lines of SwiftUI: start-session, unit selection (beer/wine/cocktail/shot/
+  other), session control (save/discard), settings, EN+CZ translations, icons.
+- **No state, no network, no persistence.** `SessionModel` is an in-memory
+  counter; `SessionViewModel` has a literal `// communication with database
+here` TODO. All Firebase/Auth/Database/AppDelegate code is commented out.
+- **No WatchConnectivity (WCSession)** on either side.
+- **Not in the Podfile** → the watch target has no Firebase SDK.
+- **Orphaned from the build.** The real iOS app target is `kiroku` (lowercase);
+  all three schemes build only `kiroku` + `kirokuTests`. The watch app is
+  embedded solely in a legacy capital-`Kiroku` `watchapp2-container` wrapper that
+  no scheme builds. It has **never shipped** — no review liability, but reviving
+  it means re-wiring into `kiroku` essentially from scratch.
+- Bundle id is still the RN template default
+  (`org.reactjs.native.example.alcohol-tracker.watch`); the watch provisioning
+  profiles in `ios/` are 2–3 years old → expired.
+
+## Confirmed API contract (what the watch must replicate)
+
+The current data path, verified against `src/libs/`:
+
+- **Endpoints:** `POST /v1/sessions/update` (start / add units / save) and
+  `POST /v1/sessions/delete` (discard). Defined in
+  [`src/libs/API/kirokuRoutes.ts`](../src/libs/API/kirokuRoutes.ts).
+- **Auth:** a **Firebase ID token** as `Authorization: Bearer <token>` on every
+  call ([`src/libs/HttpUtils.ts`](../src/libs/HttpUtils.ts)). Auto-refresh on
+  `407`, forced sign-out on `401`.
+- **Base URL:** `https://api.kiroku.cz` (prod) / `https://api-dev.kiroku.cz`
+  (dev) — [`src/CONFIG.ts`](../src/CONFIG.ts).
+- **Request body:** plain JSON, `Content-Type: application/json`. For a session
+  write the body is literally `{ sessionId, session, sessionIsLive }`; discard is
+  `{ sessionId, sessionIsLive }`.
+- **Session id:** `generatePushID()` — Firebase push-id (20 chars, timestamp-
+  prefixed, lexicographically sortable). Algorithm in
+  [`src/libs/generatePushID.ts`](../src/libs/generatePushID.ts); a ~40-line Swift
+  port gives the watch compatible ids.
+- **Session shape**
+  ([`src/types/onyx/DrinkingSession.ts`](../src/types/onyx/DrinkingSession.ts) /
+  `getEmptySession` in
+  [`src/libs/DrinkingSessionUtils.ts`](../src/libs/DrinkingSessionUtils.ts)):
+  `id`, `start_time`, `end_time`, `blackout`, `note`, `timezone`, `type`
+  (`'live'`), `ongoing` (`true`), and `drinks` =
+  `Record<Timestamp, Record<DrinkKey, number>>` (drink keys: `small_beer`,
+  `beer`, `cocktail`, `wine`, `strong_shot`, `weak_shot`, `other`).
+- **Firebase is auth-only.** No RTDB on the session write path.
+
+A runnable, documented reproduction of this exact contract lives in
+[`scripts/watch-spike/`](../scripts/watch-spike/) (Phase 0).
+
+## MVP definition
+
+A wrist remote that talks to the real kiroku-api: **start a live session →
++1 / −1 a unit → save or discard**, posting directly to the API. The auth token
+is handed over from the signed-in phone via WatchConnectivity. It works whenever
+the phone has been recently active and **degrades gracefully** ("Open Kiroku on
+your phone") when the token is stale.
+
+**Big simplification:** because the MVP gets its token from the phone, the watch
+never signs in itself → **no Firebase SDK, no Podfile change, no
+GoogleService-Info on the watch.** It is a pure `URLSession` + `WCSession` app.
+
+### Architecture decision
+
+The watch is an **independent API client** (talks to kiroku-api directly over its
+own network); WCSession is used only to hand the credential + the current
+ongoing-session snapshot from phone to watch. This avoids the React Native
+background-execution trap (a relay model would require running JS in the
+background to perform writes, which iOS does not reliably allow).
+
+### Explicitly NOT in this MVP
+
+Each is a real follow-on, deliberately deferred:
+
+- Backend custom-token endpoint / true cellular-standalone use.
+- On-watch offline queue.
+- **Real-time** cross-device live-unit streaming — the phone reflects the watch's
+  session on its next session read (eventual consistency). This matches the known
+  unsolved increment (#947).
+- Complications / widgets.
+- Drink-type richness beyond the single default unit.
+
+## Task list
+
+Each phase is an independently spawnable unit (its own worktree/session). The
+critical path is **0 → 1 → 2 → 3**; Phases 5–7 overlap once the bridge works.
+
+### Phase 0 — Spike: prove the data path (½–1 day) ← in progress
+
+- [ ] **0.1** From [`scripts/watch-spike/post-session.mjs`](../scripts/watch-spike/post-session.mjs),
+      with a dev account's Firebase ID token, `POST /v1/sessions/update`
+      (`sessionIsLive: true`) to `api-dev`, then `/v1/sessions/delete`.
+  - **Accept:** the session shows up in the phone app (dev account) and discard
+    removes it. Validates envelope + push-id format + server acceptance before
+    any Xcode work.
+
+### Phase 1 — Target & build wiring (1–2 days)
+
+- [ ] **1.1** Delete the dead wiring: the orphaned capital-`Kiroku`
+      `watchapp2-container` target, its "Embed Watch Content" phase, and the stale
+      `KirokuWatch*.mobileprovision.gpg` profiles.
+- [ ] **1.2** Add a fresh modern watchOS App target embedded in `kiroku`. Import
+      the existing `.swift` files as source. Real bundle id
+      (`org.reactjs.native.example.alcohol-tracker.watchkitapp`),
+      `WKCompanionAppBundleIdentifier` → the app, watchOS deploy target 10.2+.
+- [ ] **1.3** Add the watch to all three schemes (dev/AdHoc/production) so it
+      archives with the app.
+  - **Accept:** the watch app builds + runs in the simulator paired with `kiroku`;
+    a production-scheme archive embeds it.
+
+### Phase 2 — Watch networking + models, pure Swift (2–3 days)
+
+- [ ] **2.1** Codable models mirroring `DrinkingSession`
+      (`drinks` = `[Timestamp: [DrinkKey: Int]]`).
+- [ ] **2.2** PushID generator — port `generatePushID()` to Swift.
+- [ ] **2.3** `KirokuAPI` client: `URLSession` JSON POST, `Bearer` header,
+      dev/prod base URL, map 407/401/network to typed results.
+- [ ] **2.4** Operations: `start`, `update` (whole-session PUT), `save`,
+      `discard`, hitting the two endpoints.
+  - **Accept:** a unit test round-trips a session against `api-dev` with a pasted
+    token.
+
+### Phase 3 — Credential bridge (3–4 days — the meatiest piece)
+
+- [ ] **3.1** RN iOS native module `WatchBridge` exposing
+      `updateCredential({ idToken, uid, expiresAt, ongoingSession })` to JS; holds the
+      latest and pushes to the watch via `WCSession.updateApplicationContext`.
+- [ ] **3.2** JS wiring: call `WatchBridge.updateCredential(...)` whenever a fresh
+      token exists — on app foreground, after login, after the 407 refresh in
+      `HttpUtils.ts`, and on `ONGOING_SESSION_DATA` change.
+- [ ] **3.3** Watch `SessionConnectivity` (`WCSession` delegate): receive
+      credential + ongoing snapshot, cache the token in Keychain, expose it +
+      staleness to the view model.
+- [ ] **3.4** Token lifecycle: use the cached token until `expiresAt`/`401`; when
+      stale, surface "Open Kiroku on your phone to reconnect."
+  - **Accept:** sign in on phone → watch receives a token within seconds → a
+    watch-initiated start/save succeeds with no token pasted anywhere.
+
+### Phase 4 — Wire the UI to a real view model (1–2 days)
+
+- [ ] **4.1** Replace the in-memory `SessionModel`/`SessionViewModel` with one
+      backed by `KirokuAPI` + `SessionConnectivity`; reflect the ongoing session
+      pushed from the phone.
+- [ ] **4.2** Loading / no-active-session / disconnected states, haptic on tap,
+      inline error on failed write.
+  - **Accept:** full happy path on a real paired device: start → +1 ×3 → save, all
+    visible in the phone app after sync; discard path too.
+
+### Phase 5 — Sync & conflict handling (1–2 days)
+
+- [ ] **5.1** Adopt the phone's ongoing session id when one is active (log into
+      the _same_ session, no duplicate); only mint a new id when nothing is active.
+- [ ] **5.2** Coalesce taps — debounce rapid +/− into one `update` (mirror the
+      app's ~500ms persist); last-writer-wins on the whole-session PUT.
+- [ ] **5.3** Save/discard clears live status server-side; confirm the phone
+      reflects it on next session read.
+  - **Accept:** starting on phone then bumping on watch updates one session, not
+    two; rapid taps don't spam the API.
+
+### Phase 6 — Signing, CI, store plumbing (1–2 days)
+
+- [ ] **6.1** Register the watch App ID + provisioning profiles (use the
+      `ios-signing` skill); re-encrypt into `ios/`. No GoogleService-Info / Firebase
+      pod needed (token comes from the phone).
+- [ ] **6.2** Fastlane: sign + embed the watch in the dev/adhoc/prod lanes;
+      green test build.
+- [ ] **6.3** Store metadata: watch screenshots + App Store watch listing fields.
+
+### Phase 7 — QA matrix (1 day)
+
+- [ ] **7.1** Cross-product: phone foreground / background / force-quit; watch in
+      BT range vs not; token fresh vs stale/expired; each of start/+/−/save/discard;
+      airplane mode on the watch.
+  - **Accept:** every cell is correct or shows the right graceful-degradation
+    message — no silent data loss.
+
+## Sizing & risks
+
+- **Walking skeleton** (Phases 0–4 happy path): ~3–5 focused days.
+- **Polished, signed, store-ready MVP:** ~2–3 weeks of solo work.
+- **Critical path:** 0 → 1 → 2 → 3.
+- **Top risks:** the credential bridge (Phase 3) is the only genuinely new
+  pattern; real-time phone reflection is deliberately deferred (#947).
+- **Recommendation:** keep off the launch critical path; land as a fast-follow.

--- a/scripts/watch-spike/README.md
+++ b/scripts/watch-spike/README.md
@@ -1,0 +1,57 @@
+# Apple Watch — Phase 0 spike
+
+Proves the watchOS **data path** before any Xcode/Swift work: it posts a live
+drinking session to kiroku-api exactly as the future watch client will, then
+deletes it. If this round-trips, the request envelope, push-id format, and
+server acceptance are all validated — the only remaining unknown for the watch is
+plumbing (target wiring + the credential bridge), not the contract.
+
+This script is the **executable spec** of the contract Phase 2 reimplements in
+Swift. See [`docs/apple-watch-mvp.md`](../../docs/apple-watch-mvp.md) for the full
+scope.
+
+## Run it
+
+Requires Node 18+ (global `fetch`). No dependencies.
+
+```bash
+# Dev (default): create a 2-unit live session, then delete it.
+node scripts/watch-spike/post-session.mjs --token "<FIREBASE_ID_TOKEN>"
+
+# Keep the session so the phone app can display it (manual confirm).
+node scripts/watch-spike/post-session.mjs --token "<TOKEN>" --units 3 --keep
+
+# Help.
+node scripts/watch-spike/post-session.mjs --help
+```
+
+You can also pass the token via the `KIROKU_ID_TOKEN` env var instead of
+`--token`. The token is never logged.
+
+## Getting a Firebase ID token (dev account)
+
+The token is a short-lived (~1h) Firebase ID token for a **dev** account. Easiest
+ways to grab one:
+
+- **From the running web app** (`npm run web`, dev backend): sign in, then in the
+  browser console run
+  `await firebase.auth().currentUser.getIdToken()` (or grab the `Authorization:
+Bearer …` header off any `api-dev.kiroku.cz` request in the Network tab).
+- **From a signed-in simulator/device:** copy the `Authorization` header from any
+  outbound kiroku-api request (Charles/Proxyman, or a temporary log in
+  `HttpUtils.ts`).
+
+Tokens expire after ~1 hour — if you see a `401`/`407`, grab a fresh one.
+
+## Acceptance (Phase 0)
+
+- `--keep` run returns `2xx` on `/v1/sessions/update`, **and** the session shows
+  up in the phone app for the same dev account as a live session.
+- Default run reports `✓ Round-trip OK: create + delete both succeeded.`
+
+## What this does NOT prove
+
+- Token **refresh** on the watch (Phase 3) — this uses a hand-grabbed token.
+- The WCSession credential handover (Phase 3).
+- The Swift port of `generatePushID` / the models (Phase 2) — this is the JS
+  reference they must match.

--- a/scripts/watch-spike/post-session.mjs
+++ b/scripts/watch-spike/post-session.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/* eslint-disable no-bitwise */
+/**
+ * Kiroku Apple Watch — Phase 0 spike (zero-dependency).
+ *
+ * Proves the watchOS data path WITHOUT any Xcode/Swift work: it reproduces the
+ * exact request the watch will send, posting a live drinking session to
+ * kiroku-api the same way the app does, then (by default) deleting it again.
+ *
+ * This is the executable spec of the contract the native watch client must
+ * replicate in Phase 2. It mirrors:
+ *   - `generatePushID()`            (src/libs/generatePushID.ts)      → session id
+ *   - `getEmptySession()`           (src/libs/DrinkingSessionUtils.ts)→ session body
+ *   - `UPDATE_SESSION`/`DELETE_SESSION` routes (src/libs/API/kirokuRoutes.ts)
+ *   - the `Authorization: Bearer <idToken>` + JSON body from HttpUtils.ts
+ *
+ * Requires Node 18+ (global fetch). No npm dependencies.
+ *
+ * Usage:
+ *   node scripts/watch-spike/post-session.mjs --token <FIREBASE_ID_TOKEN>
+ *   node scripts/watch-spike/post-session.mjs --env prod --units 3 --keep
+ *
+ * The token is a short-lived (~1h) Firebase ID token for a DEV account. See the
+ * README in this folder for how to grab one. Pass it via --token or the
+ * KIROKU_ID_TOKEN env var. The token is never logged.
+ */
+
+import {randomBytes} from 'node:crypto';
+import process from 'node:process';
+
+const API_ROOTS = {
+  dev: 'https://api-dev.kiroku.cz',
+  prod: 'https://api.kiroku.cz',
+};
+
+const DRINK_KEYS = [
+  'small_beer',
+  'beer',
+  'cocktail',
+  'wine',
+  'strong_shot',
+  'weak_shot',
+  'other',
+];
+
+// ---------------------------------------------------------------------------
+// generatePushID — faithful port of src/libs/generatePushID.ts
+// ---------------------------------------------------------------------------
+
+const PUSH_CHARS =
+  '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+let lastPushTime = 0;
+const lastRandChars = new Array(12).fill(0);
+
+function rerollRandChars() {
+  const bytes = randomBytes(9);
+  for (let i = 0; i < 12; i++) {
+    const bitPos = i * 6;
+    const bytePos = bitPos >> 3;
+    const bitOffset = bitPos & 7;
+    const hi = bytes[bytePos];
+    const lo = bytePos + 1 < bytes.length ? bytes[bytePos + 1] : 0;
+    const bits = (hi << 8) | lo;
+    lastRandChars[i] = (bits >> (10 - bitOffset)) & 0x3f;
+  }
+}
+
+function generatePushID() {
+  let now = Date.now();
+  const duplicateTime = now === lastPushTime;
+  lastPushTime = now;
+
+  const timeStampChars = new Array(8);
+  for (let i = 7; i >= 0; i--) {
+    timeStampChars[i] = PUSH_CHARS.charAt(now % 64);
+    now = Math.floor(now / 64);
+  }
+  if (now !== 0) {
+    throw new Error('generatePushID: timestamp did not fully convert');
+  }
+
+  let id = timeStampChars.join('');
+
+  if (!duplicateTime) {
+    rerollRandChars();
+  } else {
+    let i = 11;
+    for (; i >= 0 && lastRandChars[i] === 63; i--) {
+      lastRandChars[i] = 0;
+    }
+    if (i >= 0) {
+      lastRandChars[i]++;
+    } else {
+      rerollRandChars();
+    }
+  }
+
+  for (let i = 0; i < 12; i++) {
+    id += PUSH_CHARS.charAt(lastRandChars[i]);
+  }
+
+  if (id.length !== 20) {
+    throw new Error('generatePushID: generated id length is not 20');
+  }
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {env: 'dev', units: 2, keep: false, drink: 'beer'};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--token') {
+      args.token = argv[++i];
+    } else if (a === '--env') {
+      args.env = argv[++i];
+    } else if (a === '--units') {
+      args.units = Number(argv[++i]);
+    } else if (a === '--drink') {
+      args.drink = argv[++i];
+    } else if (a === '--keep') {
+      args.keep = true;
+    } else if (a === '--help' || a === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function usage() {
+  console.log(`Kiroku Apple Watch — Phase 0 spike
+
+Posts a live drinking session to kiroku-api exactly as the watch will, then
+deletes it (unless --keep).
+
+Options:
+  --token <idToken>   Firebase ID token (DEV account). Or set KIROKU_ID_TOKEN.
+  --env dev|prod      API environment (default: dev).
+  --units <n>         Number of units to log (default: 2).
+  --drink <key>       Drink key (default: beer). One of:
+                      ${DRINK_KEYS.join(', ')}.
+  --keep              Do NOT delete the session afterwards (leave it for the
+                      phone app to display).
+  -h, --help          Show this help.`);
+}
+
+/** Build a session body equivalent to getEmptySession(...) + drinks. */
+function buildSession(sessionId, units, drinkKey) {
+  const now = Date.now();
+  const drinks = {};
+  if (units > 0) {
+    // The app groups drinks by timestamp; one bucket at "now" is enough here.
+    drinks[String(now)] = {[drinkKey]: units};
+  }
+  return {
+    id: sessionId,
+    start_time: now,
+    end_time: now,
+    blackout: false,
+    note: '',
+    timezone: 'Europe/Prague',
+    type: 'live',
+    ongoing: true,
+    ...(units > 0 ? {drinks} : {}),
+  };
+}
+
+async function postJson(root, path, token, body) {
+  const res = await fetch(`${root}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  let parsed;
+  const text = await res.text();
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    parsed = text;
+  }
+  return {status: res.status, body: parsed};
+}
+
+function explainAuthFailure(status) {
+  if (status === 401) {
+    return 'HTTP 401 — the token is revoked/invalid. Grab a fresh one.';
+  }
+  if (status === 407) {
+    return 'jsonCode/HTTP 407 — the ID token is expired (they last ~1h). Grab a fresh one.';
+  }
+  return null;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    usage();
+    return;
+  }
+
+  const token = args.token || process.env.KIROKU_ID_TOKEN;
+  if (!token) {
+    console.error(
+      'Missing token. Pass --token <idToken> or set KIROKU_ID_TOKEN.\n',
+    );
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+  const root = API_ROOTS[args.env];
+  if (!root) {
+    console.error(`Unknown --env "${args.env}". Use "dev" or "prod".`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!DRINK_KEYS.includes(args.drink)) {
+    console.error(
+      `Unknown --drink "${args.drink}". One of: ${DRINK_KEYS.join(', ')}.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (args.env === 'prod') {
+    console.warn('⚠️  Targeting PRODUCTION. This writes a real session.\n');
+  }
+
+  const sessionId = generatePushID();
+  const session = buildSession(sessionId, args.units, args.drink);
+
+  console.log(`→ env=${args.env}  root=${root}`);
+  console.log(`→ sessionId=${sessionId}  units=${args.units} ${args.drink}`);
+  console.log('→ POST /v1/sessions/update  (sessionIsLive: true)');
+
+  const update = await postJson(root, '/v1/sessions/update', token, {
+    sessionId,
+    session,
+    sessionIsLive: true,
+  });
+  console.log(`  ← ${update.status}`, JSON.stringify(update.body));
+
+  const authMsg = explainAuthFailure(update.status);
+  if (authMsg) {
+    console.error(`\n✗ ${authMsg}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (update.status < 200 || update.status >= 300) {
+    console.error('\n✗ update failed — see response above.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('\n✓ Session created.');
+  if (args.keep) {
+    console.log(
+      `Kept session ${sessionId}. Open the phone app (same account) to confirm ` +
+        'it appears as a live session, then discard it from the app.',
+    );
+    return;
+  }
+
+  console.log('→ POST /v1/sessions/delete  (cleanup)');
+  const del = await postJson(root, '/v1/sessions/delete', token, {
+    sessionId,
+    sessionIsLive: true,
+  });
+  console.log(`  ← ${del.status}`, JSON.stringify(del.body));
+  if (del.status < 200 || del.status >= 300) {
+    console.error(
+      `\n⚠️  delete failed — session ${sessionId} may still exist. Remove it from the app.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\n✓ Round-trip OK: create + delete both succeeded.');
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err?.message ?? err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Kicks off the Apple Watch companion effort with the **scope doc** and **Phase 0 spike** (the data-path proof). No app/runtime code changes — docs + a standalone script.

### `docs/apple-watch-mvp.md`
Canonical reference for the watchOS effort:
- **Verdict & audit** — the existing `ios/Kiroku Watch App/` is a UI mock-up disconnected from everything (in-memory state, all Firebase commented out, no WatchConnectivity) and **orphaned from the build** (embedded only in a legacy `watchapp2-container` wrapper no scheme builds → never shipped).
- **Confirmed API contract** — the watch data path verified against `src/libs/`: `POST /v1/sessions/update` & `/delete`, Firebase ID token as `Authorization: Bearer`, plain-JSON `{sessionId, session, sessionIsLive}` body, `generatePushID()` ids.
- **MVP** — independent API client on the watch + a WCSession credential bridge from the phone (avoids the RN background-execution trap). No Firebase SDK on the watch.
- **Phased task list** — critical path 0→1→2→3, with sizing and an explicit "NOT in MVP" list.

### `scripts/watch-spike/` (Phase 0)
A zero-dependency Node CLI that reproduces the watch's request **before any Xcode work**: faithful `generatePushID` port + `getEmptySession` body, posts a live session, then deletes it. It's the executable spec Phase 2 reimplements in Swift.

## How to validate (Phase 0 acceptance)

Requires a dev-account Firebase ID token (see `scripts/watch-spike/README.md`):

\`\`\`bash
node scripts/watch-spike/post-session.mjs --token "<DEV_ID_TOKEN>" --keep
\`\`\`

**Accept:** returns `2xx` and the session appears in the phone app (same dev account) as a live session. The default (no `--keep`) run also exercises delete and reports a clean round-trip.

> I couldn't run the round-trip end-to-end here (no signed-in dev credential in this session). Syntax, `--help`, and the missing-token guard are smoke-tested; the live round-trip is the one manual step.

## Not in this PR
The native watch implementation (Phases 1–7) — tracked as separate tasks per the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)