### PR TITLE
fix(session): persist offline live-session edits across app restarts

### DIFF
--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
 /* eslint-disable rulesdir/no-api-in-views -- this test asserts on the mocked API.write pipeline; it is not a view */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this test references the mocked Onyx.merge/set to assert what the action issues; it is not app code */
 
 import type {OnyxKey} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
@@ -359,17 +360,21 @@ describe('finalize is the deterministic last writer', () => {
 
 describe('offline live-session persistence across restarts', () => {
   // The module is fully mocked above; these are the jest.fn instances the
-  // action layer writes through.
+  // action layer writes through. Typed explicitly (not the bare `jest.Mock`
+  // the real `Onyx.set`/`Onyx.merge` declarations widen to) so `.mock.calls`
+  // stays a known tuple instead of `any`.
   const mockedOnyx = {
-    set: Onyx.set as unknown as jest.Mock,
-    merge: Onyx.merge as unknown as jest.Mock,
+    set: Onyx.set as unknown as jest.Mock<Promise<void>, [OnyxKey, unknown]>,
+    merge: Onyx.merge as unknown as jest.Mock<
+      Promise<void>,
+      [OnyxKey, unknown]
+    >,
   };
 
   /** The stamp of the last persisted ONGOING_SESSION_SYNC write. */
   function lastSyncMarker(): {sessionId: string; editedAt: number} {
     const setCalls = mockedOnyx.set.mock.calls.filter(
-      (call: unknown[]) =>
-        call[0] === ONYXKEYS.ONGOING_SESSION_SYNC && call[1] !== null,
+      call => call[0] === ONYXKEYS.ONGOING_SESSION_SYNC && call[1] !== null,
     );
     return setCalls[setCalls.length - 1][1] as {
       sessionId: string;
@@ -384,10 +389,12 @@ describe('offline live-session persistence across restarts', () => {
 
     tap();
 
-    expect(mockedOnyx.set).toHaveBeenCalledWith(
-      ONYXKEYS.ONGOING_SESSION_SYNC,
-      expect.objectContaining({sessionId: 's1', editedAt: expect.any(Number)}),
-    );
+    // Assert via the typed helper (not `expect.any(Number)`, which is `any`
+    // and trips the type-checked lint): a marker for this session with a
+    // numeric edit stamp was persisted.
+    const marker = lastSyncMarker();
+    expect(marker.sessionId).toBe('s1');
+    expect(typeof marker.editedAt).toBe('number');
   });
 
   it('flush stamps enqueuedAt synchronously and acknowledges via successData', () => {

--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -6,6 +6,7 @@
 /* eslint-disable rulesdir/no-api-in-views -- this test asserts on the mocked API.write pipeline; it is not a view */
 
 import type {OnyxKey} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
 import * as API from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
@@ -53,6 +54,8 @@ jest.mock('@libs/API', () => ({write: jest.fn()}));
 
 // Run the debounced persist's deferred body synchronously when the InteractionManager
 // callback is invoked, and hand back a cancel handle the action layer can call.
+// The action layer detects this synchronous completion and must not store the
+// handle as a pending task (see scheduleLiveSessionPersist).
 jest.mock('react-native', () => ({
   Alert: {alert: jest.fn()},
   InteractionManager: {
@@ -119,6 +122,15 @@ function liveUpdateCalls() {
   );
 }
 
+/**
+ * Let the debounced live persist run to completion (or prove it has nothing to
+ * run): past the 500ms debounce the mocked InteractionManager runs the flush
+ * synchronously.
+ */
+function runLivePersistDebounce() {
+  jest.advanceTimersByTime(500);
+}
+
 /** Extract the `session` payload from a captured UPDATE_SESSION write call. */
 function sessionOf(
   call: ReturnType<typeof liveUpdateCalls>[number],
@@ -126,12 +138,23 @@ function sessionOf(
   return (call[1] as {session?: DrinkingSession}).session;
 }
 
-beforeEach(() => {
+// Install fake timers ONCE for the whole suite (jest/setupAfterEnv.ts forces
+// real timers per file). Per-test useFakeTimers would re-install and DISCARD
+// pending timers without running them, leaking the module-level persist
+// handles (`hasPendingLiveSessionPersist` would read armed-forever).
+beforeAll(() => {
   jest.useFakeTimers();
+});
+
+beforeEach(() => {
+  // Drain whatever a previous test left armed (debounce and/or interaction
+  // task) so the module-level pending handles reset, then clear the mock calls
+  // that draining produced.
+  jest.runAllTimers();
   jest.clearAllMocks();
-  jest.clearAllTimers();
-  // Reset the DrinkingSession.ts module cache the flush reads.
+  // Reset the DrinkingSession.ts module caches the flush and sync guards read.
   driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, null);
+  driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, null);
   mockedDSUtils.clearOngoingSessionCache.mockReset();
 });
 
@@ -147,7 +170,7 @@ describe('live-session persistence', () => {
     // Debounced: nothing is written until the user pauses.
     expect(mockedWrite).not.toHaveBeenCalled();
 
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
 
     expect(liveUpdateCalls()).toHaveLength(1);
     const call = liveUpdateCalls()[0];
@@ -156,8 +179,16 @@ describe('live-session persistence', () => {
       session,
       sessionIsLive: true,
     });
-    // No third onyxData arg → no optimistic cachedDrinkingSessions merge.
-    expect(call).toHaveLength(2);
+    // No optimistic cachedDrinkingSessions merge; the flush only carries
+    // successData (the sync acknowledgement stamp), which applies off the
+    // touch frame when the response lands.
+    const onyxData = call[2] as
+      | {optimisticData?: unknown; successData?: Array<{key: string}>}
+      | undefined;
+    expect(onyxData?.optimisticData).toBeUndefined();
+    expect(onyxData?.successData).toEqual([
+      expect.objectContaining({key: ONYXKEYS.ONGOING_SESSION_SYNC}),
+    ]);
   });
 
   it('synchronously caches the composed session so rapid taps compose on the latest', () => {
@@ -181,7 +212,7 @@ describe('live-session persistence', () => {
     routeTo(ONYXKEYS.EDIT_SESSION_DATA, session);
 
     tap('e1');
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
 
     expect(mockedWrite).not.toHaveBeenCalled();
   });
@@ -194,7 +225,7 @@ describe('live-session persistence', () => {
     tap();
     // The session is finalized/cleared before the debounce fires.
     driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, null);
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
 
     expect(mockedWrite).not.toHaveBeenCalled();
   });
@@ -227,7 +258,7 @@ describe('finalize is the deterministic last writer', () => {
     );
 
     // The cancelled debounce must not fire a trailing live write.
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
     expect(liveUpdateCalls()).toHaveLength(1);
   });
 
@@ -289,7 +320,7 @@ describe('finalize is the deterministic last writer', () => {
 
     // A straggler tap whose handler runs after Save must be a no-op.
     tap();
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
 
     const updates = liveUpdateCalls();
     expect(updates).toHaveLength(1);
@@ -316,13 +347,210 @@ describe('finalize is the deterministic last writer', () => {
 
     expect(mockedDSUtils.clearOngoingSessionCache).toHaveBeenCalledTimes(1);
     // Discard issues a DELETE_SESSION, never an UPDATE_SESSION.
-    jest.advanceTimersByTime(500);
+    runLivePersistDebounce();
     expect(liveUpdateCalls()).toHaveLength(0);
     expect(
       mockedWrite.mock.calls.filter(
         call => call[0] === WRITE_COMMANDS.DELETE_SESSION,
       ),
     ).toHaveLength(1);
+  });
+});
+
+describe('offline live-session persistence across restarts', () => {
+  // The module is fully mocked above; these are the jest.fn instances the
+  // action layer writes through.
+  const mockedOnyx = {
+    set: Onyx.set as unknown as jest.Mock,
+    merge: Onyx.merge as unknown as jest.Mock,
+  };
+
+  /** The stamp of the last persisted ONGOING_SESSION_SYNC write. */
+  function lastSyncMarker(): {sessionId: string; editedAt: number} {
+    const setCalls = mockedOnyx.set.mock.calls.filter(
+      (call: unknown[]) =>
+        call[0] === ONYXKEYS.ONGOING_SESSION_SYNC && call[1] !== null,
+    );
+    return setCalls[setCalls.length - 1][1] as {
+      sessionId: string;
+      editedAt: number;
+    };
+  }
+
+  it('stamps a persisted un-synced edit marker on every live tap', () => {
+    const session = makeOngoing('s1');
+    routeTo(ONYXKEYS.ONGOING_SESSION_DATA, session);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, session);
+
+    tap();
+
+    expect(mockedOnyx.set).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_SYNC,
+      expect.objectContaining({sessionId: 's1', editedAt: expect.any(Number)}),
+    );
+  });
+
+  it('flush stamps enqueuedAt synchronously and acknowledges via successData', () => {
+    const session = makeOngoing('s1');
+    routeTo(ONYXKEYS.ONGOING_SESSION_DATA, session);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, session);
+
+    tap();
+    const {editedAt} = lastSyncMarker();
+    // The marker must feed the flush through the synchronous module cache, not
+    // wait on an Onyx.connect round-trip, so no driveOnyx here on purpose.
+    runLivePersistDebounce();
+
+    // Enqueued: stamped at flush time so a restart won't re-enqueue these edits.
+    expect(mockedOnyx.merge).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_SYNC,
+      {enqueuedAt: editedAt},
+    );
+    // Synced: only a successful response may clear the dirty state.
+    const call = liveUpdateCalls()[0];
+    expect(call[2]).toEqual({
+      successData: [
+        expect.objectContaining({
+          key: ONYXKEYS.ONGOING_SESSION_SYNC,
+          value: {syncedAt: editedAt},
+        }),
+      ],
+    });
+  });
+
+  it('never touches the buffer while the snapshot has not hydrated', async () => {
+    const session = {...makeOngoing('s1'), drinks: {1_000: {beer: 2}}};
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, session);
+
+    // Cold start: the cached snapshot has not loaded yet (undefined). This used
+    // to Onyx.set(ONGOING_SESSION_DATA, null) and destroy the persisted buffer.
+    await DS.syncLocalLiveSessionData(null, undefined);
+
+    expect(mockedOnyx.set).not.toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      expect.anything(),
+    );
+  });
+
+  it('keeps un-synced offline edits instead of rolling back to a stale snapshot', async () => {
+    // Restart state: buffer hydrated with offline drinks, marker says the
+    // edits were enqueued but never acknowledged (the queue is waiting for
+    // connectivity), no in-memory debounce (it died with the app).
+    const buffered = {...makeOngoing('s1'), drinks: {1_000: {beer: 2}}};
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, buffered);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, {
+      sessionId: 's1',
+      editedAt: 100,
+      enqueuedAt: 100,
+    });
+
+    // The snapshot only has the optimistic (empty) session from session start.
+    const stale = makeOngoing('s1');
+    await DS.syncLocalLiveSessionData('s1', {s1: stale});
+
+    expect(mockedOnyx.set).not.toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      expect.anything(),
+    );
+    expect(mockedDSUtils.setLocalSessionCache).not.toHaveBeenCalled();
+  });
+
+  it('adopts the snapshot once the server has acknowledged every local edit', async () => {
+    const buffered = makeOngoing('s1');
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, buffered);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, {
+      sessionId: 's1',
+      editedAt: 100,
+      enqueuedAt: 100,
+      syncedAt: 100,
+    });
+
+    const serverSession = {...makeOngoing('s1'), drinks: {2_000: {beer: 3}}};
+    await DS.syncLocalLiveSessionData('s1', {s1: serverSession});
+
+    expect(mockedOnyx.set).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      expect.objectContaining({id: 's1', drinks: {2_000: {beer: 3}}}),
+    );
+  });
+
+  it('clears the buffer when the loaded snapshot has no ongoing session and nothing is un-synced', async () => {
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, {
+      ...makeOngoing('s1'),
+      ongoing: false,
+    });
+
+    await DS.syncLocalLiveSessionData(null, {});
+
+    expect(mockedOnyx.set).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      null,
+    );
+  });
+
+  it('keeps an un-synced offline session even when the snapshot lacks it', async () => {
+    const buffered = {...makeOngoing('s1'), drinks: {1_000: {beer: 2}}};
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, buffered);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, {sessionId: 's1', editedAt: 100});
+
+    await DS.syncLocalLiveSessionData(null, {});
+
+    expect(mockedOnyx.set).not.toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      null,
+    );
+  });
+
+  it('re-arms the persist on launch for edits killed inside the debounce window', () => {
+    // Restart state: buffer hydrated with drinks whose flush never ran (the
+    // app was killed inside the 500ms debounce), so editedAt > enqueuedAt.
+    const buffered = {...makeOngoing('s1'), drinks: {1_000: {beer: 2}}};
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, buffered);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, {sessionId: 's1', editedAt: 100});
+
+    runLivePersistDebounce();
+
+    const updates = liveUpdateCalls();
+    expect(updates).toHaveLength(1);
+    expect(sessionOf(updates[0])).toEqual(buffered);
+    expect(mockedOnyx.merge).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_SYNC,
+      {enqueuedAt: 100},
+    );
+  });
+
+  it('does not re-arm when the queued request already covers the edits', () => {
+    const buffered = {...makeOngoing('s1'), drinks: {1_000: {beer: 2}}};
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, buffered);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_SYNC, {
+      sessionId: 's1',
+      editedAt: 100,
+      enqueuedAt: 100,
+    });
+
+    runLivePersistDebounce();
+
+    expect(liveUpdateCalls()).toHaveLength(0);
+  });
+
+  it('clears the sync marker when the live session is finalized', async () => {
+    const session = makeOngoing('s1');
+    routeTo(ONYXKEYS.ONGOING_SESSION_DATA, session);
+    driveOnyx(ONYXKEYS.ONGOING_SESSION_DATA, session);
+    tap();
+
+    await DS.saveDrinkingSessionData(
+      'uid',
+      {...session, ongoing: false},
+      's1',
+      ONYXKEYS.ONGOING_SESSION_DATA,
+      true,
+    );
+
+    expect(mockedOnyx.set).toHaveBeenCalledWith(
+      ONYXKEYS.ONGOING_SESSION_SYNC,
+      null,
+    );
   });
 });
 

