### PR TITLE
feat(watch): re-embed in archive + wire watch App Store screenshot pipeline

### DIFF
--- a/contributingGuides/SCREENSHOTS.md
+++ b/contributingGuides/SCREENSHOTS.md
@@ -129,6 +129,31 @@ changes) lives in the `store-screenshots` skill.
 > unmapped. Growing to the full marketing set (Statistics, an alcohol-free streak)
 > needs new captures plus native-test edits and lands in a follow-up PR.
 
+### Apple Watch screenshot (captured by hand)
+
+The App Store build embeds the watchOS companion, so App Store Connect requires
+an Apple Watch screenshot (`APP_WATCH_SERIES_4`) before the iOS version can be
+submitted for review. The watch shot is **not** part of the fastlane `snapshot`
+matrix: the companion is a phone-tethered remote, so a watchOS UI test on an
+unpaired simulator only shows the "Open Kiroku on your phone" reconnect screen.
+Capture it by hand instead:
+
+1. In Xcode, run the **`Kiroku Watch App`** target on a watch simulator paired
+   with a booted iPhone that is signed in to the demo account (so a credential
+   reaches the watch and it shows a live session, not the reconnect screen).
+2. Start a session and log a couple of units so the screen has real content.
+3. Screenshot the watch simulator (`Cmd-S` in the Simulator, or
+   `xcrun simctl io booted screenshot watch.png`).
+4. Drop the PNG at `fastlane/store-screenshots/raw/<locale>/watch.png` for each
+   locale in the manifest (capture per locale, or reuse the same shot).
+5. Run `npm run frame-screenshots -- --device watch` to render the framed
+   `410×502` output at `framed/<locale>/watch/01_watch.png`.
+
+The framing pipeline scales any watch capture to fit the exact `410×502`
+Series 7+/Ultra slot on the brand background with a caption; the size, caption,
+and per-device scoping (`kind: 'watch'`) live in the manifest. Guideline 2.3.3
+still applies: the capture must be the real shipped watch UI.
+
 ---
 
 ## Local fallback

--- a/docs/apple-watch-mvp.md
+++ b/docs/apple-watch-mvp.md
@@ -230,12 +230,32 @@ critical path is **0 → 1 → 2 → 3**; Phases 5–7 overlap once the bridge w
 
 ### Phase 6 — Signing, CI, store plumbing (1–2 days)
 
