### PR TITLE
feat(watch): WatchConnectivity credential bridge (Phase 3)

### DIFF
--- a/__tests__/unit/WatchBridge.test.ts
+++ b/__tests__/unit/WatchBridge.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the phone-side watch credential bridge wiring
+ * (src/libs/WatchBridge/index.ios.ts; jest-expo resolves the .ios fork).
+ * react-native and the heavy transitive imports are mocked so the real payload
+ * assembly, dedupe, and signed-out paths run against a mock native module.
+ */
+import type {DrinkingSession} from '@src/types/onyx';
+
+const mockUpdateCredential = jest.fn();
+const mockClearCredential = jest.fn();
+
+jest.mock('react-native', () => ({
+  NativeModules: {
+    WatchBridge: {
+      updateCredential: mockUpdateCredential,
+      clearCredential: mockClearCredential,
+    },
+  },
+}));
+
+// Without `__esModule` in the factory, babel's CJS interop hands default
+// imports the whole mock object, which is exactly the shape these need.
+jest.mock('react-native-onyx', () => ({connect: jest.fn()}));
+
+jest.mock('@src/CONST', () => ({
+  DEFAULT_TIME_ZONE: {automatic: true, selected: 'UTC'},
+  SESSION: {TYPES: {LIVE: 'live', EDIT: 'edit'}},
+}));
+
+jest.mock('@libs/ApiUtils', () => ({
+  getKirokuApiEnv: jest.fn(() => 'dev'),
+}));
+
+jest.mock('@libs/AppStateMonitor', () => ({
+  addBecameActiveListener: jest.fn(),
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: jest.fn(),
+}));
+
+jest.mock('@libs/Log', () => ({hmmm: jest.fn()}));
+
+const {getFirebaseAuth} = jest.requireMock<{getFirebaseAuth: jest.Mock}>(
+  '@libs/Firebase/FirebaseApp',
+);
+
+const EXPIRATION_TIME = '2026-07-08T12:00:00.000Z';
+const EXPIRATION_MS = 1783512000000;
+
+type WatchBridgeJsModule = {
+  pushCredentialToWatch: () => Promise<void>;
+  serializeOngoingSession: (
+    session: DrinkingSession | undefined,
+  ) => string | undefined;
+};
+
+describe('WatchBridge', () => {
+  let pushCredentialToWatch: WatchBridgeJsModule['pushCredentialToWatch'];
+  let serializeOngoingSession: WatchBridgeJsModule['serializeOngoingSession'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Fresh module instance per test so the dedupe state resets.
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const watchBridge = require<WatchBridgeJsModule>('@libs/WatchBridge');
+      pushCredentialToWatch = watchBridge.pushCredentialToWatch;
+      serializeOngoingSession = watchBridge.serializeOngoingSession;
+    });
+  });
+
+  const DRINK_TS = 1700000001000;
+  const liveSession: DrinkingSession = {
+    id: '-Abc123',
+    start_time: 1700000000000,
+    end_time: 1700000005000,
+    timezone: 'Europe/Prague',
+    type: 'live',
+    ongoing: true,
+    drinks: {
+      [DRINK_TS]: {beer: 2, wine: {count: 1, volume_ml: 150}},
+    },
+    drinksTimeParts: {[DRINK_TS]: {year: 2023, month: 11, day: 14}},
+  } as unknown as DrinkingSession;
+
+  describe('serializeOngoingSession', () => {
+    it('returns undefined when there is no live session to mirror', () => {
+      expect(serializeOngoingSession(undefined)).toBeUndefined();
+      expect(
+        serializeOngoingSession({...liveSession, ongoing: false}),
+      ).toBeUndefined();
+      expect(
+        serializeOngoingSession({...liveSession, id: undefined}),
+      ).toBeUndefined();
+    });
+
+    it('whitelists wire fields and collapses drink entries to counts', () => {
+      const json = serializeOngoingSession(liveSession);
+      expect(json).toBeDefined();
+      const parsed = JSON.parse(json ?? '') as Record<string, unknown>;
+      expect(parsed).toEqual({
+        id: '-Abc123',
+        start_time: 1700000000000,
+        end_time: 1700000005000,
+        blackout: false,
+        note: '',
+        timezone: 'Europe/Prague',
+        type: 'live',
+        ongoing: true,
+        // The object-form wine entry is collapsed to its count; the JS-only
+        // drinksTimeParts field must not survive serialization.
+        drinks: {[DRINK_TS]: {beer: 2, wine: 1}},
+      });
+    });
+
+    it('omits drinks entirely when every entry is zero', () => {
+      const session = {
+        ...liveSession,
+        drinks: {[DRINK_TS]: {beer: 0}},
+      } as DrinkingSession;
+      const parsed = JSON.parse(
+        serializeOngoingSession(session) ?? '',
+      ) as Record<string, unknown>;
+      expect(parsed.drinks).toBeUndefined();
+    });
+
+    it('fills the fields the watch Codable model requires', () => {
+      const minimal = {
+        id: '-Min1',
+        start_time: 1700000000000,
+        ongoing: true,
+      } as DrinkingSession;
+      const parsed = JSON.parse(
+        serializeOngoingSession(minimal) ?? '',
+      ) as Record<string, unknown>;
+      expect(parsed.end_time).toBe(1700000000000);
+      expect(parsed.blackout).toBe(false);
+      expect(parsed.note).toBe('');
+      expect(parsed.timezone).toBe('UTC');
+      expect(parsed.type).toBe('live');
+    });
+  });
+
+  describe('pushCredentialToWatch', () => {
+    const mockSignedInUser = () => {
+      getFirebaseAuth.mockReturnValue({
+        currentUser: {
+          uid: 'uid-42',
+          getIdTokenResult: jest.fn().mockResolvedValue({
+            token: 'id-token',
+            expirationTime: EXPIRATION_TIME,
+          }),
+        },
+      });
+    };
+
+    it('pushes the credential with expiresAt converted to epoch ms', async () => {
+      mockSignedInUser();
+      await pushCredentialToWatch();
+      expect(mockUpdateCredential).toHaveBeenCalledTimes(1);
+      expect(mockUpdateCredential).toHaveBeenCalledWith({
+        idToken: 'id-token',
+        uid: 'uid-42',
+        expiresAt: EXPIRATION_MS,
+        apiEnv: 'dev',
+      });
+      expect(new Date(EXPIRATION_TIME).getTime()).toBe(EXPIRATION_MS);
+    });
+
+    it('dedupes identical payloads', async () => {
+      mockSignedInUser();
+      await pushCredentialToWatch();
+      await pushCredentialToWatch();
+      expect(mockUpdateCredential).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the credential once when signed out', async () => {
+      getFirebaseAuth.mockReturnValue({currentUser: null});
+      await pushCredentialToWatch();
+      await pushCredentialToWatch();
+      expect(mockClearCredential).toHaveBeenCalledTimes(1);
+      expect(mockUpdateCredential).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/apple-watch-mvp.md
+++ b/docs/apple-watch-mvp.md
@@ -142,21 +142,36 @@ critical path is **0 → 1 → 2 → 3**; Phases 5–7 overlap once the bridge w
   - **Accept:** a unit test round-trips a session against `api-dev` with a pasted
     token.
 
-### Phase 3 — Credential bridge (3–4 days — the meatiest piece)
+### Phase 3 — Credential bridge (3–4 days — the meatiest piece) ← done
 
-- [ ] **3.1** RN iOS native module `WatchBridge` exposing
+- [x] **3.1** RN iOS native module `WatchBridge` exposing
       `updateCredential({ idToken, uid, expiresAt, ongoingSession })` to JS; holds the
       latest and pushes to the watch via `WCSession.updateApplicationContext`.
-- [ ] **3.2** JS wiring: call `WatchBridge.updateCredential(...)` whenever a fresh
-      token exists — on app foreground, after login, after the 407 refresh in
-      `HttpUtils.ts`, and on `ONGOING_SESSION_DATA` change.
-- [ ] **3.3** Watch `SessionConnectivity` (`WCSession` delegate): receive
-      credential + ongoing snapshot, cache the token in Keychain, expose it +
-      staleness to the view model.
-- [ ] **3.4** Token lifecycle: use the cached token until `expiresAt`/`401`; when
-      stale, surface "Open Kiroku on your phone to reconnect."
+      Implemented in [`ios/kiroku/WatchBridge.swift`](../ios/kiroku/WatchBridge.swift)
+      (legacy `RCT_EXTERN_MODULE`; payload also carries `apiEnv` so the watch
+      hits the same backend as the phone).
+- [x] **3.2** JS wiring ([`src/libs/WatchBridge/`](../src/libs/WatchBridge/)):
+      one `auth.onIdTokenChanged` listener covers login, sign-out, and the 407
+      forced refresh (Reauthentication middleware's `getIdToken(true)` fires
+      it), plus `AppStateMonitor` foreground + `ONGOING_SESSION_DATA` Onyx
+      triggers, throttled and deduped. Initialized from `src/setup/index.ts`.
+- [x] **3.3** Watch `SessionConnectivity` (`WCSession` delegate): receives
+      credential + ongoing snapshot, caches the token in the Keychain
+      (`CredentialStore`), exposes it + staleness to the view model
+      ([`ios/Kiroku Watch App/Connectivity/`](../ios/Kiroku%20Watch%20App/Connectivity/)).
+- [x] **3.4** Token lifecycle: the cached token is used until
+      `expiresAt` (60s safety margin) or a server 401/407; when stale, the
+      watch shows "Open Kiroku on your phone to reconnect."
   - **Accept:** sign in on phone → watch receives a token within seconds → a
     watch-initiated start/save succeeds with no token pasted anywhere.
+  - **Limitation (by design):** iOS never runs the RN JS bridge in the
+    background, so tokens are refreshed/pushed only while the phone app is
+    alive (foreground, or briefly while backgrounding). The watch caches the
+    last token in its Keychain and uses it until `expiresAt` (~1h); past that
+    it degrades to the reconnect message until the phone app is opened again.
+    `updateApplicationContext` is last-value-wins and delivered even while the
+    watch app is dead, and `WCSession` persists the last received context, so
+    a cold-started watch always sees the newest credential the phone ever sent.
 
 ### Phase 4 — Wire the UI to a real view model (1–2 days)
 

--- a/ios/Kiroku Watch App/Connectivity/CredentialStore.swift
+++ b/ios/Kiroku Watch App/Connectivity/CredentialStore.swift
@@ -1,0 +1,107 @@
+//
+//  CredentialStore.swift
+//  Kiroku Watch App
+//
+//  Keychain-backed cache for the phone-bridged Firebase credential (Phase 3 of
+//  docs/apple-watch-mvp.md). The phone pushes {idToken, uid, expiresAt, apiEnv}
+//  over WatchConnectivity; the watch persists it here so a cold-started watch
+//  app can call kiroku-api without waiting for a fresh delivery. The token is
+//  used until `expiresAt`; iOS will not run the phone's RN JS bridge in the
+//  background, so no refresh can happen until the phone app is next alive.
+//
+
+import Foundation
+import Security
+
+/// The credential the phone hands over. All timestamps are epoch milliseconds,
+/// matching the wire contract in `ios/kiroku/WatchBridge.swift`.
+struct StoredCredential: Codable, Equatable {
+    /// The Firebase ID token to send as `Authorization: Bearer <idToken>`.
+    let idToken: String
+
+    /// The Firebase uid the token belongs to.
+    let uid: String
+
+    /// Epoch-millisecond expiry of `idToken` (Firebase ID tokens live ~1h).
+    let expiresAt: Double
+
+    /// Which kiroku-api backend the phone build talks to: "dev" or "prod".
+    let apiEnv: String
+
+    /// Treat the token as stale this long before actual expiry so a request
+    /// never carries a token that dies in flight.
+    static let stalenessMarginMs: Double = 60_000
+
+    /// Whether the token is expired (or about to expire) at `nowMs`.
+    func isStale(nowMs: Double) -> Bool {
+        nowMs >= expiresAt - Self.stalenessMarginMs
+    }
+
+    /// Whether the token is expired (or about to expire) right now.
+    var isStale: Bool {
+        isStale(nowMs: Date().timeIntervalSince1970 * 1000)
+    }
+
+    /// The `KirokuAPI` environment matching the phone's backend selection.
+    /// Defaults to prod for unknown values; a prod token is rejected by the dev
+    /// API (and vice versa), so guessing wrong fails loudly rather than writing
+    /// into the wrong backend.
+    var environment: KirokuEnvironment {
+        apiEnv == "dev" ? .dev : .prod
+    }
+}
+
+/// Minimal Keychain wrapper for the single credential item. Generic-password
+/// class, readable after first unlock so background WCSession deliveries can
+/// persist it while the watch is on the wrist.
+enum CredentialStore {
+    private static let service = "cz.kiroku.watch.credential"
+    private static let account = "firebase-id-token"
+
+    private static var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    /// Persist the credential, replacing any previous one.
+    static func save(_ credential: StoredCredential) {
+        guard let data = try? JSONEncoder().encode(credential) else {
+            return
+        }
+        SecItemDelete(baseQuery as CFDictionary)
+        var attributes = baseQuery
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    /// The last persisted credential, if any (stale or not; callers decide).
+    static func load() -> StoredCredential? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else {
+            return nil
+        }
+        return try? JSONDecoder().decode(StoredCredential.self, from: data)
+    }
+
+    /// Remove the persisted credential (sign-out on the phone).
+    static func clear() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+
+    /// The `KirokuAPI.tokenProvider` seam: the cached token, or nil when absent
+    /// or stale (which surfaces as `KirokuAPIError.missingToken`).
+    static func validToken() -> String? {
+        guard let credential = load(), !credential.isStale else {
+            return nil
+        }
+        return credential.idToken
+    }
+}

--- a/ios/Kiroku Watch App/Connectivity/SessionConnectivity.swift
+++ b/ios/Kiroku Watch App/Connectivity/SessionConnectivity.swift
@@ -1,0 +1,136 @@
+//
+//  SessionConnectivity.swift
+//  Kiroku Watch App
+//
+//  Watch-side half of the Phase 3 credential bridge (docs/apple-watch-mvp.md).
+//  The phone's `WatchBridge` native module pushes an application context with
+//  the Firebase credential and the current ongoing-session snapshot; this class
+//  receives it, caches the credential in the Keychain (CredentialStore), and
+//  publishes both to the view model.
+//
+//  Wire contract (all plist-safe; `ongoingSession` travels as a JSON string):
+//    v: Int (schema version, 1)
+//    signedIn: Bool (false means: clear the cached credential)
+//    idToken: String, uid: String, expiresAt: Double (epoch ms), apiEnv: String
+//    ongoingSession: String (JSON of DrinkingSession fields; absent when none)
+//
+
+import Combine
+import Foundation
+import WatchConnectivity
+
+/// Receives credential + ongoing-session pushes from the phone over
+/// `WCSession`. `updateApplicationContext` is last-value-wins and delivered in
+/// the background, and WCSession persists the last received context across
+/// launches, so between the Keychain and `receivedApplicationContext` a
+/// cold-started watch app has the newest credential the phone ever sent.
+final class SessionConnectivity: NSObject, ObservableObject {
+    static let shared = SessionConnectivity()
+
+    /// The last credential received from the phone (or restored from the
+    /// Keychain on launch). Nil after a phone sign-out or before first pairing.
+    @Published private(set) var credential: StoredCredential?
+
+    /// The phone's ongoing live-session snapshot, when one exists. The watch
+    /// adopts its id so watch taps land in the same session (no duplicate).
+    @Published private(set) var ongoingSession: DrinkingSession?
+
+    /// Whether `WCSession` finished activating.
+    @Published private(set) var isActivated = false
+
+    /// True when the watch has no usable token, which drives the
+    /// "Open Kiroku on your phone to reconnect." UI. Time passing can flip
+    /// this without a publish; action paths re-check via `CredentialStore`.
+    var needsPhoneReconnect: Bool {
+        guard let credential else {
+            return true
+        }
+        return credential.isStale
+    }
+
+    override private init() {
+        super.init()
+        // Restore from the Keychain first so a cold start is signed in even
+        // before WCSession activates or delivers anything.
+        credential = CredentialStore.load()
+        guard WCSession.isSupported() else {
+            return
+        }
+        WCSession.default.delegate = self
+        WCSession.default.activate()
+    }
+
+    /// Apply a received application context. Internal so unit tests can drive
+    /// it with hand-built dictionaries (no WCSession involved).
+    func apply(_ context: [String: Any]) {
+        let signedIn = context["signedIn"] as? Bool ?? false
+        var newCredential: StoredCredential?
+        if signedIn,
+           let idToken = context["idToken"] as? String, !idToken.isEmpty,
+           let uid = context["uid"] as? String,
+           let expiresAt = (context["expiresAt"] as? NSNumber)?.doubleValue {
+            newCredential = StoredCredential(
+                idToken: idToken,
+                uid: uid,
+                expiresAt: expiresAt,
+                apiEnv: context["apiEnv"] as? String ?? "prod"
+            )
+        }
+
+        // Tolerant decode: a snapshot that fails to parse leaves the session
+        // nil without discarding the credential.
+        var newSession: DrinkingSession?
+        if let json = context["ongoingSession"] as? String,
+           let data = json.data(using: .utf8) {
+            newSession = try? JSONDecoder().decode(DrinkingSession.self, from: data)
+        }
+
+        if let newCredential {
+            CredentialStore.save(newCredential)
+        } else {
+            CredentialStore.clear()
+        }
+
+        DispatchQueue.main.async {
+            self.credential = newCredential
+            self.ongoingSession = newSession
+        }
+    }
+
+    /// The cached token turned out unusable (stale by time at action time, or
+    /// the API answered 401/407). Drop it and publish, so the reconnect banner
+    /// appears immediately; the phone's next push restores the credential.
+    func markCredentialRejected() {
+        CredentialStore.clear()
+        DispatchQueue.main.async {
+            self.credential = nil
+        }
+    }
+}
+
+extension SessionConnectivity: WCSessionDelegate {
+    // watchOS only requires this activation callback (the DidBecomeInactive /
+    // DidDeactivate pair is iOS-side, for multi-watch handoff).
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        DispatchQueue.main.async {
+            self.isActivated = activationState == .activated
+        }
+        // Cold-start path: WCSession persists the last delivered context, so a
+        // push sent while the watch app was dead is available right here.
+        let persisted = session.receivedApplicationContext
+        if !persisted.isEmpty {
+            apply(persisted)
+        }
+    }
+
+    func session(
+        _ session: WCSession,
+        didReceiveApplicationContext applicationContext: [String: Any]
+    ) {
+        apply(applicationContext)
+    }
+}

--- a/ios/Kiroku Watch App/ContentView.swift
+++ b/ios/Kiroku Watch App/ContentView.swift
@@ -9,12 +9,30 @@ import SwiftUI
 import Foundation
 
 struct ContentView: View {
+    // Instantiating the singleton here guarantees WCSession activates at watch
+    // app launch, before any view-model action needs the credential.
+    @ObservedObject private var connectivity = SessionConnectivity.shared
+
     var body: some View {
         ZStack {
             AppColors.backgroundColor
                 .edgesIgnoringSafeArea(.all) // This ensures the color covers the entire screen
-            
+
             InitialView()
+
+            if connectivity.needsPhoneReconnect {
+                VStack {
+                    Spacer()
+                    Text(Translate.getText(for: "openPhoneToReconnect"))
+                        .font(.footnote)
+                        .multilineTextAlignment(.center)
+                        .padding(8)
+                        .background(Color.black.opacity(0.75))
+                        .cornerRadius(8)
+                        .padding(.horizontal, 8)
+                }
+                .allowsHitTesting(false)
+            }
         }
     }
 }

--- a/ios/Kiroku Watch App/Translations/CzechTexts.swift
+++ b/ios/Kiroku Watch App/Translations/CzechTexts.swift
@@ -14,5 +14,6 @@ struct CzechTexts {
         "stopButton": "Stop",
         "errorMessage": "An error occurred. Please try again.",
         "tapToStartSession": "Tap to Start Session",
+        "openPhoneToReconnect": "Otevřete Kiroku na telefonu a obnovte připojení.",
     ]
 }

--- a/ios/Kiroku Watch App/Translations/EnglishTexts.swift
+++ b/ios/Kiroku Watch App/Translations/EnglishTexts.swift
@@ -14,5 +14,6 @@ struct EnglishTexts {
         "stopButton": "Stop",
         "errorMessage": "An error occurred. Please try again.",
         "tapToStartSession": "Tap to Start Session",
+        "openPhoneToReconnect": "Open Kiroku on your phone to reconnect.",
     ]
 }

--- a/ios/Kiroku Watch App/ViewModels/SessionViewModel.swift
+++ b/ios/Kiroku Watch App/ViewModels/SessionViewModel.swift
@@ -4,32 +4,108 @@
 //
 //  Created by PetrCala on 07.07.2024.
 //
+//  Phase 3 (docs/apple-watch-mvp.md) wires the existing local counter UI to the
+//  real kiroku-api through the phone-bridged credential: start/save/discard now
+//  POST the session using the Keychain-cached token from CredentialStore.
+//  Phase 4 replaces SessionModel with fully DrinkingSession-backed state.
+//
 
 import Combine
 import Foundation
 
+@MainActor
 class SessionViewModel: ObservableObject {
     @Published var session = SessionModel.shared
-    
+
+    /// Inline error for a failed write; nil when the last operation succeeded.
+    @Published var lastError: String?
+
+    private let connectivity = SessionConnectivity.shared
+
+    /// The session being logged, in wire form. Seeded on start (adopting the
+    /// phone's ongoing session when there is one) and posted whole on save.
+    private var liveSession: DrinkingSession?
+
     func startSession() {
         session.startSession()
-        // Trigger other functionality like communication with database here
-        // For example: DatabaseManager.shared.startSession()
+        guard let api = makeAPI() else {
+            return
+        }
+        // Adopt the phone's ongoing session when one exists so watch taps land
+        // in the same session (no duplicate); mint a new push id otherwise.
+        var newSession = connectivity.ongoingSession
+            ?? DrinkingSession.newLive(id: PushID.generate())
+        newSession.ongoing = true
+        liveSession = newSession
+        let sessionToStart = newSession
+        perform { try await api.start(sessionToStart) }
     }
 
     func saveSession() {
+        let count = session.unitCount
         session.saveSession()
+        guard let api = makeAPI(), var finished = liveSession else {
+            return
+        }
+        liveSession = nil
+        // The MVP logs a single generic unit type; map the counter onto
+        // `.other`, on top of whatever an adopted phone session already had.
+        if count > finished.totalUnits {
+            finished.addDrinks(count - finished.totalUnits, of: .other)
+        }
+        finished.endTime = DrinkingSession.nowMillis()
+        finished.ongoing = false
+        let sessionToSave = finished
+        perform { try await api.save(sessionToSave) }
     }
-    
+
     func discardSession() {
         session.discardSession()
+        guard let api = makeAPI(), let live = liveSession else {
+            return
+        }
+        liveSession = nil
+        perform { try await api.discard(sessionId: live.id) }
     }
-    
+
     func addUnit() {
+        // Local only; the whole session posts on save.
         session.addUnit()
     }
-    
+
     func subtractUnit() {
         session.subtractUnit()
+    }
+
+    /// An API client backed by the cached credential, or nil when the token is
+    /// absent/stale, in which case the reconnect banner (driven by
+    /// SessionConnectivity) takes over.
+    private func makeAPI() -> KirokuAPI? {
+        guard let credential = CredentialStore.load(), !credential.isStale else {
+            // Drop the dead credential so the banner appears now instead of on
+            // the next delivery; the phone's next push restores it.
+            connectivity.markCredentialRejected()
+            return nil
+        }
+        return KirokuAPI(environment: credential.environment) {
+            CredentialStore.validToken()
+        }
+    }
+
+    private func perform(_ operation: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await operation()
+                lastError = nil
+            } catch KirokuAPIError.missingToken,
+                    KirokuAPIError.tokenExpired,
+                    KirokuAPIError.tokenRevoked {
+                // The server disagreed with our local expiry check: the token
+                // is unusable either way. Same recovery as stale-by-time.
+                connectivity.markCredentialRejected()
+            } catch {
+                lastError = Translate.getText(for: "errorMessage")
+            }
+        }
     }
 }

