### PR TITLE
fix(ios): stop CI auto-submitting production builds for App Store review

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -373,8 +373,7 @@ platform :ios do
       # app_version needs to be set to the short version, without the last digit e.g. '1.0.92'
       app_version: ENV["VERSION"].rpartition(".")[0],
 
-      # We want to submit the version for Apple to review
-      submit_for_review: true,
+      submit_for_review: false,
 
       # Do NOT auto-release on approval — keep the approved build as Pending
       # Developer Release so we control the public launch date.


### PR DESCRIPTION
## Problem

The 0.3.20 production deploy completed with **failure** — Android shipped, but the iOS job failed at the very last step. The binary built, was signed, uploaded, and distributed to TestFlight successfully; the failure was `deliver` → `create_review_submission`:

```
appStoreVersions ... is not in valid state. This resource cannot be reviewed
App screenshot missing (APP_WATCH_SERIES_4). A screenshot with type watch is required but was not provided
```

**Root cause:** 0.3.20 embedded the Apple Watch app, so App Store Connect now requires an Apple Watch screenshot before the iOS version can be submitted for review. The `:production` lane runs `deliver(submit_for_review: true, skip_screenshots: true)`, so it auto-submits for review without an APP_WATCH_SERIES_4 screenshot and the submission is rejected. precheck passes — the rejection comes from the ASC submit API, not a build/signing problem.

## Fix

Set `submit_for_review: false` in the `:production` lane.

- CI still uploads metadata to the ASC draft and distributes the build to TestFlight (both already work, both unchanged).
- The App Store **review submission** becomes a deliberate manual step (`asc` skill / App Store Connect UI), instead of an auto-submit that breaks the whole deploy on any unmet ASC requirement.
- This matches the existing manual-control intent of `automatic_release: false` right below it — public launch was already manual; now the review submission is too.

## Why this approach over the alternatives

- **Add a Watch screenshot + keep auto-submit:** zero code change, but it makes a still-in-development Watch app publicly visible on the store listing just to make CI green — wrong reason to flip that product switch.
- **Un-embed the Watch app from the App Store build:** the right long-term move *if* the Watch app stays store-deferred, but it's brittle build-config work and can't help the already-uploaded 0.3.20 binary.
- **This (decouple submit-for-review):** one low-risk line, fixes every future production deploy, and leaves the Watch-app store decision to a deliberate manual submission.

## Follow-up (not in this PR)

When a version is actually ready for the public App Store, submit it manually — and resolve the Watch question once: either upload the required Apple Watch screenshot (launch it) or ship a build that excludes the Watch target (keep it deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)