-- [ ] **6.1** Register the watch App ID + provisioning profiles (use the
+- [x] **6.1** Register the watch App ID + provisioning profiles (use the
       `ios-signing` skill); re-encrypt into `ios/`. No GoogleService-Info / Firebase
-      pod needed (token comes from the phone).
-- [ ] **6.2** Fastlane: sign + embed the watch in the dev/adhoc/prod lanes;
-      green test build.
-- [ ] **6.3** Store metadata: watch screenshots + App Store watch listing fields.
+      pod needed (token comes from the phone). Done in PR #1447 (two App IDs
+      `…watchkitapp` + `…adhoc.watchkitapp`; profiles minted, gpg-encrypted into
+      `ios/`, covered by `scripts/ios-signing.mjs` renew/check).
+- [x] **6.2** Fastlane: sign + embed the watch in the dev/adhoc/prod lanes;
+      green test build. Done in #1447, reverted in `e5b344a5b` to unblock the App
+      Store submit, then **re-embedded** here (revert of `e5b344a5b`): the
+      "Embed Watch Content" copy-files phase + watch `PBXTargetDependency` are
+      back on the `kiroku` target and the watch build entry is back in all three
+      shared schemes. The #1450 phase ordering (embed right after
+      "[User] Copy GoogleService-Info.plist", before the no-output script phases)
+      and the #1452/#1456 watch↔host version-sync are preserved, so the archive
+      neither cycles nor 409s on upload.
+- [~] **6.3** Store metadata: watch screenshots + App Store watch listing fields.
+  **Framing pipeline wired** here: the Apple Watch device seam
+  (`410×502`, `kind: 'watch'`) is live in
+  [`scripts/store-screenshots.config.mjs`](../scripts/store-screenshots.config.mjs),
+  the framer scopes the watch shot to the watch slot and numbers it `01`, and
+  the ingest mapper skips it. **Remaining (manual, needs ASC + a paired
+  sim):** capture the real watch screen by hand into
+  `raw/<locale>/watch.png` (a watchOS `snapshot` UI test can't drive the
+  phone-tethered remote), `npm run frame-screenshots -- --device watch`,
+  then upload the `410×502` shot to ASC and fill the watchOS listing fields
+  before the next `asc submit`. See
+  [`contributingGuides/SCREENSHOTS.md`](../contributingGuides/SCREENSHOTS.md#apple-watch-screenshot-captured-by-hand).
 
 ### Phase 7 — QA matrix (1 day)
 

--- a/fastlane/store-screenshots/README.md
+++ b/fastlane/store-screenshots/README.md
@@ -38,6 +38,16 @@ See the `store-screenshots` skill for the full capture → ingest → frame → 
 
 4. Upload `framed/**` to ASC (manually, or wire it into `deliver` later).
 
+## Apple Watch shot
+
+The App Store build embeds the watch app, so ASC requires an Apple Watch
+screenshot before the iOS version can be submitted. It is captured **by hand**
+(the watch is a phone-tethered remote, so a UI test on an unpaired sim shows
+only the reconnect screen): run the `Kiroku Watch App` target on a watch sim
+paired with a signed-in phone, screenshot a live session, drop it at
+`raw/<locale>/watch.png`, then `npm run frame-screenshots -- --device watch`
+renders the exact `410x502` slot. Steps: `contributingGuides/SCREENSHOTS.md`.
+
 `raw/` and `framed/` are git-ignored — they're inputs/outputs, not source.
 
 > **Apple Guideline 2.3.3:** screenshots must depict the real app. This tool

--- a/ios/kiroku.xcodeproj/project.pbxproj
+++ b/ios/kiroku.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 				96EE1767D138A900D6E3A4421BAD14EF /* Frameworks */,
 				B9F8269ED055C5C64E7601A97DC265CB /* Resources */,
 				A93D5E4D4B3C14C35A07B0AB64D8AFE8 /* [User] Copy GoogleService-Info.plist */,
+				99C9732089753FE060B2B9AB /* Embed Watch Content */,
 				F3EDCA035BBAB0CF568F51A01F8CD5C4 /* Bundle React Native code and images */,
 				D30FCE1E350F4965931BD17D /* [CP] Embed Pods Frameworks */,
 				F4913D0151294198FC1A8191 /* [CP] Copy Pods Resources */,
@@ -565,6 +566,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				99914CCF269EA90978B1A36F /* PBXTargetDependency */,
 			);
 			name = kiroku;
 			productName = kiroku;

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (AdHoc).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (AdHoc).xcscheme
@@ -54,6 +54,20 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
+               BuildableName = "Kiroku Watch App.app"
+               BlueprintName = "Kiroku Watch App"
+               ReferencedContainer = "container:kiroku.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (development).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (development).xcscheme
@@ -54,6 +54,20 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
+               BuildableName = "Kiroku Watch App.app"
+               BlueprintName = "Kiroku Watch App"
+               ReferencedContainer = "container:kiroku.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme
+++ b/ios/kiroku.xcodeproj/xcshareddata/xcschemes/Kiroku (production).xcscheme
@@ -54,6 +54,20 @@
                ReferencedContainer = "container:kiroku.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1821A5F349D591C181E1BE15261F44F4"
+               BuildableName = "Kiroku Watch App.app"
+               BlueprintName = "Kiroku Watch App"
+               ReferencedContainer = "container:kiroku.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/scripts/frame-app-store-screenshots.mjs
+++ b/scripts/frame-app-store-screenshots.mjs
@@ -214,11 +214,17 @@ async function runRender(targetLocales, targetDevices) {
     }
   }
 