--- a/ios/Kiroku Watch AppTests/Kiroku_Watch_AppTests.swift
+++ b/ios/Kiroku Watch AppTests/Kiroku_Watch_AppTests.swift
@@ -4,33 +4,177 @@
 //
 //  Created by PetrCala on 29.06.2024.
 //
+//  Phase 3 credential-bridge tests: the applicationContext parsing in
+//  SessionConnectivity, the staleness contract of StoredCredential (epoch
+//  milliseconds, 60s margin), and the CredentialStore Keychain round-trip.
+//
 
 import XCTest
 @testable import Kiroku_Watch_App
 
 final class Kiroku_Watch_AppTests: XCTestCase {
+    private var nowMs: Double {
+        Date().timeIntervalSince1970 * 1000
+    }
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        CredentialStore.clear()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        CredentialStore.clear()
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Tests marked async will run the test method on an arbitrary thread managed by the Swift runtime.
+    /// Spin the main run loop once so SessionConnectivity's async publishes land.
+    private func drainMainQueue() {
+        let expectation = expectation(description: "main queue drained")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1)
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    // MARK: - StoredCredential staleness
+
+    func testCredentialIsFreshBeforeExpiryMargin() {
+        let credential = StoredCredential(
+            idToken: "token", uid: "uid", expiresAt: nowMs + 120_000, apiEnv: "dev"
+        )
+        XCTAssertFalse(credential.isStale)
     }
 
+    func testCredentialIsStaleInsideExpiryMargin() {
+        // 30s of life left is inside the 60s safety margin.
+        let credential = StoredCredential(
+            idToken: "token", uid: "uid", expiresAt: nowMs + 30_000, apiEnv: "dev"
+        )
+        XCTAssertTrue(credential.isStale)
+    }
+
+    func testStalenessBoundaryIsExactAtMargin() {
+        let expiresAt: Double = 1_000_000
+        let credential = StoredCredential(
+            idToken: "token", uid: "uid", expiresAt: expiresAt, apiEnv: "dev"
+        )
+        XCTAssertTrue(credential.isStale(nowMs: expiresAt - StoredCredential.stalenessMarginMs))
+        XCTAssertFalse(credential.isStale(nowMs: expiresAt - StoredCredential.stalenessMarginMs - 1))
+    }
+
+    func testEnvironmentMapping() {
+        let dev = StoredCredential(idToken: "t", uid: "u", expiresAt: 0, apiEnv: "dev")
+        let prod = StoredCredential(idToken: "t", uid: "u", expiresAt: 0, apiEnv: "prod")
+        let unknown = StoredCredential(idToken: "t", uid: "u", expiresAt: 0, apiEnv: "staging")
+        XCTAssertEqual(dev.environment, .dev)
+        XCTAssertEqual(prod.environment, .prod)
+        // Unknown values fail toward prod, where a mismatched token is rejected.
+        XCTAssertEqual(unknown.environment, .prod)
+    }
+
+    // MARK: - CredentialStore
+
+    func testCredentialStoreRoundTrip() {
+        let credential = StoredCredential(
+            idToken: "round-trip-token", uid: "uid-1", expiresAt: nowMs + 3_600_000, apiEnv: "dev"
+        )
+        CredentialStore.save(credential)
+        XCTAssertEqual(CredentialStore.load(), credential)
+        XCTAssertEqual(CredentialStore.validToken(), "round-trip-token")
+
+        CredentialStore.clear()
+        XCTAssertNil(CredentialStore.load())
+        XCTAssertNil(CredentialStore.validToken())
+    }
+
+    func testValidTokenIsNilWhenStale() {
+        let credential = StoredCredential(
+            idToken: "stale-token", uid: "uid-1", expiresAt: nowMs - 1_000, apiEnv: "dev"
+        )
+        CredentialStore.save(credential)
+        XCTAssertNotNil(CredentialStore.load(), "stale credentials stay loadable")
+        XCTAssertNil(CredentialStore.validToken(), "but never usable as a token")
+    }
+
+    // MARK: - SessionConnectivity.apply
+
+    func testApplyFullPayloadStoresCredentialAndDecodesSession() {
+        let expiresAt = nowMs + 3_600_000
+        // The unknown key mirrors JS-only fields; the decoder must ignore them.
+        let ongoingJSON = """
+        {"id":"-Abc123","start_time":1700000000000,"end_time":1700000000000,\
+        "blackout":false,"note":"","timezone":"Europe/Prague","type":"live",\
+        "ongoing":true,"drinks":{"1700000001000":{"beer":2}},"someUnknownKey":1}
+        """
+        SessionConnectivity.shared.apply([
+            "v": 1,
+            "signedIn": true,
+            "idToken": "pushed-token",
+            "uid": "uid-42",
+            "expiresAt": expiresAt,
+            "apiEnv": "dev",
+            "ongoingSession": ongoingJSON,
+        ])
+        drainMainQueue()
+
+        let stored = CredentialStore.load()
+        XCTAssertEqual(stored?.idToken, "pushed-token")
+        XCTAssertEqual(stored?.uid, "uid-42")
+        XCTAssertEqual(stored?.expiresAt, expiresAt)
+        XCTAssertEqual(stored?.apiEnv, "dev")
+
+        XCTAssertEqual(SessionConnectivity.shared.credential, stored)
+        XCTAssertFalse(SessionConnectivity.shared.needsPhoneReconnect)
+
+        let session = SessionConnectivity.shared.ongoingSession
+        XCTAssertEqual(session?.id, "-Abc123")
+        XCTAssertEqual(session?.startTime, 1_700_000_000_000)
+        XCTAssertEqual(session?.type, .live)
+        XCTAssertEqual(session?.ongoing, true)
+        XCTAssertEqual(session?.totalUnits, 2)
+    }
+
+    func testApplySignedOutPayloadClearsCredential() {
+        CredentialStore.save(StoredCredential(
+            idToken: "old", uid: "uid", expiresAt: nowMs + 3_600_000, apiEnv: "dev"
+        ))
+        SessionConnectivity.shared.apply(["v": 1, "signedIn": false])
+        drainMainQueue()
+
+        XCTAssertNil(CredentialStore.load())
+        XCTAssertNil(SessionConnectivity.shared.credential)
+        XCTAssertTrue(SessionConnectivity.shared.needsPhoneReconnect)
+    }
+
+    func testApplyMalformedOngoingSessionKeepsCredential() {
+        SessionConnectivity.shared.apply([
+            "v": 1,
+            "signedIn": true,
+            "idToken": "still-good",
+            "uid": "uid-42",
+            "expiresAt": nowMs + 3_600_000,
+            "apiEnv": "prod",
+            "ongoingSession": "{not valid json",
+        ])
+        drainMainQueue()
+
+        XCTAssertEqual(CredentialStore.load()?.idToken, "still-good")
+        XCTAssertNil(SessionConnectivity.shared.ongoingSession)
+    }
+
+    func testMarkCredentialRejectedClearsStoreAndPublishes() {
+        SessionConnectivity.shared.apply([
+            "v": 1,
+            "signedIn": true,
+            "idToken": "doomed",
+            "uid": "uid",
+            "expiresAt": nowMs + 3_600_000,
+            "apiEnv": "dev",
+        ])
+        drainMainQueue()
+        XCTAssertNotNil(SessionConnectivity.shared.credential)
+
+        SessionConnectivity.shared.markCredentialRejected()
+        drainMainQueue()
+
+        XCTAssertNil(CredentialStore.load())
+        XCTAssertNil(SessionConnectivity.shared.credential)
+        XCTAssertTrue(SessionConnectivity.shared.needsPhoneReconnect)
+    }
 }

