### PR TITLE
feat(watch): pure-Swift networking + models for Apple Watch (Phase 2)

### DIFF
--- a/ios/KirokuWatchCore/.gitignore
+++ b/ios/KirokuWatchCore/.gitignore
@@ -1,0 +1,4 @@
+# SwiftPM build artifacts
+.build/
+.swiftpm/
+DerivedData/

--- a/ios/KirokuWatchCore/Package.swift
+++ b/ios/KirokuWatchCore/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// KirokuWatchCore — the pure-Swift (no Firebase SDK) networking + model layer
+// for the Apple Watch companion app (Apple Watch MVP, Phase 2).
+//
+// It is intentionally packaged as a standalone SwiftPM library so it can:
+//   - be built and unit-tested today via `swift test` on the macOS host
+//     (the watchOS Xcode target is orphaned and gets rebuilt in Phase 1), and
+//   - be dropped into the `kiroku` watch target later, either as a local
+//     package dependency or by adding `Sources/KirokuWatchCore/*.swift` to it.
+//
+// The only system frameworks used are Foundation (URLSession, JSONEncoder) and
+// Security (SecRandomCopyBytes) — both available on watchOS, iOS and macOS — so
+// the same sources compile unchanged on the watch and under host tests.
+let package = Package(
+    name: "KirokuWatchCore",
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v15),
+        .watchOS(.v10),
+    ],
+    products: [
+        .library(name: "KirokuWatchCore", targets: ["KirokuWatchCore"]),
+    ],
+    targets: [
+        .target(name: "KirokuWatchCore"),
+        .testTarget(
+            name: "KirokuWatchCoreTests",
+            dependencies: ["KirokuWatchCore"]
+        ),
+    ]
+)

--- a/ios/KirokuWatchCore/README.md
+++ b/ios/KirokuWatchCore/README.md
@@ -1,0 +1,62 @@
+# KirokuWatchCore
+
+The pure-Swift (no Firebase SDK) **networking + model layer** for the Kiroku
+Apple Watch companion — Apple Watch MVP **Phase 2**
+([`docs/apple-watch-mvp.md`](../../docs/apple-watch-mvp.md)).
+
+It is the Swift reimplementation of the executable contract proven by the Phase 0
+spike ([`scripts/watch-spike/post-session.mjs`](../../scripts/watch-spike/post-session.mjs)):
+mint a Firebase-compatible session id, build a live `DrinkingSession`, and post
+it to kiroku-api with a `Bearer` token — then delete it.
+
+## What's here
+
+| File | Mirrors | Purpose |
+| --- | --- | --- |
+| `Sources/KirokuWatchCore/DrinkingSession.swift` | `src/types/onyx/DrinkingSession.ts`, `src/types/onyx/Drinks.ts` | Codable session + `DrinkKey`/`SessionType`; `start_time`/`end_time` map to snake_case on the wire; `drinks` = `[Timestamp: [DrinkKey: Int]]`. |
+| `Sources/KirokuWatchCore/PushID.swift` | `src/libs/generatePushID.ts` | 20-char, time-sortable Firebase push-id generator (8 timestamp chars + 72 random bits, same-ms carry). |
+| `Sources/KirokuWatchCore/KirokuAPI.swift` | `src/libs/HttpUtils.ts`, `src/libs/API/kirokuRoutes.ts`, `src/CONFIG.ts` | `URLSession` JSON client: `Bearer` auth, dev/prod base URL, `start`/`update`/`save`/`discard`, typed 407/401/network/server errors. |
+
+No Firebase SDK, no `WCSession` — the auth token is injected by a caller-provided
+closure so the Phase 3 credential bridge plugs in without this layer knowing
+anything about WatchConnectivity. The only frameworks used are Foundation and
+Security, so the same sources compile on watchOS, iOS, and the macOS test host.
+
+## Why a standalone SwiftPM package
+
+The watchOS Xcode target is currently orphaned and gets rebuilt in Phase 1, so
+these files are packaged as a library that:
+
+- builds and unit-tests **today** via `swift test` on the macOS host, and
+- drops into the `kiroku` watch target in Phase 1 — either added as a local
+  package dependency, or by adding `Sources/KirokuWatchCore/*.swift` to the
+  target directly.
+
+## Operations (the contract)
+
+- `start(session)` / `update(session)` / `save(session)` →
+  `POST /v1/sessions/update`, body `{ sessionId, session, sessionIsLive: true }`.
+  They share one wire contract; drinks are part of the session object (there is
+  no per-drink endpoint). `save` should pass a session with `ongoing == false`.
+- `discard(sessionId:)` → `POST /v1/sessions/delete`, body
+  `{ sessionId, sessionIsLive: true }`.
+
+Auth mapping (from `HttpUtils.ts`): `407 → .tokenExpired` (refresh), `401 →
+.tokenRevoked` (re-auth); transport failures → `.network`; other non-2xx →
+`.server`.
+
+## Tests
+
+```bash
+# Offline suite (models, push-id, error mapping) — no network, no token:
+swift test --package-path ios/KirokuWatchCore
+
+# Live acceptance round-trip — create + delete against api-dev with a dev token:
+KIROKU_ID_TOKEN="<dev firebase id token>" \
+  swift test --package-path ios/KirokuWatchCore --filter KirokuAPIRoundTripTests
+```
+
+The round-trip test **skips cleanly** when `KIROKU_ID_TOKEN` is unset. Grab a dev
+token the way the spike's [README](../../scripts/watch-spike/README.md) describes
+(it expires after ~1h). Optional env: `KIROKU_API_ENV=dev|prod` (default `dev`),
+`KIROKU_UNITS` (default `2`).

