### PR TITLE
feat(watch): debounce+single-flight live-update sync (Phase 5)

### DIFF
--- a/docs/apple-watch-mvp.md
+++ b/docs/apple-watch-mvp.md
@@ -198,16 +198,35 @@ critical path is **0 → 1 → 2 → 3**; Phases 5–7 overlap once the bridge w
     directly in Xcode to run this. Re-embedding plus the watch store listing is
     Phase 6.3.)_
 
-### Phase 5 — Sync & conflict handling (1–2 days)
+### Phase 5 — Sync & conflict handling (1–2 days) ← done
 
-- [ ] **5.1** Adopt the phone's ongoing session id when one is active (log into
+- [x] **5.1** Adopt the phone's ongoing session id when one is active (log into
       the _same_ session, no duplicate); only mint a new id when nothing is active.
-- [ ] **5.2** Coalesce taps — debounce rapid +/- into one `update` (mirror the
-      app's ~500ms persist); last-writer-wins on the whole-session PUT.
-- [ ] **5.3** Save/discard clears live status server-side; confirm the phone
-      reflects it on next session read.
+      Done in Phase 4's
+      [`LiveSessionController`](../ios/KirokuWatchCore/Sources/KirokuWatchCore/LiveSessionController.swift)
+      (`begin(adopting:)` reuses the phone's ongoing id, `reflectOngoing` adopts a
+      live phone session when the watch is idle); the finished-id guard keeps a
+      lagging snapshot from resurrecting a just-saved session.
+- [x] **5.2** Coalesce taps. `+`/`−` stay instant locally and are fed to a pure
+      [`LiveUpdateCoalescer`](../ios/KirokuWatchCore/Sources/KirokuWatchCore/LiveUpdateCoalescer.swift)
+      that debounces a burst into a single `/v1/sessions/update` PUT after a
+      ~500ms quiet window (mirroring the app's `LIVE_SESSION_PERSIST_DEBOUNCE_MS`),
+      with a strict single-flight rule so two whole-session PUTs never race or land
+      out of order (last-writer-wins then can't keep a stale body). The coalescer
+      is a Foundation-only state machine (host-unit-tested via `swift test`); the
+      `@MainActor` `SessionViewModel` owns the real `Task.sleep` timer + `KirokuAPI`
+      call and reads the latest session at flush time. Background sync errors are
+      silent except auth failures, which route to reconnect (same as Phase 4); the
+      authoritative persistence stays start + save.
+- [x] **5.3** Save/discard cancels the coalescer and awaits any in-flight update
+      before the finalizing write (so `ongoing:false` / delete is the last write
+      the server sees), which clears live status server-side; the phone reflects it
+      on its next session read (eventual consistency, per #947).
   - **Accept:** starting on phone then bumping on watch updates one session, not
-    two; rapid taps don't spam the API.
+    two; rapid taps don't spam the API. _(Validated by `swift test` in
+    `ios/KirokuWatchCore` and a watchOS-SDK typecheck of the whole watch target;
+    the watch is de-embedded from the archive so CI does not compile it. A paired
+    device/sim run is the remaining manual check, alongside Phase 4.2's.)_
 
 ### Phase 6 — Signing, CI, store plumbing (1–2 days)
 

--- a/ios/Kiroku Watch App/ViewModels/SessionViewModel.swift
+++ b/ios/Kiroku Watch App/ViewModels/SessionViewModel.swift
@@ -14,8 +14,11 @@
 //    - wires start / +1 / -1 / save / discard,
 //    - exposes loading / disconnected / error state for the UI.
 //
-//  +/- are kept local here; the whole session is persisted on start and save.
-//  Debounced live-update posting on every tap is Phase 5.
+//  Phase 5 adds debounced live-update posting: +/- stay instant locally and, via
+//  the pure `LiveUpdateCoalescer`, coalesce into a single `/v1/sessions/update`
+//  PUT once tapping pauses (~500ms), single-flight so writes never race. The
+//  authoritative persistence stays start + save; the debounced update is a quiet
+//  best-effort sync (errors are silent except auth, which routes to reconnect).
 //
 
 import Combine
@@ -45,12 +48,20 @@ final class SessionViewModel: ObservableObject {
 
     private let connectivity: SessionConnectivity
     private let controller: LiveSessionController
+    private let coalescer: LiveUpdateCoalescer
     private let haptics: WatchHaptics
     private let makeWriter: (KirokuEnvironment, @escaping @Sendable () -> String?) -> SessionWriting
+
+    /// The armed debounce timer for the pending live update, if any.
+    private var debounceTask: Task<Void, Never>?
+    /// The in-flight live-update PUT, if any. Save/discard awaits it so a
+    /// finalizing write is ordered after any update already on the wire.
+    private var flushTask: Task<Void, Never>?
 
     init(
         connectivity: SessionConnectivity = .shared,
         controller: LiveSessionController = LiveSessionController(),
+        coalescer: LiveUpdateCoalescer = LiveUpdateCoalescer(),
         haptics: WatchHaptics = SystemWatchHaptics(),
         makeWriter: @escaping (KirokuEnvironment, @escaping @Sendable () -> String?) -> SessionWriting = {
             KirokuAPI(environment: $0, tokenProvider: $1)
@@ -58,6 +69,7 @@ final class SessionViewModel: ObservableObject {
     ) {
         self.connectivity = connectivity
         self.controller = controller
+        self.coalescer = coalescer
         self.haptics = haptics
         self.makeWriter = makeWriter
 
@@ -91,6 +103,9 @@ final class SessionViewModel: ObservableObject {
             haptics.play(.failure)
             return
         }
+        // Drop any stale debounced update left over from a previous session so it
+        // can't land against the id we are about to begin.
+        cancelLivePersist()
         let session = controller.begin(
             adopting: connectivity.ongoingSession,
             newId: PushID.generate()
@@ -109,12 +124,14 @@ final class SessionViewModel: ObservableObject {
         guard controller.addUnit() else { return }
         haptics.play(.click)
         syncPublished()
+        scheduleLivePersist()
     }
 
     func subtractUnit() {
         guard controller.subtractUnit() else { return }
         haptics.play(.click)
         syncPublished()
+        scheduleLivePersist()
     }
 
     func saveSession() {
@@ -123,6 +140,9 @@ final class SessionViewModel: ObservableObject {
             haptics.play(.failure)
             return
         }
+        // Stop new debounced updates; the in-flight one (if any) is awaited in
+        // `runBlocking` so this save is ordered last (last-writer-wins).
+        cancelLivePersist()
         runBlocking(
             work: { try await writer.save(finalized) },
             onSuccess: { self.controller.markFinished() }
@@ -135,10 +155,96 @@ final class SessionViewModel: ObservableObject {
             haptics.play(.failure)
             return
         }
+        cancelLivePersist()
         runBlocking(
             work: { try await writer.discard(sessionId: session.id) },
             onSuccess: { self.controller.markFinished() }
         )
+    }
+
+    // MARK: - Live-update coalescing (Phase 5)
+
+    /// Feed a +/- edit to the coalescer and act on its command. The whole session
+    /// is read at flush time, so the newest drinks are always sent.
+    private func scheduleLivePersist() {
+        apply(coalescer.schedule())
+    }
+
+    /// Stop the debounce timer and drop the coalescer's pending state so no new
+    /// debounced update starts. Any already in-flight flush is left running and
+    /// awaited by the finalizing save/discard for correct ordering.
+    private func cancelLivePersist() {
+        coalescer.cancel()
+        debounceTask?.cancel()
+        debounceTask = nil
+    }
+
+    private func apply(_ command: LiveUpdateCoalescer.Command) {
+        switch command {
+        case .none:
+            break
+        case let .scheduleTimer(generation, delayMillis):
+            armDebounce(generation: generation, delayMillis: delayMillis)
+        case .flush:
+            flushLiveUpdate()
+        }
+    }
+
+    /// Arm (or re-arm) the quiet-window timer. The view model is `@MainActor`, so
+    /// the unstructured `Task` inherits the main actor and touches state safely
+    /// after the sleep. A stale fire is a no-op inside the coalescer (generation).
+    private func armDebounce(generation: Int, delayMillis: Int) {
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delayMillis) * 1_000_000)
+            guard let self, !Task.isCancelled else { return }
+            self.debounceTask = nil
+            self.apply(self.coalescer.timerFired(generation: generation))
+        }
+    }
+
+    /// Send one whole-session update PUT for the current live session, quietly.
+    /// Reads the latest session at call time. Auth failures route to reconnect
+    /// (same as Phase 4); every other failure is swallowed so a transient network
+    /// blip never disturbs an active session (the authoritative save re-sends).
+    private func flushLiveUpdate() {
+        guard let session = controller.currentSession(), session.ongoing else {
+            // Nothing live to persist (finished between arm and flush); settle.
+            apply(coalescer.flushCompleted(success: true))
+            return
+        }
+        guard let writer = currentWriter() else {
+            // No usable credential: `currentWriter` already routed to reconnect.
+            apply(coalescer.flushCompleted(success: false))
+            return
+        }
+        flushTask = Task { [weak self] in
+            guard let self else { return }
+            var success = false
+            do {
+                try await writer.update(session)
+                success = true
+            } catch let error as KirokuAPIError {
+                self.handleBackgroundSyncError(error)
+            } catch {
+                // Quiet: a background sync blip must not disturb the session UI.
+            }
+            self.flushTask = nil
+            self.apply(self.coalescer.flushCompleted(success: success))
+        }
+    }
+
+    /// Route a live-update (background sync) error: auth failures recover via the
+    /// phone (same as Phase 4), everything else stays silent. No haptics or inline
+    /// error, since the user did not initiate this write.
+    private func handleBackgroundSyncError(_ error: KirokuAPIError) {
+        switch error {
+        case .missingToken, .tokenExpired, .tokenRevoked:
+            connectivity.markCredentialRejected()
+            needsReconnect = true
+        case .server, .network, .invalidResponse:
+            break
+        }
     }
 
     // MARK: - Internals
@@ -160,9 +266,12 @@ final class SessionViewModel: ObservableObject {
         return makeWriter(credential.environment) { CredentialStore.validToken() }
     }
 
-    /// Run a non-blocking write (start): map errors, no spinner.
+    /// Run a non-blocking write (start): map errors, no spinner. Tracked in
+    /// `flushTask` so a quick save/discard right after start awaits it and stays
+    /// ordered last (the start POST and a finalizing PUT share the session id).
     private func perform(_ operation: @escaping () async throws -> Void) {
-        Task {
+        flushTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 try await operation()
                 self.lastError = nil
@@ -171,11 +280,14 @@ final class SessionViewModel: ObservableObject {
             } catch {
                 self.reportGenericFailure()
             }
+            self.flushTask = nil
         }
     }
 
     /// Run a blocking write (save/discard): show the spinner, finish on success,
-    /// keep the session and surface an error on failure so it can be retried.
+    /// keep the session and surface an error on failure so it can be retried. Any
+    /// live-update PUT already on the wire is awaited first so this finalizing
+    /// write is the last one the server sees (last-writer-wins).
     private func runBlocking(
         work: @escaping () async throws -> Void,
         onSuccess: @escaping () -> Void
@@ -184,6 +296,7 @@ final class SessionViewModel: ObservableObject {
         isBusy = true
         Task {
             defer { self.isBusy = false }
+            await self.flushTask?.value
             do {
                 try await work()
                 onSuccess()
@@ -224,6 +337,7 @@ final class SessionViewModel: ObservableObject {
 /// substitute a spy. `KirokuAPI` satisfies it as-is.
 protocol SessionWriting {
     @discardableResult func start(_ session: DrinkingSession) async throws -> KirokuAPIResponse
+    @discardableResult func update(_ session: DrinkingSession) async throws -> KirokuAPIResponse
     @discardableResult func save(_ session: DrinkingSession) async throws -> KirokuAPIResponse
     @discardableResult func discard(sessionId: String) async throws -> KirokuAPIResponse
 }

--- a/ios/KirokuWatchCore/Sources/KirokuWatchCore/LiveUpdateCoalescer.swift
+++ b/ios/KirokuWatchCore/Sources/KirokuWatchCore/LiveUpdateCoalescer.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// The pure (Foundation-only) sequencer behind the watch's debounced live-session
+/// update posts (Apple Watch MVP, Phase 5; docs/apple-watch-mvp.md).
+///
+/// Rapid `+`/`−` taps must not each fire their own `/v1/sessions/update` PUT.
+/// That would spam the API and, worse, let two whole-session writes race and
+/// arrive out of order: because the endpoint is last-writer-wins on the whole
+/// session, a slower earlier PUT landing last would overwrite newer drinks. This
+/// mirrors the phone app's debounced live persist (`LIVE_SESSION_PERSIST_DEBOUNCE_MS`,
+/// 500ms in `src/libs/actions/DrinkingSession.ts`):
+///
+///   - **Debounce.** Each tap re-arms a quiet-window timer, so a burst of taps
+///     coalesces into a single update once the user pauses.
+///   - **Single-flight.** At most one update PUT is ever outstanding. A tap that
+///     arrives while a PUT is in flight is remembered and flushed once, after
+///     that PUT resolves, never concurrently, so PUTs can never overlap or land
+///     out of order.
+///
+/// It is intentionally pure: it holds no session, owns no timer, and does no
+/// networking. It only decides *what the caller should do next* by returning a
+/// ``Command``. The `@MainActor` view model owns the real `Task.sleep` timer and
+/// the `KirokuAPI` call, and reads the latest session at flush time (so the newest
+/// drinks are always sent, exactly like the app reading `ONGOING_SESSION_DATA` at
+/// flush time). Keeping the sequencing here, off the main actor and WatchKit, is
+/// what makes it host-unit-testable via `swift test`.
+public final class LiveUpdateCoalescer {
+    /// What the caller must do in response to an event.
+    public enum Command: Equatable, Sendable {
+        /// Nothing to do.
+        case none
+        /// Arm a one-shot timer for `delayMillis`. When it fires, call
+        /// ``timerFired(generation:)`` with this `generation`. A later
+        /// ``schedule()`` supersedes it: the stale timer's `timerFired` is ignored.
+        case scheduleTimer(generation: Int, delayMillis: Int)
+        /// Send one update PUT now with the latest session, then report the
+        /// outcome via ``flushCompleted(success:)``.
+        case flush
+    }
+
+    private let debounceMillis: Int
+    /// Local edits not yet acknowledged by a completed flush.
+    private var pendingDirty = false
+    /// The debounce quiet window has elapsed for the pending edits.
+    private var quietWindowElapsed = false
+    /// An update PUT is in flight (single-flight guard).
+    private var isFlushing = false
+    /// Bumped on every `schedule()`/`cancel()` so a stale timer fire is ignored.
+    private var timerGeneration = 0
+
+    /// - Parameter debounceMillis: the quiet window a burst of taps coalesces
+    ///   into one write. Defaults to 500ms to match the phone app.
+    public init(debounceMillis: Int = 500) {
+        self.debounceMillis = debounceMillis
+    }
+
+    /// Whether the server may not yet reflect the latest local drinks (a write
+    /// is in flight or edits are still waiting to be sent). Save/discard uses this
+    /// only for reasoning; it always ``cancel()``s and then sends authoritatively.
+    public var hasPendingWork: Bool { pendingDirty || isFlushing }
+
+    /// Record a `+`/`−` edit. (Re)arms the quiet-window timer so a burst of taps
+    /// coalesces into a single update.
+    public func schedule() -> Command {
+        pendingDirty = true
+        quietWindowElapsed = false
+        timerGeneration += 1
+        return .scheduleTimer(generation: timerGeneration, delayMillis: debounceMillis)
+    }
+
+    /// A scheduled timer fired. Ignored (returns ``Command/none``) when a newer
+    /// ``schedule()`` has superseded it; otherwise the quiet window has elapsed,
+    /// so flush if nothing is already in flight.
+    public func timerFired(generation: Int) -> Command {
+        guard generation == timerGeneration else {
+            return .none
+        }
+        quietWindowElapsed = true
+        return startFlushIfReady()
+    }
+
+    /// The update PUT resolved. On success, flush again when edits arrived while
+    /// it was in flight and their quiet window has already elapsed; otherwise wait
+    /// for the pending timer (or go idle). On failure, stay quiet: keep the dirty
+    /// edits so the next tap re-arms and the authoritative save re-sends the whole
+    /// session, but do not auto-retry (background sync errors are silent).
+    public func flushCompleted(success: Bool) -> Command {
+        isFlushing = false
+        guard success else {
+            // A superseding tap may already have re-armed the timer; require that
+            // fresh quiet window rather than retrying this failed body immediately.
+            quietWindowElapsed = false
+            return .none
+        }
+        return startFlushIfReady()
+    }
+
+    /// Drop all pending work and invalidate any armed timer. Called when the
+    /// session ends (save/discard) or is abandoned, so a debounced update can
+    /// never land after the finalizing write.
+    public func cancel() {
+        pendingDirty = false
+        quietWindowElapsed = false
+        isFlushing = false
+        timerGeneration += 1
+    }
+
+    private func startFlushIfReady() -> Command {
+        guard pendingDirty, quietWindowElapsed, !isFlushing else {
+            return .none
+        }
+        // The pending edits are about to be sent; a tap during the flight will
+        // re-arm and set these again for the next flush.
+        pendingDirty = false
+        quietWindowElapsed = false
+        isFlushing = true
+        return .flush
+    }
+}

--- a/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/LiveUpdateCoalescerTests.swift
+++ b/ios/KirokuWatchCore/Tests/KirokuWatchCoreTests/LiveUpdateCoalescerTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import KirokuWatchCore
+
+/// Phase 5 (docs/apple-watch-mvp.md) coverage for the debounce + single-flight
+/// sequencer that coalesces rapid +/- taps into one `/v1/sessions/update` PUT.
+/// The coalescer is a pure state machine, so the tests drive it by feeding the
+/// events the view model's timer/network would (schedule / timerFired /
+/// flushCompleted) and asserting the returned commands.
+final class LiveUpdateCoalescerTests: XCTestCase {
+    /// A single tap arms one timer; the timer firing flushes once.
+    func testSingleTapDebouncesToOneFlush() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertTrue(coalescer.hasPendingWork)
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+        XCTAssertFalse(coalescer.hasPendingWork)
+    }
+
+    /// A burst of taps re-arms the timer each time; only the final generation's
+    /// timer flushes, and the earlier (superseded) timers are ignored. One flush.
+    func testBurstCoalescesIntoOneFlush() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 3, delayMillis: 500))
+
+        // Stale timers (from the first two taps) fire late and do nothing.
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .none)
+        XCTAssertEqual(coalescer.timerFired(generation: 2), .none)
+        // Only the latest generation's timer flushes.
+        XCTAssertEqual(coalescer.timerFired(generation: 3), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+    }
+
+    /// A tap during an in-flight flush is remembered and flushed once the PUT
+    /// resolves, never concurrently (single-flight). No overlapping flush.
+    func testTapDuringFlightFlushesAgainAfterCompletion() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+
+        // A tap lands while the first PUT is still in flight.
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        // Its quiet window elapses mid-flight: cannot start a second PUT yet.
+        XCTAssertEqual(coalescer.timerFired(generation: 2), .none)
+
+        // On completion, the accumulated edit is flushed as one follow-up PUT.
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+        XCTAssertFalse(coalescer.hasPendingWork)
+    }
+
+    /// A tap during flight whose quiet window has NOT elapsed by the time the PUT
+    /// completes waits for its own timer rather than flushing early.
+    func testTapDuringFlightWaitsForItsTimerWhenNotYetQuiet() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+
+        // Tap mid-flight, but its timer has not fired yet when the PUT resolves.
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+        XCTAssertTrue(coalescer.hasPendingWork, "the mid-flight edit is still pending")
+
+        // When its own timer finally fires (no longer in flight), it flushes.
+        XCTAssertEqual(coalescer.timerFired(generation: 2), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+    }
+
+    /// A failed flush stays quiet: no auto-retry, but the edits remain pending so
+    /// the next tap re-arms and the authoritative save re-sends the whole session.
+    func testFailedFlushStaysQuietAndKeepsEditsPending() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+
+        // Edit arrives during the flight, then the PUT fails.
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        XCTAssertEqual(coalescer.flushCompleted(success: false), .none, "no immediate retry")
+        XCTAssertTrue(coalescer.hasPendingWork)
+
+        // A fresh quiet window (its re-armed timer) is what re-attempts the write.
+        XCTAssertEqual(coalescer.timerFired(generation: 2), .flush)
+    }
+
+    /// Cancel drops pending edits and invalidates the armed timer, so a debounced
+    /// update can never land after a save/discard.
+    func testCancelInvalidatesArmedTimer() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        coalescer.cancel()
+        XCTAssertFalse(coalescer.hasPendingWork)
+        // The timer armed before the cancel fires late and does nothing.
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .none)
+    }
+
+    /// A flush in flight when cancel is called does not spawn a follow-up flush
+    /// on completion (the finalizing save/discard is now the source of truth).
+    func testCancelDuringFlightSuppressesFollowUp() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+        // A tap lands mid-flight, then the user saves (cancel) before it resolves.
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        coalescer.cancel()
+
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+        XCTAssertFalse(coalescer.hasPendingWork)
+    }
+
+    /// Taps after a full flush cycle start a fresh generation and flush again.
+    func testSecondBurstAfterIdleFlushesAgain() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 500)
+
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 1), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+
+        // A brand new burst much later.
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 2, delayMillis: 500))
+        XCTAssertEqual(coalescer.timerFired(generation: 2), .flush)
+        XCTAssertEqual(coalescer.flushCompleted(success: true), .none)
+    }
+
+    /// The debounce window is configurable and reported back in the command.
+    func testCustomDebounceWindowIsReported() {
+        let coalescer = LiveUpdateCoalescer(debounceMillis: 250)
+        XCTAssertEqual(coalescer.schedule(), .scheduleTimer(generation: 1, delayMillis: 250))
+    }
+}

