### PR TITLE
fix(ios): sync embedded Watch app version with host on bump

### DIFF
--- a/.github/actions/javascript/bumpVersion/index.js
+++ b/.github/actions/javascript/bumpVersion/index.js
@@ -27775,7 +27775,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.PLIST_PATH_TEST = exports.PLIST_PATH = exports.BUILD_GRADLE_PATH = void 0;
+exports.PLIST_PATH_WATCH = exports.PLIST_PATH_TEST = exports.PLIST_PATH = exports.BUILD_GRADLE_PATH = void 0;
 exports.updateiOSVersion = updateiOSVersion;
 exports.updateAndroidVersion = updateAndroidVersion;
 exports.generateAndroidVersionCode = generateAndroidVersionCode;
@@ -27792,6 +27792,11 @@ const PLIST_PATH = './ios/kiroku/Info.plist';
 exports.PLIST_PATH = PLIST_PATH;
 const PLIST_PATH_TEST = './ios/kirokuTests/Info.plist';
 exports.PLIST_PATH_TEST = PLIST_PATH_TEST;
+// The embedded Apple Watch app must carry the exact same CFBundleShortVersionString
+// and CFBundleVersion as its containing iOS app, or App Store Connect rejects the
+// upload with a "CFBundleVersion Mismatch" (409) validation error.
+const PLIST_PATH_WATCH = './ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist';
+exports.PLIST_PATH_WATCH = PLIST_PATH_WATCH;
 /**
  * Pad a number to be two digits (with leading zeros if necessary).
  */
@@ -27842,6 +27847,9 @@ function updateiOSVersion(version) {
     (0, child_process_1.execSync)(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`);
     (0, child_process_1.execSync)(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`);
     (0, child_process_1.execSync)(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`);
+    // Single-quote the watch plist path because it contains spaces.
+    (0, child_process_1.execSync)(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" '${PLIST_PATH_WATCH}'`);
+    (0, child_process_1.execSync)(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" '${PLIST_PATH_WATCH}'`);
     // Return the cfVersion so we can set the NEW_IOS_VERSION in ios.yml
     return cfVersion;
 }

--- a/.github/libs/nativeVersionUpdater.ts
+++ b/.github/libs/nativeVersionUpdater.ts
@@ -16,6 +16,10 @@ const BUILD_GRADLE_PATH =
     : './android/app/build.gradle';
 const PLIST_PATH = './ios/kiroku/Info.plist';
 const PLIST_PATH_TEST = './ios/kirokuTests/Info.plist';
+// The embedded Apple Watch app must carry the exact same CFBundleShortVersionString
+// and CFBundleVersion as its containing iOS app, or App Store Connect rejects the
+// upload with a "CFBundleVersion Mismatch" (409) validation error.
+const PLIST_PATH_WATCH = './ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist';
 
 /**
  * Pad a number to be two digits (with leading zeros if necessary).
@@ -92,6 +96,13 @@ function updateiOSVersion(version: string): string {
   execSync(
     `/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`,
   );
+  // Single-quote the watch plist path because it contains spaces.
+  execSync(
+    `/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" '${PLIST_PATH_WATCH}'`,
+  );
+  execSync(
+    `/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" '${PLIST_PATH_WATCH}'`,
+  );
 
   // Return the cfVersion so we can set the NEW_IOS_VERSION in ios.yml
   return cfVersion;
@@ -104,4 +115,5 @@ export {
   BUILD_GRADLE_PATH,
   PLIST_PATH,
   PLIST_PATH_TEST,
+  PLIST_PATH_WATCH,
 };

--- a/ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist
+++ b/ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.3.20</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.1.1</string>
+	<string>0.3.20.9</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Problem

With the archive build cycle fixed (#1450), the iOS deploy now reaches the App Store Connect upload — and fails there. `altool` rejects the binary with a **409 validation error** ([run 28257715937](https://github.com/PetrCala/Kiroku/actions/runs/28257715937), `0.3.20-10`):

```
Validation failed (409) CFBundleVersion Mismatch. The CFBundleVersion value
'0.0.1.1' of watch application 'kiroku.app/Watch/Kiroku Watch App.app' does
not match the CFBundleVersion value '0.3.20.10' of its containing iOS app.

Validation failed (409) CFBundleShortVersionString Mismatch. '0.0.1' (watch)
does not match '0.3.20' (host).
```

Apple requires an embedded watch app's `CFBundleShortVersionString` **and** `CFBundleVersion` to match the containing iOS app exactly. (Android is unaffected and already deploys.)

## Root cause

The deploy's version bump — `updateiOSVersion()` in [`.github/libs/nativeVersionUpdater.ts`](.github/libs/nativeVersionUpdater.ts) — `PlistBuddy`-sets the version on the **host** (`ios/kiroku/Info.plist`) and **test** (`ios/kirokuTests/Info.plist`) plists, but never the watch app's `ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist`, which stayed pinned at its literal `0.0.1` / `0.0.1.1`. The watch was embedded in #1445; this versioning gap was simply never reachable until the cycle fix let the archive get to the upload.

## Fix

- Add `PLIST_PATH_WATCH` and two `PlistBuddy` `Set` calls to `updateiOSVersion()`, mirroring exactly how host + test are handled — so all three plists move in lockstep on every bump. The watch path contains spaces, so it's **single-quoted** in the command.
- Align the committed watch plist (`0.0.1` → `0.3.20` / `0.3.20.9`) with the host, so the checked-in state is consistent for ad-hoc archives (which skip Apple's match check).
- Rebuilt the bundled `bumpVersion` action (`npm run gh-actions-build -- bumpVersion`), since CI runs the compiled `index.js`.

## Verification

- ✅ Ran the exact generated command against a spaced-path copy of the watch plist: `0.3.20`/`0.3.20.9` → `0.3.21`/`0.3.21.5`, plist stays `plutil -lint` clean — confirms the single-quoting handles the spaces.
- ✅ `ncc` rebuild compiled the `bumpVersion.ts` → `nativeVersionUpdater.ts` path cleanly (TypeScript 5.9.3); the bundled `index.js` now contains the watch plist path.
- ✅ No unit test references this module (host/test plist handling has none either), so nothing to update.
- The conclusive gate is the next staging deploy: the version bump will write the same `0.3.20`/`0.3.20.x` into all three plists, and altool's match validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
