### PR TITLE
test(e2e): bound dev-gate clicks so cold-boot sign-in can't burn the 90s timeout

### DIFF
--- a/e2e/web/fixtures/devGates.ts
+++ b/e2e/web/fixtures/devGates.ts
@@ -24,9 +24,21 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
   const confirmTerms = page.getByRole('button', {name: 'Confirm'});
   const agreeToTerms = page.getByRole('checkbox').first();
 
+  // Every gate interaction below is BOUNDED. A blind `.click()` inherits the
+  // (90 s) test/fixture timeout, so when the verify-email modal overlays a Home
+  // that is still settling on a cold boot, Playwright's actionability wait can
+  // burn the whole budget on a single click — the cause of the first-attempt
+  // sign-in flake (the fixture timed out mid-click even though Home had already
+  // rendered). A short per-click budget fails fast and lets the loop re-try once
+  // the page settles, then fall through to the Home check below. Home being up
+  // is the real success signal; the gates are best-effort and re-cleared on
+  // later loads (the worker session's auth token is already valid by then).
+  const GATE_CLICK_TIMEOUT = 4_000;
+  const GATE_DISMISS_TIMEOUT = 4_000;
+
   // A couple of gates can stack between sign-in and Home; clear whatever is up
   // until Home renders (or we run out of attempts and assert below).
-  for (let attempt = 0; attempt < 8; attempt += 1) {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
     if (await home.isVisible().catch(() => false)) {
       // VerifyEmailModal can mount ~1 s after Home (fires after the Firebase auth
       // callback) and covers the NavigationRoot with a high z-index. Playwright's
@@ -44,22 +56,34 @@ export async function reachAuthenticatedApp(page: Page): Promise<void> {
 
     if (await confirmTerms.isVisible().catch(() => false)) {
       if (await agreeToTerms.isVisible().catch(() => false)) {
-        await agreeToTerms.click();
+        await agreeToTerms.click({timeout: GATE_CLICK_TIMEOUT}).catch(() => {});
       }
-      await confirmTerms.click();
+      await confirmTerms.click({timeout: GATE_CLICK_TIMEOUT}).catch(() => {});
+      // Converge on the gate actually clearing rather than racing the next
+      // iteration; bounded so a click that didn't land just re-tries next pass.
+      await confirmTerms
+        .waitFor({state: 'hidden', timeout: GATE_DISMISS_TIMEOUT})
+        .catch(() => {});
     } else if (await skipVerification.isVisible().catch(() => false)) {
-      await skipVerification.click();
+      await skipVerification
+        .click({timeout: GATE_CLICK_TIMEOUT})
+        .catch(() => {});
+      await skipVerification
+        .waitFor({state: 'hidden', timeout: GATE_DISMISS_TIMEOUT})
+        .catch(() => {});
+    } else {
+      // Neither a gate nor Home is up yet (cold first paint) — wait for the next
+      // screen to mount before retrying.
+      await home
+        .or(skipVerification)
+        .or(confirmTerms)
+        .first()
+        .waitFor({state: 'visible', timeout: 15_000})
+        .catch(() => {});
     }
-
-    // Wait for the next screen (Home or another gate) to mount before retrying.
-    await home
-      .or(skipVerification)
-      .or(confirmTerms)
-      .first()
-      .waitFor({state: 'visible', timeout: 15_000})
-      .catch(() => {});
   }
 
-  // Final assertion: surfaces a clear failure if Home never came up.
+  // Final assertion: Home being up is the real success signal — surfaces a clear
+  // failure if it never came up.
   await home.waitFor({state: 'visible'});
 }


### PR DESCRIPTION
## Background

Follow-up to #1406. A manual `workflow_dispatch` of `deployWeb.yml` (PR #1406's preview) ran the full Playwright suite green **on retry** — but the log showed the first test (`calendar.spec.ts`, alphabetically first) failed on attempt 1 with:

```
Fixture "workerStorageState" timeout of 90000ms exceeded during setup.
  - attempting click action  (on "Skip verification (dev only)")
    - waiting for element to be visible, enabled and stable   ← re-polling to 90s
```

## Root cause (from the failed-attempt artifact)

The failed attempt's **page snapshot shows a fully-rendered, interactive Home** — sign-in had already succeeded; there was no splash and no stuck gate. So the 90s was **not** legitimate sign-in work (a normal sign-in here is ~5–7s; the same test passed on retry in 6.5s).

The time was burned inside the shared sign-in helper `reachAuthenticatedApp` (`e2e/web/fixtures/devGates.ts`): it cleared the email-verification gate with a blind `.click()`, which **inherits the 90s test/fixture timeout**. The verify-email modal mounts ~1s after Home and overlays it; on a cold preview boot Home is still settling, so Playwright's actionability wait (visible/stable/receives-pointer-events) never found a quiet frame and the single click consumed the whole budget — the fixture died mid-click. It only hit `calendar.spec.ts` because that's now the first test to trigger the one-time worker sign-in.

## Fix

Bound every gate interaction so no single click can wedge the fixture:
- `.click({timeout: 4_000})` (caught) on the Skip/Confirm/agree buttons,
- a bounded `waitFor({state: 'hidden'})` after each so the loop converges,
- the loop then falls through to `home.waitFor()` — **Home being up is the real success signal**, and the gates are best-effort (re-cleared on later loads once the worker session's token is valid).

This is deliberately **not** a timeout bump: 90s should be ample for a sign-in, so the right fix is to stop a stuck click from consuming it, not to give the stuck click more room.

## What this does NOT fix

Why the click couldn't land for so long implies Home wasn't reaching a *stable* frame on that boot. That may be the known Home render-churn class (#<see linked issue>) surfacing with an ongoing session on the account. This PR makes the harness resilient regardless; the potential product churn is tracked separately.

## Verification

- Locally: deleted the cached `.auth`, forced a fresh sign-in through the modified helper — `smoke` sign-in + `session-lifecycle` + `calendar` all pass.
- Will re-dispatch `deployWeb.yml` against this PR to confirm the first attempt is green on the cold preview channel (probabilistic flake, so a green run is a strong signal; the fix is structurally sound by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)