--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -51,6 +51,13 @@
 		E7B715AA87095EA0860A562B52B7C0BB /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7F0F9082C37DDC79066DFE0B03E80EE2 /* Info.plist */; };
 		EF9D890B86812601ABFEC945C2E3E8C7 /* kirokuTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 588A590E6BED68E1F6FD0254E55C2F6C /* kirokuTests.m */; };
 		EFB7AA8916E578EFEB6F9665AF5AF9C7 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49139152A47AFDA44AD894FFDC4658D1 /* Colors.swift */; };
+		FB0000000000000000000001 /* WatchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000001 /* WatchBridge.swift */; };
+		FB0000000000000000000002 /* WatchBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000002 /* WatchBridge.m */; };
+		FB0000000000000000000003 /* KirokuAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000003 /* KirokuAPI.swift */; };
+		FB0000000000000000000004 /* DrinkingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000004 /* DrinkingSession.swift */; };
+		FB0000000000000000000005 /* PushID.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000005 /* PushID.swift */; };
+		FB0000000000000000000006 /* SessionConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000006 /* SessionConnectivity.swift */; };
+		FB0000000000000000000007 /* CredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000007 /* CredentialStore.swift */; };
 		F243724B34C5C9FB6F62F24D /* Pods_kiroku.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0478232408D4311F0113E613 /* Pods_kiroku.framework */; };
 		F47F8A41F5D448D71B54676D1D4404B1 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B02FACB14F5B45F97FCC201FB3AF24 /* Helpers.swift */; };
 /* End PBXBuildFile section */
