### PR TITLE
fix(deploy): give the Android Gradle build a timeout it can actually meet

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -108,9 +108,14 @@ jobs:
       - name: Run Fastlane
         uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
         with:
-          timeout_minutes: 40
+          # A cold build compiles RN, Hermes, Skia, etc. from source (~65-75 min);
+          # a timeout below that kills attempt 1 mid-build and retries resume on its intermediates
+          timeout_minutes: 90
           max_attempts: 3
           command: bundle exec fastlane android ${{ inputs.SHOULD_DEPLOY_PRODUCTION && 'production' || 'beta' }}
+          # A killed attempt can leave native intermediates Gradle wrongly considers
+          # up-to-date (truncated prefab .so files); retries must not reuse them
+          on_retry_command: rm -rf node_modules/*/android/build android/app/.cxx
         env:
           MYAPP_UPLOAD_STORE_PASSWORD: ${{ secrets.MYAPP_UPLOAD_STORE_PASSWORD }}
           MYAPP_UPLOAD_KEY_PASSWORD: ${{ secrets.MYAPP_UPLOAD_KEY_PASSWORD }}


### PR DESCRIPTION
## Problem

The staging deploy for 0.3.21-4 ([run 28584590513](https://github.com/PetrCala/Kiroku/actions/runs/28584590513)) failed on the Android job. The `Run Fastlane` step wraps the Gradle build in `nick-fields/retry` with `timeout_minutes: 40`, but a cold Android build compiles RN core, Hermes, Skia, Reanimated, Worklets, and Nitro from source (~65–75 min):

1. Attempt 1 was SIGKILLed at exactly 40 min while still making progress (`:app:buildCMakeRelWithDebInfo[armeabi-v7a]`).
2. The kill truncated `react-native-nitro-modules`' prefab `libNitroModules.so` while Gradle's up-to-date tracking still considered the producing task done.
3. Attempts 2–3 resumed on the same workspace and died in ~29 s each on `:react-native-nitro-modules:bundleReleaseLocalLintAar` → "Could not add file … libNitroModules.so to ZIP".

The last *successful* deploy (0.3.21-1) followed the same pattern and only passed because attempt 2 resumed from warm intermediates and finished in 39m21s — the pipeline has been surviving on a kill-and-resume gamble.

## Fix

- Raise the Android per-attempt `timeout_minutes` from 40 to 90 so a full cold build completes within one attempt (iOS already gets 60).
- Add `on_retry_command` that removes `node_modules/*/android/build` and `android/app/.cxx` so any genuine retry starts from consistent native state instead of a possibly poisoned workspace.

## Notes

- `deploy.yml` executes the workflow from the `staging` branch, so this takes effect with the next release bump after merge.
- Longer term, upstream Expensify dropped the retry wrapper around Gradle entirely and prebuilds RN Android artifacts in a separate workflow — worth considering if build times keep growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)