### PR TITLE
fix(ios): commit the watch plist on version bump via git add -u

### DIFF
--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -104,12 +104,27 @@ jobs:
 
       - name: Commit new version
         run: |
-          git add \
-            ./package.json \
-            ./package-lock.json \
-            ./android/app/build.gradle \
-            ./ios/kiroku/Info.plist \
-            ./ios/kirokuTests/Info.plist
+          set -eo pipefail
+
+          # Stage every tracked file the bump modified. This job runs on a fresh
+          # master checkout where only the bumpVersion action edits tracked files
+          # (package.json, package-lock.json, android/app/build.gradle, and the
+          # iOS Info.plists incl. the embedded Watch app), so `-u` captures
+          # exactly them — without a hardcoded allow-list that silently drops a
+          # newly added native version file (the cause of the watch-app version
+          # mismatch that broke the iOS upload).
+          git add -u
+
+          # A bump must change something; fail loudly rather than erroring out on
+          # an empty commit if bumpVersion produced no diff.
+          if git diff --cached --quiet; then
+            echo "::error::No version files changed; bumpVersion produced no diff to commit."
+            exit 1
+          fi
+
+          echo "Committing version bump for:" >> "$GITHUB_STEP_SUMMARY"
+          git diff --cached --name-only | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+
           git commit -m "chore: release $NEW_VERSION"
 
       - name: Push version bump branch

--- a/ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist
+++ b/ios/Kiroku Watch App/Kiroku-Watch-App-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.3.20</string>
 	<key>CFBundleVersion</key>
-	<string>0.3.20.9</string>
+	<string>0.3.20.12</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Problem

The `0.3.20-12` staging deploy ([run 28300097083](https://github.com/PetrCala/Kiroku/actions/runs/28300097083)) still failed the App Store Connect upload with a 409 — the numbers *moved* but didn't match:

```
CFBundleVersion '0.3.20.9' (watch)  ≠  '0.3.20.12' (host)
```

#1452 correctly taught `updateiOSVersion()` to `PlistBuddy`-rewrite the embedded Watch app's `Info.plist`, but the **commit** step in [`createNewVersion.yml`](.github/workflows/createNewVersion.yml) staged a **hardcoded `git add` allow-list** (`package.json`, `package-lock.json`, `build.gradle`, host + test plists) that never included the watch plist. So the bump rewrote it on disk and the commit dropped it — confirmed against the release commits: host `0.3.20.11`/`0.3.20.12`, watch stuck at `0.3.20.9` in every one.

## Fix

Replace the allow-list with **`git add -u`** so every tracked file the bump modifies is staged. The job runs on a fresh `master` checkout where only the `bumpVersion` action edits tracked files, so this stages exactly the bumped version files — and a future native version file never needs a workflow edit (this hardcoded list was the root cause: a version file had to be added in *two* places, and #1452 only did one).

Guardrails so `-u` stays safe and observable:
- **Sanity check** — fail loudly (`::error::`) if the bump produced no staged diff, instead of erroring out on an empty `git commit`.
- **Log the committed files** to the step summary for auditability.
- `set -eo pipefail`, matching sibling steps.

Also align the committed watch plist (`0.3.20.9` → `0.3.20.12`) with the current host so master isn't left mismatched until the next bump.

## Verification

- ✅ `js-yaml` parses the workflow; `plutil -lint` passes on the plist.
- ✅ Confirmed no step before the commit (no `npm install`/codegen) dirties other tracked files, so `-u` only ever stages the bump's edits.
- The next bump (this PR's merge triggers `0.3.20-13`) stages host + test + watch together, so the archived watch matches the host and altool's version check passes — that deploy is the end-to-end confirmation.

Third and final link in the chain: **#1450** (archive cycle) → **#1452** (bump rewrites the watch plist) → this (the bump commit keeps it, durably).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