@@ -169,6 +176,13 @@
 		EB96FF0F5A710B1EE53CE4DB /* Pods-kiroku-kirokuTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kiroku-kirokuTests.debug.xcconfig"; path = "Target Support Files/Pods-kiroku-kirokuTests/Pods-kiroku-kirokuTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EED2CAA158622481E69D1D7775C83089 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F90E4662CD4C73E9774EEA208AAE068D /* Kiroku_Watch_AppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kiroku_Watch_AppUITests.swift; sourceTree = "<group>"; };
+		FA0000000000000000000001 /* WatchBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WatchBridge.swift; path = kiroku/WatchBridge.swift; sourceTree = "<group>"; };
+		FA0000000000000000000002 /* WatchBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WatchBridge.m; path = kiroku/WatchBridge.m; sourceTree = "<group>"; };
+		FA0000000000000000000003 /* KirokuAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KirokuAPI.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/KirokuAPI.swift"; sourceTree = SOURCE_ROOT; };
+		FA0000000000000000000004 /* DrinkingSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DrinkingSession.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/DrinkingSession.swift"; sourceTree = SOURCE_ROOT; };
+		FA0000000000000000000005 /* PushID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushID.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/PushID.swift"; sourceTree = SOURCE_ROOT; };
+		FA0000000000000000000006 /* SessionConnectivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConnectivity.swift; sourceTree = "<group>"; };
+		FA0000000000000000000007 /* CredentialStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialStore.swift; sourceTree = "<group>"; };
 		FC94F72FE31465CA8BCABD916FE6A2C6 /* RCTBootSplash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RCTBootSplash.mm; path = kiroku/RCTBootSplash.mm; sourceTree = "<group>"; };
 		FCBF9C1AD1D6D46631D118FD0EFF49A8 /* ExpensifyNeue-Regular.otf */ = {isa = PBXFileReference; includeInIndex = 1; path = "ExpensifyNeue-Regular.otf"; sourceTree = "<group>"; };
 		FCC932AE708BEAD1D1F250D3CC3196F3 /* Kiroku Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Kiroku Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -276,6 +290,8 @@
 				7F0F9082C37DDC79066DFE0B03E80EE2 /* Info.plist */,
 				3FC14E075100224A5C18F4B89B5FDAA8 /* RCTBootSplash.h */,
 				FC94F72FE31465CA8BCABD916FE6A2C6 /* RCTBootSplash.mm */,
