### PR TITLE
fix(friends): show skeletons until first live friend-list sync of each app run

### DIFF
--- a/__tests__/unit/useFriendsData.test.tsx
+++ b/__tests__/unit/useFriendsData.test.tsx
@@ -1,0 +1,194 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable @typescript-eslint/no-require-imports, global-require -- jest mock factories require their deps lazily */
+
+/**
+ * Coverage for useFriendsData's cold-load gate.
+ *
+ * `USER_DATA_LIST` persists across app restarts, so cache PRESENCE says
+ * nothing about cache AGE. The gate must hold the first open of an app run on
+ * a live sync (skeletons) even when a stale cache exists, then hand over to
+ * stale-while-revalidate for every later mount. Offline and slow-network
+ * openings fall back to the cache instead of holding skeletons forever.
+ */
+import {act, renderHook} from '@testing-library/react-native';
+import {useOnyx} from 'react-native-onyx';
+import useFriendsData, {
+  resetFriendsDataSessionSyncForTests,
+} from '@hooks/useFriendsData';
+import useNetwork from '@hooks/useNetwork';
+import * as Profile from '@userActions/Profile';
+import CONST from '@src/CONST';
+import type {UserDataList} from '@src/types/onyx';
+
+jest.mock('react-native-onyx', () => ({
+  __esModule: true,
+  useOnyx: jest.fn(),
+  default: {},
+}));
+
+// Run the focus callback as a plain effect: these tests exercise mount and
+// unmount, not navigation focus transitions.
+jest.mock('@react-navigation/native', () => ({
+  __esModule: true,
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const {useEffect} = require('react') as typeof import('react');
+    useEffect(callback, [callback]);
+  },
+}));
+
+jest.mock('@hooks/useNetwork', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@userActions/Profile', () => ({
+  __esModule: true,
+  fetchUsersData: jest.fn(),
+}));
+
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedUseNetwork = jest.mocked(useNetwork);
+const mockedFetchUsersData = jest.mocked(Profile.fetchUsersData);
+
+const FRIENDS = ['f1', 'f2'];
+const NO_FRIENDS: string[] = [];
+
+/** A persisted-looking cache entry for f1 (profile + status). */
+const CACHED_LIST: UserDataList = {
+  f1: {
+    profile: {display_name: 'Friend One', photo_url: ''},
+    user_status: {last_online: 1},
+  },
+} as unknown as UserDataList;
+
+let mockIsOffline = false;
+type FetchResult = Awaited<ReturnType<typeof Profile.fetchUsersData>>;
+let resolveFetch: (value: FetchResult) => void;
+let rejectFetch: (reason: unknown) => void;
+
+function setOnyx(value: UserDataList | undefined): void {
+  mockedUseOnyx.mockReturnValue([value, {status: 'loaded'}] as ReturnType<
+    typeof useOnyx
+  >);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetFriendsDataSessionSyncForTests();
+  mockIsOffline = false;
+  mockedUseNetwork.mockImplementation(() => ({isOffline: mockIsOffline}));
+  mockedFetchUsersData.mockImplementation(
+    () =>
+      new Promise<FetchResult>((resolve, reject) => {
+        resolveFetch = resolve;
+        rejectFetch = reject;
+      }),
+  );
+  setOnyx(CACHED_LIST);
+});
+
+describe('useFriendsData cold-load gate', () => {
+  it('holds the first open of an app run on the live sync even when a cache exists', async () => {
+    const {result} = renderHook(() => useFriendsData(FRIENDS));
+
+    // A persisted cache alone must NOT release the gate: painting it would
+    // show last run's snapshot and reshuffle when fresh statuses land.
+    expect(result.current.isLoading).toBe(true);
+    expect(mockedFetchUsersData).toHaveBeenCalledWith(FRIENDS);
+
+    await act(async () => {
+      resolveFetch({profiles: {}, statuses: {}});
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('paints the cache instantly on later mounts of a synced run (stale-while-revalidate)', async () => {
+    const first = renderHook(() => useFriendsData(FRIENDS));
+    await act(async () => {
+      resolveFetch({profiles: {}, statuses: {}});
+    });
+    first.unmount();
+
+    const second = renderHook(() => useFriendsData(FRIENDS));
+
+    // No gate on the revisit; the on-focus refresh still fires in the
+    // background (one call per mount).
+    expect(second.result.current.isLoading).toBe(false);
+    expect(mockedFetchUsersData).toHaveBeenCalledTimes(2);
+  });
+
+  it('still gates the first-ever load with nothing cached', async () => {
+    setOnyx(undefined);
+    const {result} = renderHook(() => useFriendsData(FRIENDS));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.profileList).toEqual({});
+
+    await act(async () => {
+      resolveFetch({profiles: {}, statuses: {}});
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('paints the cache immediately when offline (nothing fresh can arrive)', () => {
+    mockIsOffline = true;
+    const {result} = renderHook(() => useFriendsData(FRIENDS));
+
+    expect(result.current.isLoading).toBe(false);
+    // The cache-derived maps are what gets painted.
+    expect(result.current.profileList.f1).toBeDefined();
+    expect(result.current.userStatusList.f1).toBeDefined();
+  });
+
+  it('releases the gate after the bounded wait when the sync is slow, without marking the run synced', () => {
+    // The repo's setupAfterEnv runs on real timers; this test drives the
+    // bounded-wait timer, so fake them locally and restore before cleanup.
+    jest.useFakeTimers();
+    try {
+      const first = renderHook(() => useFriendsData(FRIENDS));
+      expect(first.result.current.isLoading).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(CONST.TIMING.FRIENDS_COLD_SYNC_TIMEOUT);
+      });
+
+      // Timed out: fall back to the cached snapshot (pre-gate behavior).
+      expect(first.result.current.isLoading).toBe(false);
+      first.unmount();
+
+      // The timeout must not count as a sync, so the next mount of this run
+      // gates again and retries for freshness.
+      const second = renderHook(() => useFriendsData(FRIENDS));
+      expect(second.result.current.isLoading).toBe(true);
+      second.unmount();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('releases the gate on a failed sync and does not re-gate later mounts', async () => {
+    const first = renderHook(() => useFriendsData(FRIENDS));
+
+    await act(async () => {
+      rejectFetch(new Error('boom'));
+    });
+
+    // Degrade to the cached list rather than skeletons forever.
+    expect(first.result.current.isLoading).toBe(false);
+    first.unmount();
+
+    // A settled (even failed) sync marks the run: no repeat gating while the
+    // API is down. Data self-heals via the on-focus and reconnect refreshes.
+    const second = renderHook(() => useFriendsData(FRIENDS));
+    expect(second.result.current.isLoading).toBe(false);
+  });
+
+  it('never gates or fetches for an empty friend set', () => {
+    const {result} = renderHook(() => useFriendsData(NO_FRIENDS));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockedFetchUsersData).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/useFriendsData.test.tsx
+++ b/__tests__/unit/useFriendsData.test.tsx
@@ -12,9 +12,8 @@
  */
 import {act, renderHook} from '@testing-library/react-native';
 import {useOnyx} from 'react-native-onyx';
-import useFriendsData, {
-  resetFriendsDataSessionSyncForTests,
-} from '@hooks/useFriendsData';
+import useFriendsData from '@hooks/useFriendsData';
+import {resetSyncedThisAppRunForTests} from '@hooks/useFriendsData/sessionSync';
 import useNetwork from '@hooks/useNetwork';
 import * as Profile from '@userActions/Profile';
 import CONST from '@src/CONST';
@@ -31,7 +30,9 @@ jest.mock('react-native-onyx', () => ({
 jest.mock('@react-navigation/native', () => ({
   __esModule: true,
   useFocusEffect: (callback: () => void | (() => void)) => {
-    const {useEffect} = require('react') as typeof import('react');
+    const {useEffect} = require('react') as {
+      useEffect: (effect: () => void | (() => void), deps: unknown[]) => void;
+    };
     useEffect(callback, [callback]);
   },
 }));
@@ -74,7 +75,7 @@ function setOnyx(value: UserDataList | undefined): void {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  resetFriendsDataSessionSyncForTests();
+  resetSyncedThisAppRunForTests();
   mockIsOffline = false;
   mockedUseNetwork.mockImplementation(() => ({isOffline: mockIsOffline}));
   mockedFetchUsersData.mockImplementation(

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -1051,6 +1051,10 @@ const CONST = {
     SEARCH_OPTION_LIST_DEBOUNCE_TIME: 300,
     TOOLTIP_SENSE: 1000,
     TEST_TOOLS_MODAL_THROTTLE_TIME: 800,
+    /** How long the friend list's first-open-of-run cold gate may hold
+     *  skeletons while waiting for the live sync before falling back to the
+     *  persisted cache (slow networks shouldn't hide data we already have). */
+    FRIENDS_COLD_SYNC_TIMEOUT: 4000,
   },
   TIME_PERIOD: {
     AM: 'AM',

--- a/src/components/Social/UserListComponent.tsx
+++ b/src/components/Social/UserListComponent.tsx
@@ -12,12 +12,16 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {View} from 'react-native';
 import FlatList from '@components/FlatList';
 import {PressableWithFeedback} from '@components/Pressable';
-import FlexibleLoadingIndicator from '@components/FlexibleLoadingIndicator';
 import useCurrentUserData from '@hooks/useCurrentUserData';
 import useLocalize from '@hooks/useLocalize';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import FriendOfflineFeedback from './FriendOfflineFeedback';
 import UserOverview from './UserOverview';
+import UserOverviewSkeleton from './UserOverviewSkeleton';
+
+/** Upper bound on cold-load placeholder rows: enough to fill a tall phone
+ *  screen; anything below the fold would render (and animate) unseen. */
+const MAX_SKELETON_ROWS = 10;
 
 type UserListProps = {
   fullUserArray: UserArray;
@@ -130,14 +134,24 @@ function UserListComponent({
   };
 
   if (isLoading) {
+    // Cold load: the first paint of real data should already be live (fresh
+    // ordering + statuses), so hold row-shaped skeletons instead of painting a
+    // stale snapshot that would visibly reshuffle a round trip later. One
+    // skeleton per known friend, bounded to a screenful.
+    const skeletonCount = Math.min(
+      Math.max(fullUserArray.length, 1),
+      initialLoadSize,
+      MAX_SKELETON_ROWS,
+    );
     return (
       <View
-        style={[
-          styles.flex1,
-          styles.justifyContentCenter,
-          styles.alignItemsCenter,
-        ]}>
-        <FlexibleLoadingIndicator />
+        style={[styles.flex1, styles.pt1]}
+        accessibilityLabel={translate('common.loading')}>
+        {Array.from({length: skeletonCount}, (_, index) => (
+          // Static placeholder list: index keys are stable here.
+          // eslint-disable-next-line react/no-array-index-key
+          <UserOverviewSkeleton key={`user-overview-skeleton-${index}`} />
+        ))}
       </View>
     );
   }

--- a/src/components/Social/UserOverviewSkeleton.tsx
+++ b/src/components/Social/UserOverviewSkeleton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {View} from 'react-native';
+import Skeleton from '@components/Skeleton';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+
+/**
+ * Placeholder friend row for the list's cold load, mirroring `UserOverview`
+ * geometry (same container padding, avatar circle, name bar on the left,
+ * status block on the right) so the swap to real rows causes no layout shift.
+ */
+function UserOverviewSkeleton() {
+  const styles = useThemeStyles();
+  return (
+    <View style={styles.userOverviewContainer}>
+      <View style={styles.userOverviewLeftContent}>
+        <Skeleton height={variables.avatarSizeLarge} circle />
+        <Skeleton width={140} height={16} style={styles.ml3} />
+      </View>
+      <View
+        style={[
+          styles.flexColumn,
+          styles.justifyContentCenter,
+          styles.alignItemsCenter,
+        ]}>
+        <Skeleton width={64} height={12} />
+        <Skeleton width={44} height={12} style={styles.mt1} />
+      </View>
+    </View>
+  );
+}
+
+UserOverviewSkeleton.displayName = 'UserOverviewSkeleton';
+
+export default UserOverviewSkeleton;

--- a/src/hooks/useFriendsData/index.ts
+++ b/src/hooks/useFriendsData/index.ts
@@ -3,6 +3,7 @@ import React, {useRef, useState} from 'react';
 import {useOnyx} from 'react-native-onyx';
 import useNetwork from '@hooks/useNetwork';
 import * as Profile from '@userActions/Profile';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ProfileList, UserStatusList} from '@src/types/onyx';
 import type {UserArray} from '@src/types/onyx/OnyxCommon';
@@ -11,13 +12,32 @@ type UseFriendsDataReturn = {
   /** Profile map for `friendIDs`, read back from `USER_DATA_LIST`. */
   profileList: ProfileList;
   /** Status map for `friendIDs`, read back from `USER_DATA_LIST` (denied/hidden
-   *  friends have no entry — the server evicts their status to `null`). */
+   *  friends have no entry; the server evicts their status to `null`). */
   userStatusList: UserStatusList;
-  /** Cold-load gate ONLY: true just for the first load of a friend set with
-   *  nothing cached yet. Never flips back to true for the on-focus refresh, so a
-   *  rendered list never blanks back to a full-screen spinner. */
+  /** Cold-load gate: true while the FIRST live sync of this app run is still
+   *  pending (even when a persisted cache exists; see the freshness note in
+   *  the hook docblock) and for the first-ever load with nothing cached. Never
+   *  flips back to true for a background refresh, so a rendered list never
+   *  blanks back to placeholders. */
   isLoading: boolean;
 };
+
+/**
+ * Whether any friends-data batch read has settled during this app run. Module
+ * scope on purpose: it resets exactly at the boundary the cold gate cares
+ * about (an app restart) with no Onyx write, no persistence, and no cleanup
+ * hook. While false, a persisted `USER_DATA_LIST` cache from a previous run is
+ * treated as stale-of-unknown-age: the first friend-list open gates on a live
+ * fetch (skeleton rows) instead of painting last run's snapshot and visibly
+ * reshuffling when fresh statuses land. Once true, later mounts paint the
+ * cache instantly and refresh in the background, exactly as before.
+ */
+let hasSyncedThisAppRun = false;
+
+/** Test-only: module state would otherwise leak between jest cases. */
+function resetFriendsDataSessionSyncForTests(): void {
+  hasSyncedThisAppRun = false;
+}
 
 /**
  * Single source of truth for a friend list's profile + presence data.
@@ -25,11 +45,18 @@ type UseFriendsDataReturn = {
  * Fires ONE combined batched read (`Profile.fetchUsersData` →
  * `GET /v1/users/batch?fields=profile,status`) for the whole friend set and
  * reads the result back from the shared `USER_DATA_LIST` Onyx cache the read
- * merges into. Because rendering is driven by Onyx (not a per-mount local
- * `useState` cache, as the old `useProfileList` did), a revisit paints instantly
- * from cache while a background refresh lands (stale-while-revalidate). The read
- * repeats on screen focus so presence stays fresh; a request token makes the
- * loading gate latest-wins so a stale refresh can't flip it out of turn.
+ * merges into. The read repeats on screen focus so presence stays fresh; a
+ * request token makes the loading gate latest-wins so a stale refresh can't
+ * flip it out of turn.
+ *
+ * Freshness policy: `USER_DATA_LIST` persists across app restarts, so cache
+ * PRESENCE says nothing about cache AGE. The first open of an app run
+ * therefore holds `isLoading` until the live fetch settles, bounded by
+ * `TIMING.FRIENDS_COLD_SYNC_TIMEOUT` (slow network → fall back to painting
+ * the cache) and skipped entirely while offline with a cache (reads are
+ * discarded offline, so there is nothing fresh to wait for; the reconnect
+ * handler refreshes in place). Every later mount is stale-while-revalidate: a
+ * revisit paints instantly from cache while a background refresh lands.
  *
  * This replaces the friend list's previous TWO separate fetches (one profile,
  * one status) AND the duplicate `useProfileList` instance, collapsing the
@@ -47,8 +74,31 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
   // newer one must not flip the cold-load gate.
   const currentTokenRef = useRef(0);
 
+  // Re-issue the batched read when connectivity resumes. `fetchUsersData` goes
+  // through `makeRequestWithSideEffects`, which DISCARDS a read while offline
+  // instead of queueing it (unlike `API.write`). `useFocusEffect` only recovers
+  // a tab switch, so a stay-on-screen reconnect would leave the list stale:
+  // mirror the focus-effect body here (same latest-wins token) so going back
+  // online refreshes `USER_DATA_LIST` in place without a tab switch.
+  const {isOffline} = useNetwork({
+    onReconnect: () => {
+      if (friendIDs.length === 0) {
+        return;
+      }
+      const token = ++currentTokenRef.current;
+      Profile.fetchUsersData(friendIDs)
+        .finally(() => {
+          hasSyncedThisAppRun = true;
+          if (token === currentTokenRef.current) {
+            setHasResolvedInitial(true);
+          }
+        })
+        .catch(() => undefined);
+    },
+  });
+
   // Derive the per-friend profile + status maps from the shared cache. Left
-  // unmemoized on purpose — the React Compiler handles it; manual memoization is
+  // unmemoized on purpose: the React Compiler handles it; manual memoization is
   // disallowed (CLEAN-REACT-0).
   const profileList: ProfileList = {};
   const userStatusList: UserStatusList = {};
@@ -65,48 +115,65 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
   const hasCachedData = friendIDs.some(
     userID => !!userDataList?.[userID]?.profile,
   );
+  // The cache is cold when there is nothing in it at all OR when it predates
+  // this app run (persisted snapshot of unknown age). Either way the gate holds
+  // until this mount's fetch settles or times out, except offline with a
+  // cache, where nothing fresh can arrive and stale beats blank.
+  const isColdCache = !hasCachedData || !hasSyncedThisAppRun;
   const isLoading =
-    friendIDs.length > 0 && !hasCachedData && !hasResolvedInitial;
+    friendIDs.length > 0 &&
+    isColdCache &&
+    !hasResolvedInitial &&
+    !(hasCachedData && isOffline);
 
   useFocusEffect(
     React.useCallback(() => {
       if (friendIDs.length === 0) {
-        // Nothing to fetch yet. Don't touch the cold gate here — `isLoading`
+        // Nothing to fetch yet. Don't touch the cold gate here: `isLoading`
         // already returns false for an empty set, and resolving it now would
         // poison the gate for the transient `friends=[]` render that precedes
-        // the real list (suppressing the spinner when the friends arrive).
+        // the real list (suppressing the skeletons when the friends arrive).
         return;
       }
       const token = ++currentTokenRef.current;
-      Profile.fetchUsersData(friendIDs).finally(() => {
-        if (token === currentTokenRef.current) {
-          setHasResolvedInitial(true);
+      // Bounded wait: if this app run's first live sync is slow, release the
+      // gate after a few seconds and fall back to painting the cached snapshot
+      // (the pre-gate behavior) rather than holding skeletons over data we
+      // already have. The timeout deliberately does NOT mark the run synced;
+      // only a settled fetch does.
+      let timeoutID: ReturnType<typeof setTimeout> | undefined;
+      if (!hasSyncedThisAppRun) {
+        timeoutID = setTimeout(() => {
+          if (token === currentTokenRef.current) {
+            setHasResolvedInitial(true);
+          }
+        }, CONST.TIMING.FRIENDS_COLD_SYNC_TIMEOUT);
+      }
+      Profile.fetchUsersData(friendIDs)
+        .finally(() => {
+          // Settling (success OR failure) marks the run synced: a failed fetch
+          // must degrade to the cached list, not re-gate every later mount
+          // while the API is down. Data still self-heals via the on-focus and
+          // reconnect refreshes.
+          hasSyncedThisAppRun = true;
+          if (token === currentTokenRef.current) {
+            setHasResolvedInitial(true);
+          }
+        })
+        // Non-2xx reads reject (see the API error pipeline); the gate is
+        // already released in `finally`, so swallow to avoid an unhandled
+        // rejection.
+        .catch(() => undefined);
+      return () => {
+        if (timeoutID !== undefined) {
+          clearTimeout(timeoutID);
         }
-      });
+      };
     }, [friendIDs]),
   );
-
-  // Re-issue the batched read when connectivity resumes. `fetchUsersData` goes
-  // through `makeRequestWithSideEffects`, which DISCARDS a read while offline
-  // instead of queueing it (unlike `API.write`). `useFocusEffect` only recovers
-  // a tab switch, so a stay-on-screen reconnect would leave the list stale —
-  // mirror the focus-effect body here (same latest-wins token) so going back
-  // online refreshes `USER_DATA_LIST` in place without a tab switch.
-  useNetwork({
-    onReconnect: () => {
-      if (friendIDs.length === 0) {
-        return;
-      }
-      const token = ++currentTokenRef.current;
-      Profile.fetchUsersData(friendIDs).finally(() => {
-        if (token === currentTokenRef.current) {
-          setHasResolvedInitial(true);
-        }
-      });
-    },
-  });
 
   return {profileList, userStatusList, isLoading};
 }
 
 export default useFriendsData;
+export {resetFriendsDataSessionSyncForTests};

--- a/src/hooks/useFriendsData/index.ts
+++ b/src/hooks/useFriendsData/index.ts
@@ -7,6 +7,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ProfileList, UserStatusList} from '@src/types/onyx';
 import type {UserArray} from '@src/types/onyx/OnyxCommon';
+import {hasSyncedThisAppRun, markSyncedThisAppRun} from './sessionSync';
 
 type UseFriendsDataReturn = {
   /** Profile map for `friendIDs`, read back from `USER_DATA_LIST`. */
@@ -21,23 +22,6 @@ type UseFriendsDataReturn = {
    *  blanks back to placeholders. */
   isLoading: boolean;
 };
-
-/**
- * Whether any friends-data batch read has settled during this app run. Module
- * scope on purpose: it resets exactly at the boundary the cold gate cares
- * about (an app restart) with no Onyx write, no persistence, and no cleanup
- * hook. While false, a persisted `USER_DATA_LIST` cache from a previous run is
- * treated as stale-of-unknown-age: the first friend-list open gates on a live
- * fetch (skeleton rows) instead of painting last run's snapshot and visibly
- * reshuffling when fresh statuses land. Once true, later mounts paint the
- * cache instantly and refresh in the background, exactly as before.
- */
-let hasSyncedThisAppRun = false;
-
-/** Test-only: module state would otherwise leak between jest cases. */
-function resetFriendsDataSessionSyncForTests(): void {
-  hasSyncedThisAppRun = false;
-}
 
 /**
  * Single source of truth for a friend list's profile + presence data.
@@ -88,7 +72,7 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
       const token = ++currentTokenRef.current;
       Profile.fetchUsersData(friendIDs)
         .finally(() => {
-          hasSyncedThisAppRun = true;
+          markSyncedThisAppRun();
           if (token === currentTokenRef.current) {
             setHasResolvedInitial(true);
           }
@@ -119,7 +103,7 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
   // this app run (persisted snapshot of unknown age). Either way the gate holds
   // until this mount's fetch settles or times out, except offline with a
   // cache, where nothing fresh can arrive and stale beats blank.
-  const isColdCache = !hasCachedData || !hasSyncedThisAppRun;
+  const isColdCache = !hasCachedData || !hasSyncedThisAppRun();
   const isLoading =
     friendIDs.length > 0 &&
     isColdCache &&
@@ -142,7 +126,7 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
       // already have. The timeout deliberately does NOT mark the run synced;
       // only a settled fetch does.
       let timeoutID: ReturnType<typeof setTimeout> | undefined;
-      if (!hasSyncedThisAppRun) {
+      if (!hasSyncedThisAppRun()) {
         timeoutID = setTimeout(() => {
           if (token === currentTokenRef.current) {
             setHasResolvedInitial(true);
@@ -155,7 +139,7 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
           // must degrade to the cached list, not re-gate every later mount
           // while the API is down. Data still self-heals via the on-focus and
           // reconnect refreshes.
-          hasSyncedThisAppRun = true;
+          markSyncedThisAppRun();
           if (token === currentTokenRef.current) {
             setHasResolvedInitial(true);
           }
@@ -176,4 +160,3 @@ function useFriendsData(friendIDs: UserArray): UseFriendsDataReturn {
 }
 
 export default useFriendsData;
-export {resetFriendsDataSessionSyncForTests};

--- a/src/hooks/useFriendsData/sessionSync.ts
+++ b/src/hooks/useFriendsData/sessionSync.ts
@@ -1,0 +1,28 @@
+/**
+ * Whether any friends-data batch read has settled during this app run. Module
+ * scope on purpose: it resets exactly at the boundary the cold gate cares
+ * about (an app restart) with no Onyx write, no persistence, and no cleanup
+ * hook. Kept behind accessors (not a bare exported variable) so the hook stays
+ * free of module-variable reassignment, which the React Compiler lint rejects
+ * inside components.
+ */
+let hasSynced = false;
+
+function hasSyncedThisAppRun(): boolean {
+  return hasSynced;
+}
+
+function markSyncedThisAppRun(): void {
+  hasSynced = true;
+}
+
+/** Test-only: module state would otherwise leak between jest cases. */
+function resetSyncedThisAppRunForTests(): void {
+  hasSynced = false;
+}
+
+export {
+  hasSyncedThisAppRun,
+  markSyncedThisAppRun,
+  resetSyncedThisAppRunForTests,
+};


### PR DESCRIPTION
## Problem

Opening the friend list for the first time in an app run painted a stale snapshot from the previous run (persisted `USER_DATA_LIST`), then visibly reshuffled and swapped row contents once the live batch read landed. Ordering is dominated by time-sensitive status (ongoing session, last session decay), so the jump happened right as the user started reading.

Root cause: the cold-load gate in `useFriendsData` was presence-based (`isLoading` only when nothing cached), treating a days-old disk cache the same as a seconds-old in-memory one.

## Fix

The gate is now freshness-aware. The first friend-list open of each app run holds skeleton rows until the live sync settles; every later mount keeps the existing stale-while-revalidate behavior (instant paint from cache plus background refresh).

- `useFriendsData`: a module-scope session marker (`sessionSync.ts`, resets on app restart) records whether a batch read has settled this run. The cold gate holds while it's unset, with two escape hatches:
  - offline with a cache: paint immediately (offline reads are discarded, nothing fresh can arrive; the reconnect handler refreshes in place)
  - slow network: `TIMING.FRIENDS_COLD_SYNC_TIMEOUT` (4s) releases the gate and falls back to the cached snapshot, so the worst case equals the old behavior
  - a settled fetch (success or failure) marks the run synced, so a failing API degrades to the cached list instead of re-gating every mount
- `UserListComponent`: the loading branch renders `UserOverviewSkeleton` rows (same geometry as `UserOverview`: avatar circle, name bar, status block) instead of a centered spinner, capped to a screenful.

## Verification

- New unit suite `__tests__/unit/useFriendsData.test.tsx` covers: stale-cache first open gates until settle, later mounts paint instantly, zero-cache first load still gates, offline paints cache, bounded-wait timeout releases without marking the run synced, failed sync releases and marks, empty set never gates or fetches.
- `FriendListBootstrap.test.tsx`, lint-changed, typecheck-tsgo, and the React Compiler compliance check all pass. Full `__tests__/unit` run: only pre-existing failures unrelated to this diff (`DrinkingSessionUtils`, `StatsContextProvider`), confirmed failing at the parent commit too.
- Live check against `npm run web` with the friends e2e spec (passes), plus a manual throttled run: skeleton rows show during the delayed batch read, then settle into the live list.

| Cold load (sync in flight) | Settled (live data) |
| --- | --- |
| skeleton rows matching row geometry | fresh ordering and statuses |
