### PR TITLE
fix(android): extract native libs to recover libc++_shared.so DSO crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,6 +109,20 @@ android {
         resConfigs "en", "cs"
     }
 
+    // Extract native libraries to the install's nativeLibraryDir at install time
+    // (extractNativeLibs=true) instead of loading them compressed from inside the APK.
+    // SoLoader's DirectApkSoSource (the default, uncompressed path) fails with
+    // "couldn't find DSO to load: libc++_shared.so" in environments where the OS-selected
+    // ABI and the runtime-reported primary ABI disagree (x86/x86_64 devices with ARM
+    // translation, emulators, cloud phones, app cloners, partial Play installs). Forcing
+    // extraction lets those installs resolve the lib via ApplicationSoSource. Trade-off:
+    // slightly larger on-disk install size.
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     flavorDimensions "default"
     productFlavors {
         // we need to define a production flavor but since it has default config, we can leave it empty


### PR DESCRIPTION
## Problem

Firebase Crashlytics reports a fatal launch crash on Android (~17 crashes / 5 users on the 0.3.19 line):

```
Fatal Exception: com.facebook.soloader.SoLoaderDSONotFoundError:
couldn't find DSO to load: libc++_shared.so
  at ...ReactNativeFeatureFlagsCxxInterop.<clinit>
  at ...DefaultNewArchitectureEntryPoint.load
  at ...ReactNativeApplicationEntryPoint.loadReactNative
  at com.alcohol_tracker.MainApplication.onCreate(MainApplication.kt:49)
```

The app dies at the first line of startup, before any JS runs, because SoLoader can't find `libc++_shared.so` (the C++ runtime every RN native lib depends on).

## Root cause — ABI / install mismatch, not a code defect

The crash trace's SoSource list contradicts itself:

- **SoSource 0** (`ApplicationSoSource`) → extracted native-lib dir is `.../lib/`**`x86_64`** (the OS installed the app as x86_64).
- **SoSource 1** (`DirectApkSoSource`) → searches inside the split APKs at `!/lib/`**`arm64-v8a`** (runtime reports arm64 as the primary ABI).

The OS laid the app down as x86_64 but `Build.SUPPORTED_ABIS` reports arm64 first, so SoLoader's uncompressed `DirectApkSoSource` looks in the arm64 folder and finds nothing loadable. The install also has *every* ABI split present at once (`x86`, `x86_64`, `arm64_v8a`, `armeabi_v7a`), which a normal Play install never does.

That signature points to **non-standard runtime environments**: x86/x86_64 devices with ARM translation (libhoudini / Intel Bridge), emulators, cloud-phone / app-cloning services, Windows Subsystem for Android, or corrupted/partial Play installs. The bounded count (5 users) confirms it — a true packaging/code defect would crash 100% of Android launches.

## Fix

We were on AGP defaults (`useLegacyPackaging = false` → `extractNativeLibs = false`), which keeps native libs compressed inside the APK and loads them via the failing `DirectApkSoSource` path. This PR sets:

```gradle
packagingOptions {
    jniLibs {
        useLegacyPackaging = true
    }
}
```

Forcing extraction at install time lets these installs resolve `libc++_shared.so` via `ApplicationSoSource` (the path that already resolved to the device's actual ABI dir) instead of guessing from inside the APK. This is the standard mitigation for the "couldn't find DSO `libc++_shared.so`" symptom on App Bundle installs.

**Trade-off:** slightly larger on-disk install size. It won't recover genuinely corrupted installs (those still need a reinstall / clear-data), but it should recover the emulator/translation-layer cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)