+				FA0000000000000000000001 /* WatchBridge.swift */,
+				FA0000000000000000000002 /* WatchBridge.m */,
 				A19095879D0F5A5F11311FBA6371E13F /* kiroku.entitlements */,
 			);
 			name = kiroku;
@@ -365,6 +381,8 @@
 		CC4028DFABA22F2B894CB6ACB0524F51 /* Kiroku Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				FC0000000000000000000001 /* Connectivity */,
+				FC0000000000000000000002 /* KirokuWatchCore */,
 				6131D7EE3500A2D60142FA287C792680 /* Models */,
 				8CBD8A636D60DFCD7C4BA2D998EEDFFB /* Translations */,
 				4171FFEA62094A4054A4BF980B511CA6 /* Utilities */,
@@ -377,6 +395,25 @@
 				D17B18F000F10331F3702AFEF2670158 /* PrivacyInfo.xcprivacy */,
 			);
 			path = "Kiroku Watch App";
+			sourceTree = "<group>";
+		};
+		FC0000000000000000000001 /* Connectivity */ = {
+			isa = PBXGroup;
+			children = (
+				FA0000000000000000000007 /* CredentialStore.swift */,
+				FA0000000000000000000006 /* SessionConnectivity.swift */,
+			);
+			path = Connectivity;
+			sourceTree = "<group>";
+		};
+		FC0000000000000000000002 /* KirokuWatchCore */ = {
+			isa = PBXGroup;
+			children = (
+				FA0000000000000000000004 /* DrinkingSession.swift */,
+				FA0000000000000000000003 /* KirokuAPI.swift */,
+				FA0000000000000000000005 /* PushID.swift */,
+			);
+			name = KirokuWatchCore;
 			sourceTree = "<group>";
 		};
 		D04E6F991354770904E61C4565FB8BC4 /* Supporting Files */ = {
@@ -890,6 +927,8 @@
 				2277E0348F15E2F05F9D299348664B51 /* AppDelegate.swift in Sources */,
 				26D171A980698257B1C52A1C8AC6E6B0 /* ExpoModulesProvider.swift in Sources */,
 				2FC41EC86A043DE6B063268BD4EF74ED /* RCTBootSplash.mm in Sources */,
+				FB0000000000000000000001 /* WatchBridge.swift in Sources */,
+				FB0000000000000000000002 /* WatchBridge.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -900,6 +939,11 @@
 				EFB7AA8916E578EFEB6F9665AF5AF9C7 /* Colors.swift in Sources */,
 				0003B1D50D35F4B29CA69A269A654B52 /* Constants.swift in Sources */,
 				5F2594213B6739843D542E9AD460E687 /* ContentView.swift in Sources */,
+				FB0000000000000000000007 /* CredentialStore.swift in Sources */,
+				FB0000000000000000000004 /* DrinkingSession.swift in Sources */,
+				FB0000000000000000000003 /* KirokuAPI.swift in Sources */,
+				FB0000000000000000000005 /* PushID.swift in Sources */,
+				FB0000000000000000000006 /* SessionConnectivity.swift in Sources */,
 				85D3A2428FB7A384E0E90E056C100D01 /* CzechTexts.swift in Sources */,
 				5E4ACD6C1EE6FBC1E05D75AE525E2969 /* EnglishTexts.swift in Sources */,
 				6F3319D785115B5E3BBC9021CD9C847E /* Extensions.swift in Sources */,
@@ -1173,7 +1217,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -1372,7 +1415,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Kiroku Watch App";
@@ -1406,7 +1448,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Kiroku Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Kiroku Watch App";
@@ -1441,7 +1482,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -1545,7 +1585,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -1688,7 +1727,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Kiroku Watch App";
@@ -2201,7 +2239,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -2480,7 +2517,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -2514,7 +2550,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Kiroku Watch App";
@@ -2574,7 +2609,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Kiroku Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Kiroku Watch App";
@@ -2700,7 +2734,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Kiroku Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Kiroku Watch App";
@@ -2889,7 +2922,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -3117,7 +3149,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -3262,7 +3293,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Kiroku Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Kiroku Watch App";
@@ -3296,7 +3326,6 @@
 				SDKROOT = watchos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -3330,7 +3359,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "kiroku-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_TARGET_NAME = "Kiroku Watch App";

--- a/ios/kiroku/WatchBridge.m
+++ b/ios/kiroku/WatchBridge.m
@@ -1,0 +1,17 @@
+//
+//  WatchBridge.m
+//  Kiroku
+//
+//  Legacy-bridge export of the Swift WatchBridge module (see WatchBridge.swift).
+//  Works under the New Architecture via the interop layer, same as
+//  RCTBootSplash; no TurboModule codegen needed for a fire-and-forget module.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(WatchBridge, NSObject)
+
+RCT_EXTERN_METHOD(updateCredential:(NSDictionary *)credential)
+RCT_EXTERN_METHOD(clearCredential)
+
+@end

--- a/ios/kiroku/WatchBridge.swift
+++ b/ios/kiroku/WatchBridge.swift
@@ -1,0 +1,151 @@
+//
+//  WatchBridge.swift
+//  Kiroku
+//
+//  Phone-side half of the Phase 3 credential bridge (docs/apple-watch-mvp.md).
+//  JS calls `updateCredential` whenever a fresh Firebase ID token exists (login,
+//  token refresh, app foreground, ongoing-session change); this module holds
+//  the latest payload and pushes it to the watch via
+//  `WCSession.updateApplicationContext`, which is last-value-wins and delivered
+//  even when the watch app is not running.
+//
+//  Wire contract (applicationContext; all values plist-safe, no NSNull):
+//    v: Int (schema version, 1)
+//    signedIn: Bool (false means: watch clears its cached credential)
+//    idToken: String, uid: String, expiresAt: Double (epoch ms), apiEnv: String
+//    ongoingSession: String (JSON of DrinkingSession fields; absent when none)
+//
+//  Deliberately no per-push timestamp key: WCSession suppresses byte-identical
+//  contexts and this module dedupes on the payload, both of which a
+//  always-changing key would defeat.
+//
+
+import Foundation
+import WatchConnectivity
+
+@objc(WatchBridge)
+final class WatchBridge: NSObject {
+    /// Serializes all state access: RN calls arrive on the module's method
+    /// queue, WCSession delegate callbacks on a WatchConnectivity thread.
+    private let queue = DispatchQueue(label: "cz.kiroku.watchbridge")
+
+    /// The latest whitelisted context from JS, held so activation completing
+    /// (or the watch being paired later) can push it retroactively.
+    private var latest: [String: Any]?
+
+    /// The last successfully pushed context, for dedupe.
+    private var lastPushed: NSDictionary?
+
+    @objc
+    static func requiresMainQueueSetup() -> Bool {
+        false
+    }
+
+    /// Receive a fresh credential (+ optional ongoing-session JSON) from JS and
+    /// push it to the watch. Whitelists and type-checks every field so nothing
+    /// non-plist-safe can reach `updateApplicationContext`.
+    @objc
+    func updateCredential(_ credential: NSDictionary) {
+        guard WCSession.isSupported() else {
+            return
+        }
+        queue.async {
+            guard let idToken = credential["idToken"] as? String, !idToken.isEmpty else {
+                return
+            }
+            var context: [String: Any] = ["v": 1, "signedIn": true, "idToken": idToken]
+            if let uid = credential["uid"] as? String {
+                context["uid"] = uid
+            }
+            if let expiresAt = credential["expiresAt"] as? NSNumber {
+                context["expiresAt"] = expiresAt.doubleValue
+            }
+            if let apiEnv = credential["apiEnv"] as? String {
+                context["apiEnv"] = apiEnv
+            }
+            if let ongoingSession = credential["ongoingSession"] as? String, !ongoingSession.isEmpty {
+                context["ongoingSession"] = ongoingSession
+            }
+            self.latest = context
+            self.activateAndPush()
+        }
+    }
+
+    /// Signed out on the phone: tell the watch to drop its cached credential.
+    @objc
+    func clearCredential() {
+        guard WCSession.isSupported() else {
+            return
+        }
+        queue.async {
+            self.latest = ["v": 1, "signedIn": false]
+            self.activateAndPush()
+        }
+    }
+
+    /// Must be called on `queue`.
+    private func activateAndPush() {
+        let session = WCSession.default
+        if session.delegate !== self {
+            session.delegate = self
+        }
+        guard session.activationState == .activated else {
+            // `pushIfPossible` re-runs from `activationDidCompleteWith`; the
+            // payload is held in `latest`, so nothing is dropped, only delayed.
+            session.activate()
+            return
+        }
+        pushIfPossible()
+    }
+
+    /// Must be called on `queue`.
+    private func pushIfPossible() {
+        let session = WCSession.default
+        guard session.activationState == .activated,
+              session.isPaired,
+              session.isWatchAppInstalled,
+              let latest else {
+            return
+        }
+        let candidate = latest as NSDictionary
+        guard !candidate.isEqual(to: lastPushed as? [AnyHashable: Any] ?? [:]) else {
+            return
+        }
+        do {
+            try session.updateApplicationContext(latest)
+            lastPushed = candidate
+        } catch {
+            // Never let a watch push take the app down; the next trigger
+            // (foreground, token refresh, session change) retries.
+            NSLog("[WatchBridge] updateApplicationContext failed: %@", error.localizedDescription)
+        }
+    }
+}
+
+extension WatchBridge: WCSessionDelegate {
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        queue.async {
+            self.pushIfPossible()
+        }
+    }
+
+    // iOS-side required stubs for multi-watch handoff.
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+
+    /// Pairing or watch-app installation changed: re-send the held payload
+    /// (dedupe reset so a re-paired watch is not skipped as "already sent").
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        queue.async {
+            self.lastPushed = nil
+            self.pushIfPossible()
+        }
+    }
+}

