### PR TITLE
fix(network): never drop offline-queued writes on transient failures

### DIFF
--- a/__tests__/actions/DrinkingSession.test.ts
+++ b/__tests__/actions/DrinkingSession.test.ts
@@ -413,13 +413,21 @@ describe('offline live-session persistence across restarts', () => {
       ONYXKEYS.ONGOING_SESSION_SYNC,
       {enqueuedAt: editedAt},
     );
-    // Synced: only a successful response may clear the dirty state.
+    // Synced: only a successful response may clear the dirty state. Dropped:
+    // if the queue permanently drops the request, failureData re-opens the
+    // "never enqueued" state so the persist re-arms and re-sends.
     const call = liveUpdateCalls()[0];
     expect(call[2]).toEqual({
       successData: [
         expect.objectContaining({
           key: ONYXKEYS.ONGOING_SESSION_SYNC,
           value: {syncedAt: editedAt},
+        }),
+      ],
+      failureData: [
+        expect.objectContaining({
+          key: ONYXKEYS.ONGOING_SESSION_SYNC,
+          value: {enqueuedAt: null, flushDropCount: 1},
         }),
       ],
     });

--- a/__tests__/actions/OfflineWriteDurability.test.ts
+++ b/__tests__/actions/OfflineWriteDurability.test.ts
@@ -1,0 +1,419 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+/* eslint-disable rulesdir/no-api-in-views -- this integration test drives the real API.write/SequentialQueue pipeline; it is not a view */
+/* eslint-disable rulesdir/prefer-actions-set-data -- this test seeds/asserts Onyx directly to model offline persistence and replay */
+/* eslint-disable rulesdir/no-multiple-api-calls -- each API.write models an independent user action in a separate test case */
+
+/**
+ * Durability coverage for offline-queued session writes.
+ *
+ * Drives the REAL write pipeline (API.write -> SequentialQueue ->
+ * PersistedRequests -> Request middleware) against real Onyx with only the
+ * HTTP layer stubbed, and proves the queue's failure semantics:
+ *
+ *  - transient failures (network-layer, 5xx) can NEVER permanently drop a
+ *    persisted write, no matter how many retries they burn; the request stays
+ *    queued and delivers once conditions recover,
+ *  - a deterministic 4xx still drops, but the session payload survives it:
+ *    a dropped live flush re-arms the debounced persist (capped), and a
+ *    dropped finalize is parked in UNSYNCED_SESSION_WRITES and re-sent by
+ *    the next app run.
+ *
+ * Regression guard for the "drink logged offline vanished" bug: flapping
+ * between airplane mode and flaky connectivity used to exhaust the throttle's
+ * lifetime retry budget and silently delete the queued UpdateSession.
+ */
+import Onyx from 'react-native-onyx';
+import type {OnyxKey} from 'react-native-onyx';
+import * as API from '@libs/API';
+import * as DSUtils from '@libs/DrinkingSessionUtils';
+import HttpsError from '@libs/Errors/HttpsError';
+import * as SequentialQueue from '@libs/Network/SequentialQueue';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import * as DS from '@userActions/DrinkingSession';
+import * as PersistedRequests from '@userActions/PersistedRequests';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {
+  DrinkingSession,
+  DrinksToUnits,
+  OngoingSessionSync,
+  UnsyncedSessionWriteList,
+} from '@src/types/onyx';
+
+// Onyx batches updates through react-dom's unstable_batchedUpdates, which is
+// undefined in this RN test environment; run the callback synchronously.
+jest.mock('react-native-onyx/dist/batch', () => ({
+  __esModule: true,
+  default: (callback: () => void) => callback(),
+}));
+
+// Capture every outbound request; per-test implementations model a healthy
+// server, a network-layer failure, or an HTTP error status.
+const mockXhr = jest.fn();
+jest.mock('@libs/HttpUtils', () => ({
+  __esModule: true,
+  default: {
+    xhr: (command: string, data: Record<string, unknown>): Promise<unknown> =>
+      mockXhr(command, data) as Promise<unknown>,
+    cancelPendingRequests: jest.fn(),
+  },
+}));
+
+jest.mock('@libs/Firebase/FirebaseApp', () => ({
+  getFirebaseAuth: () => ({currentUser: {uid: 'user-1'}}),
+}));
+
+// The sequential queue only flushes from the leader client.
+jest.mock('@libs/ActiveClientManager', () => ({
+  isClientTheLeader: () => true,
+  isReady: () => true,
+}));
+
+jest.mock('@libs/Pusher/pusher', () => ({getPusherSocketID: () => ''}));
+
+// Failing requests route through the RecheckConnection middleware, which asks
+// NetInfo for a connectivity probe; the native module doesn't exist in jest.
+jest.mock('@react-native-community/netinfo', () =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  require('@react-native-community/netinfo/jest/netinfo-mock'),
+);
+
+// generatePushID pulls expo-crypto (ESM), which this jest environment cannot
+// transform; the tests here mint their own ids anyway.
+jest.mock('@libs/generatePushID', () => ({
+  __esModule: true,
+  default: () => 'generated-session-id',
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+}));
+
+jest.mock('@libs/Localize', () => ({translateLocal: (key: string) => key}));
+
+jest.setTimeout(30000);
+
+const ME = 'user-1';
+const DRINKS_TO_UNITS: DrinksToUnits = {
+  small_beer: 1,
+  beer: 1,
+  cocktail: 1,
+  other: 1,
+  strong_shot: 1,
+  weak_shot: 1,
+  wine: 1,
+};
+
+// Shrink the retry budget and waits so exhausting them takes milliseconds
+// instead of the production ~40-80 seconds.
+type MutableNetworkTuning = {
+  MAX_REQUEST_RETRIES: number;
+  MIN_RETRY_WAIT_TIME_MS: number;
+  MAX_RANDOM_RETRY_WAIT_TIME_MS: number;
+  MAX_RETRY_WAIT_TIME_MS: number;
+};
+const networkTuning = CONST.NETWORK as unknown as MutableNetworkTuning;
+const originalTuning: MutableNetworkTuning = {
+  MAX_REQUEST_RETRIES: networkTuning.MAX_REQUEST_RETRIES,
+  MIN_RETRY_WAIT_TIME_MS: networkTuning.MIN_RETRY_WAIT_TIME_MS,
+  MAX_RANDOM_RETRY_WAIT_TIME_MS: networkTuning.MAX_RANDOM_RETRY_WAIT_TIME_MS,
+  MAX_RETRY_WAIT_TIME_MS: networkTuning.MAX_RETRY_WAIT_TIME_MS,
+};
+const TEST_MAX_RETRIES = 2;
+
+function okResponse(): Promise<unknown> {
+  return Promise.resolve({
+    jsonCode: 200,
+    onyxData: [],
+    lastUpdateID: 0,
+    previousUpdateID: 0,
+  });
+}
+
+// Flush microtasks + a few macrotask ticks so real Onyx writes and the
+// SequentialQueue settle (jsdom lacks setImmediate, so avoid it).
+async function settle(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+/** Poll `predicate` (sync or async) until true or the timeout elapses. */
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 10000,
+): Promise<void> {
+  const start = Date.now();
+  // eslint-disable-next-line no-await-in-loop
+  while (!(await predicate())) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+// Read a single Onyx key once. Uses Onyx.connect because this node-style action
+// test has no React render context for useOnyx().
+function readOnyx<T>(key: OnyxKey): Promise<T | undefined> {
+  return new Promise<T | undefined>(resolve => {
+    // eslint-disable-next-line rulesdir/no-onyx-connect, rulesdir/prefer-onyx-connect-in-libs -- test-only Onyx read; useOnyx() requires a React render this node test doesn't have
+    const connection = Onyx.connect({
+      key,
+      callback: (value: unknown) => {
+        Onyx.disconnect(connection);
+        resolve(value as T | undefined);
+      },
+    });
+  });
+}
+
+async function setNetwork(isOffline: boolean): Promise<void> {
+  await Onyx.merge(ONYXKEYS.NETWORK, {isOffline});
+  await settle();
+}
+
+function networkFailure(): Promise<never> {
+  // What a dead fetch produces: an error with no HTTP status at all.
+  return Promise.reject(new Error('Failed to fetch'));
+}
+
+function httpFailure(status: string): Promise<never> {
+  return Promise.reject(new HttpsError({message: `HTTP ${status}`, status}));
+}
+
+function queuedCommands(): string[] {
+  return PersistedRequests.getAll().map(request => request.command);
+}
+
+beforeAll(() => {
+  Onyx.init({keys: ONYXKEYS});
+  networkTuning.MAX_REQUEST_RETRIES = TEST_MAX_RETRIES;
+  networkTuning.MIN_RETRY_WAIT_TIME_MS = 1;
+  networkTuning.MAX_RANDOM_RETRY_WAIT_TIME_MS = 2;
+  networkTuning.MAX_RETRY_WAIT_TIME_MS = 4;
+});
+
+afterAll(() => {
+  Object.assign(networkTuning, originalTuning);
+});
+
+beforeEach(async () => {
+  mockXhr.mockReset();
+  mockXhr.mockImplementation(() => okResponse());
+  SequentialQueue.resetQueue();
+  await Onyx.clear();
+  // Resolve NetworkStore readiness (it waits for SESSION + CREDENTIALS).
+  await Onyx.multiSet({
+    [ONYXKEYS.SESSION]: {authToken: 'tok'},
+    [ONYXKEYS.CREDENTIALS]: {},
+  });
+  await settle();
+});
+
+describe('Offline write durability (real write pipeline)', () => {
+  it('keeps a queued write through retry exhaustion on network-layer failures, then delivers it', async () => {
+    await setNetwork(true);
+    const session = DSUtils.getEmptySession({
+      id: 'sess-net',
+      type: CONST.SESSION.TYPES.LIVE,
+      ongoing: false,
+    });
+    API.write(
+      WRITE_COMMANDS.UPDATE_SESSION,
+      {sessionId: 'sess-net', session, sessionIsLive: false},
+      {},
+    );
+    await settle();
+    expect(queuedCommands()).toEqual([WRITE_COMMANDS.UPDATE_SESSION]);
+    expect(mockXhr).not.toHaveBeenCalled();
+
+    // Reconnect against a dead network (the app believes it is online, every
+    // fetch fails). The retry budget is exhausted...
+    mockXhr.mockImplementation(networkFailure);
+    await setNetwork(false);
+    await waitFor(() => mockXhr.mock.calls.length >= TEST_MAX_RETRIES + 1);
+    await settle();
+
+    // ...but the request is NOT dropped, and waitForIdle() is not wedged.
+    expect(queuedCommands()).toEqual([WRITE_COMMANDS.UPDATE_SESSION]);
+    await SequentialQueue.waitForIdle();
+
+    // The next reconnection delivers it and empties the queue.
+    mockXhr.mockImplementation(() => okResponse());
+    await setNetwork(true);
+    await setNetwork(false);
+    await waitFor(() => PersistedRequests.getAll().length === 0);
+  });
+
+  it('keeps a queued write through retry exhaustion on 5xx responses, then delivers it', async () => {
+    await setNetwork(true);
+    const session = DSUtils.getEmptySession({
+      id: 'sess-5xx',
+      type: CONST.SESSION.TYPES.LIVE,
+      ongoing: false,
+    });
+    API.write(
+      WRITE_COMMANDS.UPDATE_SESSION,
+      {sessionId: 'sess-5xx', session, sessionIsLive: false},
+      {},
+    );
+    await settle();
+    expect(queuedCommands()).toEqual([WRITE_COMMANDS.UPDATE_SESSION]);
+
+    // A server outage (500s) burns the whole retry budget...
+    mockXhr.mockImplementation(() => httpFailure('500'));
+    await setNetwork(false);
+    await waitFor(() => mockXhr.mock.calls.length >= TEST_MAX_RETRIES + 1);
+    await settle();
+
+    // ...and still must not destroy the write.
+    expect(queuedCommands()).toEqual([WRITE_COMMANDS.UPDATE_SESSION]);
+
+    mockXhr.mockImplementation(() => okResponse());
+    await setNetwork(true);
+    await setNetwork(false);
+    await waitFor(() => PersistedRequests.getAll().length === 0);
+  });
+
+  it('parks a finalize dropped on a deterministic 4xx and re-sends it on the next run', async () => {
+    await setNetwork(true);
+    const session: DrinkingSession = {
+      ...DSUtils.getEmptySession({
+        id: 'sess-final',
+        type: CONST.SESSION.TYPES.LIVE,
+        ongoing: false,
+      }),
+      drinks: {1000: {beer: 2}},
+    };
+    await DS.saveDrinkingSessionData(
+      ME,
+      session,
+      'sess-final',
+      ONYXKEYS.EDIT_SESSION_DATA,
+      false,
+    );
+    await settle();
+    expect(queuedCommands()).toEqual([WRITE_COMMANDS.UPDATE_SESSION]);
+
+    // The server deterministically rejects the payload: the request is
+    // dropped, but the full payload is parked instead of lost.
+    mockXhr.mockImplementation(() => httpFailure('400'));
+    await setNetwork(false);
+    await waitFor(() => PersistedRequests.getAll().length === 0);
+    await settle();
+    const parked = await readOnyx<UnsyncedSessionWriteList>(
+      ONYXKEYS.UNSYNCED_SESSION_WRITES,
+    );
+    expect(parked?.['sess-final']).toMatchObject({
+      sessionId: 'sess-final',
+      userID: ME,
+      sessionIsLive: false,
+    });
+    expect(parked?.['sess-final'].session.drinks).toMatchObject({
+      1000: {beer: 2},
+    });
+
+    // "Next app run" against a healed server: the parked write is
+    // re-enqueued, delivered, and the parked entry cleared.
+    mockXhr.mockImplementation(() => okResponse());
+    const callsBeforeResend = mockXhr.mock.calls.length;
+    DS.resendUnsyncedSessionWrites();
+    await waitFor(
+      () =>
+        mockXhr.mock.calls.length > callsBeforeResend &&
+        PersistedRequests.getAll().length === 0,
+    );
+    await settle();
+    expect(mockXhr).toHaveBeenLastCalledWith(
+      WRITE_COMMANDS.UPDATE_SESSION,
+      expect.objectContaining({sessionId: 'sess-final'}),
+    );
+    const parkedAfter = await readOnyx<UnsyncedSessionWriteList>(
+      ONYXKEYS.UNSYNCED_SESSION_WRITES,
+    );
+    expect(parkedAfter?.['sess-final']).toBeUndefined();
+  });
+
+  it('re-arms a dropped live flush up to the cap, keeps the buffer, and recovers on the next edit', async () => {
+    const live = DSUtils.getEmptySession({
+      id: 'live-1',
+      type: CONST.SESSION.TYPES.LIVE,
+      ongoing: true,
+    });
+    await Onyx.set(ONYXKEYS.ONGOING_SESSION_DATA, live);
+    await settle();
+
+    // Log a drink fully offline: the debounced flush queues an UpdateSession
+    // and stamps `enqueuedAt`.
+    await setNetwork(true);
+    DS.updateDrinks(
+      'live-1',
+      CONST.DRINKS.KEYS.BEER,
+      1,
+      CONST.DRINKS.ACTIONS.ADD,
+      DRINKS_TO_UNITS,
+    );
+    await waitFor(() => PersistedRequests.getAll().length === 1, 5000);
+    let sync = await readOnyx<OngoingSessionSync>(
+      ONYXKEYS.ONGOING_SESSION_SYNC,
+    );
+    expect(sync?.sessionId).toBe('live-1');
+    expect(sync?.enqueuedAt).toBe(sync?.editedAt);
+
+    // The server deterministically rejects it. Each drop re-arms the persist
+    // (failureData clears `enqueuedAt`), until the drop cap stops the loop.
+    mockXhr.mockImplementation(() => httpFailure('400'));
+    await setNetwork(false);
+    await waitFor(async () => {
+      const current = await readOnyx<OngoingSessionSync>(
+        ONYXKEYS.ONGOING_SESSION_SYNC,
+      );
+      return current?.flushDropCount === 3;
+    }, 20000);
+    await waitFor(() => PersistedRequests.getAll().length === 0);
+    await settle();
+
+    // The re-arm loop stopped: no new request within another debounce window.
+    const callsAtCap = mockXhr.mock.calls.length;
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 800);
+    });
+    expect(mockXhr.mock.calls.length).toBe(callsAtCap);
+    expect(PersistedRequests.getAll()).toHaveLength(0);
+
+    // The local buffer still holds the drink: nothing was wiped.
+    const buffer = await readOnyx<DrinkingSession>(
+      ONYXKEYS.ONGOING_SESSION_DATA,
+    );
+    expect(Object.keys(buffer?.drinks ?? {})).toHaveLength(1);
+
+    // A new edit grants a fresh drop budget; with a healed server the flush
+    // now succeeds and `syncedAt` catches up to `editedAt`.
+    mockXhr.mockImplementation(() => okResponse());
+    DS.updateDrinks(
+      'live-1',
+      CONST.DRINKS.KEYS.BEER,
+      1,
+      CONST.DRINKS.ACTIONS.ADD,
+      DRINKS_TO_UNITS,
+    );
+    await waitFor(async () => {
+      const current = await readOnyx<OngoingSessionSync>(
+        ONYXKEYS.ONGOING_SESSION_SYNC,
+      );
+      return (
+        current?.syncedAt !== undefined && current.syncedAt === current.editedAt
+      );
+    }, 5000);
+    sync = await readOnyx<OngoingSessionSync>(ONYXKEYS.ONGOING_SESSION_SYNC);
+    expect(sync?.flushDropCount).toBeUndefined();
+  });
+});

