### PR TITLE
build(ios): don't embed Apple Watch app in App Store archive

### DIFF
--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -516,7 +516,6 @@
 				96EE1767D138A900D6E3A4421BAD14EF /* Frameworks */,
 				B9F8269ED055C5C64E7601A97DC265CB /* Resources */,
 				A93D5E4D4B3C14C35A07B0AB64D8AFE8 /* [User] Copy GoogleService-Info.plist */,
-				99C9732089753FE060B2B9AB /* Embed Watch Content */,
 				F3EDCA035BBAB0CF568F51A01F8CD5C4 /* Bundle React Native code and images */,
 				D30FCE1E350F4965931BD17D /* [CP] Embed Pods Frameworks */,
 				F4913D0151294198FC1A8191 /* [CP] Copy Pods Resources */,
@@ -526,7 +525,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				99914CCF269EA90978B1A36F /* PBXTargetDependency */,
 			);
 			name = kiroku;
 			productName = kiroku;

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (AdHoc).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (AdHoc).xcscheme
@@ -54,20 +54,6 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
-               BuildableName = "Kiroku Watch App.app"
-               BlueprintName = "Kiroku Watch App"
-               ReferencedContainer = "container:kiroku.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (development).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (development).xcscheme
@@ -54,20 +54,6 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
-               BuildableName = "Kiroku Watch App.app"
-               BlueprintName = "Kiroku Watch App"
-               ReferencedContainer = "container:kiroku.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme
@@ -54,20 +54,6 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
-               BuildableName = "Kiroku Watch App.app"
-               BlueprintName = "Kiroku Watch App"
-               ReferencedContainer = "container:kiroku.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
## Why

App Store Connect refuses to accept the 0.3.21 submission because the uploaded build (0.3.20.17) embeds the Apple Watch app, which makes ASC require an `APP_WATCH_SERIES_4` screenshot:

```
STATE_ERROR.SCREENSHOT_REQUIRED.APP_WATCH_SERIES_4
"A screenshot with type watch is required but was not provided"
```

The watch app is still a non-functional shell (screenshot capture for it is deliberately deferred in `scripts/store-screenshots.config.mjs`), so we don't want to advertise it or put it in front of a reviewer yet. Rather than ship a placeholder watch screenshot, this stops the app archive from embedding the watch app so ASC no longer demands one.

## What changed

- `ios/kiroku.xcodeproj/project.pbxproj`: removed the `Embed Watch Content` copy-files phase reference and the watch `PBXTargetDependency` from the main `kiroku` target. The phase/dependency **object definitions are left orphaned on purpose** so reverting is a two-line re-add.
- `Kiroku (production|AdHoc|development).xcscheme`: removed the `Kiroku Watch App` build-for-archiving entry so archives don't build the watch target.

The Watch app targets and all watch source stay in the project untouched. This is a **blanket** exclusion: dev / ad-hoc / local Xcode runs also stop embedding the watch app until this is reverted, so on-device watch testing pauses in the meantime.

## Not touched (harmless no-ops now)

- `fastlane/Fastfile` still maps the `watchkitapp` provisioning profiles in `export_options` (xcodebuild ignores mappings for bundles not in the archive).
- `platformDeploy.yml` / `testBuild.yml` still decrypt the watch profile and run `xcodebuild -downloadPlatform watchOS`.

Left in to keep the diff minimal and the revert clean; they can be cleaned up when the watch app ships for real.

## Validation

- `plutil -lint project.pbxproj` → OK
- `xmllint --noout` on all three schemes → valid
- `xcodebuild -list` parses; `kiroku` target and all schemes intact

Final proof is the CI iOS archive (this can't be fully verified locally).

## Revert path

When the watch app is ready to ship publicly (and real watch screenshots are added in ASC), revert this PR to re-embed it.