--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		FB0000000000000000000004 /* DrinkingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000004 /* DrinkingSession.swift */; };
 		FB0000000000000000000005 /* PushID.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000005 /* PushID.swift */; };
 		FB0000000000000000000008 /* LiveSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000008 /* LiveSessionController.swift */; };
+		FB0000000000000000000009 /* LiveUpdateCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000009 /* LiveUpdateCoalescer.swift */; };
 		FB0000000000000000000006 /* SessionConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000006 /* SessionConnectivity.swift */; };
 		FB0000000000000000000007 /* CredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000000000000000000007 /* CredentialStore.swift */; };
 		F243724B34C5C9FB6F62F24D /* Pods_kiroku.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0478232408D4311F0113E613 /* Pods_kiroku.framework */; };
@@ -181,6 +182,7 @@
 		FA0000000000000000000004 /* DrinkingSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DrinkingSession.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/DrinkingSession.swift"; sourceTree = SOURCE_ROOT; };
 		FA0000000000000000000005 /* PushID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushID.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/PushID.swift"; sourceTree = SOURCE_ROOT; };
 		FA0000000000000000000008 /* LiveSessionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveSessionController.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/LiveSessionController.swift"; sourceTree = SOURCE_ROOT; };
+		FA0000000000000000000009 /* LiveUpdateCoalescer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveUpdateCoalescer.swift; path = "KirokuWatchCore/Sources/KirokuWatchCore/LiveUpdateCoalescer.swift"; sourceTree = SOURCE_ROOT; };
 		FA0000000000000000000006 /* SessionConnectivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConnectivity.swift; sourceTree = "<group>"; };
 		FA0000000000000000000007 /* CredentialStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialStore.swift; sourceTree = "<group>"; };
 		FC94F72FE31465CA8BCABD916FE6A2C6 /* RCTBootSplash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RCTBootSplash.mm; path = kiroku/RCTBootSplash.mm; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				FA0000000000000000000003 /* KirokuAPI.swift */,
 				FA0000000000000000000005 /* PushID.swift */,
 				FA0000000000000000000008 /* LiveSessionController.swift */,