--- a/src/libs/ApiUtils.ts
+++ b/src/libs/ApiUtils.ts
@@ -95,4 +95,22 @@ function getKirokuApiRoot(): string {
   return root.replace(/\/+$/, '');
 }
 
-export {getApiRoot, getCommandURL, getKirokuApiRoot, isUsingStagingApi};
+/**
+ * Which kiroku-api backend this build talks to, in the watch credential
+ * bridge's vocabulary. Same PROD/STAGING-to-prod rule as `getKirokuApiRoot` so
+ * the watch always hits the same backend as the phone.
+ */
+function getKirokuApiEnv(): 'dev' | 'prod' {
+  return ENV_NAME === CONST.ENVIRONMENT.PROD ||
+    ENV_NAME === CONST.ENVIRONMENT.STAGING
+    ? 'prod'
+    : 'dev';
+}
+
+export {
+  getApiRoot,
+  getCommandURL,
+  getKirokuApiEnv,
+  getKirokuApiRoot,
+  isUsingStagingApi,
+};

--- a/src/libs/WatchBridge/index.ios.ts
+++ b/src/libs/WatchBridge/index.ios.ts
@@ -1,0 +1,161 @@
+/**
+ * Phone-side JS wiring of the Apple Watch credential bridge (Phase 3 of
+ * docs/apple-watch-mvp.md). Whenever a fresh Firebase ID token exists, it is
+ * handed (with the current ongoing-session snapshot) to the native
+ * `WatchBridge` module, which pushes it to the watch over WatchConnectivity.
+ *
+ * Known limitation: iOS does not reliably run the RN JS bridge in the
+ * background, so pushes only happen while the app is alive/foreground. The
+ * watch caches the last token until its expiry and then asks the user to open
+ * the app on the phone.
+ */
+import {NativeModules} from 'react-native';
+import throttle from 'lodash/throttle';
+import Onyx from 'react-native-onyx';
+import {getKirokuApiEnv} from '@libs/ApiUtils';
+import AppStateMonitor from '@libs/AppStateMonitor';
+import {getDrinkCount} from '@libs/DrinkEntryUtils';
+import {getFirebaseAuth} from '@libs/Firebase/FirebaseApp';
+import Log from '@libs/Log';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {DrinkingSession} from '@src/types/onyx';
+import type {WatchBridgeModule, WatchCredentialPayload} from './types';
+
+// Under jest the react-native mock has no NativeModules at all, hence the
+// optional chain; on a device the module is compiled into the app target.
+const WatchBridge: WatchBridgeModule | undefined = NativeModules?.WatchBridge;
+
+const SIGNED_OUT_SENTINEL = 'signed-out';
+
+let ongoingSessionJson: string | undefined;
+let lastPayloadKey: string | undefined;
+let isInitialized = false;
+
+/**
+ * Serialize the ongoing session into the exact shape the watch's Codable model
+ * (ios/KirokuWatchCore .../DrinkingSession.swift) decodes: every non-optional
+ * field present, drink entries collapsed to plain counts, JS-only fields
+ * (drinksTimeParts) dropped. Returns undefined when there is nothing live to
+ * mirror, so the payload key is omitted (never null: NSNull is not plist-safe).
+ */
+function serializeOngoingSession(
+  session: DrinkingSession | undefined,
+): string | undefined {
+  if (!session?.ongoing || !session.id) {
+    return undefined;
+  }
+  const drinks: Record<string, Record<string, number>> = {};
+  Object.entries(session.drinks ?? {}).forEach(([timestamp, bucket]) => {
+    const normalized: Record<string, number> = {};
+    Object.entries(bucket ?? {}).forEach(([drinkKey, entry]) => {
+      const count = getDrinkCount(entry);
+      if (count > 0) {
+        normalized[drinkKey] = count;
+      }
+    });
+    if (Object.keys(normalized).length > 0) {
+      drinks[timestamp] = normalized;
+    }
+  });
+  const hasDrinks = Object.keys(drinks).length > 0;
+  return JSON.stringify({
+    id: session.id,
+    start_time: session.start_time,
+    end_time: session.end_time ?? session.start_time,
+    blackout: !!session.blackout,
+    note: session.note ?? '',
+    timezone: session.timezone ?? CONST.DEFAULT_TIME_ZONE.selected,
+    type: session.type ?? CONST.SESSION.TYPES.LIVE,
+    ongoing: true,
+    ...(hasDrinks ? {drinks} : {}),
+  });
+}
+
+/**
+ * Gather the current credential (+ ongoing-session snapshot) and hand it to
+ * the native module. Deduped here on the composed payload; the native side
+ * dedupes again as a backstop before touching WCSession.
+ */
+async function pushCredentialToWatch(): Promise<void> {
+  if (!WatchBridge) {
+    return;
+  }
+  const user = getFirebaseAuth().currentUser;
+  if (!user) {
+    if (lastPayloadKey !== SIGNED_OUT_SENTINEL) {
+      lastPayloadKey = SIGNED_OUT_SENTINEL;
+      WatchBridge.clearCredential();
+    }
+    return;
+  }
+  try {
+    // Returns the cached token unless it is about to expire; only then does it
+    // hit the network, so this is cheap to call on every trigger.
+    const result = await user.getIdTokenResult();
+    const payload: WatchCredentialPayload = {
+      idToken: result.token,
+      uid: user.uid,
+      expiresAt: new Date(result.expirationTime).getTime(),
+      apiEnv: getKirokuApiEnv(),
+      ...(ongoingSessionJson ? {ongoingSession: ongoingSessionJson} : {}),
+    };
+    const payloadKey = [
+      payload.uid,
+      payload.idToken,
+      payload.expiresAt,
+      payload.apiEnv,
+      ongoingSessionJson ?? '',
+    ].join('|');
+    if (payloadKey === lastPayloadKey) {
+      return;
+    }
+    lastPayloadKey = payloadKey;
+    WatchBridge.updateCredential(payload);
+  } catch (error) {
+    Log.hmmm('[WatchBridge] Failed to push the credential to the watch', {
+      error,
+    });
+  }
+}
+
+// Leading edge makes the first trigger of a burst (e.g. login) push
+// immediately; the trailing edge guarantees the final state of a tap burst
+// lands. 2s keeps the watch close behind while capping WCSession traffic.
+const throttledPush = throttle(pushCredentialToWatch, 2000);
+
+function init(): void {
+  if (isInitialized || !WatchBridge) {
+    return;
+  }
+  isInitialized = true;
+
+  // Fires on login, sign-out, and every token refresh, including the forced
+  // `getIdToken(true)` the 407 path runs in Middleware/Reauthentication.ts,
+  // so one listener covers "after login" and "after the 407 refresh".
+  getFirebaseAuth().onIdTokenChanged(() => {
+    throttledPush();
+  });
+
+  // App foreground: the recovery path after long background gaps, during
+  // which no refresh could run (see the limitation note above).
+  AppStateMonitor.addBecameActiveListener(() => {
+    throttledPush();
+  });
+
+  // Ongoing-session changes; sign-out's Onyx.clear and the finalize/discard
+  // `Onyx.set(null)` land here too and clear the mirrored snapshot.
+  // This is module-scope bridge wiring with no React context to hang a
+  // useOnyx on, the same pattern as HttpUtils' NETWORK connection.
+  // eslint-disable-next-line rulesdir/no-onyx-connect
+  Onyx.connect({
+    key: ONYXKEYS.ONGOING_SESSION_DATA,
+    callback: value => {
+      ongoingSessionJson = serializeOngoingSession(value ?? undefined);
+      throttledPush();
+    },
+  });
+}
+
+export default {init};
+export {pushCredentialToWatch, serializeOngoingSession};