--- a/__tests__/unit/RequestThrottle.test.ts
+++ b/__tests__/unit/RequestThrottle.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/naming-convention -- jest mock factory keys (__esModule) are dictated by Node module shape */
+import RequestThrottle from '@libs/RequestThrottle';
+import type {RequestError} from '@libs/Network/SequentialQueue';
+import CONST from '@src/CONST';
+
+// RequestThrottle logs through @libs/Log, which touches Onyx; Onyx batches
+// updates through react-dom's unstable_batchedUpdates, undefined in this RN
+// test environment. Run the callback synchronously instead.
+jest.mock('react-native-onyx/dist/batch', () => ({
+  __esModule: true,
+  default: (callback: () => void) => callback(),
+}));
+
+// Shrink the budget and waits so the test runs in milliseconds.
+type MutableNetworkTuning = {
+  MAX_REQUEST_RETRIES: number;
+  MIN_RETRY_WAIT_TIME_MS: number;
+  MAX_RANDOM_RETRY_WAIT_TIME_MS: number;
+  MAX_RETRY_WAIT_TIME_MS: number;
+};
+const networkTuning = CONST.NETWORK as unknown as MutableNetworkTuning;
+const originalTuning: MutableNetworkTuning = {
+  MAX_REQUEST_RETRIES: networkTuning.MAX_REQUEST_RETRIES,
+  MIN_RETRY_WAIT_TIME_MS: networkTuning.MIN_RETRY_WAIT_TIME_MS,
+  MAX_RANDOM_RETRY_WAIT_TIME_MS: networkTuning.MAX_RANDOM_RETRY_WAIT_TIME_MS,
+  MAX_RETRY_WAIT_TIME_MS: networkTuning.MAX_RETRY_WAIT_TIME_MS,
+};
+
+beforeAll(() => {
+  networkTuning.MAX_REQUEST_RETRIES = 2;
+  networkTuning.MIN_RETRY_WAIT_TIME_MS = 1;
+  networkTuning.MAX_RANDOM_RETRY_WAIT_TIME_MS = 2;
+  networkTuning.MAX_RETRY_WAIT_TIME_MS = 4;
+});
+
+afterAll(() => {
+  Object.assign(networkTuning, originalTuning);
+});
+
+describe('RequestThrottle', () => {
+  const error: RequestError = new Error('Failed to fetch');
+
+  it('rejects once the retry budget is exhausted', async () => {
+    const throttle = new RequestThrottle('test');
+    await throttle.sleep(error, 'Cmd');
+    await throttle.sleep(error, 'Cmd');
+    await expect(throttle.sleep(error, 'Cmd')).rejects.toBeUndefined();
+  });
+
+  it('resetBudget grants a fresh consecutive-failure budget', async () => {
+    const throttle = new RequestThrottle('test');
+    await throttle.sleep(error, 'Cmd');
+    await throttle.sleep(error, 'Cmd');
+    // Simulates a reconnection: the next online window starts from zero
+    // instead of inheriting failures burned in earlier windows.
+    throttle.resetBudget();
+    await throttle.sleep(error, 'Cmd');
+    await throttle.sleep(error, 'Cmd');
+    await expect(throttle.sleep(error, 'Cmd')).rejects.toBeUndefined();
+  });
+});

