### PR TITLE
fix(home): don't jump the last-session banner to months/years on calendar boundaries

### DIFF
--- a/__tests__/unit/getRelativeDayTier.test.ts
+++ b/__tests__/unit/getRelativeDayTier.test.ts
@@ -1,0 +1,123 @@
+import getRelativeDayTier from '@libs/getRelativeDayTier';
+import type {RelativeDayTier} from '@libs/getRelativeDayTier';
+
+describe('getRelativeDayTier', () => {
+  describe('day tiers use calendar days', () => {
+    test('same calendar day → today', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2026-07-02T01:00:00'),
+          new Date('2026-07-02T23:00:00'),
+        ),
+      ).toEqual({unit: 'today'});
+    });
+
+    test('previous calendar day → yesterday, even if only hours apart', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2026-07-01T23:30:00'),
+          new Date('2026-07-02T00:30:00'),
+        ),
+      ).toEqual({unit: 'yesterday'});
+    });
+
+    test('two calendar days back → 2 days ago', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2026-06-30T22:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'days', count: 2});
+    });
+  });
+
+  describe('calendar-boundary crossings stay in the finer tier', () => {
+    test('Jun 29 viewed on Jul 2 → 3 days ago, NOT 1 month ago', () => {
+      // Regression: differenceInCalendarMonths reported 1 here because the
+      // month index changed, even though only 3 days had passed.
+      expect(
+        getRelativeDayTier(
+          new Date('2026-06-29T21:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'days', count: 3});
+    });
+
+    test('Dec 31 viewed on Jan 1 → yesterday, NOT 1 year ago', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2025-12-31T22:00:00'),
+          new Date('2026-01-01T10:00:00'),
+        ),
+      ).toEqual({unit: 'yesterday'});
+    });
+
+    test('30 days across a month boundary, under a full month → 30 days ago', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2026-06-02T21:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'days', count: 30});
+    });
+  });
+
+  describe('months tier starts after a full month', () => {
+    test('a full month plus a day → 1 month ago', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2026-06-01T09:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'months', count: 1});
+    });
+
+    test('~5 weeks → 1 month ago, NOT 2 months ago', () => {
+      // Regression: May 30 → Jul 2 crossed two month indexes (May→Jun→Jul) and
+      // showed "2 months ago" after only 33 days.
+      expect(
+        getRelativeDayTier(
+          new Date('2026-05-30T20:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'months', count: 1});
+    });
+
+    test('11 full months → 11 months ago, not yet a year', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2025-07-10T12:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'months', count: 11});
+    });
+  });
+
+  describe('years tier starts after a full year', () => {
+    test('exactly one year → 1 year ago', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2025-07-02T10:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'years', count: 1});
+    });
+
+    test('18 months → 1 year ago (full years, no rounding up)', () => {
+      expect(
+        getRelativeDayTier(
+          new Date('2025-01-02T10:00:00'),
+          new Date('2026-07-02T10:00:00'),
+        ),
+      ).toEqual({unit: 'years', count: 1});
+    });
+  });
+
+  test('future date (clock skew) falls back to today', () => {
+    const tier: RelativeDayTier = getRelativeDayTier(
+      new Date('2026-07-03T10:00:00'),
+      new Date('2026-07-02T10:00:00'),
+    );
+    expect(tier).toEqual({unit: 'today'});
+  });
+});

--- a/src/hooks/useLastSession.ts
+++ b/src/hooks/useLastSession.ts
@@ -1,14 +1,10 @@
 import {useMemo} from 'react';
-import {
-  differenceInCalendarDays,
-  differenceInCalendarMonths,
-  differenceInCalendarYears,
-} from 'date-fns';
 import useCurrentUserDrinkingSessions from '@hooks/useCurrentUserDrinkingSessions';
 import useCurrentUserPreferences from '@hooks/useCurrentUserPreferences';
 import useLocalize from '@hooks/useLocalize';
 import {timestampToDateString} from '@libs/DataHandling';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
+import getRelativeDayTier from '@libs/getRelativeDayTier';
 import type {DrinkingSessionId} from '@src/types/onyx/DrinkingSession';
 import type {DateString} from '@src/types/onyx/OnyxCommon';
 
@@ -34,7 +30,8 @@ function formatUnits(value: number): string {
  * or only an ongoing session) — the caller renders no banner in that case.
  *
  * Relative time is rounded to whole days (Today / Yesterday / N days ago) and
