### PR TITLE
ci(web): run Playwright smoke suite after staging web deploys

### DIFF
--- a/.github/workflows/deployWeb.yml
+++ b/.github/workflows/deployWeb.yml
@@ -25,6 +25,14 @@ name: Deploy web
 # After the preview channel deploys, a `playwright` job runs the web smoke suite
 # (e2e/web) against the preview URL. It needs two repo secrets holding a
 # dev-backend test account: E2E_TEST_EMAIL and E2E_TEST_PASSWORD.
+#
+# After a `staging` push deploy, a separate `playwrightStaging` job runs the
+# same suite against the live app-dev.kiroku.cz site as a non-gating post-deploy
+# canary (the deploy already happened by the time this runs; a red run is a
+# signal picked up by the repo's failure-notifier/Discord alerting, not a
+# block -- `deployLive` never depends on it). It reuses the same two secrets.
+# `production` pushes never run Playwright: the test account only exists on the
+# DEV Firebase project, and the suite writes data that must never hit prod.
 on:
   push:
     branches: [staging, production]
@@ -82,6 +90,18 @@ jobs:
       - name: Stage .env.adhoc from secret
         if: ${{ github.ref_name == 'staging' }}
         run: echo "${{ secrets.ADHOC_ENV_FILE }}" > .env.adhoc
+
+      # .env.adhoc points at the same Firebase project (dev-alcohol-tracker-db)
+      # as .env.development, which the deployPreview job builds with this same
+      # bypass for the same reason: the E2E test account may lack
+      # onboarding.completed_at, so without it OnboardingGuard redirects the
+      # post-deploy Playwright run (job `playwrightStaging`, below) into an
+      # unhandled onboarding screen and it times out. This flag is baked into
+      # the live build, so it also affects real visitors to app-dev.kiroku.cz --
+      # acceptable for a dev-only site, but worth knowing before touching this.
+      - name: Enable onboarding bypass for Playwright build
+        if: ${{ github.ref_name == 'staging' }}
+        run: echo "SKIP_ONBOARDING=true" >> .env.adhoc
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
@@ -184,7 +204,9 @@ jobs:
   # Smoke-tests the freshly deployed preview channel. `needs: [deployPreview]`
   # both supplies the preview URL and scopes this to the preview path only: when
   # deployPreview is skipped (the staging/production push paths) this job is
-  # skipped too, so live deploys are never gated on a smoke run.
+  # skipped too, so live deploys are never gated on a smoke run. See
+  # `playwrightStaging` below for the equivalent post-deploy canary on staging
+  # pushes.
   playwright:
     name: Playwright web smoke
     needs: [deployPreview]
@@ -229,5 +251,50 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
+          path: e2e/web/playwright-report/
+          retention-days: 7
+
+  # Post-deploy smoke canary for the `staging` push path. `needs: [deployLive]`
+  # alone is not enough to scope this to staging -- deployLive also runs on
+  # `production` pushes -- so the branch check lives in `if:`. Deliberately
+  # excludes `production`: the E2E test account only exists on the DEV Firebase
+  # project auth (dev-alcohol-tracker-db), and the suite writes data that must
+  # never land in the prod DB. Non-gating by design: the deploy has already
+  # happened by the time this runs, so a red run here is a signal (surfaced via
+  # the repo's failure-notifier/Discord alerting), not a block -- deployLive
+  # never depends on this job.
+  playwrightStaging:
+    name: Playwright web smoke (staging)
+    needs: [deployLive]
+    if: ${{ github.event_name == 'push' && github.ref_name == 'staging' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Install Playwright browser (Chromium)
+        run: npx playwright install --with-deps chromium
+
+      # PLAYWRIGHT_BASE_URL points the suite at the live site deployLive just
+      # published. E2E_TEST_EMAIL / E2E_TEST_PASSWORD are the same dev-backend
+      # test account secrets the preview-path `playwright` job uses above (the
+      # adhoc build shares the same DEV Firebase project as the preview build --
+      # see the "Enable onboarding bypass" step in deployLive for why
+      # SKIP_ONBOARDING is also needed here).
+      - name: Run web smoke suite against app-dev.kiroku.cz
+        env:
+          PLAYWRIGHT_BASE_URL: https://app-dev.kiroku.cz
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+        run: npm run test:e2e:web
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-staging
           path: e2e/web/playwright-report/
           retention-days: 7


### PR DESCRIPTION
## Summary

- Add a `playwrightStaging` job to `deployWeb.yml` that runs the existing `e2e/web` Playwright smoke suite against `https://app-dev.kiroku.cz` right after `deployLive` finishes deploying a `staging` push. Non-gating: `deployLive` never depends on it, so a red run is a signal (picked up by the repo's existing failure-notifier/Discord alerting), not a merge/deploy blocker.
- Scoped to `staging` only via `if: github.event_name == 'push' && github.ref_name == 'staging'` — `needs: [deployLive]` alone isn't enough since `deployLive` also runs on `production` pushes. `production` is deliberately excluded: the `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD` account only exists on the DEV Firebase project auth, and the suite writes data that must never land in the prod DB.
- Steps mirror the existing preview-path `playwright` job (checkout, `setupNode` composite action, install Chromium, run `npm run test:e2e:web`, upload the Playwright report). The report artifact is named `playwright-report-staging` so it never collides with the preview job's `playwright-report` when both run in the same workflow (e.g. a PR merge that both labels-builds a preview and pushes to staging).
- Verified (not assumed) that the onboarding bypass matters here: `.env.adhoc` (staging build) and `.env.development` (preview build) point at the **same** Firebase project (`dev-alcohol-tracker-db`), and `SKIP_ONBOARDING=true` was added to the preview build in 8aeb122ae for a concrete reason — "the test account... may lack onboarding.completed_at" — not defensively. Since the staging build shares that backend and that account, the same failure mode (OnboardingGuard redirect → unhandled screen → fixture timeout) applies, so this PR stages `SKIP_ONBOARDING=true` into `.env.adhoc` for staging pushes, guarded by the same `if: github.ref_name == 'staging'` as the existing "Stage .env.adhoc" step.
  - **Caveat called out in the workflow comment:** unlike the preview channel (a throwaway, non-indexed URL), this flag is baked into the live `app-dev.kiroku.cz` build, so it also bypasses onboarding for real visitors to the dev site. That's a dev-only site anyone can already reach, so this seems acceptable, but flagging it explicitly in case anyone relies on exercising the dev-site onboarding flow.
- Updated the header comment block and the existing `playwright` job's comment to describe/cross-reference the new staging path.

## Test plan

- [x] `actionlint .github/workflows/deployWeb.yml` — clean, no findings.
- [x] `npx prettier --write .github/workflows/deployWeb.yml` — no changes needed.
- [ ] No local way to fully exercise a workflow change; the real test is the next push to `staging`, where `playwrightStaging` should run automatically post-deploy and both pass and be non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)