--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -114,6 +114,13 @@ const ONYXKEYS = {
    */
   ONGOING_SESSION_SYNC: 'ongoingSessionSync',
 
+  /**
+   * Finalized session writes the request queue permanently dropped (a
+   * deterministic server rejection). Parked here so the data survives; each
+   * app run re-enqueues them once and a successful delivery clears the entry.
+   */
+  UNSYNCED_SESSION_WRITES: 'unsyncedSessionWrites',
+
   /** Edit session data */
   EDIT_SESSION_DATA: 'editSessionData',
 
@@ -334,6 +341,7 @@ type OnyxValuesMapping = {
   [ONYXKEYS.NVP_LAST_VIEWED_CALENDAR_DATE]: Record<string, DateString>;
   [ONYXKEYS.ONGOING_SESSION_DATA]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.ONGOING_SESSION_SYNC]: OnyxTypes.OngoingSessionSync;
+  [ONYXKEYS.UNSYNCED_SESSION_WRITES]: OnyxTypes.UnsyncedSessionWriteList;
   [ONYXKEYS.EDIT_SESSION_DATA]: OnyxTypes.DrinkingSession;
   [ONYXKEYS.IS_CREATING_NEW_SESSION]: boolean;
   [ONYXKEYS.SESSIONS_CALENDAR_MONTHS_LOADED]: number;

--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -31,6 +31,32 @@ let isQueuePaused = false;
 const sequentialQueueRequestThrottle = new RequestThrottle('SequentialQueue');
 
 /**
+ * Whether a request that exhausted its retry budget may be dropped from the
+ * persisted queue. Only a deterministic client error qualifies: an actual
+ * server response with a non-retryable 4xx status, meaning the server
+ * actively rejected this exact payload and replaying it can never succeed.
+ *
+ * Everything else is transient by nature: network-layer failures carry no
+ * response at all (fetch failure, timeout, a reauth attempt while offline),
+ * and 5xx / 429 mean the server itself is unhealthy or throttling. Dropping a
+ * persisted write on those destroys user data that would have delivered once
+ * conditions recovered (an offline-logged drinking session, for example), so
+ * such requests stay queued for the next flush trigger instead.
+ */
+function isDroppableFailure(error: RequestError): boolean {
+  const status = Number(error.status);
+  if (!Number.isFinite(status) || status <= 0) {
+    // No (parseable) server response: a network-layer failure.
+    return false;
+  }
+  return (
+    status >= 400 &&
+    status < 500 &&
+    status !== CONST.HTTP_STATUS.TOO_MANY_REQUESTS
+  );
+}
+
+/**
  * Puts the queue into a paused state so that no requests will be processed
  */
 function pause() {
@@ -130,6 +156,26 @@ function process(): Promise<void> {
         .sleep(error, requestToProcess.command)
         .then(process)
         .catch(() => {
+          // The retry budget is exhausted. Drop the request only when the
+          // server deterministically rejected it (see `isDroppableFailure`);
+          // a transient failure (network-layer, 5xx, 429) keeps the request
+          // persisted and stalls the queue until the next flush trigger
+          // (reconnection, app foreground, a new write) retries it with a
+          // fresh budget. Dropping on transient failures silently destroyed
+          // offline-queued session writes during flaky-network windows.
+          if (!isDroppableFailure(error)) {
+            Log.info(
+              '[SequentialQueue] Request failed too many times; keeping it queued for the next flush trigger.',
+              false,
+              {error, request: requestToProcess},
+            );
+            sequentialQueueRequestThrottle.clear();
+            // Unblock `waitForIdle()` waiters the same way the offline
+            // early-return does: the queue is intentionally stalled, and
+            // holding reads hostage to an unreachable server helps nobody.
+            resolveIsReadyPromise?.();
+            return;
+          }
           Onyx.update(requestToProcess.failureData ?? []);
           Log.info(
             '[SequentialQueue] Removing persisted request because it failed too many times.',
@@ -233,8 +279,16 @@ function isPaused(): boolean {
   return isQueuePaused;
 }
 
-// Flush the queue when the connection resumes
-NetworkStore.onReconnection(flush);
+// Flush the queue when the connection resumes. Each online window also gets a
+// fresh retry budget: the throttle counter only resets on success or drop, so
+// without this, brief dead windows (VPN black-hole, airplane-mode toggles)
+// would each burn a few of the lifetime retries and an offline-queued write
+// could exhaust its budget cumulatively across flaps. `resetBudget` (never
+// `clear`) so an armed retry timer keeps its resolve.
+NetworkStore.onReconnection(() => {
+  sequentialQueueRequestThrottle.resetBudget();
+  flush();
+});
 
 function handleConflictActions(
   conflictAction: ConflictData,

--- a/src/libs/RequestThrottle.ts
+++ b/src/libs/RequestThrottle.ts
@@ -29,6 +29,17 @@ class RequestThrottle {
     Log.info(`[RequestThrottle - ${this.name}] cleared`);
   }
 
+  /**
+   * Zero the retry budget without touching an armed retry timer. Used on
+   * reconnection so each online window gets a fresh budget; `clear()` is not
+   * safe there, because clearing a pending `sleep` timeout would leave its
+   * promise unsettled and wedge the sequential queue's processing chain.
+   */
+  resetBudget() {
+    this.requestWaitTime = 0;
+    this.requestRetryCount = 0;
+  }
+
   getRequestWaitTime() {
     if (this.requestWaitTime) {
       this.requestWaitTime = Math.min(

--- a/src/libs/actions/DrinkingSession.ts
+++ b/src/libs/actions/DrinkingSession.ts
@@ -6,8 +6,10 @@ import type {
   DrinksToUnits,
   DrinksTimestamp,
   OngoingSessionSync,
+  UnsyncedSessionWriteList,
   UserDataList,
 } from '@src/types/onyx';
+import Log from '@libs/Log';
 import * as Localize from '@libs/Localize';
 import * as DSUtils from '@libs/DrinkingSessionUtils';
 import type {UserID} from '@src/types/onyx/OnyxCommon';
@@ -64,6 +66,68 @@ Onyx.connect({
     maybeResumeLiveSessionPersist();
   },
 });
+
+// Parked finalize writes (see `UNSYNCED_SESSION_WRITES`): kept in a module
+// cache so the one-shot boot re-send below can read them without a React
+// context, same pattern as the sync marker above.
+let unsyncedSessionWrites: UnsyncedSessionWriteList | undefined;
+let hasProcessedInitialUnsyncedWrites = false;
+// eslint-disable-next-line rulesdir/no-onyx-connect -- module-scope action-layer wiring with no React context to hang a useOnyx on, same as the sync-marker connection above
+Onyx.connect({
+  key: ONYXKEYS.UNSYNCED_SESSION_WRITES,
+  callback: value => {
+    unsyncedSessionWrites = value ?? undefined;
+    // Re-enqueue parked writes exactly once per app run, on first hydration.
+    // Entries parked later in THIS run are deliberately left alone until the
+    // next run: the server just deterministically rejected them, so an
+    // immediate replay would only fail again.
+    if (!hasProcessedInitialUnsyncedWrites) {
+      hasProcessedInitialUnsyncedWrites = true;
+      resendUnsyncedSessionWrites();
+    }
+  },
+});
+
+/**
+ * Re-enqueue every parked session write (a finalize the request queue
+ * permanently dropped in an earlier run; see `saveDrinkingSessionData`). The
+ * optimistic data resurfaces the session in the cached snapshot, and only a
+ * successful delivery clears the parked entry, so the payload survives any
+ * number of further failed runs.
+ */
+function resendUnsyncedSessionWrites(): void {
+  const entries = Object.values(unsyncedSessionWrites ?? {});
+  if (entries.length === 0) {
+    return;
+  }
+  Log.hmmm('[DrinkingSession] Re-enqueueing parked session writes', {
+    count: entries.length,
+  });
+  entries.forEach(entry => {
+    API.write(
+      WRITE_COMMANDS.UPDATE_SESSION,
+      {
+        sessionId: entry.sessionId,
+        session: entry.session,
+        sessionIsLive: entry.sessionIsLive,
+      },
+      {
+        optimisticData: cachedSessionReplace(
+          entry.userID,
+          entry.sessionId,
+          entry.session,
+        ),
+        successData: [
+          {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: ONYXKEYS.UNSYNCED_SESSION_WRITES,
+            value: {[entry.sessionId]: null},
+          },
+        ],
+      },
+    );
+  });
+}
 
 // Cached copy of the user-data list so the session-write paths can read the
 // current `earliest_session_at` without an extra Firebase round trip on every
@@ -213,6 +277,10 @@ async function updateLocalData(
 // and then write the full session themselves, so a debounced live write can never
 // land after them.
 const LIVE_SESSION_PERSIST_DEBOUNCE_MS = 500;
+// How many consecutive permanent drops of an enqueued live flush (deterministic
+// server rejections after retries) the automatic re-arm tolerates before it
+// stops re-enqueueing the same payload. See `maybeResumeLiveSessionPersist`.
+const MAX_LIVE_FLUSH_DROPS = 3;
 let liveSessionPersistTimer: ReturnType<typeof setTimeout> | null = null;
 let liveSessionPersistInteraction: {cancel: () => void} | null = null;
 
@@ -261,6 +329,9 @@ function markLiveSessionEdited(sessionId: DrinkingSessionId): void {
     sessionId,
     editedAt: Math.max(Date.now(), (previous?.editedAt ?? 0) + 1),
   };
+  // A new edit is a new payload: it gets a fresh drop budget (see
+  // `maybeResumeLiveSessionPersist`).
+  delete next.flushDropCount;
   ongoingSessionSync = next;
   Onyx.set(ONYXKEYS.ONGOING_SESSION_SYNC, next);
 }
@@ -310,6 +381,21 @@ function maybeResumeLiveSessionPersist(): void {
   if (sync.editedAt <= Math.max(sync.enqueuedAt ?? 0, sync.syncedAt ?? 0)) {
     return;
   }
+  // The request queue permanently dropped this payload several times in a row
+  // (deterministic server rejections; transient failures never drop). Stop
+  // auto-re-enqueueing it: the buffer stays guarded locally (`syncedAt` never
+  // advanced), and the next explicit edit or the finalize sends a fresh
+  // full-session payload anyway.
+  if ((sync.flushDropCount ?? 0) >= MAX_LIVE_FLUSH_DROPS) {
+    Log.hmmm(
+      '[DrinkingSession] Live flush dropped too many times; not re-arming',
+      {
+        sessionId: session.id,
+        flushDropCount: sync.flushDropCount,
+      },
+    );
+    return;
+  }
   if (hasPendingLiveSessionPersist()) {
     return;
   }
@@ -355,6 +441,23 @@ function flushLiveSessionPersist(): void {
               onyxMethod: Onyx.METHOD.MERGE,
               key: ONYXKEYS.ONGOING_SESSION_SYNC,
               value: {syncedAt: coversEditedAt},
+            },
+          ],
+          // Applied only if the request queue permanently drops this request
+          // (a deterministic server rejection after retries; transient
+          // failures are never dropped). Clearing `enqueuedAt` re-opens the
+          // "never reached the queue" state, so the next hydration or edit
+          // re-arms the persist and the following full-session flush re-sends
+          // everything; `flushDropCount` caps that loop (see
+          // `maybeResumeLiveSessionPersist`).
+          failureData: [
+            {
+              onyxMethod: Onyx.METHOD.MERGE,
+              key: ONYXKEYS.ONGOING_SESSION_SYNC,
+              value: {
+                enqueuedAt: null,
+                flushDropCount: (sync?.flushDropCount ?? 0) + 1,
+              },
             },
           ],
         },
@@ -583,6 +686,26 @@ async function saveDrinkingSessionData(
         sessionKey,
         sessionToPersist,
       ),
+      // Applied only if the request queue permanently drops this request (a
+      // deterministic server rejection after retries; transient failures are
+      // never dropped). Nothing later re-sends a finalize, so park the full
+      // payload; the next app run re-enqueues it once
+      // (`resendUnsyncedSessionWrites`) and a successful delivery clears it.
+      failureData: [
+        {
+          onyxMethod: Onyx.METHOD.MERGE,
+          key: ONYXKEYS.UNSYNCED_SESSION_WRITES,
+          value: {
+            [sessionKey]: {
+              sessionId: sessionKey,
+              session: sessionToPersist,
+              userID,
+              sessionIsLive: !!sessionIsLive,
+              enqueuedAt: Date.now(),
+            },
+          },
+        },
+      ],
     },
   );
 
@@ -944,6 +1067,7 @@ export {
   navigateToEditSessionScreen,
   navigateToOngoingSessionScreen,
   removeDrinkingSessionData,
+  resendUnsyncedSessionWrites,
   saveDrinkingSessionData,
   setIsCreatingNewSession,
   startLiveDrinkingSession,

--- a/src/types/onyx/OngoingSessionSync.ts
+++ b/src/types/onyx/OngoingSessionSync.ts
@@ -32,6 +32,16 @@ type OngoingSessionSync = {
    * cannot reflect the buffer, so the buffer must not be rolled back to it.
    */
   syncedAt?: Timestamp;
+
+  /**
+   * How many enqueued live flushes in a row the request queue permanently
+   * dropped (a deterministic server rejection after retries; transient
+   * failures are never dropped). Caps the automatic re-arm in
+   * `maybeResumeLiveSessionPersist` so a payload the server always rejects
+   * cannot re-enqueue itself forever. Reset by the next local edit, since a
+   * new payload deserves a fresh budget.
+   */
+  flushDropCount?: number;
 };
 
 export default OngoingSessionSync;

--- a/src/types/onyx/UnsyncedSessionWrite.ts
+++ b/src/types/onyx/UnsyncedSessionWrite.ts
@@ -1,0 +1,37 @@
+import type DrinkingSession from './DrinkingSession';
+import type {DrinkingSessionId} from './DrinkingSession';
+import type {Timestamp, UserID} from './OnyxCommon';
+
+/**
+ * A finalized session write the request queue permanently dropped (the server
+ * deterministically rejected it after retries; transient failures are never
+ * dropped). Unlike a live-session flush, nothing later re-sends a finalize,
+ * so the payload is parked here instead of being lost: the next app run
+ * re-enqueues it once (`resendUnsyncedSessionWrites`), and a successful
+ * delivery clears the entry.
+ *
+ * Cleared on sign-out along with the persisted request queue (neither is in
+ * `KEYS_TO_PRESERVE`), so entries always belong to the signed-in user.
+ */
+type UnsyncedSessionWrite = {
+  /** Id of the session the dropped write was for. */
+  sessionId: DrinkingSessionId;
+
+  /** The full session payload exactly as the dropped request carried it. */
+  session: DrinkingSession;
+
+  /** Owner of the session (the signed-in user at enqueue time). */
+  userID: UserID;
+
+  /** Whether the original write was flagged live (mirrors into user status). */
+  sessionIsLive: boolean;
+
+  /** When the original write was enqueued (epoch ms), for debugging. */
+  enqueuedAt: Timestamp;
+};
+
+/** All parked session writes, keyed by session id. */
+type UnsyncedSessionWriteList = Record<DrinkingSessionId, UnsyncedSessionWrite>;
+
+export default UnsyncedSessionWrite;
+export type {UnsyncedSessionWriteList};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -36,6 +36,8 @@ import type NicknameToId from './NicknameToId';
 import type PendingOAuthCredential from './PendingOAuthCredential';
 import type {Nickname, NicknameKey, NicknameToIdList} from './NicknameToId';
 import type OngoingSessionSync from './OngoingSessionSync';
+import type UnsyncedSessionWrite from './UnsyncedSessionWrite';
+import type {UnsyncedSessionWriteList} from './UnsyncedSessionWrite';
 import type {
   OnyxUpdateEvent,
   OnyxUpdatesFromServer,
@@ -128,6 +130,8 @@ export type {
   PendingOAuthCredential,
   OnboardingData,
   OngoingSessionSync,
+  UnsyncedSessionWrite,
+  UnsyncedSessionWriteList,
   OnyxUpdateEvent,
   OnyxUpdatesFromServer,
   Preferences,


### PR DESCRIPTION
# Details

Root-cause fix for units logged offline vanishing (observed on 0.3.23-9 despite the offline live-session persistence work).

## The bug

`SequentialQueue` retries a failed request with exponential backoff, but after `MAX_REQUEST_RETRIES` (10) it permanently deletes the request from the persisted queue, applying only `failureData`. Session writes carried none, so the drop was silent: no rollback, no re-send, and the next `app/open` clean-replace erased the optimistic record. The throttle counter is a single in-memory budget that resets only on success or drop, so the 10 lifetime retries were consumed cumulatively across every "believes online but requests fail" window: airplane-mode toggles, VPN black-hole windows before the healthz probe flips (~26s), reauth failures right after reconnect. Enough flaps during one offline session and the queued `UpdateSession` carrying the drinks was silently destroyed.

## The fix

1. **Classify failures at the drop decision.** Only a deterministic client error (a real server response with a non-retryable 4xx) may drop a request after retry exhaustion. Network-layer failures (no response), 5xx, and 429 keep the request queued and stall the queue until the next flush trigger (reconnection, foreground, new write) retries with a fresh budget. `waitForIdle()` is resolved on the stall so reads are not held hostage.
2. **Reset the retry budget on reconnection** (`RequestThrottle.resetBudget`, wired into `onReconnection`). Restores "N consecutive failures within one online window" semantics. `resetBudget` rather than `clear` because clearing a pending sleep timer would orphan its promise and wedge the queue.
3. **Session writes survive even a deterministic drop.**
   - The live flush now carries `failureData` that clears `enqueuedAt` and bumps a `flushDropCount`: the persist re-arms and the next full-session flush re-sends everything, capped at 3 consecutive drops (a new edit resets the budget).
   - A dropped finalize is parked in the new `UNSYNCED_SESSION_WRITES` Onyx key with its full payload; the next app run re-enqueues it once (`resendUnsyncedSessionWrites`) and a successful delivery clears the entry.

Upstream note: Expensify's queue has the same drop-after-N semantics, but every upstream write carries rollback `failureData` and surfaces the failure in the UI. Items 1 and 2 are deliberate, documented divergences in forked infra; 3 is Kiroku action-layer code only.

## Tests

- `__tests__/actions/OfflineWriteDurability.test.ts`: drives the real `API.write` -> `SequentialQueue` -> `PersistedRequests` pipeline with only HTTP stubbed. Proves: retry exhaustion on network-layer failures and on 5xx never drops a queued write (fails against the previous code); a finalize dropped on 400 is parked and re-sent on the next run; a dropped live flush re-arms up to the cap, never wipes the buffer, and recovers on the next edit.
- `__tests__/unit/RequestThrottle.test.ts`: budget exhaustion + `resetBudget` semantics.
- Existing suites updated/passing: `DrinkingSession.test.ts` (flush now asserts the failureData), `FriendsOfflineReplay.test.ts`.

`lint-changed`, `typecheck-tsgo`, and the React Compiler compliance check all pass.