--- a/src/libs/WatchBridge/index.ts
+++ b/src/libs/WatchBridge/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Watch credential bridge, iOS-only (see ./index.ios.ts). On every other
+ * platform (and under jest, where the native module is absent) there is no
+ * watch to feed, so initialization is a no-op.
+ */
+function init(): void {}
+
+export default {init};

--- a/src/libs/WatchBridge/types.ts
+++ b/src/libs/WatchBridge/types.ts
@@ -1,0 +1,31 @@
+/**
+ * The credential payload JS hands to the native `WatchBridge` module, which
+ * forwards it to the watch via `WCSession.updateApplicationContext`. Every
+ * value must be plist-safe (no null/undefined properties); the ongoing session
+ * travels as a JSON string and is decoded on the watch
+ * (ios/Kiroku Watch App/Connectivity/SessionConnectivity.swift).
+ */
+type WatchCredentialPayload = {
+  /** Firebase ID token the watch sends as its Bearer header */
+  idToken: string;
+
+  /** Firebase uid the token belongs to */
+  uid: string;
+
+  /** Token expiry as epoch milliseconds */
+  expiresAt: number;
+
+  /** Which kiroku-api backend this build talks to */
+  apiEnv: 'dev' | 'prod';
+
+  /** JSON string of the whitelisted ongoing-session fields; omitted when none */
+  ongoingSession?: string;
+};
+
+/** The native module surface (ios/kiroku/WatchBridge.swift) */
+type WatchBridgeModule = {
+  updateCredential: (payload: WatchCredentialPayload) => void;
+  clearCredential: () => void;
+};
+
+export type {WatchBridgeModule, WatchCredentialPayload};

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -9,6 +9,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import intlPolyfill from '@libs/IntlPolyfill';
 import {initFirebaseAuth} from '@libs/Firebase/FirebaseApp';
 import StartupMetrics from '@libs/StartupMetrics';
+import WatchBridge from '@libs/WatchBridge';
 import initializeLastVisitedPath from './initializeLastVisitedPath';
 import platformSetup from './platformSetup';
 import suppressSkiaPathDeprecationWarnings from './suppressSkiaPathDeprecationWarnings';