--- a/eslint.seatbelt.tsv
+++ b/eslint.seatbelt.tsv
@@ -881,7 +881,7 @@
 "src/libs/UserUtils.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/App.ts"	"rulesdir/no-onyx-connect"	3
 "src/libs/actions/Device/index.ts"	"rulesdir/no-onyx-connect"	1
-"src/libs/actions/DrinkingSession.ts"	"rulesdir/no-onyx-connect"	2
+"src/libs/actions/DrinkingSession.ts"	"rulesdir/no-onyx-connect"	3
 "src/libs/actions/OnyxUpdateManager/index.ts"	"rulesdir/no-onyx-connect"	3
 "src/libs/actions/OnyxUpdateManager/utils/__mocks__/applyUpdates.ts"	"rulesdir/no-onyx-connect"	1
 "src/libs/actions/OnyxUpdateManager/utils/index.ts"	"@typescript-eslint/prefer-nullish-coalescing"	1

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -107,6 +107,13 @@ const ONYXKEYS = {
   /** Ongoing session data */
   ONGOING_SESSION_DATA: 'ongoingSessionData',
 
+  /**
+   * Sync bookkeeping for the live-session buffer: which local edit stamp was
+   * enqueued to / acknowledged by the server. Lets a cold start keep offline
+   * live edits authoritative instead of rolling them back to a stale snapshot.
+   */
+  ONGOING_SESSION_SYNC: 'ongoingSessionSync',
+
   /** Edit session data */
   EDIT_SESSION_DATA: 'editSessionData',
 
@@ -326,6 +333,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.NVP_PREFERRED_LOCALE]: OnyxTypes.Locale;
   [ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE]: Record<string, DateString>;
   [ONYXKEYS.ONGOING_SESSION_DATA]: OnyxTypes.DrinkingSession;