+				FA0000000000000000000009 /* LiveUpdateCoalescer.swift */,
 			);
 			name = KirokuWatchCore;
 			sourceTree = "<group>";
@@ -942,6 +945,7 @@
 				FB0000000000000000000003 /* KirokuAPI.swift in Sources */,
 				FB0000000000000000000005 /* PushID.swift in Sources */,
 				FB0000000000000000000008 /* LiveSessionController.swift in Sources */,
+				FB0000000000000000000009 /* LiveUpdateCoalescer.swift in Sources */,
 				FB0000000000000000000006 /* SessionConnectivity.swift in Sources */,
 				85D3A2428FB7A384E0E90E056C100D01 /* CzechTexts.swift in Sources */,
 				5E4ACD6C1EE6FBC1E05D75AE525E2969 /* EnglishTexts.swift in Sources */,


### PR DESCRIPTION
Phase 5 of the Apple Watch companion effort (`docs/apple-watch-mvp.md`): **Sync & conflict handling**. Builds on Phase 4 (#1496).

## What this does

`+`/`−` taps stayed local after Phase 4; the whole session was only persisted on start and save. This adds a debounced background sync so a running session on the watch keeps the server (and, on its next read, the phone) roughly in step, without spamming the API.

### 5.1 Adopt the phone's ongoing session
Already handled by Phase 4's `LiveSessionController` (`begin(adopting:)` reuses the phone's ongoing id, `reflectOngoing` adopts a live phone session when the watch is idle, finished-id guard blocks re-adoption). Verified and closed out.