-  // Build the full task list up front, then render in parallel.
+  // Build the full task list up front, then render in parallel. A shot only
+  // renders on a device whose `kind` matches (default 'phone' on both sides), so
+  // the watch shot stays off the phones and vice versa. Numbering is per device
+  // so each slot starts at 01.
   const tasks = [];
   for (const locale of targetLocales) {
     for (const device of targetDevices) {
-      shots.forEach((shot, index) => tasks.push({shot, index, locale, device}));
+      const deviceKind = device.kind ?? 'phone';
+      shots
+        .filter(shot => (shot.kind ?? 'phone') === deviceKind)
+        .forEach((shot, index) => tasks.push({shot, index, locale, device}));
     }
   }
   const results = await Promise.all(

--- a/scripts/ingest-store-screenshots.mjs
+++ b/scripts/ingest-store-screenshots.mjs
@@ -137,8 +137,12 @@ function main() {
     `${checkOnly ? '[check] ' : ''}Ingesting captures from ${rel(sourceRoot)}\n`,
   );
 
+  // Only phone-kind shots come from a fastlane `snapshot` capture. Watch shots
+  // (kind: 'watch') are captured by hand straight into raw/ (see the config and
+  // SCREENSHOTS.md), so the mapper never looks for them in the iPhone folder.
+  const phoneShots = shots.filter(s => (s.kind ?? 'phone') === 'phone');
   const mapped = new Set(
-    shots.filter(s => s.snapshot).map(s => `${s.snapshot}.png`),
+    phoneShots.filter(s => s.snapshot).map(s => `${s.snapshot}.png`),
   );
   const targetLocales = locales.filter(l => !onlyLocale || l === onlyLocale);
   let copied = 0;
@@ -154,7 +158,7 @@ function main() {
     const localeSrcDir = join(sourceRoot, captureLocale);
     const deviceDir = resolveDeviceDir(localeSrcDir, locale);
     if (!deviceDir || !existsSync(deviceDir)) {
-      missing += shots.length;
+      missing += phoneShots.length;
       continue;
     }
 
@@ -166,7 +170,7 @@ function main() {
       }
     }
 
-    for (const shot of shots) {
+    for (const shot of phoneShots) {
       if (!shot.snapshot) {
         console.warn(
           `  ! ${locale}: shot ${shot.raw} has no "snapshot" mapping, skipped`,

--- a/scripts/store-screenshots.config.mjs
+++ b/scripts/store-screenshots.config.mjs
@@ -17,18 +17,23 @@ const OUT_DIR = 'fastlane/store-screenshots/framed';
 // ─── Output device sizes (portrait, EXACT App Store pixel dimensions) ────────
 // 6.9" satisfies the mandatory largest-iPhone slot and ASC will down-scale it
 // for 6.7"/6.5". Add/remove sizes as needed.
+//
+// `kind` scopes which shots render on a device: a shot renders on a device only
+// when their kinds match ('phone' is the default for both). This keeps the four
+// iPhone shots off the tiny watch slot and the single watch shot off the phones.
 const devices = [
-  {id: '6.9', width: 1320, height: 2868}, // iPhone 16/17 Pro Max
-  {id: '6.7', width: 1290, height: 2796}, // iPhone 15 Pro Max
-  // ─── Apple Watch (DEFERRED — Apple Watch MVP Phase 6.3) ───────────────────
-  // The watchOS companion ships as a non-functional UI shell until the MVP is
-  // wired (Phases 2–5), so watch App Store screenshots are intentionally NOT
-  // captured yet. When the watch app is functional, add the ASC Apple Watch
-  // slot here (confirm the exact size against App Store Connect — Series 7+/
-  // Ultra is 410×502) AND add a watch simulator entry to fastlane/Snapfile so
-  // `snapshot` captures from the watch; the framing/upload pipeline then needs a
-  // watch-shaped frame + caption. Until then this stays commented out.
-  // {id: 'watch', width: 410, height: 502}, // Apple Watch Series 7+/Ultra
+  {id: '6.9', width: 1320, height: 2868, kind: 'phone'}, // iPhone 16/17 Pro Max
+  {id: '6.7', width: 1290, height: 2796, kind: 'phone'}, // iPhone 15 Pro Max
+  // ─── Apple Watch (Apple Watch MVP Phase 6.3) ──────────────────────────────
+  // The watchOS companion is a functional remote (MVP Phases 4 and 5), so the
+  // watch is embedded in the App Store build again and ASC now requires an Apple
+  // Watch screenshot (APP_WATCH_SERIES_4) before the iOS version can be
+  // submitted. Size is the Series 7+/Ultra slot (410×502, portrait). Unlike the
+  // iPhone shots, the watch capture is taken MANUALLY (see the watch shot below
+  // and contributingGuides/SCREENSHOTS.md): a watchOS `snapshot` UI test can't
+  // drive a phone-tethered remote, and an unpaired sim only shows the reconnect
+  // screen. Drop the real capture at RAW_DIR/<locale>/watch.png, then frame.
+  {id: 'watch', width: 410, height: 502, kind: 'watch'}, // Apple Watch Series 7+/Ultra
 ];
 
 // ─── Locales (must match RAW_DIR subfolders and caption keys below) ──────────
@@ -104,6 +109,20 @@ const shots = [
     caption: {
       'en-US': 'Stay on track with friends',
       cs: 'Zůstaňte na správné cestě s přáteli',
+    },
+  },
+  // Apple Watch shot (kind: 'watch'). Renders ONLY on the watch device, and is
+  // skipped by the ingest mapper because it has no fastlane `snapshot` source.
+  // Capture it by hand from the `Kiroku Watch App` target running in a watch
+  // simulator paired with a signed-in phone (so it shows a live session, not the
+  // reconnect screen), then drop it at RAW_DIR/<locale>/watch.png. The Czech
+  // caption is a first pass; run the translation-review skill before shipping.
+  {
+    kind: 'watch',
+    raw: 'watch.png',
+    caption: {
+      'en-US': 'Log a drink from your wrist',
+      cs: 'Zaznamenejte nápoj přímo z hodinek',
     },
   },
 ];


### PR DESCRIPTION
## Apple Watch MVP Phase 6.2 (re-embed) + 6.3 (store screenshot pipeline)

Re-embeds the watchOS companion in the App Store build (reversing the temporary un-embed) and wires the store-screenshot pipeline for the Apple Watch slot. The two must ship together: embedding the watch makes App Store Connect require an `APP_WATCH_SERIES_4` screenshot before the iOS version can be submitted (see the deploy-block history). Phases 0 to 5 are already merged; the watch is now a functional phone-tethered remote, so it is no longer the non-functional shell that made a store listing premature.

### 6.2 Re-embed (revert of `e5b344a5b`)

- Restores the "Embed Watch Content" copy-files phase + watch `PBXTargetDependency` on the `kiroku` target and the watch `BuildActionEntry` in all three shared schemes (dev / AdHoc / production). Exact inverse of the un-embed: +44 lines matching the 44 it removed.
- **#1450 ordering preserved:** the embed phase sits right after `[User] Copy GoogleService-Info.plist`, before the no-output script phases, so a real distribution-signed archive does not hit the "Cycle inside kiroku" error.
- **#1452/#1456 version-sync preserved:** the bumpVersion action still writes the watch plist and `createNewVersion.yml` still stages it with `git add -u`; the committed watch plist (0.3.23.5) already matches the host, so the archive will not 409 on upload.
- pbxproj edited by `git revert` only; `objectVersion` stays 54 and `plutil -lint` passes (no Xcode 26). All restored references (target dependency, container proxy, embed build-file, watch product) resolve to intact definitions that the un-embed never touched.
- CI plumbing that was left as no-ops during the un-embed is load-bearing again and confirmed present: watch profile decrypt + `xcodebuild -downloadPlatform watchOS` in both `platformDeploy.yml` and `testBuild.yml`, and the `KirokuWatch` / `KirokuWatch_AdHoc` export mappings in the Fastfile.

### 6.3 Store screenshot pipeline (framing side wired)

- Un-comments the Apple Watch device seam in `scripts/store-screenshots.config.mjs` at the exact ASC Series 7+/Ultra size (410x502) and adds a `kind` field so a shot renders only on a device of matching kind. The watch shot is scoped `kind: 'watch'`; the four iPhone shots default to `kind: 'phone'`. This keeps the phone shots off the tiny watch slot and the watch shot off the phones.
- `frame-app-store-screenshots.mjs` filters shot x device by kind and numbers per device (watch shot renders as `01_watch.png` at exactly 410x502). `ingest-store-screenshots.mjs` skips watch-kind shots because they have no fastlane `snapshot` source.
- Verified locally by rendering a synthetic capture: the watch shot produces a 410x502 framed image (gradient + caption + rounded capture), phone shots stay on 6.9"/6.7" only, and nothing cross-renders.

**Watch capture is manual (by design).** The companion is a phone-tethered remote, so a watchOS `snapshot` UI test on an unpaired simulator only shows the "Open Kiroku on your phone" reconnect screen. The real screen is captured by hand from the `Kiroku Watch App` target on a watch sim paired with a signed-in phone, dropped at `raw/<locale>/watch.png`, then framed. Documented in `contributingGuides/SCREENSHOTS.md` and the store-screenshots README. Guideline 2.3.3 (screenshot must depict the shipped app) still applies.

### Remaining manual steps (operator, before the next submit)

These need ASC credentials + a paired watch simulator and are not part of this PR:

1. Capture the real watch screen and run `npm run frame-screenshots -- --device watch`.
2. Upload the 410x502 shot to App Store Connect and fill the watchOS listing fields.
3. Then `asc submit` (the prod Fastfile lane runs `deliver` with `submit_for_review: false`; submission stays manual per the no-automatic-release policy). Without a watch screenshot in ASC, that submit will still be blocked, exactly as before.

### Verification

- `plutil -lint` on the pbxproj: OK. `objectVersion` unchanged (54).
- Framer render check: watch output is exactly 410x502; per-kind scoping confirmed.
- prettier clean on the three scripts.
- The archive cycle + upload 409 checks are inherently CI-only (the cycle reproduces only under real distribution signing), so the definitive confirmation is the next staging deploy.