+  [ONYXKEYS.ONGOING_SESSION_SYNC]: OnyxTypes.OngoingSessionSync;
   [ONYXKEYS.EDIT_SESSION_DATA]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.IS_CREATING_NEW_SESSION]: boolean;
   [ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED]: number;

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -5,6 +5,7 @@ import type {
   DrinkKey,
   DrinksToUnits,
   DrinksTimestamp,
+  OngoingSessionSync,
   UserDataList,
 } from '@src/types/onyx';
 import * as Localize from '@libs/Localize';
@@ -40,6 +41,27 @@ Onyx.connect({
     // debounced live persist reads this cache at flush time; a stale (ongoing:true)
     // copy would let it re-emit the session as ongoing after the finalize.
     ongoingSessionData = value ?? undefined;
+    maybeResumeLiveSessionPersist();
+  },
+});
+
+// Persisted bookkeeping for the live-session persist pipeline: which local edit
+// stamp was enqueued to / acknowledged by the server. Debounce timers die with
+// the JS runtime, so after an app kill this is the only record that the hydrated
+// `ONGOING_SESSION_DATA` buffer holds edits the server has never seen. See
+// `markLiveSessionEdited` / `hasUnsyncedLiveSessionEdits`.
+let ongoingSessionSync: OngoingSessionSync | undefined;
+// Onyx fires the initial connect callback (with undefined for an absent key)
+// only after the storage read resolves. Until then "no marker" is
+// indistinguishable from "marker not hydrated yet", and acting on the latter
+// could roll back or wipe offline edits, so sync decisions wait for this flag.
+let ongoingSessionSyncLoaded = false;
+Onyx.connect({
+  key: ONYXKEYS.ONGOING_SESSION_SYNC,
+  callback: value => {
+    ongoingSessionSync = value ?? undefined;
+    ongoingSessionSyncLoaded = true;
+    maybeResumeLiveSessionPersist();
   },
 });
 