### 5.2 Coalesce taps (the meat)
New pure `LiveUpdateCoalescer` (Foundation-only state machine in `KirokuWatchCore`):
- **Debounce** — each tap re-arms a ~500ms quiet-window timer, so a burst coalesces into one `/v1/sessions/update` PUT (mirrors the app's `LIVE_SESSION_PERSIST_DEBOUNCE_MS`).
- **Single-flight** — at most one update PUT is ever outstanding. A tap arriving mid-flight is remembered and flushed once, after the in-flight PUT resolves, never concurrently. So two whole-session writes can't race or land out of order (last-writer-wins then can't keep a stale body).

The coalescer holds no session/timer/network; it returns a `Command` (`scheduleTimer` / `flush` / `none`) that the `@MainActor` `SessionViewModel` acts on with a real `Task.sleep` timer + `KirokuAPI.update`, reading the latest session at flush time. Keeping the sequencing pure makes it host-unit-testable.

Background sync errors are silent except auth failures, which route to reconnect (same as Phase 4). Authoritative persistence stays start + save.

### 5.3 Save/discard ordering
Save/discard cancels the coalescer and awaits any in-flight update before the finalizing write, so `ongoing:false` / delete is the last write the server sees. The phone reflects it on its next session read (eventual consistency, per #947).

## Testing

- `swift test` in `ios/KirokuWatchCore` — 9 new coalescer tests (debounce, burst-coalescing, mid-flight tap, quiet-window wait, failed-flush quiet, cancel invalidation, cancel-during-flight, re-burst). Full suite: 48 tests, 0 failures.
- Typechecked the entire `Kiroku Watch App` target (27 Swift files) against the watchOS SDK, 0 errors. The watch is de-embedded from the archive so CI does not compile it; a paired device/sim run remains the manual check (alongside Phase 4.2's).

## Notes

- New core file added to both the SwiftPM sources and the watch target's `project.pbxproj` build phase (objectVersion stays 54).
- No JS touched.
