### PR TITLE
fix(tests): pin jest TZ to utc and unref log flush timer

### DIFF
--- a/__tests__/unit/libs/DrinkingSessionUtils.test.ts
+++ b/__tests__/unit/libs/DrinkingSessionUtils.test.ts
@@ -205,8 +205,9 @@ describe('setLocalSessionCache / compose-on-latest', () => {
   });
 
   it('three adds then one remove, each composing on the cache, net +2 (dropped-tap repro)', () => {
-    // Mirrors what updateDrinks does per tap: read the cache, modify, write back
-    // synchronously — without driving any async Onyx.connect refresh in between.
+    // Mirrors what updateDrinks does per tap: read the cache, modify, write
+    // back synchronously, without driving any async Onyx.connect refresh in
+    // between.
     DSUtils.setLocalSessionCache(ONYXKEYS.ONGOING_SESSION_DATA, liveBase);
 
     const sequence = [
@@ -247,7 +248,7 @@ const LA = 'America/Los_Angeles' as SelectedTimezone; // UTC-8 (Jan)
 const NY = 'America/New_York' as SelectedTimezone;
 
 /**
- * Local-noon `Date` whose `yyyy-MM-dd` label is stable under any process tz —
+ * Local-noon `Date` whose `yyyy-MM-dd` label is stable under any process tz:
  * the bucketers read the viewed day via `format(date)`, so a noon anchor keeps
  * that label from drifting while the window is computed in the session tz.
  */
@@ -255,7 +256,7 @@ function viewDay(year: number, monthZeroBased: number, day: number): Date {
   return new Date(year, monthZeroBased, day, 12);
 }
 
-describe('getSingleDayDrinkingSessions — buckets by each session timezone', () => {
+describe('getSingleDayDrinkingSessions buckets by each session timezone', () => {
   // 06:00 UTC on 2024-01-15 is 15:00 (Jan 15) in Tokyo but 22:00 (Jan 14) in LA.
   const crossInstant = Date.UTC(2024, 0, 15, 6, 0);
   const sessions: DrinkingSessionList = {
@@ -309,7 +310,7 @@ describe('getSingleDayDrinkingSessions — buckets by each session timezone', ()
   });
 });
 
-describe('getSingleMonthDrinkingSessions — buckets by each session timezone', () => {
+describe('getSingleMonthDrinkingSessions buckets by each session timezone', () => {
   // 20:00 UTC on 2024-01-31 is 05:00 (Feb 1) in Tokyo but 12:00 (Jan 31) in LA.
   const monthEdgeInstant = Date.UTC(2024, 0, 31, 20, 0);
   const arr: DrinkingSessionArray = [
@@ -334,7 +335,9 @@ describe('getSingleMonthDrinkingSessions — buckets by each session timezone', 
   });
 
   it('untilToday=true drops sessions later than the current instant', () => {
-    // Pin "now" so the until-today clamp is deterministic.
+    // Pin "now" so the until-today clamp is deterministic. The suite baseline
+    // is real timers (jest/setupAfterEnv.ts), so install fake ones just for
+    // this test and restore in the finally.
     jest.useFakeTimers({now: new Date('2024-01-15T12:00:00Z')});
     try {
       const sameMonth: DrinkingSessionArray = [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,9 @@
+// CI and `npm test` always run the suite under TZ=utc; several date tests
+// (session day-bucketing, statistics filters) encode UTC expectations. Pin it
+// here too so direct `npx jest` / IDE runs behave the same on any machine,
+// while still honoring an explicitly exported TZ.
+process.env.TZ = process.env.TZ ?? 'utc';
+
 const testFileExtension = '[jt]s?(x)';
 module.exports = {
   preset: 'jest-expo',

--- a/src/libs/Log.ts
+++ b/src/libs/Log.ts
@@ -67,6 +67,20 @@ type RequestParams = Merge<
 >;
 
 /**
+ * (Re)arm the 10-minute log-flush timer. The handle is unref'd so it never
+ * holds a Node process (Jest) open; React Native timers have no unref, hence
+ * the optional call.
+ */
+function scheduleLogFlush(logger: Logger): void {
+  clearTimeout(timeout);
+  timeout = setTimeout(
+    () => logger.info('Flushing logs older than 10 minutes', true, {}, true),
+    10 * 60 * 1000,
+  );
+  (timeout as unknown as {unref?: () => void}).unref?.();
+}
+
+/**
  * Network interface for logger.
  */
 function serverLoggingCallback(
@@ -80,11 +94,7 @@ function serverLoggingCallback(
   if (requestParams.parameters) {
     requestParams.parameters = JSON.stringify(requestParams.parameters);
   }
-  clearTimeout(timeout);
-  timeout = setTimeout(
-    () => logger.info('Flushing logs older than 10 minutes', true, {}, true),
-    10 * 60 * 1000,
-  );
+  scheduleLogFlush(logger);
   return LogCommand(requestParams);
 }
 
@@ -111,9 +121,6 @@ const Log = new Logger({
   },
   isDebug: true,
 });
-timeout = setTimeout(
-  () => Log.info('Flushing logs older than 10 minutes', true, {}, true),
-  10 * 60 * 1000,
-);
+scheduleLogFlush(Log);
 
 export default Log;


### PR DESCRIPTION
## Problem

Two unit suites failed when jest was invoked directly (`npx jest ... --ci`) on a non-UTC machine, while CI (`npm test`, which exports `TZ=utc`) stayed green:

- `DrinkingSessionUtils.test.ts`: the no-session-timezone fallback test asserts device-tz behavior with UTC-day expectations.
- `StatsContextProvider.test.tsx`: custom range persistence asserts `yyyy-MM-dd` strings that only match when the process runs in UTC (in Europe/Prague, `2026-02-20T23:59:59Z` formats as `2026-02-21`).

Separately, every run of the `DrinkingSessionUtils` suite ended with "A worker process has failed to exit gracefully" (worker mode) or an indefinite hang plus a post-teardown `TypeError` crash in `OnyxUtils` (in-band mode).

## Fix

- **jest.config.js**: pin `process.env.TZ` to `utc` (honoring an explicitly exported TZ) so direct `npx jest` and IDE runs behave exactly like CI on any machine. No behavior change for `npm test` or CI.
- **src/libs/Log.ts**: the module-scope 10-minute log-flush `setTimeout` was the open handle keeping the node process alive after the run (found via `--detectOpenHandles`; the suite baseline is real timers per `jest/setupAfterEnv.ts`). Both schedule sites now go through one helper that `unref()`s the handle: a no-op in React Native runtimes, but it lets jest exit cleanly. The lingering process was also what gave stray Onyx batch timers the chance to fire after module-registry teardown and crash the worker.
- **DrinkingSessionUtils.test.ts**: comment cleanup only (dash style); the fake-timer pattern is unchanged.

## Verification

- `npx jest <both suites> --ci` with no TZ exported: both pass, jest exits immediately, no teardown warning.
- Full `npm test`: 113 suites / 1000 tests pass, zero "failed to exit gracefully" or "did not exit" warnings in the log.
- `typecheck-tsgo`, `lint-changed`, prettier all clean.