@@ -219,6 +241,82 @@ function cancelLiveSessionPersist(): void {
 }
 
 /**
+ * Record a local edit to the live-session buffer. The stamp is written both to
+ * the synchronous cache and to persisted Onyx so it survives an app kill:
+ * `editedAt > syncedAt` marks the buffer as holding edits the server never
+ * acknowledged, and `editedAt > enqueuedAt` marks edits that never even reached
+ * the request queue (killed inside the debounce window) and so must be
+ * re-enqueued on the next launch. Strictly monotonic (`prev + 1` floor) so an
+ * edit landing in the same millisecond as a flush still reads as newer.
+ */
+function markLiveSessionEdited(sessionId: DrinkingSessionId): void {
+  const previous =
+    ongoingSessionSync?.sessionId === sessionId
+      ? ongoingSessionSync
+      : undefined;
+  const next: OngoingSessionSync = {
+    // A changed session id starts fresh stamps; stale enqueued/synced values
+    // from an older session must not mask the new session's edits.
+    ...(previous ?? {}),
+    sessionId,
+    editedAt: Math.max(Date.now(), (previous?.editedAt ?? 0) + 1),
+  };
+  ongoingSessionSync = next;
+  Onyx.set(ONYXKEYS.ONGOING_SESSION_SYNC, next);
+}
+
+/**
+ * Whether the live-session buffer holds local edits for `sessionId` that no
+ * successful `UPDATE_SESSION` has acknowledged yet. While true, the cached
+ * snapshot cannot reflect those edits (the live persist deliberately writes no
+ * optimistic snapshot data), so the buffer must stay authoritative and must not
+ * be rolled back to the snapshot. Survives restarts, unlike the in-memory
+ * `hasPendingLiveSessionPersist`.
+ */
+function hasUnsyncedLiveSessionEdits(sessionId: DrinkingSessionId): boolean {
+  return (
+    ongoingSessionSync?.sessionId === sessionId &&
+    ongoingSessionSync.editedAt > (ongoingSessionSync.syncedAt ?? 0)
+  );
+}
+
+/**
+ * Clear the live-session sync bookkeeping. Called when the live session stops
+ * existing as such: on start (fresh session, fresh stamps), and on finalize/
+ * discard (those requests carry the full session themselves, so any stamps are
+ * moot and must not linger to shadow a future session).
+ */
+function clearLiveSessionSyncState(): void {
+  ongoingSessionSync = undefined;
+  Onyx.set(ONYXKEYS.ONGOING_SESSION_SYNC, null);
+}
+
+/**
+ * Re-arm the debounced live persist after a restart when the hydrated buffer
+ * holds edits that never reached the request queue (the app was killed inside
+ * the debounce window). Runs from both hydration callbacks above, so it fires
+ * once both the buffer and the sync stamps are available, whichever lands
+ * last. Guarded by `enqueuedAt` (not `syncedAt`): edits that are already
+ * queued offline replay by themselves, and only THIS device's un-enqueued
+ * edits may trigger a write, so a device that merely adopted the session
+ * cross-device never re-emits stale data.
+ */
+function maybeResumeLiveSessionPersist(): void {
+  const session = ongoingSessionData;
+  const sync = ongoingSessionSync;
+  if (!session?.ongoing || !session.id || sync?.sessionId !== session.id) {
+    return;
+  }
+  if (sync.editedAt <= Math.max(sync.enqueuedAt ?? 0, sync.syncedAt ?? 0)) {
+    return;
+  }
+  if (hasPendingLiveSessionPersist()) {
+    return;
+  }
+  scheduleLiveSessionPersist();
+}
+
+/**
  * Persist the current live session via kiroku-api. Reads the latest
  * `ONGOING_SESSION_DATA` at flush time (not a captured snapshot) so it always
  * sends the newest drinks; if the session was finalized/discarded in the
@@ -231,11 +329,50 @@ function flushLiveSessionPersist(): void {
   if (!session?.ongoing || !session.id) {
     return;
   }
-  API.write(WRITE_COMMANDS.UPDATE_SESSION, {
-    sessionId: session.id,
-    session,
-    sessionIsLive: true,
-  });
+  // Stamp how far this flush covers the local edits: `enqueuedAt` synchronously
+  // (the request now exists in the persisted queue, so a restart must not
+  // re-enqueue these edits), `syncedAt` via successData (only a successful
+  // response proves the server, and therefore any future snapshot, has them).
+  const sync = ongoingSessionSync;
+  const coversEditedAt =
+    sync?.sessionId === session.id ? sync.editedAt : undefined;
+  if (sync && coversEditedAt !== undefined) {
+    ongoingSessionSync = {...sync, enqueuedAt: coversEditedAt};
+    Onyx.merge(ONYXKEYS.ONGOING_SESSION_SYNC, {enqueuedAt: coversEditedAt});
+  }
+  API.write(
+    WRITE_COMMANDS.UPDATE_SESSION,
+    {
+      sessionId: session.id,
+      session,
+      sessionIsLive: true,
+    },
+    coversEditedAt === undefined
+      ? {}
+      : {
+          successData: [
+            {
+              onyxMethod: Onyx.METHOD.MERGE,
+              key: ONYXKEYS.ONGOING_SESSION_SYNC,
+              value: {syncedAt: coversEditedAt},
+            },
+          ],
+        },
+  );
+}
+
+/**
+ * Record a local live-session mutation: stamp it as un-synced (so it survives
+ * an app kill as "the server never saw this") and (re)arm the debounced
+ * persist. Every live mutator funnels through this; `sessionId` is always set
+ * when the mutation routed into `ONGOING_SESSION_DATA`, the guard only
+ * satisfies the type system.
+ */
+function recordLiveSessionEdit(sessionId: DrinkingSessionId | undefined): void {
+  if (sessionId) {
+    markLiveSessionEdited(sessionId);
+  }
+  scheduleLiveSessionPersist();
 }
 
 /**
@@ -251,12 +388,19 @@ function scheduleLiveSessionPersist(): void {
   }
   liveSessionPersistTimer = setTimeout(() => {
     liveSessionPersistTimer = null;
-    liveSessionPersistInteraction = InteractionManager.runAfterInteractions(
-      () => {
-        liveSessionPersistInteraction = null;
-        flushLiveSessionPersist();
-      },
-    );
+    let ranSynchronously = false;
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      ranSynchronously = true;
+      liveSessionPersistInteraction = null;
+      flushLiveSessionPersist();
+    });
+    // Store the handle only if the task is still pending. Some environments
+    // (tests mock InteractionManager this way) run the task synchronously
+    // inside runAfterInteractions; storing the handle then would resurrect a
+    // completed task as pending-forever and wedge `hasPendingLiveSessionPersist`.
+    if (!ranSynchronously) {
+      liveSessionPersistInteraction = interaction;
+    }
   }, LIVE_SESSION_PERSIST_DEBOUNCE_MS);
 }
 
@@ -270,7 +414,16 @@ async function syncLocalLiveSessionData(
   ongoingSessionId: DrinkingSessionId | undefined | null,
   drinkingSessionData: DrinkingSessionList | undefined | null,
 ) {
-  if (ongoingSessionId && drinkingSessionData) {
+  // No snapshot at all means it simply has not hydrated/loaded yet (cold start,
+  // or offline before `app/open` ever ran). That transient must never touch the
+  // buffer: clearing it here used to wipe an offline live session's persisted
+  // drinks on every cold boot, before the real snapshot arrived. The same goes
+  // for the sync stamps: until they hydrate we can't tell whether the buffer
+  // holds un-acknowledged offline edits, so no adopt/wipe decision is safe.
+  if (!drinkingSessionData || !ongoingSessionSyncLoaded) {
+    return;
+  }
+  if (ongoingSessionId) {
     const newData = drinkingSessionData[ongoingSessionId];
     if (!newData) {
       return;
@@ -289,12 +442,32 @@ async function syncLocalLiveSessionData(
     ) {
       return;
     }
+    // Same rule across restarts: the in-memory pending flag dies with the app,
+    // but the persisted stamps know the buffer still holds edits no successful
+    // request has acknowledged (e.g. everything queued offline). The snapshot
+    // can only be older than the buffer then, so adopting it would roll the
+    // offline edits back. Once the queued request succeeds, `syncedAt` catches
+    // up and the next sync adopts server truth again.
+    if (hasUnsyncedLiveSessionEdits(ongoingSessionId)) {
+      return;
+    }
     await updateLocalData(
       ONYXKEYS.ONGOING_SESSION_DATA,
       newData,
       ongoingSessionId,
     );
   } else {
+    // The loaded snapshot shows no ongoing session. Keep the buffer anyway if
+    // it holds un-acknowledged local edits (the snapshot may predate an
+    // offline-started session whose create is still queued); otherwise clear
+    // it, e.g. after the session was finalized on another device.
+    if (
+      ongoingSessionData?.ongoing &&
+      ongoingSessionData.id &&
+      hasUnsyncedLiveSessionEdits(ongoingSessionData.id)
+    ) {
+      return;
+    }
     Onyx.set(ONYXKEYS.ONGOING_SESSION_DATA, null);
   }
 }
@@ -340,6 +513,10 @@ async function startLiveDrinkingSession(
     },
   );
 
+  // Fresh session, fresh sync stamps: any leftover marker from a previous
+  // (crashed/stale) session must not shadow this one's edits.
+  clearLiveSessionSyncState();
+
   // Seed the synchronous cache so a tap fired before the Onyx.connect callback
   // lands still composes on the new session instead of an empty base.
   DSUtils.setLocalSessionCache(ONYXKEYS.ONGOING_SESSION_DATA, newSessionData);
@@ -379,9 +556,11 @@ async function saveDrinkingSessionData(
   // writer for it. Cancel any pending debounced live persist, and synchronously
   // drop the cached ongoing copy so a stray tap whose handler runs in this same
   // tick can't re-route into ONGOING_SESSION_DATA and re-create the session.
+  // The sync stamps go too: this request carries every local edit itself.
   if (sessionIsLive) {
     cancelLiveSessionPersist();
     DSUtils.clearOngoingSessionCache();
+    clearLiveSessionSyncState();
   }
 
   const sessionToPersist = withSessionTimeParts(newSessionData);
@@ -426,9 +605,11 @@ async function removeDrinkingSessionData(
   // This delete must be the deterministic last writer for the session. Cancel any
   // pending debounced live persist, and synchronously drop the cached ongoing
   // copy so a stray tap landing in this same tick can't re-create the session.
+  // The sync stamps go too: there is nothing left to persist.
   if (sessionIsLive) {
     cancelLiveSessionPersist();
     DSUtils.clearOngoingSessionCache();
+    clearLiveSessionSyncState();
   }
 
   // The server removes the session and its GPS locations, recomputes the
@@ -501,7 +682,7 @@ function updateDrinks(
   // Live (ongoing) sessions sync to the server through the debounced action-layer
   // persist; edit sessions persist only on save, so don't schedule for them.
   if (onyxKey === ONYXKEYS.ONGOING_SESSION_DATA) {
-    scheduleLiveSessionPersist();
+    recordLiveSessionEdit(sessionId);
   }
 
   if (action !== CONST.DRINKS.ACTIONS.ADD || !drinksList) {
@@ -542,7 +723,7 @@ function updateNote(
       DSUtils.setLocalSessionCache(onyxKey, {...current, note: newNote});
     }
     if (onyxKey === ONYXKEYS.ONGOING_SESSION_DATA) {
-      scheduleLiveSessionPersist();
+      recordLiveSessionEdit(current?.id ?? session?.id);
     }
   }
 }
@@ -561,7 +742,7 @@ function updateBlackout(
       DSUtils.setLocalSessionCache(onyxKey, {...current, blackout});
     }
     if (onyxKey === ONYXKEYS.ONGOING_SESSION_DATA) {
-      scheduleLiveSessionPersist();
+      recordLiveSessionEdit(current?.id ?? session?.id);
     }
   }
 }
@@ -590,7 +771,7 @@ function updateTimezone(
       });
     }
     if (onyxKey === ONYXKEYS.ONGOING_SESSION_DATA) {
-      scheduleLiveSessionPersist();
+      recordLiveSessionEdit(current?.id ?? session?.id);
     }
   }
 }
@@ -630,7 +811,7 @@ async function updateSessionDate(
     : ONYXKEYS.EDIT_SESSION_DATA;
   await updateLocalData(onyxKey, modifiedSession, sessionId);
   if (shouldUpdateLiveSessionData) {
-    scheduleLiveSessionPersist();
+    recordLiveSessionEdit(sessionId);
   }
 }
 

--- a/src/types/onyx/OngoingSessionSync.ts
+++ b/src/types/onyx/OngoingSessionSync.ts
@@ -1,0 +1,37 @@
+import type {Timestamp} from './OnyxCommon';
+import type {DrinkingSessionId} from './DrinkingSession';
+
+/**
+ * Persisted sync bookkeeping for the device-local live-session buffer
+ * (`ONGOING_SESSION_DATA`). Live drink taps write only the local buffer and a
+ * debounced `UPDATE_SESSION` request; the cached snapshot deliberately gets no
+ * optimistic copy of them. This marker records how far that pipeline got so a
+ * cold start (especially an offline one) can tell "the buffer holds edits the
+ * server has never acknowledged" apart from "the snapshot is at least as fresh
+ * as the buffer", and act accordingly: keep the buffer authoritative and
+ * re-arm the persist, instead of rolling the buffer back to a stale snapshot.
+ */
+type OngoingSessionSync = {
+  /** The live session these stamps belong to. */
+  sessionId: DrinkingSessionId;
+
+  /** Stamp of the newest local edit to the live session buffer. */
+  editedAt: Timestamp;
+
+  /**
+   * `editedAt` value covered by the most recent enqueued `UPDATE_SESSION`
+   * write. Edits with `editedAt > enqueuedAt` were never handed to the request
+   * queue (e.g. the app was killed inside the persist debounce window) and
+   * must be re-enqueued on the next launch.
+   */
+  enqueuedAt?: Timestamp;
+
+  /**
+   * `editedAt` value most recently acknowledged by a successful
+   * `UPDATE_SESSION` response. While `editedAt > syncedAt` the cached snapshot
+   * cannot reflect the buffer, so the buffer must not be rolled back to it.
+   */
+  syncedAt?: Timestamp;
+};
+
+export default OngoingSessionSync;

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -35,6 +35,7 @@ import type Network from './Network';
 import type NicknameToId from './NicknameToId';
 import type PendingOAuthCredential from './PendingOAuthCredential';
 import type {Nickname, NicknameKey, NicknameToIdList} from './NicknameToId';