--- a/ios/KirokuWatchCore/Sources/KirokuWatchCore/DrinkingSession.swift
+++ b/ios/KirokuWatchCore/Sources/KirokuWatchCore/DrinkingSession.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// A drink-type identifier, mirroring `CONST.DRINKS.KEYS`
+/// (`src/CONST.ts`) and the `DrinkKey` union in `src/types/onyx/Drinks.ts`.
+///
+/// The raw values are the exact wire strings the API expects as keys inside a
+/// session's `drinks` buckets.
+public enum DrinkKey: String, Codable, CaseIterable, Sendable {
+    case smallBeer = "small_beer"
+    case beer
+    case cocktail
+    case wine
+    case strongShot = "strong_shot"
+    case weakShot = "weak_shot"
+    case other
+}
+
+/// The kind of a session, mirroring `CONST.SESSION.TYPES`
+/// (`SESSION_TYPES` in `src/CONST.ts`). The watch only ever creates `.live`
+/// sessions; `.edit` exists so a session decoded from the phone (Phase 3) never
+/// fails to parse.
+public enum SessionType: String, Codable, CaseIterable, Sendable {
+    case live
+    case edit
+}
+
+/// A single timestamp bucket of drinks: `drinkKey -> count`.
+///
+/// The keys are `DrinkKey` raw strings. Modelled as `[String: Int]` (not
+/// `[DrinkKey: Int]`) so the JSON encodes as a plain object with string keys —
+/// `{"beer": 2}` — exactly like the source contract and the Phase 0 spike. The
+/// numeric form is the only one the watch writes; the app's richer per-event
+/// `{count, volume_ml, abv}` arm (`DrinkEntry` in `src/types/onyx/Drinks.ts`) is
+/// out of scope for the MVP.
+public typealias DrinkBucket = [String: Int]
+
+/// A collection of timestamped drink buckets, keyed by an epoch-millisecond
+/// timestamp rendered as a string — mirroring `DrinksList`
+/// (`Record<Timestamp, Record<DrinkKey, number>>`) in
+/// `src/types/onyx/Drinks.ts`.
+public typealias DrinksList = [String: DrinkBucket]
+
+/// A Codable mirror of `DrinkingSession` (`src/types/onyx/DrinkingSession.ts`)
+/// as produced by `getEmptySession(...)` and posted by the Phase 0 spike
+/// (`scripts/watch-spike/post-session.mjs`).
+///
+/// Field names map to the snake_case wire format (`start_time`, `end_time`) via
+/// `CodingKeys`; everything else is already wire-identical. `drinks` is encoded
+/// only when present, matching the spike (which omits the key when no units have
+/// been logged).
+public struct DrinkingSession: Codable, Equatable, Sendable {
+    /// A unique session identifier — a Firebase push id (see ``PushID``).
+    public var id: String
+
+    /// Epoch-millisecond start time.
+    public var startTime: Int
+
+    /// Epoch-millisecond end time. For a live session this tracks "now".
+    public var endTime: Int
+
+    /// Whether the user reported a blackout.
+    public var blackout: Bool
+
+    /// A private free-text note.
+    public var note: String
+
+    /// IANA timezone identifier the session took place in (e.g. `Europe/Prague`).
+    public var timezone: String
+
+    /// The session kind. Always `.live` for watch-originated sessions.
+    public var type: SessionType
+
+    /// Whether the session is still going on. `true` while live; set `false`
+    /// when saving to end it.
+    public var ongoing: Bool
+
+    /// Timestamped drink buckets. `nil`/omitted when nothing has been logged.
+    public var drinks: DrinksList?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case startTime = "start_time"
+        case endTime = "end_time"
+        case blackout
+        case note
+        case timezone
+        case type
+        case ongoing
+        case drinks
+    }
+
+    public init(
+        id: String,
+        startTime: Int,
+        endTime: Int,
+        blackout: Bool = false,
+        note: String = "",
+        timezone: String,
+        type: SessionType = .live,
+        ongoing: Bool = true,
+        drinks: DrinksList? = nil
+    ) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+        self.blackout = blackout
+        self.note = note
+        self.timezone = timezone
+        self.type = type
+        self.ongoing = ongoing
+        self.drinks = drinks
+    }
+}
+
+public extension DrinkingSession {
+    /// Build a fresh live session, mirroring `getEmptySession('live', ...)` plus
+    /// the spike's `buildSession`: `start_time == end_time == now`, `ongoing`,
+    /// no drinks yet.
+    ///
+    /// - Parameters:
+    ///   - id: the session id (typically `PushID.generate()`).
+    ///   - now: epoch-millisecond timestamp for start/end (defaults to now).
+    ///   - timezone: IANA identifier (defaults to the device's current zone).
+    static func newLive(
+        id: String,
+        now: Int = DrinkingSession.nowMillis(),
+        timezone: String = TimeZone.current.identifier
+    ) -> DrinkingSession {
+        DrinkingSession(
+            id: id,
+            startTime: now,
+            endTime: now,
+            blackout: false,
+            note: "",
+            timezone: timezone,
+            type: .live,
+            ongoing: true,
+            drinks: nil
+        )
+    }
+
+    /// Current epoch time in milliseconds — the unit `start_time`/`end_time` and
+    /// the `drinks` timestamp keys use throughout the contract.
+    static func nowMillis() -> Int {
+        Int((Date().timeIntervalSince1970 * 1000).rounded())
+    }
+
+    /// Add (or subtract, with a negative `count`) `count` drinks of `key` into the
+    /// bucket at `atMillis`. A bucket or key that drops to zero is removed so the
+    /// encoded session stays minimal; the whole `drinks` map collapses back to
+    /// `nil` when empty. The watch sends the whole session on every change, so
+    /// callers mutate the session and re-`update` it.
+    mutating func addDrinks(_ count: Int, of key: DrinkKey, atMillis: Int = DrinkingSession.nowMillis()) {
+        guard count != 0 else { return }
+        let bucketKey = String(atMillis)
+        var list = drinks ?? [:]
+        var bucket = list[bucketKey] ?? [:]
+        let next = (bucket[key.rawValue] ?? 0) + count
+        if next > 0 {
+            bucket[key.rawValue] = next
+        } else {
+            bucket[key.rawValue] = nil
+        }
+        if bucket.isEmpty {
+            list[bucketKey] = nil
+        } else {
+            list[bucketKey] = bucket
+        }
+        drinks = list.isEmpty ? nil : list
+    }
+
+    /// Total number of drinks logged across all buckets and types.
+    var totalUnits: Int {
+        (drinks ?? [:]).values.reduce(0) { $0 + $1.values.reduce(0, +) }
+    }
+}