@@ -92,6 +93,11 @@ export default function () {
   // (AsyncStorage on native, IndexedDB on web) so the session survives a cold
   // start. Resolves by platform extension, so no platform branching is needed.
   initFirebaseAuth();
+
+  // Feed the Apple Watch companion its credential (iOS-only; a no-op
+  // elsewhere). Needs the auth singleton from initFirebaseAuth() above, since
+  // it installs an onIdTokenChanged listener.
+  WatchBridge.init();
 
   // Capture native cold-start marks (process spawn → first content visible)
   // and log them in the same `Timing:` format as Timing.ts so Grafana picks

--- a/src/types/modules/react-native.d.ts
+++ b/src/types/modules/react-native.d.ts
@@ -18,6 +18,7 @@ import type {TargetedEvent} from 'react-native';
 import type {BootSplashModule} from '@libs/BootSplash/types';
 import type {EnvironmentCheckerModule} from '@libs/Environment/betaChecker/types';
 import type {ShortcutManagerModule} from '@libs/ShortcutManager';
+import type {WatchBridgeModule} from '@libs/WatchBridge/types';
 
 type HybridAppModule = {
   closeReactNativeApp: (shouldSignOut: boolean, shouldSetNVP: boolean) => void;
@@ -63,6 +64,7 @@ declare module 'react-native' {
     RNNavBarManager: RNNavBarManagerModule;
     EnvironmentChecker: EnvironmentCheckerModule;
     ShortcutManager: ShortcutManagerModule;
+    WatchBridge: WatchBridgeModule;
   }
 
   namespace Animated {


### PR DESCRIPTION
# feat(watch): WatchConnectivity credential bridge (Phase 3)

Phase 3 of the Apple Watch MVP (`docs/apple-watch-mvp.md`): hand the Firebase ID token and the current ongoing-session snapshot from the signed-in phone to the watch over `WCSession.updateApplicationContext`, so the watch can call kiroku-api directly. The watch never signs in itself: no Firebase SDK, no pods, no pasted tokens.

## Wire contract (applicationContext)

All plist-safe scalars plus one JSON string; JS never sends null values (RN would turn them into non-plist-safe `NSNull`):

| key              | type    | notes                                                                                       |
| ---------------- | ------- | ------------------------------------------------------------------------------------------- |
| `v`              | Int `1` | schema version                                                                              |
| `signedIn`       | Bool    | `false` means: watch clears its Keychain and shows the reconnect message                    |
| `idToken`        | String  | Firebase ID token                                                                           |
| `uid`            | String  | Firebase uid                                                                                |
| `expiresAt`      | Double  | epoch ms (converted from `getIdTokenResult().expirationTime`)                               |
| `apiEnv`         | String  | `"dev"` or `"prod"`, same rule as `getKirokuApiRoot()` so both devices hit the same backend |
| `ongoingSession` | String  | JSON of whitelisted session fields; key omitted when none                                   |

No per-push timestamp key: it would defeat both the JS/native dedupe and WCSession's own identical-context suppression.

## Phone side

- **`ios/kiroku/WatchBridge.swift` + `.m` (3.1)**: legacy `RCT_EXTERN_MODULE` Swift module (same interop path as `RCTBootSplash`; no TurboModule codegen). Owns `WCSession.default`, activates lazily, retains the latest whitelisted payload, pushes only when activated + paired + watch app installed, dedupes identical payloads, re-pushes from `activationDidCompleteWith` and `sessionWatchStateDidChange`. All state on a private serial queue; `updateApplicationContext` failures are logged, never fatal.
- **`src/libs/WatchBridge/` (3.2)**: `index.ios.ts` gathers `{idToken, uid, expiresAt, apiEnv, ongoingSession}` and hands it to the native module, throttled (2s, leading + trailing) and deduped. Triggers:
  - `auth.onIdTokenChanged`: covers login, sign-out (pushes a `signedIn: false` context), and the 407 forced refresh, because the Reauthentication middleware's `getIdToken(true)` fires this listener. `HttpUtils.ts` and the middleware stay untouched.
  - `AppStateMonitor.addBecameActiveListener`: app foreground, the recovery path after long background gaps.
  - `Onyx.connect(ONGOING_SESSION_DATA)`: mirrors the live session; drink entries are collapsed to plain counts (`getDrinkCount`) and JS-only fields dropped so the watch Codable model always decodes.
  - Initialized from `src/setup/index.ts` right after `initFirebaseAuth()`; `index.ts` makes it a no-op on web/Android/jest.
- `getKirokuApiEnv()` added to `src/libs/ApiUtils.ts`; `WatchBridge` typing added to `NativeModulesStatic`.

## Watch side

- **`ios/Kiroku Watch App/Connectivity/` (3.3)**: `SessionConnectivity` (WCSession delegate) applies contexts from both `didReceiveApplicationContext` and the persisted `receivedApplicationContext` at activation (cold-start path). Credential goes to `CredentialStore`, a Keychain (`kSecClassGenericPassword`, after-first-unlock) wrapper; `CredentialStore.validToken()` (nil when absent or stale) is plugged straight into `KirokuAPI`'s `tokenProvider` seam from Phase 2.
- **Token lifecycle (3.4)**: 60s staleness margin before `expiresAt`; a server 401/407 (or acting on a stale token) drops the credential and surfaces **"Open Kiroku on your phone to reconnect."** as an overlay in `ContentView` (new `openPhoneToReconnect` translation key, EN + CS).
- **Minimal real wiring for the acceptance path**: `SessionViewModel.start/save/discard` now POST through `KirokuAPI` (adopting the phone's ongoing-session id when one exists, so no duplicate session; minting a `PushID` otherwise). The counter UI and full VM rewrite stay for Phase 4.
- **`KirokuWatchCore` is now actually compiled**: the Phase 2 package was orphaned from the Xcode build; its three sources are now referenced in place by the watch target (objectVersion 54 predates local SwiftPM package references). `swift test --package-path ios/KirokuWatchCore` still exercises the package standalone.

## Known limitation (by design, documented in the MVP doc)

iOS never runs the RN JS bridge in the background, so tokens are refreshed/pushed only while the phone app is alive. The watch caches the last token until `expiresAt` (~1h) and then degrades to the reconnect message. `updateApplicationContext` is last-value-wins and delivered even while the watch app is dead, and WCSession persists the last received context, so a cold-started watch always has the newest credential the phone ever sent.

## Testing

- Swift: 9 new unit tests in `Kiroku Watch AppTests` (context parsing incl. malformed-JSON and signed-out payloads, staleness boundary at the 60s margin, Keychain round-trip, credential rejection). All 9 pass on the Apple Watch Series 11 (46mm) simulator (`xcodebuild test`). Getting them to run surfaced a pre-existing Phase 1 misconfiguration: both watch test targets inherited the phone's `kiroku-Bridging-Header.h` (which imports React headers that do not exist on watchOS), so their build broke the moment the test action compiled them. This PR removes `SWIFT_OBJC_BRIDGING_HEADER` from the 16 watch-test build configurations.
- `swift test --package-path ios/KirokuWatchCore`: 26 tests pass (token round-trip skips without `KIROKU_ID_TOKEN`, as designed).
- JS: `__tests__/unit/WatchBridge.test.ts` (7 tests) covers the session whitelisting/normalization, epoch-ms conversion, payload dedupe, and the signed-out clear.
- Builds: `Kiroku Watch App` scheme (watchOS Simulator) and `Kiroku (development)` scheme (iOS Simulator) both succeed; the new `WatchBridge.swift`/`.m` compile and link into the phone app, and the three `KirokuWatchCore` sources plus `Connectivity/` compile into the watch app.
- `npm run typecheck-tsgo`, prettier, `npm run lint-changed`: clean. React Compiler check not applicable (no components/hooks touched).
- **Not exercised here**: the live end-to-end acceptance (sign in on phone, watch banner clears within seconds, watch start/+1/save lands in the phone app) needs a paired iPhone + Watch, which this environment cannot drive. Everything up to the WCSession hop is covered by the unit tests on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