+import type OngoingSessionSync from './OngoingSessionSync';
 import type {
   OnyxUpdateEvent,
   OnyxUpdatesFromServer,
@@ -126,6 +127,7 @@ export type {
   NicknameToIdList,
   PendingOAuthCredential,
   OnboardingData,
+  OngoingSessionSync,
   OnyxUpdateEvent,
   OnyxUpdatesFromServer,
   Preferences,


### PR DESCRIPTION
## Problem

Fully offline: start a live session, add drinks, kill the app. On reopen the session's drinks were gone (and after the debounce-window kill, gone permanently, even after reconnecting).

Live drink taps deliberately write only the local `ONGOING_SESSION_DATA` buffer plus a debounced `UPDATE_SESSION` request, with no optimistic `cachedDrinkingSessions` copy (keeps Home/Stats off the touch frame). Offline, a cold start then lost those edits through three independent holes:

1. **Pre-hydration wipe.** HomeScreen's sync effect ran before the cached snapshot hydrated and called `syncLocalLiveSessionData(null, undefined)`, which unconditionally `Onyx.set(ONGOING_SESSION_DATA, null)`: the persisted buffer (with the drinks) was destroyed on every cold boot. Online this self-heals from the server snapshot; offline it cannot.
2. **Stale-snapshot rollback.** The guard against rolling the buffer back to the older snapshot was the in-memory `hasPendingLiveSessionPersist()`, which dies with the JS runtime. After a restart the effect adopted the snapshot (which never contains live drinks) over the buffer.
3. **Lost enqueue.** Killing the app inside the 500ms persist debounce meant the `UPDATE_SESSION` with the drinks was never handed to the offline request queue, and nothing ever re-sent it.

## Fix

New persisted `ONGOING_SESSION_SYNC` marker with three stamps:

- `editedAt`: newest local edit (strictly monotonic), written on every live mutation (drinks, note, blackout, timezone, date shift)
- `enqueuedAt`: stamped synchronously when the flush hands the request to the queue
- `syncedAt`: stamped via the request's `successData`, so only a successful response clears the dirty state

Behavior changes in `DrinkingSession.ts`:

- `syncLocalLiveSessionData` no-ops until both the snapshot and the marker have hydrated (fixes 1), keeps the buffer authoritative while `editedAt > syncedAt` (fixes 2), and still adopts server truth once the queued request succeeds.
- On launch, once the buffer and marker hydrate, the persist re-arms when `editedAt > enqueuedAt` (fixes 3); already-queued requests replay by themselves, and a device that merely adopted the session cross-device never re-emits stale data.
- The marker is reset on session start and cleared on finalize/discard (those requests carry the full session).
- `scheduleLiveSessionPersist` no longer stores a synchronously completed InteractionManager task as pending forever (test environments run it synchronously).

Server side: `POST /v1/sessions/update` is already a full-session idempotent upsert, so replayed queued requests need no kiroku-api changes.

## Tests

`__tests__/actions/DrinkingSession.test.ts` gains an "offline live-session persistence across restarts" suite (10 cases): marker stamping, enqueue/ack bookkeeping, the pre-hydration no-touch rule, stale-snapshot rollback protection, snapshot adoption after ack, buffer clearing rules, launch re-arm for debounce-window kills, and marker cleanup on finalize. Existing debounce/finalize tests updated for the sync acknowledgement payload; the suite's fake-timer setup moved to `beforeAll` (per-test re-install silently discarded pending timers).

## Manual test path

1. Airplane mode on, cold-start the app.
2. Start a live session, add a few drinks, kill the app within a second (and again after waiting >1s).
3. Reopen still offline: the session and its drinks are there.
4. Reconnect: the queued `UPDATE_SESSION` replays and the server session matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)