### PR TITLE
fix(ios): break archive build-phase cycle from embedded Watch app

### DIFF
--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -516,12 +516,12 @@
 				96EE1767D138A900D6E3A4421BAD14EF /* Frameworks */,
 				B9F8269ED055C5C64E7601A97DC265CB /* Resources */,
 				A93D5E4D4B3C14C35A07B0AB64D8AFE8 /* [User] Copy GoogleService-Info.plist */,
+				99C9732089753FE060B2B9AB /* Embed Watch Content */,
 				F3EDCA035BBAB0CF568F51A01F8CD5C4 /* Bundle React Native code and images */,
 				D30FCE1E350F4965931BD17D /* [CP] Embed Pods Frameworks */,
 				F4913D0151294198FC1A8191 /* [CP] Copy Pods Resources */,
 				E2C265C970ACF793BCF15D2D /* [CP-User] [RNFB] Core Configuration */,
 				9D897891346AC1496A589F0D /* [CP-User] [RNFB] Crashlytics Configuration */,
-				99C9732089753FE060B2B9AB /* Embed Watch Content */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## Problem

Every iOS staging/production deploy (`platformDeploy.yml`) fails on the production-scheme archive with:

```
error: Cycle inside kiroku; building could produce unreliable results.
** ARCHIVE FAILED **   (exit 65)
```

Deterministic across all retries (e.g. [run 28247116336](https://github.com/PetrCala/Kiroku/actions/runs/28247116336), commit `a6d776352`). Android is unaffected. `automatic_release` is `false`, so this is not a production store outage, but iOS staging/TestFlight is blocked until it lands.

Regression source: **#1445** (Phase 1, `0a35339e4`), which deleted the orphaned `watchapp2` target and added an **"Embed Watch Content"** copy-files phase (+ a watch target dependency) to the `kiroku` app target. PR test builds and ad-hoc builds only target the **simulator**, which signs ad-hoc and never materializes the cycle, so it wasn't caught pre-merge.

## Root cause

CocoaPods/RN appended "Embed Watch Content" as the **last** phase of the `kiroku` target, *after* three script phases that declare **no outputs**:

- `Bundle React Native code and images` (`alwaysOutOfDate`, no outputs)
- `[CP-User] [RNFB] Core Configuration` (reads `$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`, no outputs)
- `[CP-User] [RNFB] Crashlytics Configuration` (reads the dSYM + Info.plist, no outputs)

Because those phases declare no outputs, Xcode can't bound what they touch and orders the host `CodeSign` conservatively around them. With the watch-embed copy — which mutates the same `.app` and pulls in a **nested** `Kiroku Watch App.app` that the host `CodeSign` then re-signs — placed *after* those phases, the ordering constraints close into a loop → `Cycle inside kiroku`. It only appears once **profile-based signing resolves** (the nested `CodeSign` / `ProcessProductPackaging` nodes only exist then), which is exactly why simulator/ad-hoc builds don't hit it.

## Fix

Move "Embed Watch Content" to run **before** the no-output script phases, right after `[User] Copy GoogleService-Info.plist`:

```
  [User] Copy GoogleService-Info.plist
→ Embed Watch Content                    ← moved up (was last)
  Bundle React Native code and images
  [CP] Embed Pods Frameworks
  [CP] Copy Pods Resources
  [CP-User] [RNFB] Core Configuration
  [CP-User] [RNFB] Crashlytics Configuration
```

The watch app is a **target dependency** of `kiroku`, so its product already exists before any of the host's phases run — embedding it early is safe, and the host `CodeSign` (which runs after every phase) still signs the embedded watch. This matches Apple's canonical "embed content, then finalize/sign" ordering and removes the cyclic edge. One-line move; no functional change to any phase.

## Verification

- ✅ `plutil -lint` passes; the project parses.
- ✅ **Durable across `pod install`** — ran `pod install` on the reordered project; CocoaPods preserves the "Embed Watch Content" position (it's a user-owned phase CocoaPods doesn't manage), so re-integration doesn't undo the fix. No Podfile `post_install` hook needed.
- ⚠️ **The literal cycle can't be reproduced locally.** It only materializes when the real profile-based distribution signing resolves, which needs the encrypted assets (`*.mobileprovision.gpg` / `Certificates.p12.gpg`, decrypted in CI via `LARGE_SECRET_PASSPHRASE`). Across three local archive attempts (signing disabled, ad-hoc `-`, and default profile signing without the cert installed) the `CodeSign`/`ProcessProductPackaging` nodes were pruned and no cycle ever formed — so a local "cycle gone" check isn't possible either way. **The conclusive gate is the next staging deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
