### PR TITLE
build(ios): keep RN ccache toolchain overrides out of non-CocoaPods targets

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -107,6 +107,39 @@ target 'kiroku' do
     )
     __apply_Xcode_14_3_RC_post_install_workaround(installer)
 
+    # React Native's ccache integration (enabled above) writes CC/CXX/LD/LDPLUSPLUS
+    # and REACT_NATIVE_PATH onto the *project*-level build settings of kiroku.xcodeproj,
+    # so every target inherits them. Only CocoaPods-integrated targets get a Pods
+    # xcconfig defining PODS_ROOT; in any other target (the pure-Swift watch app,
+    # future widgets/extensions), REACT_NATIVE_PATH ($(PODS_ROOT)/../../node_modules/
+    # react-native) collapses to "/../../node_modules/react-native" and the build fails
+    # with "unable to spawn process '.../ccache-clang.sh' (No such file or directory)".
+    # Invariant: CocoaPods-managed toolchain overrides must not leak into targets
+    # CocoaPods doesn't manage. Clear the compiler/linker overrides on every target
+    # without a Pods base xcconfig so they use the default toolchain. Only matters for
+    # local builds with ccache installed; CI has no ccache, so RN never writes these
+    # settings there.
+    installer.aggregate_targets
+             .map(&:user_project)
+             .compact
+             .uniq { |project| project.path }
+             .each do |project|
+      non_pods_targets = project.native_targets.reject do |target|
+        target.build_configurations.any? do |config|
+          base = config.base_configuration_reference
+          base && File.basename(base.path).start_with?('Pods-')
+        end
+      end
+      next if non_pods_targets.empty?
+
+      non_pods_targets.each do |target|
+        target.build_configurations.each do |config|
+          %w[CC CXX LD LDPLUSPLUS].each { |key| config.build_settings[key] = '' }
+        end
+      end
+      project.save
+    end
+
     # Apple Clang 21+ (Xcode 26+) has stricter consteval evaluation that breaks
     # fmt's FMT_STRING macro. Patch base.h to disable consteval for Clang 21+.
     fmt_base_h = "#{installer.sandbox.root}/fmt/include/fmt/base.h"


### PR DESCRIPTION
## Problem

Local iOS builds fail while linking the `Kiroku Watch App` target:

```
error: unable to spawn process '/../../node_modules/react-native/scripts/xcode/ccache-clang.sh' (No such file or directory) (in target 'Kiroku Watch App' from project 'kiroku')
```

## Root cause

The `post_install` hook enables React Native's ccache integration when the `ccache` binary is on `PATH`. RN's CocoaPods helper (`react-native/scripts/cocoapods/utils.rb`, unchanged on RN `main` as of today) writes `CC`/`CXX`/`LD`/`LDPLUSPLUS` and `REACT_NATIVE_PATH` onto the **project-level** build settings of `kiroku.xcodeproj`, so every target inherits them.

Only CocoaPods-integrated targets get a `Pods-*.xcconfig` defining `PODS_ROOT`. In any other target, `REACT_NATIVE_PATH` (`$(PODS_ROOT)/../../node_modules/react-native`) collapses to `/../../node_modules/react-native` and the compiler/linker path becomes the broken `ccache-clang.sh` path above. The pure-Swift watch targets are the current victims; any future widget, complication, or extension target would hit the same wall.

It only breaks locally: CI has no `ccache` on `PATH`, so RN never writes these settings there, which is why the watch build is green on CI but fails on dev machines with ccache installed.

## Fix

Encode the invariant instead of patching the symptom: **CocoaPods-managed toolchain overrides must not leak into targets CocoaPods doesn't manage.** After `react_native_post_install`, clear `CC`/`CXX`/`LD`/`LDPLUSPLUS` on every user-project native target that has no `Pods-*.xcconfig` base configuration, so those targets use the default toolchain. No target names are hardcoded; future non-CocoaPods targets are covered automatically. The `kiroku` and `kirokuTests` targets are excluded by the predicate and keep ccache acceleration.

## Verification

After `pod install`, `xcodebuild -showBuildSettings`:

- **Kiroku Watch App**: no `CC`/`CXX`/`LD`/`LDPLUSPLUS` override at all (default watchOS clang); the broken path is gone.
- **kiroku** and **kirokuTests**: `CC` still resolves to the ccache wrapper via a valid absolute path, so ccache keeps working where it should.
- Exactly 96 cleared assignments in the pbxproj (4 settings x 8 configs x 3 watch targets), confirming the predicate touches nothing else.

Podfile-only change; the effective build settings are regenerated on each `pod install`. A follow-up upstream issue to facebook/react-native is worth filing (the helper should scope its writes to CocoaPods-integrated targets), but this fix is version-independent and does not depend on it.