### PR TITLE
fix(api): point staging-classified builds at the prod kiroku-api root

### DIFF
--- a/__tests__/unit/libs/KirokuApiRoot.test.ts
+++ b/__tests__/unit/libs/KirokuApiRoot.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+
+/**
+ * Play internal-track (staging) builds are the production flavor with the prod
+ * Firebase config baked in at build time; they merely runtime-classify as
+ * STAGING via the beta checker (installed version > latest GitHub release). If
+ * the kiroku-api root followed that classification to the dev API, the
+ * prod-issued Firebase ID token would get a 401 and trigger an instant
+ * sign-out, bouncing every login on a staging build back to the sign-in
+ * screen. These tests pin the root selection per environment:
+ * prod + staging → prod API; dev/adhoc (which bake the dev Firebase project)
+ * → dev API.
+ */
+import type * as ApiUtilsType from '@libs/ApiUtils';
+import CONFIG from '@src/CONFIG';
+import CONST from '@src/CONST';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  default: {connect: jest.fn(), disconnect: jest.fn()},
+}));
+
+// ApiUtils resolves the environment once at import; make it controllable.
+let mockEnvironment: string;
+jest.mock('@libs/Environment/Environment', () => ({
+  getEnvironment: jest.fn(() => Promise.resolve(mockEnvironment)),
+}));
+
+/**
+ * Load a fresh ApiUtils under the given environment. The env name is applied
+ * through a module-scope promise at import, so flush microtasks before reading
+ * the selected root.
+ */
+async function getKirokuApiRootFor(environment: string): Promise<string> {
+  mockEnvironment = environment;
+  jest.resetModules();
+  const ApiUtils = require('@libs/ApiUtils') as typeof ApiUtilsType;
+  await Promise.resolve();
+  await Promise.resolve();
+  return ApiUtils.getKirokuApiRoot();
+}
+
+describe('ApiUtils.getKirokuApiRoot environment selection', () => {
+  it.each([
+    [CONST.ENVIRONMENT.PROD, CONFIG.KIROKU_API.PROD_ROOT],
+    [CONST.ENVIRONMENT.STAGING, CONFIG.KIROKU_API.PROD_ROOT],
+    [CONST.ENVIRONMENT.DEV, CONFIG.KIROKU_API.DEV_ROOT],
+    [CONST.ENVIRONMENT.ADHOC, CONFIG.KIROKU_API.DEV_ROOT],
+  ])('%s builds use %s', async (environment, expectedRoot) => {
+    await expect(getKirokuApiRootFor(environment)).resolves.toBe(expectedRoot);
+  });
+});

--- a/src/libs/ApiUtils.ts
+++ b/src/libs/ApiUtils.ts
@@ -76,13 +76,20 @@ function isUsingStagingApi(): boolean {
 
 /**
  * Base URL for the kiroku-api HTTPS function, selected by environment. Prod
- * builds hit the prod project; everything else (dev/staging/adhoc) hits dev.
+ * and staging builds hit the prod project; dev/adhoc builds hit dev.
  * Route paths (see `libs/API/kirokuRoutes.ts`) include the `/v1` prefix and are
  * appended to this root.
  */
 function getKirokuApiRoot(): string {
+  // Staging builds carry the production Firebase config baked in at build time
+  // (a Play internal-track build is the production flavor that merely
+  // runtime-classifies as STAGING via the beta checker), so they must talk to
+  // the prod API: a prod-issued ID token gets a 401 from the dev API, which
+  // triggers an immediate sign-out. Only dev/adhoc builds, whose env files
+  // bake the dev Firebase project, use the dev root.
   const root =
-    ENV_NAME === CONST.ENVIRONMENT.PROD
+    ENV_NAME === CONST.ENVIRONMENT.PROD ||
+    ENV_NAME === CONST.ENVIRONMENT.STAGING
       ? CONFIG.KIROKU_API.PROD_ROOT
       : CONFIG.KIROKU_API.DEV_ROOT;
   return root.replace(/\/+$/, '');


### PR DESCRIPTION
## Problem

Signing in on the current Play Store build (internal track, 0.3.21-x) flashes the authenticated screens and immediately bounces back to the login screen, with an STG badge showing on the logo.

Play internal-track builds are the **production flavor** with the **prod Firebase config** baked in at build time — they only classify as STAGING at runtime, via the beta checker (`installed version > latest GitHub release`, see `src/libs/Environment/betaChecker/index.android.ts`). The STG badge is that classification working as intended.

The bug: `getKirokuApiRoot()` followed the runtime classification and sent staging-classified builds to the **dev** kiroku-api (`api-dev.kiroku.cz`). The dev API verifies tokens against the dev Firebase project, so the prod-issued ID token gets a **401**, which `HttpUtils` treats as a revoked token and force-signs-out. Net effect: **every** sign-in on every staging build deterministically bounced. This also silently broke Pusher auth and all API traffic on those builds.

This contradicts the intended rule already stated at the top of `ApiUtils.ts`: *"native apps use production config for both staging and prod"*.

## Fix

`getKirokuApiRoot()` now returns the prod root for both PROD and STAGING, matching the Firebase project the build actually authenticates against. Dev and adhoc builds, which bake the dev Firebase project (`dev-alcohol-tracker-db`), keep the dev root — they remain internally consistent.

Web staging builds have the same prod-Firebase-baked shape, so they're fixed by the same change.

## Tests

New unit test pins the root selection for all four environments. Verified the staging case **fails against the previous code** and passes with the fix.

- [x] Jest: 4/4 pass (`__tests__/unit/libs/KirokuApiRoot.test.ts`)
- [x] `npm run lint-changed` clean
- [x] `npm run typecheck-tsgo` clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)