- * then months / years — it never shows hours.
+ * escalates to months / years only after a full month / year has elapsed —
+ * see `getRelativeDayTier`. It never shows hours.
  */
 function useLastSession(): LastSessionView | null {
   const drinkingSessionData = useCurrentUserDrinkingSessions();
@@ -50,26 +47,31 @@ function useLastSession(): LastSessionView | null {
     const {sessionId, session} = lastSession;
 
     const date = new Date(session.start_time);
-    const now = new Date();
-    const days = differenceInCalendarDays(now, date);
-    const months = differenceInCalendarMonths(now, date);
-    const years = differenceInCalendarYears(now, date);
+    const tier = getRelativeDayTier(date, new Date());
 
     let when: string;
-    if (years >= 1) {
-      when = translate('homeScreen.banners.lastSession.yearsAgo', {
-        count: years,
-      });
-    } else if (months >= 1) {
-      when = translate('homeScreen.banners.lastSession.monthsAgo', {
-        count: months,
-      });
-    } else if (days >= 2) {
-      when = translate('homeScreen.banners.lastSession.daysAgo', {count: days});
-    } else if (days === 1) {
-      when = translate('homeScreen.banners.lastSession.yesterday');
-    } else {
-      when = translate('homeScreen.banners.lastSession.today');
+    switch (tier.unit) {
+      case 'years':
+        when = translate('homeScreen.banners.lastSession.yearsAgo', {
+          count: tier.count,
+        });
+        break;
+      case 'months':
+        when = translate('homeScreen.banners.lastSession.monthsAgo', {
+          count: tier.count,
+        });
+        break;
+      case 'days':
+        when = translate('homeScreen.banners.lastSession.daysAgo', {
+          count: tier.count,
+        });
+        break;
+      case 'yesterday':
+        when = translate('homeScreen.banners.lastSession.yesterday');
+        break;
+      case 'today':
+      default:
+        when = translate('homeScreen.banners.lastSession.today');
     }
 
     return {

--- a/src/libs/getRelativeDayTier.ts
+++ b/src/libs/getRelativeDayTier.ts
@@ -1,0 +1,40 @@
+import {
+  differenceInCalendarDays,
+  differenceInMonths,
+  differenceInYears,
+} from 'date-fns';
+
+type RelativeDayTier =
+  | {unit: 'today' | 'yesterday'}
+  | {unit: 'days' | 'months' | 'years'; count: number};
+
+/**
+ * Buckets how long ago `date` was, for day-granularity relative-time copy
+ * ("Today" / "Yesterday" / "N days ago" / "N months ago" / "N years ago").
+ *
+ * Today, Yesterday, and days compare CALENDAR days, so a session late last
+ * night is "Yesterday" even if only hours have passed. Months and years switch
+ * over only once a FULL month/year has elapsed — never on a mere calendar
+ * boundary crossing. A June 29 session viewed on July 2 is "3 days ago", not
+ * "1 month ago"; a Dec 31 session viewed on Jan 1 is "Yesterday", not
+ * "1 year ago". The days tier therefore runs up to ~30 before "1 month ago"
+ * takes over, and months run up to 11 before "1 year ago".
+ */
+function getRelativeDayTier(date: Date, now: Date): RelativeDayTier {
+  const years = differenceInYears(now, date);
+  if (years >= 1) {
+    return {unit: 'years', count: years};
+  }
+  const months = differenceInMonths(now, date);
+  if (months >= 1) {
+    return {unit: 'months', count: months};
+  }
+  const days = differenceInCalendarDays(now, date);
+  if (days >= 2) {
+    return {unit: 'days', count: days};
+  }
+  return {unit: days === 1 ? 'yesterday' : 'today'};
+}
+
+export default getRelativeDayTier;
+export type {RelativeDayTier};


### PR DESCRIPTION
## Problem

The home screen's "Last session" banner computes its relative time with `differenceInCalendarMonths` / `differenceInCalendarYears`, which count **calendar index changes**, not elapsed time. Any session near the end of a month or year jumps straight to the coarser tier:

- Session on **June 29**, viewed on **July 2** → "1 month ago" (actual: 3 days)
- Session on **Dec 31**, viewed on **Jan 1** → **"1 year ago"** (actual: yesterday)
- Session on **May 30**, viewed on **July 2** → "2 months ago" (actual: 33 days)

## Fix

Extract the tier decision into a pure `getRelativeDayTier(date, now)` helper ([src/libs/getRelativeDayTier.ts](../blob/fix/last-session-relative-time/src/libs/getRelativeDayTier.ts)) with natural semantics:

| Elapsed | Shown |
|---|---|
| same calendar day | Today |
| previous calendar day | Yesterday |
| 2 calendar days … under a full month | N days ago |
| 1–11 full months | N months ago |
| 1+ full years | N years ago |

Today/Yesterday/days keep **calendar-day** semantics (a session late last night is "Yesterday" even if only hours ago); months/years now require a **full** month/year to have elapsed (`differenceInMonths` / `differenceInYears`). `useLastSession` maps the tier to the existing translation keys — no copy or locale changes.

## Tests

New unit suite `__tests__/unit/getRelativeDayTier.test.ts` (12 cases) encodes the table above, including the three regressions.

- [x] `npx jest __tests__/unit/getRelativeDayTier.test.ts` — 12/12 pass
- [x] `npm run lint-changed`
- [x] `npm run typecheck-tsgo`
- [x] `npm run react-compiler-compliance-check check-changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)