### PR TITLE
ci: single all-green PR gate (prevention over self-heal)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,9 @@
 name: ESLint check
 
+# PR CI runs via prChecks.yml (the all-green gate); master CI via preDeploy.yml. Both call this
+# reusable workflow, so it has no standalone pull_request trigger (avoids double-runs).
 on:
   workflow_call:
-  pull_request:
-    types: [opened, synchronize]
-    branches-ignore: [staging, production]
-    paths: ['**.js', '**.ts', '**.tsx', '**.json', '**.mjs', '**.cjs']
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-lint

--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -1,0 +1,56 @@
+# Single entry point for pull-request CI.
+#
+# Triggers on EVERY pull request (no path filter) so the `all-green` gate always reports a status —
+# which makes it a reliable required check for branch protection (a path-filtered required check would
+# hang a docs-only PR on "Expected — waiting for status"). It fans out to the same reusable workflows
+# the master pipeline (preDeploy.yml) runs, so PR CI and master CI stay in lockstep. Those reusable
+# workflows no longer trigger on `pull_request` themselves, so nothing double-runs.
+name: PR checks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    uses: ./.github/workflows/typecheck.yml
+
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    uses: ./.github/workflows/test.yml
+
+  react-compiler:
+    uses: ./.github/workflows/react-compiler-compliance.yml
+
+  all-green:
+    name: all-green
+    runs-on: ubuntu-latest
+    needs: [typecheck, lint, test, react-compiler]
+    if: ${{ always() }}
+    steps:
+      - name: Require all PR checks to pass
+        env:
+          TYPECHECK: ${{ needs.typecheck.result }}
+          LINT: ${{ needs.lint.result }}
+          TEST: ${{ needs.test.result }}
+          REACT_COMPILER: ${{ needs.react-compiler.result }}
+        run: |
+          echo "typecheck=$TYPECHECK lint=$LINT test=$TEST react-compiler=$REACT_COMPILER"
+          failed=0
+          for status in "$TYPECHECK" "$LINT" "$TEST" "$REACT_COMPILER"; do
+            if [[ "$status" == "failure" || "$status" == "cancelled" ]]; then
+              failed=1
+            fi
+          done
+          if [[ "$failed" -ne 0 ]]; then
+            echo "::error::One or more required PR checks did not pass."
+            exit 1
+          fi
+          echo "All required PR checks passed (skipped checks are allowed)."

--- a/.github/workflows/react-compiler-compliance.yml
+++ b/.github/workflows/react-compiler-compliance.yml
@@ -1,11 +1,9 @@
 name: React Compiler Compliance Check
 
+# PR CI runs via prChecks.yml (the all-green gate); master CI via preDeploy.yml. Both call this
+# reusable workflow, so it has no standalone pull_request trigger (avoids double-runs).
 on:
   workflow_call:
-  pull_request:
-    types: [opened, synchronize]
-    branches-ignore: [staging, production]
-    paths: ['**.ts', '**.tsx']
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-react-compiler-compliance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,9 @@
 name: Jest Unit Tests
 
+# PR CI runs via prChecks.yml (the all-green gate); master CI via preDeploy.yml. Both call this
+# reusable workflow, so it has no standalone pull_request trigger (avoids double-runs).
 on:
   workflow_call:
-  pull_request:
-    types: [opened, synchronize]
-    branches-ignore: [staging, production]
-    paths:
-      ['**.js', '**.ts', '**.tsx', '**.sh', 'package.json', 'package-lock.json']
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-jest

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,20 +1,10 @@
 # TypeScript type-checking workflow
 name: TypeScript Checks
 
+# PR CI runs via prChecks.yml (the all-green gate); master CI via preDeploy.yml. Both call this
+# reusable workflow, so it has no standalone pull_request trigger (avoids double-runs).
 on:
   workflow_call:
-  pull_request:
-    types: [opened, synchronize]
-    branches-ignore: [staging, production]
-    paths:
-      [
-        '**.js',
-        '**.ts',
-        '**.tsx',
-        'package.json',
-        'package-lock.json',
-        'tsconfig.json',
-      ]
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-typecheck


### PR DESCRIPTION
## What

Adds one reliable **`all-green`** required-check gate for PRs, so broken code can't land on `master` in the first place — the prevention-first approach large codebases use, instead of the dispatch-only LLM self-heal (#1352, now closed).

## Why

PR CI already runs the same checks as master (`typecheck`/`lint`/`test`/`react-compiler` trigger on both `pull_request` and `workflow_call`). The real gap is **enforcement**: `master` has no branch protection, so a PR can merge while its checks are red, pending, or absent. The blocker to simply "require the checks" is that they're **path-filtered** — a required path-filtered check hangs a docs-only PR forever on *"Expected — waiting for status."*

## How

- **New [prChecks.yml](.github/workflows/prChecks.yml)** runs on **every** PR (no path filter) and fans out to the existing reusable `typecheck`/`lint`/`test`/`react-compiler` workflows, then an **`all-green`** job (`if: always()`) aggregates their results — failing only if a check failed/was cancelled (skips allowed). Because it always runs, `all-green` always reports a status → safe as the **sole required check**.
- **Removed the standalone `pull_request` triggers** from the four reusable workflows (they keep `workflow_call`), so they run **once** — via `prChecks` on PRs, via `preDeploy` on master — never twice. Cost for code PRs is unchanged; docs-only PRs now run the suite (cheap) so the gate can report.

## Follow-up (separate, after this merges to master)

Enable branch protection on `master` requiring **`all-green`**, with **admins exempt** so the KirokuAdmin release flow (`createNewVersion.yml` admin-merges) keeps working untouched. Deferring it until `all-green` exists on master + the context name is confirmed from a real run, so it doesn't block in-flight PRs.

## Verification

- `npm run gh-actions-validate`: all five workflows schema-valid; no actionlint errors in the changed files (only the pre-existing `lint.yml` untrusted-input advisory).
- This PR's own checks exercise the new gate end-to-end (the old per-check triggers are already removed on this branch, so you'll see a single `PR checks` run + `all-green`, no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)