--- a/ios/KirokuWatchCore/Sources/KirokuWatchCore/KirokuAPI.swift
+++ b/ios/KirokuWatchCore/Sources/KirokuWatchCore/KirokuAPI.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+/// The kiroku-api environment the watch talks to. Mirrors the dynamic root
+/// selection in `src/CONFIG.ts`.
+public enum KirokuEnvironment: Sendable {
+    case dev
+    case prod
+
+    /// Base URL for this environment.
+    public var baseURL: URL {
+        switch self {
+        case .dev:
+            // swiftlint:disable:next force_unwrapping
+            return URL(string: "https://api-dev.kiroku.cz")!
+        case .prod:
+            // swiftlint:disable:next force_unwrapping
+            return URL(string: "https://api.kiroku.cz")!
+        }
+    }
+}
+
+/// A typed outcome of an API call. Mirrors the auth split documented in
+/// `src/libs/HttpUtils.ts`: a `407` means the Firebase ID token is expired (the
+/// app refreshes and replays), a `401` means it is revoked (the app forces
+/// sign-out). On the watch, both surface as "open Kiroku on your phone to
+/// reconnect"; the distinction is preserved for the credential bridge (Phase 3).
+public enum KirokuAPIError: Error, Equatable, Sendable {
+    /// No token was available to authorize the request.
+    case missingToken
+    /// HTTP/jsonCode `407` — the ID token is expired. Needs a refreshed token.
+    case tokenExpired
+    /// HTTP/jsonCode `401` — the token is revoked/invalid. Needs re-auth.
+    case tokenRevoked
+    /// Any other non-2xx response. Carries the HTTP status, any `jsonCode` from
+    /// the body, and a best-effort server message.
+    case server(statusCode: Int, jsonCode: Int?, message: String?)
+    /// A transport-level failure (offline, timeout, DNS, TLS, …).
+    case network(message: String)
+    /// The response was not an HTTP response, or could not be interpreted.
+    case invalidResponse
+}
+
+/// A successful (2xx) API response. Exposes the status, any decoded `jsonCode`,
+/// and the raw body so callers aren't coupled to a rigid success schema (the
+/// session endpoints' success payload is not needed by the MVP).
+public struct KirokuAPIResponse: Sendable {
+    public let statusCode: Int
+    public let jsonCode: Int?
+    public let body: Data
+
+    /// The body decoded as a JSON object, if it is one.
+    public var json: [String: Any]? {
+        guard !body.isEmpty,
+              let object = try? JSONSerialization.jsonObject(with: body),
+              let dictionary = object as? [String: Any] else {
+            return nil
+        }
+        return dictionary
+    }
+}
+
+/// Pure-Swift (`URLSession`, no Firebase SDK) client for the two kiroku-api
+/// session endpoints the watch needs. The token is supplied by a caller-provided
+/// closure so Phase 3 can plug in the Keychain-cached, phone-bridged credential
+/// without this layer knowing anything about WatchConnectivity.
+///
+/// Every request sends `Content-Type: application/json` and, when a token is
+/// available, `Authorization: Bearer <idToken>` — exactly as `HttpUtils.ts` does.
+public final class KirokuAPI: @unchecked Sendable {
+    private let environment: KirokuEnvironment
+    private let urlSession: URLSession
+    private let tokenProvider: @Sendable () -> String?
+
+    /// - Parameters:
+    ///   - environment: dev or prod base URL.
+    ///   - urlSession: injectable for tests; defaults to `.shared`.
+    ///   - tokenProvider: returns the current Firebase ID token, or `nil` when
+    ///     none is available (yields ``KirokuAPIError/missingToken``).
+    public init(
+        environment: KirokuEnvironment,
+        urlSession: URLSession = .shared,
+        tokenProvider: @escaping @Sendable () -> String?
+    ) {
+        self.environment = environment
+        self.urlSession = urlSession
+        self.tokenProvider = tokenProvider
+    }
+
+    /// Convenience initializer for a fixed token (e.g. the acceptance test's
+    /// pasted dev token).
+    public convenience init(
+        environment: KirokuEnvironment,
+        token: String,
+        urlSession: URLSession = .shared
+    ) {
+        self.init(environment: environment, urlSession: urlSession, tokenProvider: { token })
+    }
+
+    // MARK: - Operations
+
+    /// Start a live session. POSTs the whole session to `/v1/sessions/update`
+    /// with `sessionIsLive: true`. (`start`, `update` and `save` share one wire
+    /// contract — drinks are part of the session object; there is no per-drink
+    /// endpoint. The name documents intent at the call site.)
+    @discardableResult
+    public func start(_ session: DrinkingSession) async throws -> KirokuAPIResponse {
+        try await postSessionUpdate(session)
+    }
+
+    /// Push the current state of a live session (e.g. after +/− a unit). Same
+    /// wire contract as ``start(_:)``.
+    @discardableResult
+    public func update(_ session: DrinkingSession) async throws -> KirokuAPIResponse {
+        try await postSessionUpdate(session)
+    }
+
+    /// Save (finalize) a session. Same endpoint and envelope as ``start(_:)``;
+    /// callers should pass a session with `ongoing == false` to end it.
+    @discardableResult
+    public func save(_ session: DrinkingSession) async throws -> KirokuAPIResponse {
+        try await postSessionUpdate(session)
+    }
+
+    /// Discard a live session. POSTs to `/v1/sessions/delete` with
+    /// `{ sessionId, sessionIsLive: true }`.
+    @discardableResult
+    public func discard(sessionId: String) async throws -> KirokuAPIResponse {
+        let body = DeleteSessionRequest(sessionId: sessionId, sessionIsLive: true)
+        return try await post(path: "/v1/sessions/delete", body: body)
+    }
+
+    // MARK: - Internals
+
+    private func postSessionUpdate(_ session: DrinkingSession) async throws -> KirokuAPIResponse {
+        let body = UpdateSessionRequest(sessionId: session.id, session: session, sessionIsLive: true)
+        return try await post(path: "/v1/sessions/update", body: body)
+    }
+
+    private func post<Body: Encodable>(path: String, body: Body) async throws -> KirokuAPIResponse {
+        guard let token = tokenProvider(), !token.isEmpty else {
+            throw KirokuAPIError.missingToken
+        }
+
+        // Concatenate rather than `appendingPathComponent` so the path is exact
+        // (`https://api-dev.kiroku.cz/v1/sessions/update`) with no slash surprises.
+        guard let url = URL(string: environment.baseURL.absoluteString + path) else {
+            throw KirokuAPIError.invalidResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        // Envelope keys (`sessionId`, `sessionIsLive`) are camelCase on the wire;
+        // the snake_case session fields carry their own CodingKeys, so the
+        // encoder must use default key coding (no global snake_case strategy).
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            throw KirokuAPIError.network(message: error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw KirokuAPIError.invalidResponse
+        }
+
+        let jsonCode = Self.parseJSONCode(from: data)
+        let status = http.statusCode
+
+        // Auth split — match on HTTP status or a `jsonCode` carried in the body.
+        if status == 407 || jsonCode == 407 {
+            throw KirokuAPIError.tokenExpired
+        }
+        if status == 401 || jsonCode == 401 {
+            throw KirokuAPIError.tokenRevoked
+        }
+
+        guard (200..<300).contains(status) else {
+            throw KirokuAPIError.server(
+                statusCode: status,
+                jsonCode: jsonCode,
+                message: Self.parseMessage(from: data)
+            )
+        }
+
+        return KirokuAPIResponse(statusCode: status, jsonCode: jsonCode, body: data)
+    }
+
+    private static func parseJSONCode(from data: Data) -> Int? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let code = object["jsonCode"] as? Int {
+            return code
+        }
+        if let code = object["jsonCode"] as? String {
+            return Int(code)
+        }
+        return nil
+    }
+
+    private static func parseMessage(from data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        for key in ["message", "error", "errorMessage"] {
+            if let message = object[key] as? String {
+                return message
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Request envelopes
+
+/// `{ sessionId, session, sessionIsLive }` — the body of `/v1/sessions/update`.
+private struct UpdateSessionRequest: Encodable {
+    let sessionId: String
+    let session: DrinkingSession
+    let sessionIsLive: Bool
+}
+
+/// `{ sessionId, sessionIsLive }` — the body of `/v1/sessions/delete`.
+private struct DeleteSessionRequest: Encodable {
+    let sessionId: String
+    let sessionIsLive: Bool
+}

--- a/ios/KirokuWatchCore/Sources/KirokuWatchCore/PushID.swift
+++ b/ios/KirokuWatchCore/Sources/KirokuWatchCore/PushID.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Security
+
+/// A faithful Swift port of `generatePushID()` (`src/libs/generatePushID.ts`),
+/// itself Michael Lehenbauer's canonical Firebase push-id algorithm. Produces
+/// 20-character, lexicographically-sortable keys that are format-compatible with
+/// the ids every existing drinking session already uses, so a watch-minted id is
+/// indistinguishable from a phone-minted one.
+///
+/// Layout (20 chars over the 64-char, sort-order-preserving alphabet):
+///   - chars 0–7:  the millisecond timestamp, big-endian → keys sort by time.
+///   - chars 8–19: 72 bits of secure randomness → collision resistance.
+///
+/// Two ids minted in the same millisecond stay strictly ordered: the previous
+/// 72-bit random suffix is incremented by one (with carry) instead of re-rolled.
+///
+/// The shared ``generate()`` is serialized with a lock so concurrent taps from
+/// different threads cannot corrupt the same-millisecond carry state.
+public final class PushID: @unchecked Sendable {
+    /// Process-wide generator. Mirrors the module-level state of the JS version.
+    public static let shared = PushID()
+
+    /// Modeled after the Firebase JS SDK. The ordering of this alphabet is
+    /// load-bearing: ASCII `-` < digits < uppercase < `_` < lowercase, so
+    /// lexicographic string order equals chronological order.
+    public static let pushChars = Array("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
+
+    private let lock = NSLock()
+
+    /// Timestamp (ms) of the last push, to detect same-millisecond collisions.
+    private var lastPushTime = 0
+
+    /// The 12 random "digits" (each 0–63) from the previous call. On a same-ms
+    /// collision they are incremented (not re-randomized) to preserve ordering.
+    private var lastRandChars = [Int](repeating: 0, count: 12)
+
+    public init() {}
+
+    /// Generate a new 20-character push id using the current wall-clock time.
+    public static func generate() -> String {
+        shared.generate()
+    }
+
+    /// Generate a new 20-character push id using the current wall-clock time.
+    public func generate() -> String {
+        generate(atMillis: DrinkingSession.nowMillis())
+    }
+
+    /// Generate a push id for an explicit epoch-millisecond timestamp.
+    ///
+    /// Exposed for deterministic tests (the JS reference reads `Date.now()`);
+    /// production callers use the argument-less ``generate()``.
+    public func generate(atMillis now: Int) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let duplicateTime = now == lastPushTime
+        lastPushTime = now
+
+        // chars 0–7: big-endian base-64 of the timestamp.
+        var remaining = now
+        var timeStampChars = [Character](repeating: "-", count: 8)
+        var i = 7
+        while i >= 0 {
+            timeStampChars[i] = PushID.pushChars[remaining % 64]
+            remaining /= 64
+            i -= 1
+        }
+        precondition(remaining == 0, "PushID: timestamp did not fully convert")
+
+        if !duplicateTime {
+            rerollRandChars()
+        } else {
+            // Same millisecond as the previous id: increment the 72-bit random
+            // suffix by one (with carry) so the new id still sorts strictly after.
+            var j = 11
+            while j >= 0 && lastRandChars[j] == 63 {
+                lastRandChars[j] = 0
+                j -= 1
+            }
+            if j >= 0 {
+                lastRandChars[j] += 1
+            } else {
+                // Astronomically unlikely (>2^72 ids in one ms): every digit rolled
+                // over. Reroll rather than emit a wrapped, non-monotonic suffix.
+                rerollRandChars()
+            }
+        }
+
+        var id = String(timeStampChars)
+        for k in 0..<12 {
+            id.append(PushID.pushChars[lastRandChars[k]])
+        }
+
+        precondition(id.count == 20, "PushID: generated id length is not 20")
+        return id
+    }
+
+    /// Refill `lastRandChars` with 12 fresh 6-bit values (0–63) from 72 bits of
+    /// secure randomness. The 9 random bytes are read as one big-endian 72-bit
+    /// stream and sliced into 12 six-bit chunks (9 × 8 == 12 × 6) — the exact bit
+    /// math of the JS reference.
+    private func rerollRandChars() {
+        var bytes = [UInt8](repeating: 0, count: 9)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status != errSecSuccess {
+            // SecRandomCopyBytes effectively never fails on-device; fall back to a
+            // non-crypto source rather than aborting an in-flight session write.
+            for index in bytes.indices {
+                bytes[index] = UInt8.random(in: UInt8.min...UInt8.max)
+            }
+        }
+
+        for i in 0..<12 {
+            let bitPos = i * 6
+            let bytePos = bitPos >> 3
+            let bitOffset = bitPos & 7
+            let hi = Int(bytes[bytePos])
+            let lo = bytePos + 1 < bytes.count ? Int(bytes[bytePos + 1]) : 0
+            let bits = (hi << 8) | lo
+            lastRandChars[i] = (bits >> (10 - bitOffset)) & 0x3f
+        }
+    }
+
+    #if DEBUG
+    /// Test-only: seed the 12-digit random-suffix carry state so the
+    /// same-millisecond carry path can be exercised deterministically.
+    func setLastRandCharsForTesting(_ chars: [Int]) {
+        precondition(chars.count == 12, "expected 12 digits")
+        lock.lock()
+        defer { lock.unlock() }
+        lastRandChars = chars
+    }
+    #endif
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/DrinkingSessionTests.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/DrinkingSessionTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import KirokuWatchCore
+
+final class DrinkingSessionTests: XCTestCase {
+    private func encodeToObject(_ session: DrinkingSession) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(session)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    func testEncodesWireKeysMatchingTheSpike() throws {
+        let now = 1_700_000_000_000
+        var session = DrinkingSession.newLive(id: "abc123", now: now, timezone: "Europe/Prague")
+        session.addDrinks(2, of: .beer, atMillis: now)
+
+        let object = try encodeToObject(session)
+
+        // Field set + snake_case mapping mirrors getEmptySession + the spike body.
+        XCTAssertEqual(object["id"] as? String, "abc123")
+        XCTAssertEqual(object["start_time"] as? Int, now)
+        XCTAssertEqual(object["end_time"] as? Int, now)
+        XCTAssertEqual(object["blackout"] as? Bool, false)
+        XCTAssertEqual(object["note"] as? String, "")
+        XCTAssertEqual(object["timezone"] as? String, "Europe/Prague")
+        XCTAssertEqual(object["type"] as? String, "live")
+        XCTAssertEqual(object["ongoing"] as? Bool, true)
+
+        // No camelCase leakage of the timestamp fields.
+        XCTAssertNil(object["startTime"])
+        XCTAssertNil(object["endTime"])
+
+        let drinks = try XCTUnwrap(object["drinks"] as? [String: Any])
+        let bucket = try XCTUnwrap(drinks[String(now)] as? [String: Any])
+        XCTAssertEqual(bucket["beer"] as? Int, 2)
+    }
+
+    func testDrinksOmittedWhenNoUnitsLogged() throws {
+        let session = DrinkingSession.newLive(id: "no-drinks", now: 1_700_000_000_000, timezone: "Europe/Prague")
+        let object = try encodeToObject(session)
+        // The spike omits the `drinks` key entirely when zero units are logged.
+        XCTAssertNil(object["drinks"], "drinks key must be absent for an empty session")
+        XCTAssertEqual(session.totalUnits, 0)
+    }
+
+    func testAllDrinkKeysSerializeToWireStrings() {
+        XCTAssertEqual(DrinkKey.smallBeer.rawValue, "small_beer")
+        XCTAssertEqual(DrinkKey.beer.rawValue, "beer")
+        XCTAssertEqual(DrinkKey.cocktail.rawValue, "cocktail")
+        XCTAssertEqual(DrinkKey.wine.rawValue, "wine")
+        XCTAssertEqual(DrinkKey.strongShot.rawValue, "strong_shot")
+        XCTAssertEqual(DrinkKey.weakShot.rawValue, "weak_shot")
+        XCTAssertEqual(DrinkKey.other.rawValue, "other")
+        XCTAssertEqual(Set(DrinkKey.allCases.map(\.rawValue)).count, 7)
+    }
+
+    func testAddAndRemoveDrinksCollapsesEmptyBuckets() {
+        let now = 1_700_000_000_000
+        var session = DrinkingSession.newLive(id: "x", now: now, timezone: "Europe/Prague")
+        session.addDrinks(3, of: .beer, atMillis: now)
+        XCTAssertEqual(session.totalUnits, 3)
+        session.addDrinks(-1, of: .beer, atMillis: now)
+        XCTAssertEqual(session.totalUnits, 2)
+        XCTAssertEqual(session.drinks?[String(now)]?["beer"], 2)
+        // Removing the rest collapses the bucket and the whole drinks map back to nil.
+        session.addDrinks(-2, of: .beer, atMillis: now)
+        XCTAssertEqual(session.totalUnits, 0)
+        XCTAssertNil(session.drinks)
+    }
+
+    func testMixedDrinkTypesAndTimestamps() {
+        var session = DrinkingSession.newLive(id: "x", now: 0, timezone: "Europe/Prague")
+        session.addDrinks(1, of: .beer, atMillis: 1000)
+        session.addDrinks(2, of: .wine, atMillis: 1000)
+        session.addDrinks(1, of: .cocktail, atMillis: 2000)
+        XCTAssertEqual(session.totalUnits, 4)
+        XCTAssertEqual(session.drinks?["1000"]?["beer"], 1)
+        XCTAssertEqual(session.drinks?["1000"]?["wine"], 2)
+        XCTAssertEqual(session.drinks?["2000"]?["cocktail"], 1)
+    }
+
+    func testCodableRoundTrip() throws {
+        let now = 1_700_000_000_123
+        var original = DrinkingSession.newLive(id: "round-trip", now: now, timezone: "America/New_York")
+        original.addDrinks(2, of: .strongShot, atMillis: now)
+        original.note = "a note"
+        original.blackout = true
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(DrinkingSession.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/KirokuAPIRoundTripTests.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/KirokuAPIRoundTripTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import KirokuWatchCore
+
+/// The Phase 2 acceptance test: round-trip a real live session against the live
+/// kiroku-api, mirroring the Phase 0 spike (`scripts/watch-spike/post-session.mjs`):
+/// `POST /v1/sessions/update` (create) then `POST /v1/sessions/delete` (cleanup).
+///
+/// It hits the network, so it is **gated on a pasted Firebase ID token** and
+/// skips cleanly when none is provided (CI, local runs without a token):
+///
+///   KIROKU_ID_TOKEN=<dev id token> swift test \
+///       --package-path "ios/KirokuWatchCore" \
+///       --filter KirokuAPIRoundTripTests
+///
+/// Optional env: `KIROKU_API_ENV=dev|prod` (default `dev`), `KIROKU_UNITS` (default 2).
+/// Grab a dev token the same way the spike's README describes. Tokens last ~1h;
+/// a 407/401 means it expired/was revoked — grab a fresh one.
+final class KirokuAPIRoundTripTests: XCTestCase {
+    func testCreateAndDeleteRoundTrip() async throws {
+        guard let token = ProcessInfo.processInfo.environment["KIROKU_ID_TOKEN"], !token.isEmpty else {
+            throw XCTSkip("Set KIROKU_ID_TOKEN to a dev Firebase ID token to run the live round-trip.")
+        }
+
+        let environment: KirokuEnvironment =
+            ProcessInfo.processInfo.environment["KIROKU_API_ENV"] == "prod" ? .prod : .dev
+        let units = ProcessInfo.processInfo.environment["KIROKU_UNITS"].flatMap(Int.init) ?? 2
+
+        let api = KirokuAPI(environment: environment, token: token)
+
+        let sessionId = PushID.generate()
+        var session = DrinkingSession.newLive(id: sessionId, timezone: "Europe/Prague")
+        if units > 0 {
+            session.addDrinks(units, of: .beer)
+        }
+
+        // Create.
+        do {
+            let response = try await api.start(session)
+            XCTAssertTrue((200..<300).contains(response.statusCode), "create status \(response.statusCode)")
+        } catch KirokuAPIError.tokenExpired {
+            throw XCTSkip("Token expired (407) — grab a fresh dev ID token.")
+        } catch KirokuAPIError.tokenRevoked {
+            throw XCTSkip("Token revoked (401) — grab a fresh dev ID token.")
+        }
+
+        // Cleanup — delete the session we just created.
+        let deleteResponse = try await api.discard(sessionId: sessionId)
+        XCTAssertTrue((200..<300).contains(deleteResponse.statusCode), "delete status \(deleteResponse.statusCode)")
+    }
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/KirokuAPITests.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/KirokuAPITests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import KirokuWatchCore
+
+/// Offline tests for `KirokuAPI`: envelope/headers and the 407/401/network/server
+/// mapping, driven through `MockURLProtocol` (no real network, no token needed).
+final class KirokuAPITests: XCTestCase {
+    private let token = "fake.dev.token"
+
+    private func makeAPI(environment: KirokuEnvironment = .dev) -> KirokuAPI {
+        KirokuAPI(environment: environment, token: token, urlSession: MockURLProtocol.makeSession())
+    }
+
+    private func makeSession() -> DrinkingSession {
+        var session = DrinkingSession.newLive(id: "sess-1", now: 1_700_000_000_000, timezone: "Europe/Prague")
+        session.addDrinks(2, of: .beer, atMillis: 1_700_000_000_000)
+        return session
+    }
+
+    private func ok(_ request: URLRequest, json: String = "{\"jsonCode\":200}") -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data(json.utf8))
+    }
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Envelope + headers
+
+    func testUpdateSendsCorrectUrlHeadersAndEnvelope() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api-dev.kiroku.cz/v1/sessions/update")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(self.token)")
+            return self.ok(request)
+        }
+
+        let response = try await makeAPI().update(makeSession())
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(response.jsonCode, 200)
+
+        let body = try XCTUnwrap(MockURLProtocol.lastRequestBody)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["sessionId"] as? String, "sess-1")
+        XCTAssertEqual(object["sessionIsLive"] as? Bool, true)
+
+        let nested = try XCTUnwrap(object["session"] as? [String: Any])
+        XCTAssertEqual(nested["id"] as? String, "sess-1")
+        XCTAssertEqual(nested["start_time"] as? Int, 1_700_000_000_000)
+        XCTAssertEqual(nested["type"] as? String, "live")
+        XCTAssertEqual(nested["ongoing"] as? Bool, true)
+        let drinks = try XCTUnwrap(nested["drinks"] as? [String: Any])
+        let bucket = try XCTUnwrap(drinks["1700000000000"] as? [String: Any])
+        XCTAssertEqual(bucket["beer"] as? Int, 2)
+    }
+
+    func testStartHitsTheUpdateEndpoint() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/v1/sessions/update")
+            return self.ok(request)
+        }
+        _ = try await makeAPI().start(makeSession())
+    }
+
+    func testSaveHitsTheUpdateEndpoint() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/v1/sessions/update")
+            return self.ok(request)
+        }
+        var ended = makeSession()
+        ended.ongoing = false
+        _ = try await makeAPI().save(ended)
+        // The save envelope still flags sessionIsLive: true (per the contract);
+        // the session body carries ongoing: false to end it.
+        let body = try XCTUnwrap(MockURLProtocol.lastRequestBody)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["sessionIsLive"] as? Bool, true)
+        let nested = try XCTUnwrap(object["session"] as? [String: Any])
+        XCTAssertEqual(nested["ongoing"] as? Bool, false)
+    }
+
+    func testDiscardSendsDeleteEnvelope() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api-dev.kiroku.cz/v1/sessions/delete")
+            XCTAssertEqual(request.httpMethod, "POST")
+            return self.ok(request)
+        }
+        _ = try await makeAPI().discard(sessionId: "sess-1")
+        let body = try XCTUnwrap(MockURLProtocol.lastRequestBody)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["sessionId"] as? String, "sess-1")
+        XCTAssertEqual(object["sessionIsLive"] as? Bool, true)
+        XCTAssertNil(object["session"], "delete body carries no session")
+    }
+
+    func testProdUsesProdBaseURL() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.kiroku.cz/v1/sessions/update")
+            return self.ok(request)
+        }
+        _ = try await makeAPI(environment: .prod).update(makeSession())
+    }
+
+    // MARK: - Error mapping
+
+    func testHttp407MapsToTokenExpired() async {
+        MockURLProtocol.handler = { request in
+            (HTTPURLResponse(url: request.url!, statusCode: 407, httpVersion: nil, headerFields: nil)!, Data())
+        }
+        await assertThrows(try await makeAPI().update(makeSession()), .tokenExpired)
+    }
+
+    func testHttp401MapsToTokenRevoked() async {
+        MockURLProtocol.handler = { request in
+            (HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!, Data())
+        }
+        await assertThrows(try await makeAPI().update(makeSession()), .tokenRevoked)
+    }
+
+    func testJsonCode407InBodyMapsToTokenExpired() async {
+        // Even with a 2xx HTTP status, a jsonCode of 407 in the body is honored.
+        MockURLProtocol.handler = { request in
+            self.ok(request, json: "{\"jsonCode\":407}")
+        }
+        await assertThrows(try await makeAPI().update(makeSession()), .tokenExpired)
+    }
+
+    func testServerErrorMapsToServer() async {
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, Data("{\"jsonCode\":500,\"message\":\"boom\"}".utf8))
+        }
+        do {
+            _ = try await makeAPI().update(makeSession())
+            XCTFail("expected a server error")
+        } catch let KirokuAPIError.server(statusCode, jsonCode, message) {
+            XCTAssertEqual(statusCode, 500)
+            XCTAssertEqual(jsonCode, 500)
+            XCTAssertEqual(message, "boom")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testNetworkFailureMapsToNetwork() async {
+        MockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        do {
+            _ = try await makeAPI().update(makeSession())
+            XCTFail("expected a network error")
+        } catch let KirokuAPIError.network(message) {
+            XCTAssertFalse(message.isEmpty)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testMissingTokenThrowsAndMakesNoRequest() async {
+        MockURLProtocol.handler = { request in
+            XCTFail("no request should be made without a token")
+            return self.ok(request)
+        }
+        let api = KirokuAPI(environment: .dev, urlSession: MockURLProtocol.makeSession(), tokenProvider: { nil })
+        await assertThrows(try await api.update(makeSession()), .missingToken)
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows(
+        _ expression: @autoclosure () async throws -> KirokuAPIResponse,
+        _ expected: KirokuAPIError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("expected \(expected) to be thrown", file: file, line: line)
+        } catch let error as KirokuAPIError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/MockURLProtocol.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/MockURLProtocol.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A `URLProtocol` that intercepts every request so `KirokuAPI` can be tested
+/// offline: tests install a `handler` that inspects the outgoing request and
+/// returns a canned `(HTTPURLResponse, Data)` — or throws to simulate a transport
+/// failure. The most recent request body is captured for envelope assertions.
+final class MockURLProtocol: URLProtocol {
+    /// Set per test. Throwing simulates a network/transport error.
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    /// Body of the last intercepted request (read out of the body stream).
+    static var lastRequestBody: Data?
+
+    static func reset() {
+        handler = nil
+        lastRequestBody = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        MockURLProtocol.lastRequestBody = request.readBody()
+
+        guard let handler = MockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    /// Build a `URLSession` wired to this protocol.
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private extension URLRequest {
+    /// `URLProtocol` delivers a POST body via `httpBodyStream`, not `httpBody`.
+    func readBody() -> Data? {
+        if let body = httpBody {
+            return body
+        }
+        guard let stream = httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 {
+                break
+            }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/PushIDTests.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/PushIDTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import KirokuWatchCore
+
+final class PushIDTests: XCTestCase {
+    private let pushChars = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
+
+    func testAlphabetMatchesReference() {
+        // The alphabet is load-bearing (sort order). Lock it to the JS reference.
+        XCTAssertEqual(String(PushID.pushChars), pushChars)
+        XCTAssertEqual(PushID.pushChars.count, 64)
+    }
+
+    func testIdIsTwentyCharsOverTheAlphabet() {
+        let allowed = Set(pushChars)
+        for _ in 0..<200 {
+            let id = PushID().generate()
+            XCTAssertEqual(id.count, 20, "id must be 20 chars: \(id)")
+            XCTAssertTrue(id.allSatisfy { allowed.contains($0) }, "id has out-of-alphabet char: \(id)")
+        }
+    }
+
+    func testTimestampPrefixEncoding() {
+        // now == 0 → all eight timestamp chars are the alphabet's first char.
+        let zero = PushID().generate(atMillis: 0)
+        XCTAssertEqual(String(zero.prefix(8)), "--------")
+
+        // now == 63 → low digit is the alphabet's last char, rest are the first.
+        let sixtyThree = PushID().generate(atMillis: 63)
+        XCTAssertEqual(String(sixtyThree.prefix(8)), "-------z")
+
+        // now == 64 → carries into the next digit: pushChars[1] ('0') then pushChars[0] ('-').
+        let sixtyFour = PushID().generate(atMillis: 64)
+        XCTAssertEqual(String(sixtyFour.prefix(8)), "------0-")
+    }
+
+    func testTimestampPrefixRoundTripsForRealisticMillis() {
+        let millis = 1_700_000_000_000 // 2023-11-14T22:13:20Z
+        let id = PushID().generate(atMillis: millis)
+        XCTAssertEqual(decodeTimestamp(String(id.prefix(8))), millis)
+    }
+
+    func testSameMillisecondIdsAreStrictlyIncreasing() {
+        let gen = PushID()
+        var ids: [String] = []
+        for _ in 0..<50 {
+            ids.append(gen.generate(atMillis: 1_700_000_000_000))
+        }
+        // All share the same timestamp prefix...
+        let prefixes = Set(ids.map { String($0.prefix(8)) })
+        XCTAssertEqual(prefixes.count, 1, "same-ms ids must share a timestamp prefix")
+        // ...and the full ids sort strictly ascending (random suffix incremented).
+        XCTAssertEqual(ids, ids.sorted(), "same-ms ids must be monotonically increasing")
+        XCTAssertEqual(Set(ids).count, ids.count, "same-ms ids must be unique")
+    }
+
+    func testLaterMillisSortsAfterEarlier() {
+        let gen = PushID()
+        let earlier = gen.generate(atMillis: 1_700_000_000_000)
+        let later = gen.generate(atMillis: 1_700_000_000_001)
+        XCTAssertLessThan(earlier, later, "a later-ms id must sort after an earlier one")
+    }
+
+    func testSameMillisCarryAcrossDigits() {
+        let gen = PushID()
+        let ms = 1_700_000_000_000
+        // First call at `ms` is not a duplicate (lastPushTime starts at 0); it
+        // rerolls and records `ms` as the last push time.
+        _ = gen.generate(atMillis: ms)
+        // Seed a suffix whose trailing digit is maxed so the next same-ms call
+        // carries: index 11 (63) resets to 0 and index 10 (5) increments to 6.
+        gen.setLastRandCharsForTesting([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 63])
+        let a = gen.generate(atMillis: ms)
+        // index 11 (0) simply increments to 1 — no carry.
+        let b = gen.generate(atMillis: ms)
+        XCTAssertEqual(String(a.prefix(8)), String(b.prefix(8)), "carry must not touch the timestamp prefix")
+        XCTAssertLessThan(a, b, "carried suffix must still sort ascending")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testThreadSafetyProducesUniqueIds() {
+        let gen = PushID()
+        let count = 2_000
+        let lock = NSLock()
+        var ids = Set<String>()
+        DispatchQueue.concurrentPerform(iterations: count) { _ in
+            let id = gen.generate()
+            lock.lock()
+            ids.insert(id)
+            lock.unlock()
+        }
+        XCTAssertEqual(ids.count, count, "concurrent generation must not collide or corrupt state")
+    }
+
+    // MARK: - Helpers
+
+    /// Reverse the big-endian base-64 timestamp encoding back into millis.
+    private func decodeTimestamp(_ prefix: String) -> Int {
+        var value = 0
+        for char in prefix {
+            guard let index = pushChars.firstIndex(of: char) else {
+                XCTFail("char \(char) not in alphabet")
+                return -1
+            }
+            value = value * 64 + pushChars.distance(from: pushChars.startIndex, to: index)
+        }
+        return value
+    }
+}


### PR DESCRIPTION
## Apple Watch MVP — Phase 2 (watch networking + models, pure Swift)

A Firebase-SDK-free **networking + model layer** for the watch companion. It is the Swift reimplementation of the Phase 0 executable spec ([`scripts/watch-spike/post-session.mjs`](https://github.com/PetrCala/Kiroku/blob/claude/jolly-khayyam-5bcaf2/scripts/watch-spike/post-session.mjs)); the full scope lives in `docs/apple-watch-mvp.md` (PR #1443).

### Why a standalone SwiftPM package
The watchOS Xcode target is currently orphaned and gets rebuilt in **Phase 1**. Packaging this as `ios/KirokuWatchCore` means it **builds and unit-tests today** via `swift test` on the macOS host, and **drops into the `kiroku` watch target later** (as a local package dependency, or by adding `Sources/KirokuWatchCore/*.swift` to the target). No Firebase pod, no `GoogleService-Info`, no `WCSession` here — only Foundation + Security, so the same sources compile on watchOS/iOS/macOS.

### What's in it
| Task | File | Mirrors |
| --- | --- | --- |
| 2.1 Codable models | `Sources/KirokuWatchCore/DrinkingSession.swift` | `src/types/onyx/DrinkingSession.ts`, `src/types/onyx/Drinks.ts`, `CONST.DRINKS.KEYS` |
| 2.2 PushID port | `Sources/KirokuWatchCore/PushID.swift` | `src/libs/generatePushID.ts` |
| 2.3 API client | `Sources/KirokuWatchCore/KirokuAPI.swift` | `src/libs/HttpUtils.ts`, `src/libs/API/kirokuRoutes.ts`, `src/CONFIG.ts` |
| 2.4 Operations | (in `KirokuAPI.swift`) | `start`/`update`/`save` → `/v1/sessions/update`; `discard` → `/v1/sessions/delete` |

- **Session model** — `id`, `start_time`/`end_time` (epoch ms, snake_case on the wire via `CodingKeys`), `blackout`, `note`, `timezone`, `type` (`"live"`), `ongoing`, and `drinks` = `[Timestamp(String): [DrinkKey(String): Int]]`. `drinks` is omitted when empty, matching the spike. Helpers: `newLive(...)`, `addDrinks(...)`, `totalUnits`.
- **PushID** — faithful port: 20-char, time-sortable Firebase push ids (8 timestamp chars + 72 random bits, same-millisecond increment-with-carry), thread-safe.
- **KirokuAPI** — `URLSession` JSON POST with `Authorization: Bearer <idToken>` + `Content-Type: application/json`; dev (`api-dev.kiroku.cz`) / prod (`api.kiroku.cz`) base URL. Typed outcomes: **407 → `.tokenExpired`** (refresh), **401 → `.tokenRevoked`** (re-auth), transport → `.network`, other non-2xx → `.server`, plus `.missingToken`. The token is injected via a closure so the **Phase 3** credential bridge plugs in without this layer touching WatchConnectivity. `start`/`update`/`save` share one wire contract (drinks are part of the session object; no per-drink endpoint).

### Operations (the contract)
- `start(session)` / `update(session)` / `save(session)` → `POST /v1/sessions/update`, body `{ sessionId, session, sessionIsLive: true }`. (`save` callers pass `ongoing == false` to end the session.)
- `discard(sessionId:)` → `POST /v1/sessions/delete`, body `{ sessionId, sessionIsLive: true }`.

### Tests — 26, all green (1 live test skips without a token)
```bash
# Offline suite (models, push-id, error mapping) — no network, no token:
swift test --package-path ios/KirokuWatchCore

# Acceptance round-trip — create + delete against api-dev with a dev token:
KIROKU_ID_TOKEN="<dev firebase id token>" \
  swift test --package-path ios/KirokuWatchCore --filter KirokuAPIRoundTripTests
```
- **PushID** — alphabet/length, timestamp encoding + round-trip, same-ms monotonicity, carry-across-digits, concurrency.
- **DrinkingSession** — wire-key parity with the spike, `drinks` omission, add/remove collapse, Codable round-trip.
- **KirokuAPI** — exact URL/headers/envelope (via a mock `URLProtocol`) and the full 407/401/network/server mapping, offline.
- **KirokuAPIRoundTripTests** — the **acceptance** create+delete round-trip against `api-dev`, gated on a pasted `KIROKU_ID_TOKEN`; **skips cleanly** when unset (so CI stays green).

### Acceptance
> An XCTest round-trips a session against `api-dev` with a pasted dev ID token (create then delete), mirroring the spike. ✅ `KirokuAPIRoundTripTests.testCreateAndDeleteRoundTrip`.

### Not in this PR (later phases)
- Phase 1 target/build wiring; Phase 3 `WCSession` credential bridge; Phase 4 view-model wiring. This layer is intentionally transport-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)